### PR TITLE
[object] Fix named table id bug and enable more test

### DIFF
--- a/crates/rooch-integration-test-runner/src/lib.rs
+++ b/crates/rooch-integration-test-runner/src/lib.rs
@@ -86,8 +86,7 @@ impl<'a> MoveTestAdapter<'a> for MoveOSTestAdapter<'a> {
                 )
             }
             named_address_mapping.insert(name, addr);
-
-            //TODO find better way to init account
+            //TODO find a better way to create account storage
             moveos
                 .state()
                 .create_account_storage(addr.into_inner())

--- a/moveos/moveos-cli/src/lib.rs
+++ b/moveos/moveos-cli/src/lib.rs
@@ -55,6 +55,8 @@ pub fn run_cli(move_cli: MoveCli) -> Result<()> {
         MoveCommand::Info(c) => c.execute(move_args.package_path, move_args.build_config),
         MoveCommand::New(c) => c.execute(move_args.package_path),
         MoveCommand::Prove(c) => c.execute(move_args.package_path, move_args.build_config),
+        //TODO how to custom the unit test and pass MoveOS to test plan
+        //https://github.com/move-language/move/blob/dfef14a838c8dd6399e933b77426a03f40e69c4c/language/tools/move-unit-test/src/test_runner.rs#L286
         MoveCommand::Test(c) => c.execute(
             move_args.package_path,
             move_args.build_config,

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/account_storage.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/account_storage.move
@@ -5,11 +5,13 @@ module moveos_std::account_storage {
 
     use std::string::String;
     use std::signer;
+    use std::bcs;
     use moveos_std::type_table::{Self, TypeTable};
     use moveos_std::table::{Self, Table};
     use moveos_std::object::{Self, Object};
     use moveos_std::object_storage::{Self, ObjectStorage};
     use moveos_std::storage_context::{Self, StorageContext};
+    use moveos_std::tx_context;
 
     /// The account with the given address already exists
     const EAccountAlreadyExists: u64 = 0;
@@ -17,18 +19,25 @@ module moveos_std::account_storage {
     /// The resource with the given type already exists
     const EResourceAlreadyExists: u64 = 1;
 
+    const NamedTableResource: u64 = 0;
+    const NamedTableModule: u64 = 1;
+
     struct AccountStorage has key {
         resources: TypeTable,
         modules: Table<String, vector<u8>>,
     }
 
+    //Ensure the NamedTableID generate use same method with Rust code
+    fun named_table_id(account: address, table_type: u64): address{
+        tx_context::derive_id(bcs::to_bytes(&account), table_type)
+    }
+
     /// Create a new account storage space
     public fun create_account_storage(ctx: &mut StorageContext, account: address) {
         let object_id = object::address_to_object_id(account);
-        let tx_ctx = storage_context::tx_context_mut(ctx);
         let account_storage = AccountStorage {
-            resources: type_table::new(tx_ctx),
-            modules: table::new(tx_ctx),
+            resources: type_table::new_with_id(named_table_id(account, NamedTableResource)),
+            modules: table::new_with_id(named_table_id(account, NamedTableModule)),
         };
         let object_storage = storage_context::object_storage_mut(ctx);
         assert!(!object_storage::contains<AccountStorage>(object_storage, object_id), EAccountAlreadyExists);
@@ -136,4 +145,9 @@ module moveos_std::account_storage {
         exists_module(account_storage, name) 
     }
     
+    #[test]
+    fun test_named_table_id() {
+        assert!(named_table_id(@0xae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647, NamedTableResource) == @0x04d8b5ccef4d5b55fa9371d1a9c344fcd4bd40dd9f32dd1d94696775fe3f3013, 1000);
+        assert!(named_table_id(@0xae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647, NamedTableModule) == @0xead64c5e724c9d52b0eb792b350d56001f1fe0dc2dec0e2e713420daba18109a, 1001);
+    }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
@@ -34,7 +34,7 @@ module moveos_std::object {
     /// Create a new object, the object is owned by `owner`
     /// The private generic is indicate the T should be defined in the same module as the caller. This is ensured by the verifier.
     public fun new<T: key>(ctx: &mut TxContext, owner: address, value: T): Object<T> {
-        let id = tx_context::derive_id(ctx);
+        let id = tx_context::fresh_address(ctx);
         Object<T>{id: ObjectID{id}, value, owner}
     }
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
@@ -97,7 +97,7 @@ module moveos_std::raw_table {
     }
 
     public(friend) fun new_table_handle(ctx: &mut TxContext): address {
-        tx_context::derive_id(ctx)
+        tx_context::fresh_address(ctx)
     }
 
     native fun add_box<K: copy + drop, V, B>(table_handle: address, key: K, val: Box<V>);

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -9,6 +9,8 @@ module moveos_std::table {
     use moveos_std::raw_table;
     use moveos_std::tx_context::TxContext;
 
+    friend moveos_std::account_storage;
+
     /// Type of tables
     struct Table<phantom K: copy + drop, phantom V> has store {
         handle: address,
@@ -18,6 +20,13 @@ module moveos_std::table {
     public fun new<K: copy + drop, V: store>(ctx: &mut TxContext): Table<K, V> {
         Table {
             handle: raw_table::new_table_handle(ctx),
+        }
+    }
+
+    /// Create a table with a given handle.
+    public(friend) fun new_with_id<K: copy + drop, V: store>(handle: address): Table<K, V>{
+        Table {
+            handle,
         }
     }
 
@@ -82,35 +91,41 @@ module moveos_std::table {
         raw_table::destroy(handle)
     }
 
-    #[test_only]
-    struct TableHolder<phantom K: copy + drop, phantom V: drop> has key {
-        t: Table<K, V>
-    }
+    //We can not run table unit test because move unit test runner does not support custom NativeExtension.
+    //FIXME
+    // #[test_only]
+    // struct TableHolder<phantom K: copy + drop, phantom V: drop> has key {
+    //     t: Table<K, V>
+    // }
 
-    #[test(account = @0x1)]
-    fun test_upsert(account: signer) {
-        let t = new<u64, u8>();
-        let key: u64 = 111;
-        let error_code: u64 = 1;
-        assert!(!contains(&t, key), error_code);
-        upsert(&mut t, key, 12);
-        assert!(*borrow(&t, key) == 12, error_code);
-        upsert(&mut t, key, 23);
-        assert!(*borrow(&t, key) == 23, error_code);
+    // #[test(account = @0x1)]
+    // fun test_upsert(account: signer) {
+    //     let sender = std::signer::address_of(&account);
+    //     let tx_context = moveos_std::tx_context::test_context(sender);
+    //     let t = new<u64, u8>(&mut tx_context);
+    //     let key: u64 = 111;
+    //     let error_code: u64 = 1;
+    //     assert!(!contains(&t, key), error_code);
+    //     upsert(&mut t, key, 12);
+    //     assert!(*borrow(&t, key) == 12, error_code);
+    //     upsert(&mut t, key, 23);
+    //     assert!(*borrow(&t, key) == 23, error_code);
 
-        move_to(&account, TableHolder { t });
-    }
+    //     move_to(&account, TableHolder { t });
+    // }
 
-    #[test(account = @0x1)]
-    fun test_borrow_with_default(account: signer) {
-        let t = new<u64, u8>();
-        let key: u64 = 100;
-        let error_code: u64 = 1;
-        assert!(!contains(&t, key), error_code);
-        assert!(*borrow_with_default(&t, key, &12) == 12, error_code);
-        add(&mut t, key, 1);
-        assert!(*borrow_with_default(&t, key, &12) == 1, error_code);
+    // #[test(account = @0x1)]
+    // fun test_borrow_with_default(account: signer) {
+    //     let sender = std::signer::address_of(&account);
+    //     let tx_context = moveos_std::tx_context::test_context(sender);
+    //     let t = new<u64, u8>(&mut tx_context);
+    //     let key: u64 = 100;
+    //     let error_code: u64 = 1;
+    //     assert!(!contains(&t, key), error_code);
+    //     assert!(*borrow_with_default(&t, key, &12) == 12, error_code);
+    //     add(&mut t, key, 1);
+    //     assert!(*borrow_with_default(&t, key, &12) == 1, error_code);
 
-        move_to(&account, TableHolder{ t });
-    }
+    //     move_to(&account, TableHolder{ t });
+    // }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
@@ -19,6 +19,13 @@ module moveos_std::type_table {
         }
     }
 
+    /// Create a new Table with a given handle.
+    public(friend) fun new_with_id(handle: address): TypeTable{
+        TypeTable {
+            handle,
+        }
+    }
+
     /// Note: We use Type name as key, the key will be serialized by bcs in the native function. 
     fun key<V>(): String {
         let type_name = std::type_name::get<V>();

--- a/moveos/moveos-stdlib/tests/cases/account/basic.move
+++ b/moveos/moveos-stdlib/tests/cases/account/basic.move
@@ -5,17 +5,17 @@
 //create account by bob self
 //# run --signers genesis
 script {
-    //use rooch_framework::account;
+    use rooch_framework::account;
     fun main(_sender: signer) {
-        //account::create_account_entry(@bob);
+        account::create_account_entry(@bob);
     }
 }
 
 //check
 //# run --signers bob
 script {
-    //use rooch_framework::account;
+    use rooch_framework::account;
     fun main(_sender: signer) {
-        //assert!(account::exists_at(@bob), 0);
+        assert!(account::exists_at(@bob), 0);
     }
 }

--- a/moveos/moveos-stdlib/tests/cases/object/basic.exp
+++ b/moveos/moveos-stdlib/tests/cases/object/basic.exp
@@ -1,17 +1,17 @@
 processed 10 tasks
 
-task 3 'view_object'. lines 59-61:
-RawObject { id: ObjectID(a5dac25e36ef3fdb7f496b6ab0d1916d73d025dc1c5f2560f779e62b645cac7d), owner: 0000000000000000000000000000000000000000000000000000000000000043, value: [1] }
+task 3 'view_object'. lines 56-58:
+RawObject { id: ObjectID(ae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647), owner: 0000000000000000000000000000000000000000000000000000000000000043, value: [1] }
 
-task 5 'view_object'. lines 65-68:
-RawObject { id: ObjectID(0be6975de71303c7a4ab6d2d15b14cb4320fba263cc4283cfe1d63a633247db1), owner: 0000000000000000000000000000000000000000000000000000000000000043, value: [2] }
+task 5 'view_object'. lines 62-65:
+RawObject { id: ObjectID(0bbaf311ae6768a532b1f9dee65b1758a7bb1114fd57df8fa94cb2d1cb5f6896), owner: 0000000000000000000000000000000000000000000000000000000000000043, value: [2] }
 
-task 7 'view'. lines 72-74:
+task 7 'view'. lines 69-71:
 store key 0x42::m::S {
     v: 1u8
 }
 
-task 9 'view'. lines 78-78:
+task 9 'view'. lines 75-75:
 store key 0x42::m::Cup<0x42::m::S> {
     v: 2u8
 }

--- a/moveos/moveos-stdlib/tests/cases/object/basic.move
+++ b/moveos/moveos-stdlib/tests/cases/object/basic.move
@@ -14,9 +14,6 @@ module test::m {
     struct Cup<phantom T: store> has store, key { v: u8 }
 
     public entry fun mint_s(ctx: &mut StorageContext) {
-        //TODO move to account create
-        //account_storage::create_account_storage(ctx, @0x43);
-
         let tx_ctx = storage_context::tx_context_mut(ctx);
         let sender = tx_context::sender(tx_ctx);
         let obj = object::new(tx_ctx, sender , S { v: 1});
@@ -56,23 +53,23 @@ module test::m {
 
 //# run test::m::mint_s --signers A
 
-//# view_object --object-id 0xa5dac25e36ef3fdb7f496b6ab0d1916d73d025dc1c5f2560f779e62b645cac7d
+//# view_object --object-id 0xae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647
 
 // Mint Cup<S> to A.
 
 //# run test::m::mint_cup --type-args test::m::S --signers A
 
-//# view_object --object-id 0xbe6975de71303c7a4ab6d2d15b14cb4320fba263cc4283cfe1d63a633247db1
+//# view_object --object-id 0x0bbaf311ae6768a532b1f9dee65b1758a7bb1114fd57df8fa94cb2d1cb5f6896
 
 // Move S to global.
 //Currently, we use @address to pass object argument to the transaction, define a new way to pass object argument to the transaction.
 
-//# run test::m::move_s_to_global --signers A --args @0xa5dac25e36ef3fdb7f496b6ab0d1916d73d025dc1c5f2560f779e62b645cac7d
+//# run test::m::move_s_to_global --signers A --args @0xae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647
 
 //# view --address A --resource test::m::S
 
 // Move Cup<S> to global.
 
-//# run test::m::move_cup_to_global --signers A  --type-args test::m::S --args @0xbe6975de71303c7a4ab6d2d15b14cb4320fba263cc4283cfe1d63a633247db1
+//# run test::m::move_cup_to_global --signers A  --type-args test::m::S --args @0x0bbaf311ae6768a532b1f9dee65b1758a7bb1114fd57df8fa94cb2d1cb5f6896
 
 //# view --address A --resource test::m::Cup<test::m::S>

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -36,8 +36,6 @@ impl MoveOS {
         let moveos = Self { vm, db };
         if is_genesis {
             let genesis_txn = Self::build_genesis_txn()?;
-            //TODO find a better way
-            moveos.db.create_account_storage(genesis_txn.sender)?;
             moveos.execute(genesis_txn)?;
         }
         Ok(moveos)

--- a/moveos/moveos/src/tests/mod.rs
+++ b/moveos/moveos/src/tests/mod.rs
@@ -3,6 +3,7 @@
 
 use crate::moveos::MoveOS;
 use move_core_types::{
+    account_address::AccountAddress,
     identifier::IdentStr,
     language_storage::ModuleId,
     value::{serialize_values, MoveValue},
@@ -29,5 +30,30 @@ pub fn test_moveos() {
     assert_eq!(
         result.return_values[0].0,
         serialize_values(&vec![MoveValue::U64(3)])[0]
+    );
+}
+
+#[test]
+pub fn test_check_account() {
+    let db = StateDB::new_with_memory_store();
+    let moveos = MoveOS::new(db).unwrap();
+
+    let math_module = ModuleId::new(
+        *MOVEOS_STD_ADDRESS,
+        IdentStr::new("account").unwrap().to_owned(),
+    );
+    let args = serialize_values(&vec![MoveValue::Address(AccountAddress::ZERO)]);
+    let result = moveos
+        .execute_view_function(
+            &math_module,
+            IdentStr::new("exists_at").unwrap(),
+            vec![],
+            args,
+        )
+        .unwrap();
+
+    assert_eq!(
+        result.return_values[0].0,
+        serialize_values(&vec![MoveValue::Bool(false)])[0]
     );
 }


### PR DESCRIPTION
Part of #21 , Continue #48 

1. Use the NamedTableID to ensure the resource and module table id are determined. 
2. Fix some bugs, and enable the account/basic test.