### PR TITLE
implement of basic account

### DIFF
--- a/moveos/moveos-stdlib/rooch-framework/Move.toml
+++ b/moveos/moveos-stdlib/rooch-framework/Move.toml
@@ -7,6 +7,7 @@ std = "0x1"
 moveos_std = "0x1"
 rooch_framework = "0x1"
 vm_reserved = "0x0"
+rooch_association = "0xA550C18"
 
 [dependencies]
 MoveosStdLib = { local = "../moveos-stdlib" }

--- a/moveos/moveos-stdlib/rooch-framework/sources/account.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/account.move
@@ -1,25 +1,78 @@
 module rooch_framework::account{
-   
    use std::error;
    use std::bcs;
+   use std::hash;
    use std::vector;
+   use std::signer;
+   use moveos_std::bcd;
+   #[test_only]
+   use std::debug;
+
+   friend rooch_framework::genesis;
+   friend rooch_framework::transaction_validator;
+
+   /// Resource representing an account.
+   struct Account has key, store {
+      authentication_key: vector<u8>,
+      sequence_number: u64,
+      //TODO do we need a global unique identifiers?
+      //guid_creation_num: u64,
+   }
+
+   /// A resource that holds the tokens stored in this account
+   struct Balance<phantom TokenType> has key {
+      // TODO token standard
+   }
+
+   // ResourceAccount can only be stored under address, not in other structs.
+   struct ResourceAccount has key {}
+   // SignerCapability can only be stored in other structs, not under address.
+   // So that the capability is always controlled by contracts, not by some EOA.
+   struct SignerCapability has store { addr: address }
+
+
+
+   const MAX_U64: u128 = 18446744073709551615;
+   const ZERO_AUTH_KEY: vector<u8> = x"0000000000000000000000000000000000000000000000000000000000000000";
+   // cannot be dummy key, or empty key
+   const CONTRACT_ACCOUNT_AUTH_KEY_PLACEHOLDER:vector<u8> = x"0000000000000000000000000000000000000000000000000000000000000001";
+
+   /// Scheme identifier for Ed25519 signatures used to derive authentication keys for Ed25519 public keys.
+   const ED25519_SCHEME: u8 = 0;
+   /// Scheme identifier for MultiEd25519 signatures used to derive authentication keys for MultiEd25519 public keys.
+   const MULTI_ED25519_SCHEME: u8 = 1;
+   /// Scheme identifier used when hashing an account's address together with a seed to derive the address (not the
+   /// authentication key) of a resource account. This is an abuse of the notion of a scheme identifier which, for now,
+   /// serves to domain separate hashes used to derive resource account addresses from hashes used to derive
+   /// authentication keys. Without such separation, an adversary could create (and get a signer for) a resource account
+   /// whose address matches an existing address of a MultiEd25519 wallet.
+   const DERIVE_RESOURCE_ACCOUNT_SCHEME: u8 = 255;
+   /// authentication key length
+   const AUTHENTICATION_KEY_LENGTH: u64 = 32;
+
+
+
 
    /// Account already exists
    const EAccountAlreadyExists: u64 = 1;
    /// Account does not exist
    const EAccountNotExist: u64 = 2;
+   /// Sequence number exceeds the maximum value for a u64
+   const ESequenceNumberTooBig: u64 = 3;
    /// The provided authentication key has an invalid length
    const EMalformedAuthenticationKey: u64 = 4;
    /// Cannot create account because address is reserved
    const EAddressReseved: u64 = 5;
+   /// An attempt to create a resource account on an account that has a committed transaction
+   const EResourceAccountAlreadyUsed: u64 = 6;
+   /// Resource Account can't derive resource account
+   const EAccountIsAlreadyResourceAccount: u64 = 7;
+   /// Address to create is not a valid reserved address for Rooch framework
+   const ENoValidFrameworkReservedAddress: u64 = 11;
 
-   /// Resource representing an account.
-   struct Account has key, store {
-      authentication_key: vector<u8>,
-      //TODO do we need a global account sequence number? every object has a sequence number
-      //sequence_number: u64,
-      //guid_creation_num: u64,
-   }
+
+
+
 
    /// TODO should provide a entry function at this module
    /// How to provide account extension?
@@ -46,18 +99,83 @@ module rooch_framework::account{
       let new_account = create_signer(new_address);
       let authentication_key = bcs::to_bytes(&new_address);
       assert!(
-         vector::length(&authentication_key) == 32,
+         vector::length(&authentication_key) == AUTHENTICATION_KEY_LENGTH,
          error::invalid_argument(EMalformedAuthenticationKey)
       );
+
+      // TODO event register
       move_to(
          &new_account,
          Account {
-               authentication_key,
+            authentication_key,
+            sequence_number: 0,
          }
       );
 
       new_account
    }
+
+   /// create the account for system reserved addresses
+   public(friend) fun create_framework_reserved_account(addr: address): (signer, SignerCapability) {
+      assert!(
+         addr == @0x1 ||
+             addr == @0x2 ||
+             addr == @0x3 ||
+             addr == @0x4 ||
+             addr == @0x5 ||
+             addr == @0x6 ||
+             addr == @0x7 ||
+             addr == @0x8 ||
+             addr == @0x9 ||
+             addr == @0xa,
+         error::permission_denied(ENoValidFrameworkReservedAddress),
+      );
+      let signer = create_account_unchecked(addr);
+      let signer_cap = SignerCapability { addr };
+      (signer, signer_cap)
+   }
+
+
+   /// Return the current sequence number at `addr`
+   public fun sequence_number(addr: address): u64 acquires Account {
+      sequence_number_for_account(borrow_global<Account>(addr))
+   }
+
+   public(friend) fun increment_sequence_number(addr: address) acquires Account {
+      let sequence_number = &mut borrow_global_mut<Account>(addr).sequence_number;
+
+      assert!(
+         (*sequence_number as u128) < MAX_U64,
+         error::out_of_range(ESequenceNumberTooBig)
+      );
+
+      *sequence_number = *sequence_number + 1;
+   }
+
+   /// Helper to return the sequence number field for given `account`
+   fun sequence_number_for_account(account: &Account): u64 {
+      account.sequence_number
+   }
+
+   /// Return the current TokenType balance of the account at `addr`.
+   public fun balance<TokenType: store>(_addr: address): u128 {
+      //TODO token standard, with balance precesion(u64|u128|u256)
+      0u128
+   }
+
+   #[view]
+   public fun get_authentication_key(addr: address): vector<u8> acquires Account {
+      *&borrow_global<Account>(addr).authentication_key
+   }
+
+   public fun signer_address(cap: &SignerCapability): address {
+      cap.addr
+   }
+
+   public fun is_resource_account(addr: address): bool {
+      exists<ResourceAccount>(addr)
+   }
+
 
    #[view]
    public fun exists_at(addr: address): bool {
@@ -66,4 +184,128 @@ module rooch_framework::account{
 
 
    native fun create_signer(addr: address): signer;
+
+
+   /// A resource account is used to manage resources independent of an account managed by a user.
+   /// In Rooch a resource account is created based upon the sha3 256 of the source's address and additional seed data.
+   /// A resource account can only be created once
+   public fun create_resource_account(source: &signer): (signer, SignerCapability) acquires Account {
+      let source_addr = signer::address_of(source);
+      let seed = generate_seed_bytes(&source_addr);
+      let resource_addr = create_resource_address(&source_addr, seed);
+      let resource_signer = if (exists_at(resource_addr)) {
+         let account = borrow_global<Account>(resource_addr);
+         assert!(account.sequence_number == 0, error::invalid_state(EResourceAccountAlreadyUsed));
+         create_signer(resource_addr)
+      } else {
+         create_account_unchecked(resource_addr)
+      };
+
+      // By default, only the SignerCapability should have control over the resource account and not the auth key.
+      // If the source account wants direct control via auth key, they would need to explicitly rotate the auth key
+      // of the resource account using the SignerCapability.
+      rotate_authentication_key_internal(&resource_signer, ZERO_AUTH_KEY);
+
+      assert!(!is_resource_account(resource_addr), error::invalid_state(EAccountIsAlreadyResourceAccount));
+      move_to(&resource_signer, ResourceAccount {});
+
+      let signer_cap = SignerCapability { addr: resource_addr };
+      (resource_signer, signer_cap)
+   }
+
+   /// This is a helper function to generate seed for resource address
+   fun generate_seed_bytes(addr: &address): vector<u8> acquires Account{
+      let sequence_number = Self::sequence_number(*addr);
+      // use rooch token balance as part of seed, just for new address more random.
+      // TODO token standar
+      // let balance = Self::balance<...>(*addr);
+
+      let seed_bytes = bcs::to_bytes(addr);
+      vector::append(&mut seed_bytes, bcs::to_bytes(&sequence_number));
+      // vector::append(&mut seed_bytes, bcs::to_bytes(&balance));
+
+      hash::sha3_256(seed_bytes)
+   }
+
+   /// This is a helper function to compute resource addresses. Computation of the address
+   /// involves the use of a cryptographic hash operation and should be use thoughtfully.
+   public fun create_resource_address(source: &address, seed: vector<u8>): address {
+      let bytes = bcs::to_bytes(source);
+      vector::append(&mut bytes, seed);
+      vector::push_back(&mut bytes, DERIVE_RESOURCE_ACCOUNT_SCHEME);
+      bcd::to_address(hash::sha3_256(bytes))
+   }
+
+   /// This function is used to rotate a resource account's authentication key to 0, so that no private key can control
+   /// the resource account.
+   public(friend) fun rotate_authentication_key_internal(account: &signer, new_auth_key: vector<u8>) acquires Account {
+      let addr = signer::address_of(account);
+      assert!(exists_at(addr), error::not_found(EAccountNotExist));
+      assert!(
+         vector::length(&new_auth_key) == AUTHENTICATION_KEY_LENGTH,
+         error::invalid_argument(EMalformedAuthenticationKey)
+      );
+      let account_resource = borrow_global_mut<Account>(addr);
+      account_resource.authentication_key = new_auth_key;
+   }
+
+   public fun create_signer_with_capability(capability: &SignerCapability): signer {
+      let addr = &capability.addr;
+      create_signer(*addr)
+   }
+
+   public fun get_signer_capability_address(capability: &SignerCapability): address {
+      capability.addr
+   }
+
+   #[test_only]
+   /// Create signer for testing, independently of an Rooch-style `Account`.
+   public fun create_signer_for_test(addr: address): signer { create_signer(addr) }
+
+   #[test_only]
+   public fun create_account_for_test(new_address: address): signer {
+      create_account_unchecked(new_address)
+   }
+
+   #[test]
+   /// Assert correct signer creation.
+   fun test_create_signer_for_test() {
+      assert!(signer::address_of(&create_signer_for_test(@rooch_framework)) == @0x1, 100);
+      assert!(signer::address_of(&create_signer_for_test(@0x123)) == @0x123, 101);
+   }
+
+   #[test]
+   /// Assert correct account creation.
+   fun test_create_account_for_test() acquires Account {
+      let alice_addr = @123456;
+      let alice = create_account_for_test(alice_addr);
+      let alice_addr_actual = signer::address_of(&alice);
+      let sequence_number = sequence_number(alice_addr);
+      debug::print(&get_authentication_key(alice_addr));
+      debug::print(&sequence_number);
+      assert!(alice_addr_actual == alice_addr, 103);
+      assert!(sequence_number >= 0, 104);
+   }
+
+   #[test_only]
+   struct CapResponsbility has key {
+      cap: SignerCapability
+   }
+
+   #[test]
+   fun test_create_resource_account() acquires Account {
+      let alice_addr = @123456;
+      let alice = create_account_for_test(alice_addr);
+      let (resource_account, resource_account_cap) = create_resource_account(&alice);
+      let signer_cap_addr = get_signer_capability_address(&resource_account_cap);
+      move_to(&resource_account, CapResponsbility {
+         cap: resource_account_cap
+      });
+
+      let resource_addr = signer::address_of(&resource_account);
+      debug::print(&100100);
+      debug::print(&resource_addr);
+      assert!(resource_addr != signer::address_of(&alice), 106);
+      assert!(resource_addr == signer_cap_addr, 107);
+   }
 }

--- a/moveos/moveos-stdlib/rooch-framework/sources/account.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/account.move
@@ -193,6 +193,7 @@ module rooch_framework::account{
       let source_addr = signer::address_of(source);
       let seed = generate_seed_bytes(&source_addr);
       let resource_addr = create_resource_address(&source_addr, seed);
+      assert!(!is_resource_account(resource_addr), error::invalid_state(EAccountIsAlreadyResourceAccount));
       let resource_signer = if (exists_at(resource_addr)) {
          let account = borrow_global<Account>(resource_addr);
          assert!(account.sequence_number == 0, error::invalid_state(EResourceAccountAlreadyUsed));
@@ -205,8 +206,6 @@ module rooch_framework::account{
       // If the source account wants direct control via auth key, they would need to explicitly rotate the auth key
       // of the resource account using the SignerCapability.
       rotate_authentication_key_internal(&resource_signer, ZERO_AUTH_KEY);
-
-      assert!(!is_resource_account(resource_addr), error::invalid_state(EAccountIsAlreadyResourceAccount));
       move_to(&resource_signer, ResourceAccount {});
 
       let signer_cap = SignerCapability { addr: resource_addr };

--- a/moveos/moveos-stdlib/rooch-framework/sources/block.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/block.move
@@ -1,7 +1,7 @@
 /// This module defines a struct storing the metadata of the block and new block events.
 module rooch_framework::block {
     use std::error;
-
+    use std::signer;
     use rooch_framework::core_addresses;
     // use rooch_framework::timestamp;
 
@@ -18,12 +18,14 @@ module rooch_framework::block {
 
     /// Epoch interval cannot be 0.
     const EZeroEpochInterval: u64 = 1;
+    const EBlockResourceAlreadyExist: u64 = 2;
 
 
     /// This can only be called during Genesis.
     public(friend) fun initialize(account: &signer, epoch_interval_millisecs: u64) {
         core_addresses::assert_rooch_genesis(account);
         assert!(epoch_interval_millisecs > 0, error::invalid_argument(EZeroEpochInterval));
+        assert!(!exists<BlockResource>(signer::address_of(account)), error::invalid_state(EBlockResourceAlreadyExist));
 
         move_to<BlockResource>(
             account,

--- a/moveos/moveos-stdlib/rooch-framework/sources/block.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/block.move
@@ -1,0 +1,76 @@
+/// This module defines a struct storing the metadata of the block and new block events.
+module rooch_framework::block {
+    use std::error;
+
+    use rooch_framework::core_addresses;
+    // use rooch_framework::timestamp;
+
+    friend rooch_framework::genesis;
+
+    /// Should be in-sync with BlockResource rust struct
+    // TODO BlockResource structure
+    struct BlockResource has key {
+        /// Height of the current block
+        height: u64,
+        /// Time period between epochs.
+        epoch_interval: u64,
+    }
+
+    /// Epoch interval cannot be 0.
+    const EZeroEpochInterval: u64 = 1;
+
+
+    /// This can only be called during Genesis.
+    public(friend) fun initialize(account: &signer, epoch_interval_millisecs: u64) {
+        core_addresses::assert_rooch_genesis(account);
+        assert!(epoch_interval_millisecs > 0, error::invalid_argument(EZeroEpochInterval));
+
+        move_to<BlockResource>(
+            account,
+            BlockResource {
+                height: 0,
+                epoch_interval: epoch_interval_millisecs,
+            }
+        );
+    }
+
+    /// Update the epoch interval.
+    public fun update_epoch_interval_millisecs(
+        account: &signer,
+        new_epoch_interval: u64,
+    ) acquires BlockResource {
+        core_addresses::assert_rooch_genesis(account);
+        assert!(new_epoch_interval > 0, error::invalid_argument(EZeroEpochInterval));
+
+        let block_resource = borrow_global_mut<BlockResource>(core_addresses::genesis_address());
+        let _old_epoch_interval = block_resource.epoch_interval;
+        block_resource.epoch_interval = new_epoch_interval;
+    }
+
+    #[view]
+    /// Return epoch interval in seconds.
+    public fun get_epoch_interval_secs(): u64 acquires BlockResource {
+        borrow_global<BlockResource>(core_addresses::genesis_address()).epoch_interval / 1000
+    }
+
+    /// Set the metadata for the current block.
+    /// The runtime always runs this before executing the transactions in a block.
+    // TODO blcok preduce logic
+    fun block_prologue(
+        vm: signer,
+        _hash: address,
+        _epoch: u64,
+        _round: u64,
+        _proposer: address,
+        _timestamp: u64
+    )  {
+        // Operational constraint: can only be invoked by the VM.
+        core_addresses::assert_vm(&vm);
+    }
+
+    #[view]
+    /// Get the current block height
+    public fun get_current_block_height(): u64 acquires BlockResource {
+        borrow_global<BlockResource>(core_addresses::genesis_address()).height
+    }
+}

--- a/moveos/moveos-stdlib/rooch-framework/sources/chain_id.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/chain_id.move
@@ -2,6 +2,8 @@
 /// One important role is to prevent transactions intended for one chain from being executed on another.
 /// This code provides a container for storing a chain id and functions to initialize and get it.
 module rooch_framework::chain_id {
+    use std::signer;
+    use std::error;
     use rooch_framework::core_addresses;
     friend rooch_framework::genesis;
 
@@ -13,10 +15,13 @@ module rooch_framework::chain_id {
     const DEV_CHAIN_ID: u8 = 181;
     const TEST_CHAIN_ID: u8 = 182;
 
+    const EChainIdAlreadyExist: u64 = 1;
+
     /// Only called during genesis.
     /// Publish the chain ID under the genesis account
-    public fun initialize(account: &signer, id: u8) {
+    public(friend) fun initialize(account: &signer, id: u8) {
         core_addresses::assert_rooch_genesis(account);
+        assert!(!exists<ChainId>(signer::address_of(account)), error::invalid_state(EChainIdAlreadyExist));
         move_to(account, ChainId { id })
     }
 

--- a/moveos/moveos-stdlib/rooch-framework/sources/chain_id.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/chain_id.move
@@ -1,0 +1,51 @@
+/// The chain id distinguishes between different chains (e.g., testnet and the main network).
+/// One important role is to prevent transactions intended for one chain from being executed on another.
+/// This code provides a container for storing a chain id and functions to initialize and get it.
+module rooch_framework::chain_id {
+    use rooch_framework::core_addresses;
+    friend rooch_framework::genesis;
+
+    struct ChainId has key {
+        id: u8
+    }
+
+    const MAIN_CHAIN_ID: u8 = 1;
+    const DEV_CHAIN_ID: u8 = 181;
+    const TEST_CHAIN_ID: u8 = 182;
+
+    /// Only called during genesis.
+    /// Publish the chain ID under the genesis account
+    public fun initialize(account: &signer, id: u8) {
+        core_addresses::assert_rooch_genesis(account);
+        move_to(account, ChainId { id })
+    }
+
+    #[view]
+    /// Return the chain ID of this instance.
+    public fun get(): u8 acquires ChainId {
+        borrow_global<ChainId>(@rooch_framework).id
+    }
+
+    public fun is_dev(): bool acquires ChainId {
+        get() == DEV_CHAIN_ID
+    }
+
+    public fun is_test(): bool acquires ChainId {
+        get() == TEST_CHAIN_ID
+    }
+
+    public fun is_main(): bool acquires ChainId {
+        get() == MAIN_CHAIN_ID
+    }
+
+    #[test_only]
+    public fun initialize_for_test(rooch_framework: &signer, id: u8) {
+        initialize(rooch_framework, id);
+    }
+
+    #[test(rooch_framework = @0x1)]
+    fun test_get(rooch_framework: &signer) acquires ChainId {
+        initialize_for_test(rooch_framework, 1u8);
+        assert!(get() == 1u8, 1);
+    }
+}

--- a/moveos/moveos-stdlib/rooch-framework/sources/core_addresses.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/core_addresses.move
@@ -1,0 +1,103 @@
+module rooch_framework::core_addresses {
+    use std::error;
+    use std::signer;
+
+    /// The address/account did not correspond to the genesis address
+    const ENotGenesisAddress: u64 = 1;
+    /// The address/account did not correspond to the association address
+    const ENotAssociationAddress: u64 = 2;
+    /// The operation can only be performed by the VM
+    const EVm: u64 = 3;
+    /// The address/account did not correspond to the core framework address
+    const ENotRoochFrameworkAddress: u64 = 4;
+    /// The address is not framework reserved address
+    const ENotFrameworkReservedAddress: u64 = 5;
+
+
+    public fun assert_rooch_genesis(account: &signer) {
+        assert_rooch_genesis_address(signer::address_of(account))
+    }
+
+    public fun assert_rooch_genesis_address(addr: address) {
+        assert!(is_rooch_genesis_address(addr), error::permission_denied(ENotGenesisAddress))
+    }
+
+    public fun is_rooch_genesis_address(addr: address): bool {
+        addr == genesis_address()
+    }
+
+    public fun assert_rooch_association(account: &signer) {
+        assert_rooch_association_address(signer::address_of(account))
+    }
+
+    public fun assert_rooch_association_address(addr: address) {
+        assert!(is_rooch_association_address(addr), error::permission_denied(ENotAssociationAddress))
+    }
+
+    public fun is_rooch_association_address(addr: address): bool {
+        addr == @rooch_association
+    }
+
+    public fun assert_rooch_framework(account: &signer) {
+        assert!(
+            is_rooch_framework_address(signer::address_of(account)),
+            error::permission_denied(ENotRoochFrameworkAddress),
+        )
+    }
+
+    public fun assert_framework_reserved_address(account: &signer) {
+        assert_framework_reserved(signer::address_of(account));
+    }
+
+    public fun assert_framework_reserved(addr: address) {
+        assert!(
+            is_framework_reserved_address(addr),
+            error::permission_denied(ENotFrameworkReservedAddress),
+        )
+    }
+
+    /// Return true if `addr` is 0x0 or under the on chain governance's control.
+    public fun is_framework_reserved_address(addr: address): bool {
+        is_rooch_framework_address(addr) ||
+            addr == @0x2 ||
+            addr == @0x3 ||
+            addr == @0x4 ||
+            addr == @0x5 ||
+            addr == @0x6 ||
+            addr == @0x7 ||
+            addr == @0x8 ||
+            addr == @0x9 ||
+            addr == @0xa
+    }
+
+    /// Return true if `addr` is 0x1.
+    public fun is_rooch_framework_address(addr: address): bool {
+        addr == @rooch_framework
+    }
+
+    /// Assert that the signer has the VM reserved address.
+    public fun assert_vm(account: &signer) {
+        assert!(is_vm(account), error::permission_denied(EVm))
+    }
+
+    /// Return true if `addr` is a reserved address for the VM to call system modules.
+    public fun is_vm(account: &signer): bool {
+        is_vm_address(signer::address_of(account))
+    }
+
+    /// Return true if `addr` is a reserved address for the VM to call system modules.
+    public fun is_vm_address(addr: address): bool {
+        addr == @vm_reserved
+    }
+
+    /// Return true if `addr` is either the VM address or an Rooch Framework address.
+    public fun is_reserved_address(addr: address): bool {
+        is_rooch_framework_address(addr) || is_vm_address(addr)
+    }
+
+    /// The address of the genesis
+    public fun genesis_address(): address {
+        @rooch_framework
+    }
+
+}

--- a/moveos/moveos-stdlib/rooch-framework/sources/genesis.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/genesis.move
@@ -1,0 +1,50 @@
+ module rooch_framework::genesis {
+    use rooch_framework::account;
+    use rooch_framework::block;
+    use rooch_framework::chain_id;
+    use rooch_framework::timestamp;
+    use rooch_framework::governance;
+    use rooch_framework::core_addresses;
+
+    /// Genesis step 1: Initialize rooch genesis account and core modules on chain.
+    fun initialize(
+        _gas_schedule: vector<u8>,
+        chain_id: u8,
+        _initial_version: u64,
+        epoch_interval_microsecs: u64,
+        genesis_timestamp: u64,
+
+        //TODO block reward
+
+        //TODO consensus config
+        _consensus_config: vector<u8>,
+
+        //TODO vm config
+
+        //TODO gas constants
+    ) {
+        // Initialize the rooch genesis account. This is the account where system resources and modules will be
+        // deployed to. This will be entirely managed by on-chain governance and no entities have the key or privileges
+        // to use this account.
+        let (rooch_genesis_account, rooch_genesis_signer_cap) = account::create_framework_reserved_account(core_addresses::genesis_address());
+
+        // transaction_validation::initialize(
+        //     &rooch_genesis_account,
+        //     b"script_prologue",
+        //     b"module_prologue",
+        //     b"multi_agent_script_prologue",
+        //     b"epilogue",
+        // );
+
+        // Give the decentralized on-chain governance control over the core genesis account.
+        governance::store_signer_cap(&rooch_genesis_account, core_addresses::genesis_address(), rooch_genesis_signer_cap);
+
+        // consensus_config::initialize(&rooch_genesis_account, consensus_config);
+        // version::initialize(&rooch_genesis_account, initial_version);
+        // gas_schedule::initialize(&rooch_genesis_account, gas_schedule);
+
+        chain_id::initialize(&rooch_genesis_account, chain_id);
+        block::initialize(&rooch_genesis_account, epoch_interval_microsecs);
+        timestamp::initialize(&rooch_genesis_account, genesis_timestamp);
+    }
+}

--- a/moveos/moveos-stdlib/rooch-framework/sources/governance.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/governance.move
@@ -1,0 +1,49 @@
+/**
+ * RoochGovernance represents the on-chain governance of the Rooch network.
+ *
+ */
+module rooch_framework::governance {
+    use std::error;
+    use rooch_framework::account::{Self, SignerCapability};
+    use rooch_framework::core_addresses;
+
+    friend rooch_framework::genesis;
+
+    /// Store the SignerCapabilities of accounts under the on-chain governance's control.
+    struct GovernanceResponsbility has key {
+        cap: SignerCapability
+    }
+
+    /// The governance responsbility has been store
+    const EGovernanceResponsbilityAlreadyExist: u64 = 1;
+
+    /// Can be called during genesis or by the governance itself.
+    /// Stores the signer capability for a given address.
+    public fun store_signer_cap(
+        rooch_genesis: &signer,
+        signer_address: address,
+        signer_cap: SignerCapability,
+    ) {
+        core_addresses::assert_rooch_genesis(rooch_genesis);
+        core_addresses::assert_framework_reserved(signer_address);
+
+        assert!(!exists<GovernanceResponsbility>(core_addresses::genesis_address()), error::invalid_state(EGovernanceResponsbilityAlreadyExist));
+        move_to(rooch_genesis, GovernanceResponsbility {
+            cap: signer_cap
+        });
+    }
+
+    public(friend) fun get_governance_signer_cap(): signer acquires GovernanceResponsbility {
+        let cap = borrow_global<GovernanceResponsbility>(core_addresses::genesis_address());
+        account::create_signer_with_capability(&cap.cap)
+    }
+
+    /// Initializes the state for Rooch Governance. Can only be called during Genesis with a signer
+    /// for the rooch_genesis (0x1) account.
+    /// TODO rooch governance
+    fun initialize(
+        rooch_genesis: &signer,
+    ) {
+        core_addresses::assert_rooch_genesis(rooch_genesis);
+    }
+}

--- a/moveos/moveos-stdlib/rooch-framework/sources/timestamp.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/timestamp.move
@@ -1,0 +1,89 @@
+/// This module keeps a global wall clock that stores the current Unix time in milliseconds.
+/// It interacts with the other modules in the following ways:
+/// * genesis: to initialize the timestamp
+/// * block: to reach consensus on the global wall clock time
+module rooch_framework::timestamp {
+    use std::error;
+    use rooch_framework::core_addresses;
+
+    friend rooch_framework::genesis;
+
+    /// A singleton resource holding the current Unix time in milliseconds
+    struct CurrentTimeMilliseconds has key {
+        milliseconds: u64,
+    }
+
+    /// Conversion factor between seconds and milliseconds
+    const MILLI_CONVERSION_FACTOR: u64 = 1000;
+
+    /// The blockchain is not in an operating state yet
+    const ENotOperating: u64 = 1;
+    /// An invalid timestamp was provided
+    const EInvalidTimestamp: u64 = 2;
+
+    // Initialize the global wall clock time resource.
+    public(friend) fun initialize(account: &signer, genesis_timestamp: u64) {
+        // Only callable by the genesis address
+        core_addresses::assert_rooch_genesis(account);
+        let timer = CurrentTimeMilliseconds {milliseconds: genesis_timestamp};
+        move_to<CurrentTimeMilliseconds>(account, timer);
+    }
+
+    /// Updates the wall clock time by consensus. Requires VM privilege and will be invoked during block prologue.
+    public fun update_global_time(
+        account: &signer,
+        proposer: address,
+        timestamp: u64
+    ) acquires CurrentTimeMilliseconds {
+        // Can only be invoked by VM signer.
+        core_addresses::assert_vm(account);
+
+        let global_timer = borrow_global_mut<CurrentTimeMilliseconds>(@rooch_framework);
+        let now = global_timer.milliseconds;
+        if (proposer == @vm_reserved) {
+            // NIL block with null address as proposer. Timestamp must be equal.
+            assert!(now == timestamp, error::invalid_argument(EInvalidTimestamp));
+        } else {
+            // Normal block. Time must advance
+            assert!(now < timestamp, error::invalid_argument(EInvalidTimestamp));
+            global_timer.milliseconds = timestamp;
+        };
+    }
+
+    #[test_only]
+    public fun initialize_timestamp_for_testing(account: &signer) {
+        if (!exists<CurrentTimeMilliseconds>(@rooch_framework)) {
+            initialize(account, 0);
+        };
+    }
+
+    #[view]
+    /// Gets the current time in milliseconds.
+    public fun now_milliseconds(): u64 acquires CurrentTimeMilliseconds {
+        borrow_global<CurrentTimeMilliseconds>(@rooch_framework).milliseconds
+    }
+
+    #[view]
+    /// Gets the current time in seconds.
+    public fun now_seconds(): u64 acquires CurrentTimeMilliseconds {
+        now_milliseconds() / MILLI_CONVERSION_FACTOR
+    }
+
+    #[test_only]
+    public fun update_global_time_for_test(timestamp_microsecs: u64) acquires CurrentTimeMilliseconds {
+        let global_timer = borrow_global_mut<CurrentTimeMilliseconds>(@rooch_framework);
+        let now = global_timer.milliseconds;
+        assert!(now < timestamp_microsecs, error::invalid_argument(EInvalidTimestamp));
+        global_timer.milliseconds = timestamp_microsecs;
+    }
+
+    #[test_only]
+    public fun update_global_time_for_test_secs(timestamp_seconds: u64) acquires CurrentTimeMilliseconds {
+        update_global_time_for_test(timestamp_seconds * MILLI_CONVERSION_FACTOR);
+    }
+
+    #[test_only]
+    public fun fast_forward_seconds(timestamp_seconds: u64) acquires CurrentTimeMilliseconds {
+        update_global_time_for_test_secs(now_seconds() + timestamp_seconds);
+    }
+}

--- a/moveos/moveos-stdlib/rooch-framework/sources/transaction_validator.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/transaction_validator.move
@@ -1,0 +1,163 @@
+module rooch_framework::transaction_validator {
+    use std::error;
+    use std::signer;
+    use rooch_framework::account;
+    use rooch_framework::chain_id;
+    use rooch_framework::core_addresses;
+    use rooch_framework::timestamp;
+
+    friend rooch_framework::genesis;
+
+    /// This holds information that will be picked up by the VM to call the
+    /// correct chain-specific prologue and epilogue functions
+    struct TransactionValidation has key {
+        module_addr: address,
+        module_name: vector<u8>,
+        script_prologue_name: vector<u8>,
+        module_prologue_name: vector<u8>,
+        multi_agent_prologue_name: vector<u8>,
+        user_epilogue_name: vector<u8>,
+    }
+
+    const MAX_U64: u128 = 18446744073709551615;
+
+    /// Transaction exceeded its allocated max gas
+    const EOUT_OF_GAS: u64 = 6;
+
+    /// Prologue errors. These are separated out from the other errors in this
+    /// module since they are mapped separately to major VM statuses, and are
+    /// important to the semantics of the system.
+    const EPrologueInvalidAccountAuthKey: u64 = 1001;
+    const EPrologueSequenceNuberTooOld: u64 = 1002;
+    const EPrologueSequenceNumberTooNew: u64 = 1003;
+    const EPrologueAccountDoesNotExist: u64 = 1004;
+    const EPrologueCantPayGasDeposit: u64 = 1005;
+    const EPrologueTransactionExpired: u64 = 1006;
+    const EPrologueBadChainId: u64 = 1007;
+    const EPrologueSequenceNumberTooBig: u64 = 1008;
+    const EPrologueSecondaryKeysAddressesCountMismatch: u64 = 1009;
+
+    /// Only called during genesis to initialize system resources for this module.
+    public(friend) fun initialize(
+        account: &signer,
+        script_prologue_name: vector<u8>,
+        module_prologue_name: vector<u8>,
+        multi_agent_prologue_name: vector<u8>,
+        user_epilogue_name: vector<u8>,
+    ) {
+        core_addresses::assert_rooch_genesis(account);
+
+        move_to(account, TransactionValidation {
+            module_addr: core_addresses::genesis_address(),
+            module_name: b"transaction_validator",
+            script_prologue_name,
+            module_prologue_name,
+            multi_agent_prologue_name,
+            user_epilogue_name,
+        });
+    }
+
+    fun prologue_common(
+        sender: signer,
+        txn_sequence_number: u64,
+        txn_authentication_key: vector<u8>,
+        _txn_gas_price: u64,
+        _txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
+    ) {
+        assert!(
+            timestamp::now_seconds() < txn_expiration_time,
+            error::invalid_argument(EPrologueTransactionExpired),
+        );
+        assert!(chain_id::get() == chain_id, error::invalid_argument(EPrologueBadChainId));
+
+        let transaction_sender = signer::address_of(&sender);
+        assert!(account::exists_at(transaction_sender), error::invalid_argument(EPrologueAccountDoesNotExist));
+        assert!(
+            txn_authentication_key == account::get_authentication_key(transaction_sender),
+            error::invalid_argument(EPrologueInvalidAccountAuthKey),
+        );
+
+        assert!(
+            (txn_sequence_number as u128) < MAX_U64,
+            error::out_of_range(EPrologueSequenceNumberTooBig)
+        );
+
+        let account_sequence_number = account::sequence_number(transaction_sender);
+        assert!(
+            txn_sequence_number >= account_sequence_number,
+            error::invalid_argument(EPrologueSequenceNuberTooOld)
+        );
+
+        // [PCA12]: Check that the transaction's sequence number matches the
+        // current sequence number. Otherwise sequence number is too new by [PCA11].
+        assert!(
+            txn_sequence_number == account_sequence_number,
+            error::invalid_argument(EPrologueSequenceNumberTooNew)
+        );
+
+        // TODO check transaction gas fee
+        // let max_transaction_fee = txn_gas_price * txn_max_gas_units;
+        // assert!(
+        //     coin::is_account_registered<...>(transaction_sender),
+        //     error::invalid_argument(EPrologueCantPayGasDeposit),
+        // );
+        // let balance = coin::balance<...>(transaction_sender);
+        // assert!(balance >= max_transaction_fee, error::invalid_argument(EPrologueCantPayGasDeposit));
+    }
+
+    fun module_prologue(
+        sender: signer,
+        txn_sequence_number: u64,
+        txn_public_key: vector<u8>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
+    ) {
+        prologue_common(sender, txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units, txn_expiration_time, chain_id)
+    }
+
+
+    /// Epilogue function is run after a transaction is successfully executed.
+    /// Called by the Adapter
+    fun epilogue(
+        account: signer,
+        _txn_sequence_number: u64,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        gas_units_remaining: u64
+    ) {
+        assert!(txn_max_gas_units >= gas_units_remaining, error::invalid_argument(EOUT_OF_GAS));
+        let gas_used = txn_max_gas_units - gas_units_remaining;
+
+        assert!(
+            (txn_gas_price as u128) * (gas_used as u128) <= MAX_U64,
+            error::out_of_range(EOUT_OF_GAS)
+        );
+        let addr = signer::address_of(&account);
+        //TODO handle transaction gas fee
+        // let transaction_fee_amount = txn_gas_price * gas_used;
+        // // it's important to maintain the error code consistent with vm
+        // // to do failed transaction cleanup.
+        // assert!(
+        //     coin::balance<...>(addr) >= transaction_fee_amount,
+        //     error::out_of_range(EPrologueCantPayGasDeposit),
+        // );
+        //
+        // if (features::collect_and_distribute_gas_fees()) {
+        //     // If transaction fees are redistributed to validators, collect them here for
+        //     // later redistribution.
+        //     transaction_fee::collect_fee(addr, transaction_fee_amount);
+        // } else {
+        //     // Otherwise, just burn the fee.
+        //     // TODO: this branch should be removed completely when transaction fee collection
+        //     // is tested and is fully proven to work well.
+        //     transaction_fee::burn_fee(addr, transaction_fee_amount);
+        // };
+
+        // Increment sequence number
+        account::increment_sequence_number(addr);
+    }
+}


### PR DESCRIPTION
This PR is part of https://github.com/rooch-network/rooch/issues/16

implementation including:
- Account controlled by the private key
- Account controlled by ResourceAccount
- A global wall clock that stores the current Unix time in milliseconds
- A Draft implementation of block, transaction_validator and genesis module etc.

Among them, there are a few points that need to be explained
- SignerCapability can only be stored in other structs, and cannot be droped.
- The resource account can only by controlled by SignerCapability, there has no private key can control the resource account

### TODO
1, support rotate authentication key and manager rotate capability
2, complete transaction_validator and genesis module 
3, event register and emit
