### PR TITLE
rooch move test support MoveOS runtime

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,16 +2,15 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -26,4 +25,8 @@ jobs:
     - name: Execute rust tests
       run: cargo nextest run --workspace --all-features
     - name: Build
-      run: cargo build 
+      run: cargo build
+    - name: Execute stdlib tests
+      run: cargo run --bin rooch move test -p moveos/moveos-stdlib/moveos-stdlib/
+    - name: Execute framework tests
+      run: cargo run --bin rooch move test -p moveos/moveos-stdlib/rooch-framework/

--- a/moveos/moveos-cli/Cargo.toml
+++ b/moveos/moveos-cli/Cargo.toml
@@ -19,6 +19,7 @@ bcs = { workspace = true }
 clap = { features = [ "derive",], workspace = true }
 datatest-stable = { workspace = true }
 tokio = { features = ["full"], workspace = true }
+once_cell = { workspace = true }
 
 move-binary-format = { workspace = true }
 move-bytecode-verifier = { workspace = true }
@@ -39,3 +40,4 @@ moveos = { workspace = true }
 moveos-stdlib = { workspace = true }
 moveos-client = { workspace = true }
 moveos-common = { workspace = true }
+moveos-statedb = { workspace = true }

--- a/moveos/moveos-cli/src/commands/mod.rs
+++ b/moveos/moveos-cli/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod new;
 pub mod publish;
 pub mod run_function;
 pub mod run_view_function;
+pub mod unit_test;

--- a/moveos/moveos-cli/src/commands/unit_test.rs
+++ b/moveos/moveos-cli/src/commands/unit_test.rs
@@ -1,0 +1,40 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use move_cli::base::test;
+use move_package::BuildConfig;
+use move_unit_test::extensions::set_extension_hook;
+use move_vm_runtime::native_extensions::NativeContextExtensions;
+use moveos_statedb::StateDB;
+use moveos_stdlib::natives::moveos_stdlib::raw_table::NativeTableContext;
+use moveos_stdlib::natives::{all_natives, GasParameters};
+use once_cell::sync::Lazy;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+pub struct Test {
+    #[clap(flatten)]
+    pub test: test::Test,
+}
+
+impl Test {
+    pub fn execute(self, path: Option<PathBuf>, build_config: BuildConfig) -> anyhow::Result<()> {
+        //TODO define gas metering
+        let cost_table = move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE.clone();
+        let natives = all_natives(GasParameters::zeros());
+
+        set_extension_hook(Box::new(new_moveos_natives_runtime));
+        self.test
+            .execute(path, build_config, natives, Some(cost_table))
+    }
+}
+
+static STATEDB: Lazy<Box<StateDB>> = Lazy::new(|| Box::new(StateDB::new_with_memory_store()));
+
+fn new_moveos_natives_runtime(ext: &mut NativeContextExtensions) {
+    let statedb = Lazy::force(&STATEDB).as_ref();
+    let table_ext = NativeTableContext::new(statedb);
+
+    ext.add(table_ext);
+}

--- a/moveos/moveos-cli/src/lib.rs
+++ b/moveos/moveos-cli/src/lib.rs
@@ -4,15 +4,15 @@
 use anyhow::Result;
 use commands::{
     new::New, publish::Publish, run_function::RunFunction, run_view_function::RunViewFunction,
+    unit_test::Test,
 };
 use move_cli::{
     base::{
         build::Build, coverage::Coverage, disassemble::Disassemble, docgen::Docgen, errmap::Errmap,
-        info::Info, prove::Prove, test::Test,
+        info::Info, prove::Prove,
     },
     Move,
 };
-use moveos_stdlib::natives::{all_natives, GasParameters};
 
 pub mod commands;
 pub mod types;
