### PR TITLE
Abstract interface of the DA service.

### DIFF
--- a/moveos/moveos-client/src/client.rs
+++ b/moveos/moveos-client/src/client.rs
@@ -197,3 +197,46 @@ struct RPCResponse<T> {
 trait RPCClient<T> {
     fn send_request(&self, request: RPCRequest<T>, timeout: u64) -> RPCResponse<T>;
 }
+
+// Request to store data to the DA server
+struct DAStoreRequest {
+    message: Vec<u8>,
+    timeout: u64,
+    signature: Vec<u8>,
+}
+
+// Data storage response returned by the DA server
+struct DAStoreResponse {
+    // The hash of multi-signature collection returned by multiple nodes comprising the DA committee.
+    // The actual public key collection is stored in DA and retrieved from it as needed for verification.
+    keyset_hash: Vec<u8>,
+    // Hash of the data returned by the DA Server.
+    data_hash: Vec<u8>,
+    // The timeout period for the storage backend.
+    timeout: u64,
+    // Use signersMask to extract the corresponding public key set from the keyset data.
+    signers_mask: u64,
+    // Multi-signature of the DA committee.
+    sig: Vec<u8>,
+    // The version of this struct.
+    version: u8,
+}
+
+struct DAGetRequest {
+    hash: Vec<u8>,
+}
+
+struct DAGetResponse {
+    data: Vec<u8>,
+}
+
+struct DAStatusResponse {
+    status_code: u64,
+    status_data: Vec<u8>,
+}
+
+trait DAServer {
+    fn store(&self, request: DAStoreRequest) -> DAStoreResponse;
+    fn get(&self, request: DAGetRequest) -> DAGetResponse;
+    fn status(&self) -> DAStatusResponse;
+}

--- a/rooch-da/lib.rs
+++ b/rooch-da/lib.rs
@@ -1,0 +1,42 @@
+// Request to store data to the DA server
+struct DAStoreRequest {
+    message: Vec<u8>,
+    timeout: u64,
+    signature: Vec<u8>,
+}
+
+// Data storage response returned by the DA server
+struct DAStoreResponse {
+    // The hash of multi-signature collection returned by multiple nodes comprising the DA committee.
+    // The actual public key collection is stored in DA and retrieved from it as needed for verification.
+    keyset_hash: Vec<u8>,
+    // Hash of the data returned by the DA Server.
+    data_hash: Vec<u8>,
+    // The timeout period for the storage backend.
+    timeout: u64,
+    // Use signersMask to extract the corresponding public key set from the keyset data.
+    signers_mask: u64,
+    // Multi-signature of the DA committee.
+    sig: Vec<u8>,
+    // The version of this struct.
+    version: u8,
+}
+
+struct DAGetRequest {
+    hash: Vec<u8>,
+}
+
+struct DAGetResponse {
+    data: Vec<u8>,
+}
+
+struct DAStatusResponse {
+    status_code: u64,
+    status_data: Vec<u8>,
+}
+
+trait DAClientMethods {
+    fn store(&self, request: DAStoreRequest) -> DAStoreResponse;
+    fn get(&self, request: DAGetRequest) -> DAGetResponse;
+    fn status(&self) -> DAStatusResponse;
+}


### PR DESCRIPTION
An abstract interface of the DA service has been added: The DA server is an independent service that handles user storage requests, stores user data to one or more backend, and returns response data from the DA committee.

The following issue link provides a rough explanation of the entire working process:
https://github.com/rooch-network/rooch/issues/134
