### PR TITLE
[types&framework] Fix address serialize bug and object_storage bug

### DIFF
--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -24,6 +24,7 @@ pub trait RoochSupportedAddress:
 }
 
 /// Multi chain address representation
+/// The address is distinguished by the coin id, coin id standard is defined in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MultiChainAddress {
     pub coin: Coin,

--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -12,10 +12,9 @@ use bitcoin::{
     PubkeyHash,
 };
 use ethers::types::H160;
-use fastcrypto::encoding::{Encoding, Hex};
 use move_core_types::account_address::AccountAddress;
 use moveos_types::h256::H256;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// The address type that Rooch supports
 pub trait RoochSupportedAddress:
@@ -118,7 +117,7 @@ impl FromStr for MultiChainAddress {
 }
 
 /// Rooch address type
-#[derive(Copy, Clone, Ord, PartialOrd, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Ord, PartialOrd, PartialEq, Eq, Hash)]
 pub struct RoochAddress(pub H256);
 
 impl RoochSupportedAddress for RoochAddress {
@@ -157,15 +156,56 @@ impl TryFrom<MultiChainAddress> for RoochAddress {
     }
 }
 
+// ==== Display and FromStr, Deserialize and Serialize ====
+// Should keep consistent with AccountAddress
+
 impl fmt::Display for RoochAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "0x{}", Hex::encode(self.0))
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:x}", AccountAddress::from(*self))
     }
 }
 
 impl fmt::Debug for RoochAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "0x{}", Hex::encode(self.0))
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:x}", AccountAddress::from(*self))
+    }
+}
+
+impl FromStr for RoochAddress {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let address = AccountAddress::from_str(s)?;
+        Ok(Self::from(address))
+    }
+}
+
+impl<'de> Deserialize<'de> for RoochAddress {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = <String>::deserialize(deserializer)?;
+            Self::from_str(&s).map_err(serde::de::Error::custom)
+        } else {
+            let value = AccountAddress::deserialize(deserializer)?;
+            Ok(value.into())
+        }
+    }
+}
+
+impl Serialize for RoochAddress {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            self.to_string().serialize(serializer)
+        } else {
+            let account_address: AccountAddress = (*self).into();
+            account_address.serialize(serializer)
+        }
     }
 }
 

--- a/crates/rooch/src/commands/account/create.rs
+++ b/crates/rooch/src/commands/account/create.rs
@@ -57,7 +57,7 @@ impl CreateCommand {
             ),
             ident_str!("create_account_entry").to_owned(),
             vec![],
-            vec![bcs::to_bytes(new_address.0.as_bytes()).unwrap()],
+            vec![bcs::to_bytes(&new_address).unwrap()],
         );
         let sender = AccountAddress::new(new_address.0.into());
         let txn = SimpleTransaction::new(sender, txn);

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/account_storage.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/account_storage.move
@@ -179,4 +179,22 @@ module moveos_std::account_storage {
         assert!(named_table_id(@0xae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647, NamedTableResource) == @0x04d8b5ccef4d5b55fa9371d1a9c344fcd4bd40dd9f32dd1d94696775fe3f3013, 1000);
         assert!(named_table_id(@0xae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647, NamedTableModule) == @0xead64c5e724c9d52b0eb792b350d56001f1fe0dc2dec0e2e713420daba18109a, 1001);
     }