@@ -47,9 +47,6 @@ pub async fn run_cli(move_cli: MoveCli) -> Result<()> {
     let move_args = move_cli.move_args;
     let cmd = move_cli.cmd;
     //let error_descriptions: ErrorMapping = bcs::from_bytes(moveos_stdlib::error_descriptions())?;
-    //TODO define gas metering
-    let cost_table = move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE.clone();
-    let natives = all_natives(GasParameters::zeros());
 
     match cmd {
         MoveCommand::Build(c) => c.execute(move_args.package_path, move_args.build_config),
@@ -60,14 +57,7 @@ pub async fn run_cli(move_cli: MoveCli) -> Result<()> {
         MoveCommand::Info(c) => c.execute(move_args.package_path, move_args.build_config),
         MoveCommand::New(c) => c.execute(move_args.package_path),
         MoveCommand::Prove(c) => c.execute(move_args.package_path, move_args.build_config),
-        //TODO how to custom the unit test and pass MoveOS to test plan
-        //https://github.com/move-language/move/blob/dfef14a838c8dd6399e933b77426a03f40e69c4c/language/tools/move-unit-test/src/test_runner.rs#L286
-        MoveCommand::Test(c) => c.execute(
-            move_args.package_path,
-            move_args.build_config,
-            natives,
-            Some(cost_table),
-        ),
+        MoveCommand::Test(c) => c.execute(move_args.package_path, move_args.build_config),
         MoveCommand::Publish(c) => {
             c.execute(move_args.package_path, move_args.build_config)
                 .await

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -91,41 +91,40 @@ module moveos_std::table {
         raw_table::destroy(handle)
     }
 
-    //We can not run table unit test because move unit test runner does not support custom NativeExtension.
-    //FIXME
-    // #[test_only]
-    // struct TableHolder<phantom K: copy + drop, phantom V: drop> has key {
-    //     t: Table<K, V>
-    // }
 
-    // #[test(account = @0x1)]
-    // fun test_upsert(account: signer) {
-    //     let sender = std::signer::address_of(&account);
-    //     let tx_context = moveos_std::tx_context::test_context(sender);
-    //     let t = new<u64, u8>(&mut tx_context);
-    //     let key: u64 = 111;
-    //     let error_code: u64 = 1;
-    //     assert!(!contains(&t, key), error_code);
-    //     upsert(&mut t, key, 12);
-    //     assert!(*borrow(&t, key) == 12, error_code);
-    //     upsert(&mut t, key, 23);
-    //     assert!(*borrow(&t, key) == 23, error_code);
+    #[test_only]
+    struct TableHolder<phantom K: copy + drop, phantom V: drop> has key {
+        t: Table<K, V>
+    }
 
-    //     move_to(&account, TableHolder { t });
-    // }
+    #[test(account = @0x1)]
+    fun test_upsert(account: signer) {
+        let sender = std::signer::address_of(&account);
+        let tx_context = moveos_std::tx_context::test_context(sender);
+        let t = new<u64, u8>(&mut tx_context);
+        let key: u64 = 111;
+        let error_code: u64 = 1;
+        assert!(!contains(&t, key), error_code);
+        upsert(&mut t, key, 12);
+        assert!(*borrow(&t, key) == 12, error_code);
+        upsert(&mut t, key, 23);
+        assert!(*borrow(&t, key) == 23, error_code);
 
-    // #[test(account = @0x1)]
-    // fun test_borrow_with_default(account: signer) {
-    //     let sender = std::signer::address_of(&account);
-    //     let tx_context = moveos_std::tx_context::test_context(sender);
-    //     let t = new<u64, u8>(&mut tx_context);
-    //     let key: u64 = 100;
-    //     let error_code: u64 = 1;
-    //     assert!(!contains(&t, key), error_code);
-    //     assert!(*borrow_with_default(&t, key, &12) == 12, error_code);
-    //     add(&mut t, key, 1);
-    //     assert!(*borrow_with_default(&t, key, &12) == 1, error_code);
+        move_to(&account, TableHolder { t });
+    }
 
-    //     move_to(&account, TableHolder{ t });
-    // }
+    #[test(account = @0x1)]
+    fun test_borrow_with_default(account: signer) {
+        let sender = std::signer::address_of(&account);
+        let tx_context = moveos_std::tx_context::test_context(sender);
+        let t = new<u64, u8>(&mut tx_context);
+        let key: u64 = 100;
+        let error_code: u64 = 1;
+        assert!(!contains(&t, key), error_code);
+        assert!(*borrow_with_default(&t, key, &12) == 12, error_code);
+        add(&mut t, key, 1);
+        assert!(*borrow_with_default(&t, key, &12) == 1, error_code);
+
+        move_to(&account, TableHolder{ t });
+    }
 }


### PR DESCRIPTION
1. rooch move test support MoveOS runtime
2. github workflow add unit-test for moveos-stdlib and rooch-framework

resolve #55 and #61 .