+
+    #[test_only]
+    struct Test has key{
+        addr: address,
+        version: u64
+    }
+
+    #[test(sender=@0x42)]
+    fun test_account_storage(sender: signer){
+        let sender_addr = signer::address_of(&sender);
+        let ctx = storage_context::new_test_context(sender_addr);
+        create_account_storage(&mut ctx, sender_addr);
+        global_move_to(&mut ctx, &sender, Test{
+            addr: sender_addr,
+            version: 1,
+        });
+        storage_context::drop_test_context(ctx);
+    }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
@@ -43,7 +43,7 @@ module moveos_std::storage_context {
     #[test_only]
     /// Create a StorageContext and AccountStorage for unit test
     public fun new_test_context(sender: address): StorageContext {
-        let tx_context = tx_context::test_context(sender);
+        let tx_context = tx_context::new_test_context(sender);
         // let object_storage = object_storage::new(&mut tx_context);
         let object_storage = object_storage::new_with_id(object_storage::global_object_storage_handle());
         StorageContext {

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -100,7 +100,7 @@ module moveos_std::table {
     #[test(account = @0x1)]
     fun test_upsert(account: signer) {
         let sender = std::signer::address_of(&account);
-        let tx_context = moveos_std::tx_context::test_context(sender);
+        let tx_context = moveos_std::tx_context::new_test_context(sender);
         let t = new<u64, u8>(&mut tx_context);
         let key: u64 = 111;
         let error_code: u64 = 1;
@@ -116,7 +116,7 @@ module moveos_std::table {
     #[test(account = @0x1)]
     fun test_borrow_with_default(account: signer) {
         let sender = std::signer::address_of(&account);
-        let tx_context = moveos_std::tx_context::test_context(sender);
+        let tx_context = moveos_std::tx_context::new_test_context(sender);
         let t = new<u64, u8>(&mut tx_context);
         let key: u64 = 100;
         let error_code: u64 = 1;

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/tx_context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/tx_context.move
@@ -67,7 +67,7 @@ module moveos_std::tx_context {
     
     #[test_only]
     /// Create a TxContext for unit test
-    public fun test_context(sender: address): TxContext {
+    public fun new_test_context(sender: address): TxContext {
         let tx_hash = hash::sha3_256(b"test_txn");
         TxContext {
             sender,

--- a/moveos/moveos-stdlib/rooch-framework/sources/account.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/account.move
@@ -74,14 +74,9 @@ module rooch_framework::account{
    /// Address to create is not a valid reserved address for Rooch framework
    const ENoValidFrameworkReservedAddress: u64 = 11;
 
-
-
-
-
-   /// TODO should provide a entry function at this module
-   /// How to provide account extension?
-   public entry fun create_account_entry(ctx: &mut StorageContext, auth_key: address): signer{
-      Self::create_account(ctx, auth_key)
+   /// A entry function to create an account under `new_address`
+   public entry fun create_account_entry(ctx: &mut StorageContext, new_address: address){
+      Self::create_account(ctx, new_address);
    }
 
    /// Publishes a new `Account` resource under `new_address`. A signer representing `new_address`
@@ -332,6 +327,13 @@ module rooch_framework::account{
       debug::print(&resource_addr);
       assert!(resource_addr != signer::address_of(&alice), 106);
       assert!(resource_addr == signer_cap_addr, 107);
+      storage_context::drop_test_context(ctx);
+   }
+
+   #[test(sender=@0x42)]
+   fun test_create_account_entry(sender: address){
+      let ctx = storage_context::new_test_context(sender);
+      create_account_entry(&mut ctx, sender);
       storage_context::drop_test_context(ctx);
    }
 }

--- a/moveos/moveos-stdlib/tests/cases/account/basic.exp
+++ b/moveos/moveos-stdlib/tests/cases/account/basic.exp
@@ -1,7 +1,1 @@
 processed 3 tasks
-
-task 1 'run'. lines 6-15:
-Error: VMError with status VM_EXTENSION_ERROR at location Module ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000001, name: Identifier("raw_table") } and message cannot deserialize table key or value at code offset 0 in function definition 9
-
-task 2 'run'. lines 16-23:
-Error: VMError with status VM_EXTENSION_ERROR at location Module ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000001, name: Identifier("raw_table") } and message cannot deserialize table key or value at code offset 0 in function definition 9

--- a/moveos/moveos-stdlib/tests/cases/account/basic.move
+++ b/moveos/moveos-stdlib/tests/cases/account/basic.move
@@ -1,4 +1,7 @@
-//# init --addresses genesis=0x1 bob=0x42
+//# init --addresses genesis=0x1
+
+//TODO currently, we auto create account for init addresses, so I remove the bob=0x42 from the init addresses.
+//In the future, if we create account by faucet, we can keep the init named address. 
 
 //TODO create account by faucet
 
@@ -8,16 +11,16 @@ script {
     use rooch_framework::account;
     use moveos_std::storage_context::StorageContext;
     fun main(ctx: &mut StorageContext, _sender: signer) {
-        account::create_account_entry(ctx, @bob);
+        account::create_account_entry(ctx, @0x42);
     }
 }
 
 //check
-//# run --signers bob
+//# run --signers 0x42
 script {
     use rooch_framework::account;
     use moveos_std::storage_context::StorageContext;
     fun main(ctx: &mut StorageContext, _sender: signer) {
-        assert!(account::exists_at(ctx, @bob), 0);
+        assert!(account::exists_at(ctx, @0x42), 0);
     }
 }


### PR DESCRIPTION
1. Keep RoochAddress's `serialize` & `deserialize` same as Move AccountAddress.
2. Fix ObjectStorage `contains` bug, and write a unit test for object_stroage.

resolve #107