### PR TITLE
Refactor CLI output types

### DIFF
--- a/crates/rooch-types/Cargo.toml
+++ b/crates/rooch-types/Cargo.toml
@@ -36,6 +36,8 @@ fastcrypto = { workspace = true }
 schemars = {workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+async-trait ={ workspace = true }
+
 starcoin-crypto = { workspace = true, features= ["fuzzing"] }
 
 

--- a/crates/rooch-types/src/cli.rs
+++ b/crates/rooch-types/src/cli.rs
@@ -45,8 +45,8 @@ pub enum CliError {
     IOError(String),
     #[error("Sign message error: {0}")]
     SignMessageError(String),
-    #[error("Submit TX error: {0}")]
-    SubmitTxError(String),
+    #[error("Transaction error: {0}")]
+    TransactionError(String),
     #[error("View function error: {0}")]
     ViewFunctionError(String),
 }

--- a/crates/rooch-types/src/cli.rs
+++ b/crates/rooch-types/src/cli.rs
@@ -4,6 +4,7 @@
 use std::io;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -42,6 +43,12 @@ pub enum CliError {
     BcsError(String),
     #[error("IO error: {0}")]
     IOError(String),
+    #[error("Sign message error: {0}")]
+    SignMessageError(String),
+    #[error("Submit TX error: {0}")]
+    SubmitTxError(String),
+    #[error("View function error: {0}")]
+    ViewFunctionError(String),
 }
 
 impl From<anyhow::Error> for CliError {
@@ -59,5 +66,19 @@ impl From<bcs::Error> for CliError {
 impl From<io::Error> for CliError {
     fn from(e: io::Error) -> Self {
         CliError::IOError(e.to_string())
+    }
+}
+
+#[async_trait]
+pub trait CommandAction<T: Serialize + Send>: Sized + Send {
+    /// Executes the command, returning a command specific type
+    async fn execute(self) -> CliResult<T>;
+
+    /// Executes the command, and serializes it to the common JSON output type
+    async fn execute_serialized(self) -> CliResult<String> {
+        match self.execute().await {
+            Ok(result) => Ok(serde_json::to_string_pretty(&result).unwrap()),
+            Err(e) => Err(e),
+        }
     }
 }

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -23,9 +23,11 @@ dirs  = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
+serde_json = { workspace = true }
 once_cell = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
+
 
 move-bytecode-utils = { workspace = true }
 move-binary-format = { workspace = true }

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -25,6 +25,7 @@ serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 once_cell = { workspace = true }
 tracing = { workspace = true }
+async-trait = { workspace = true }
 
 move-bytecode-utils = { workspace = true }
 move-binary-format = { workspace = true }

--- a/crates/rooch/src/commands/account/mod.rs
+++ b/crates/rooch/src/commands/account/mod.rs
@@ -1,14 +1,57 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::*;
 pub mod create;
 pub mod import;
 pub mod list;
-use crate::commands::account::{create::CreateCommand, list::ListCommand};
-use rooch_common::config::{PersistedConfig, RoochConfig};
-use rooch_types::cli::{CliError, CliResult};
-
 use self::import::ImportCommand;
+use crate::commands::account::{create::CreateCommand, list::ListCommand};
+
+use crate::config::{rooch_config_dir, Config, PersistedConfig, RoochConfig, ROOCH_CONFIG};
+use async_trait::async_trait;
+use rooch_types::cli::{CliError, CliResult, CommandAction};
+use std::path::PathBuf;
+
+#[derive(clap::Parser)]
+pub struct Account {
+    #[clap(long = "rooch.config")]
+    config: Option<PathBuf>,
+    #[clap(subcommand)]
+    cmd: Option<AccountCommand>,
+}
+
+#[async_trait]
+impl CommandAction<()> for Account {
+    async fn execute(self) -> CliResult<()> {
+        let config_path = self.config.unwrap_or(
+            rooch_config_dir()
+                .map_err(CliError::from)?
+                .join(ROOCH_CONFIG),
+        );
+
+        if !config_path.exists() {
+            return Err(CliError::ConfigNotFoundError(format!(
+                "{:?} not found.",
+                config_path
+            )));
+        }
+
+        let config: RoochConfig = PersistedConfig::read(&config_path).map_err(|err| {
+            CliError::ConfigLoadError(format!("{:?}", config_path), err.to_string())
+        })?;
+
+        if let Some(cmd) = self.cmd {
+            cmd.execute(&mut config.persisted(&config_path)).await?;
+        } else {
+            // Print help
+            let mut app = Account::command();
+            app.build();
+            app.print_help().map_err(CliError::from)?;
+        }
+        Ok(())
+    }
+}
 
 #[derive(Debug, clap::Subcommand)]
 #[clap(name = "account")]

--- a/crates/rooch/src/commands/account/mod.rs
+++ b/crates/rooch/src/commands/account/mod.rs
@@ -17,7 +17,7 @@ use rooch_types::cli::{CliError, CliResult, CommandAction};
 #[derive(clap::Parser)]
 pub struct Account {
     #[clap(subcommand)]
-    cmd: Option<AccountCommand>,
+    cmd: AccountCommand,
 }
 
 #[async_trait]
@@ -25,8 +25,8 @@ impl CommandAction<()> for Account {
     async fn execute(self) -> CliResult<()> {
         let config: RoochConfig = prompt_if_no_config().await?;
 
-        if let Some(cmd) = self.cmd {
-            cmd.execute(
+        self.cmd
+            .execute(
                 &mut config.persisted(
                     rooch_config_dir()
                         .map_err(CliError::from)?
@@ -34,14 +34,7 @@ impl CommandAction<()> for Account {
                         .as_path(),
                 ),
             )
-            .await?;
-        } else {
-            // Print help
-            let mut app = Account::command();
-            app.build();
-            app.print_help().map_err(CliError::from)?;
-        }
-        Ok(())
+            .await
     }
 }
 

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -1,7 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::config::{rooch_config_dir, Config, RoochConfig, ROOCH_CONFIG, ROOCH_KEYSTORE_FILENAME};
 use async_trait::async_trait;
 use clap::Parser;
 use rooch_common::config::{
@@ -10,7 +9,6 @@ use rooch_common::config::{
 use rooch_key::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use rooch_types::account::SignatureScheme::ED25519;
 use rooch_types::cli::{CliError, CliResult, CommandAction};
-use std::path::{Path, PathBuf};
 
 #[derive(Parser)]
 pub struct Init;
@@ -18,15 +16,7 @@ pub struct Init;
 #[async_trait]
 impl CommandAction<()> for Init {
     async fn execute(self) -> CliResult<()> {
-        let config_path = self.config.unwrap_or(
-            rooch_config_dir()
-                .map_err(CliError::from)?
-                .join(ROOCH_CONFIG),
-        );
-        prompt_if_no_config(&config_path)
-            .await
-            .map_err(CliError::from)?;
-        Ok(())
+        init().await.map_err(CliError::from)
     }
 }
 

--- a/crates/rooch/src/commands/move_cli/commands/new.rs
+++ b/crates/rooch/src/commands/move_cli/commands/new.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use async_trait::async_trait;
 use clap::Parser;
 use move_cli::base::new;
 use move_core_types::account_address::AccountAddress;
@@ -8,6 +9,7 @@ use moveos_stdlib::addresses::{
     MOVEOS_STD_ADDRESS, MOVEOS_STD_ADDRESS_NAME, ROOCH_FRAMEWORK_ADDRESS,
     ROOCH_FRAMEWORK_ADDRESS_NAME,
 };
+use rooch_types::cli::{CliError, CliResult, CommandAction};
 use std::path::PathBuf;
 
 //TODO allow external packages to be added as dependencies, add rooch-framework as dependency.
@@ -18,30 +20,36 @@ const MOVEOS_STDLIB_PKG_PATH: &str = "{ git = \"https://github.com/rooch-network
 pub struct New {
     #[clap(flatten)]
     pub new: new::New,
+
+    /// Path of the new package to create.
+    #[clap(long = "path", short = 'p', global = true, parse(from_os_str))]
+    pub path: Option<PathBuf>,
 }
 
-impl New {
-    pub fn execute(self, path: Option<PathBuf>) -> anyhow::Result<()> {
+#[async_trait]
+impl CommandAction<()> for New {
+    async fn execute(self) -> CliResult<()> {
         let name = &self.new.name.to_lowercase();
-        self.new.execute(
-            path,
-            "0.0.1",
-            //TODO add rooch_framework as dependency.
-            [(MOVEOS_STDLIB_PKG_NAME, MOVEOS_STDLIB_PKG_PATH)],
-            [
-                //TODO let dev pass the address as option.
-                (name, &AccountAddress::random().to_hex_literal()),
-                (
-                    &MOVEOS_STD_ADDRESS_NAME.to_string(),
-                    &MOVEOS_STD_ADDRESS.to_hex_literal(),
-                ),
-                (
-                    &ROOCH_FRAMEWORK_ADDRESS_NAME.to_string(),
-                    &ROOCH_FRAMEWORK_ADDRESS.to_hex_literal(),
-                ),
-            ],
-            "",
-        )?;
-        Ok(())
+        self.new
+            .execute(
+                self.path,
+                "0.0.1",
+                //TODO add rooch_framework as dependency.
+                [(MOVEOS_STDLIB_PKG_NAME, MOVEOS_STDLIB_PKG_PATH)],
+                [
+                    //TODO let dev pass the address as option.
+                    (name, &AccountAddress::random().to_hex_literal()),
+                    (
+                        &MOVEOS_STD_ADDRESS_NAME.to_string(),
+                        &MOVEOS_STD_ADDRESS.to_hex_literal(),
+                    ),
+                    (
+                        &ROOCH_FRAMEWORK_ADDRESS_NAME.to_string(),
+                        &ROOCH_FRAMEWORK_ADDRESS.to_hex_literal(),
+                    ),
+                ],
+                "",
+            )
+            .map_err(CliError::from)
     }
 }

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -2,27 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::move_cli::types::{AccountAddressWrapper, TransactionOptions};
-use anyhow::ensure;
+use async_trait::async_trait;
 use clap::Parser;
 use move_binary_format::file_format::CompiledModule;
 use move_bytecode_utils::dependency_graph::DependencyGraph;
-use move_package::BuildConfig;
+use move_bytecode_utils::Modules;
+use move_cli::Move;
 use moveos::vm::dependency_order::sort_by_dependency_order;
 use moveos_types::transaction::MoveAction;
 use rooch_client::Client;
 use rooch_types::address::RoochAddress;
+use rooch_types::cli::{CliError, CliResult, CommandAction};
 use rooch_types::transaction::authenticator::AccountPrivateKey;
 use rooch_types::transaction::rooch::RoochTransactionData;
 use std::collections::BTreeMap;
 use std::io::stderr;
-use std::path::PathBuf;
-
-use move_bytecode_utils::Modules;
 
 #[derive(Parser)]
 pub struct Publish {
     #[clap(flatten)]
     client: Client,
+
+    #[clap(flatten)]
+    move_args: Move,
 
     #[clap(flatten)]
     txn_options: TransactionOptions,
@@ -37,12 +39,22 @@ pub struct Publish {
 }
 
 impl Publish {
-    pub async fn execute(
-        self,
-        package_path: Option<PathBuf>,
-        config: BuildConfig,
-    ) -> anyhow::Result<()> {
-        let mut config = config;
+    pub fn order_modules(modules: Modules) -> anyhow::Result<Vec<CompiledModule>> {
+        //TODO ensure all module at same address.
+        //include all module and dependency modules
+        // let modules = self.package.all_modules_map();
+        let graph = DependencyGraph::new(modules.iter_modules());
+        let order_modules = graph.compute_topological_order()?;
+        Ok(order_modules.cloned().collect())
+    }
+}
+
+#[async_trait]
+impl CommandAction<()> for Publish {
+    async fn execute(self) -> CliResult<()> {
+        let package_path = self.move_args.package_path;
+        let config = self.move_args.build_config;
+        let mut config = config.clone();
         config.additional_named_addresses = self
             .named_addresses
             .into_iter()
@@ -63,27 +75,29 @@ impl Publish {
             .address()
             .to_owned();
         let mut bundles: Vec<Vec<u8>> = vec![];
-        println!("Packaging Modules:");
         // let sorted_modules = Self::order_modules(modules)?;
         let sorted_modules = sort_by_dependency_order(modules.iter_modules())?;
         for module in sorted_modules {
-            println!("\t {}", module.self_id());
             let module_address = module.self_id().address().to_owned();
-            ensure!(
-                module_address == pkg_address,
-                "module's address ({:?}) not same as package module address {:?}",
-                module_address,
-                pkg_address.clone(),
-            );
+            if module_address != pkg_address {
+                return Err(CliError::MoveCompilationError(format!(
+                    "module's address ({:?}) not same as package module address {:?}",
+                    module_address,
+                    pkg_address.clone(),
+                )));
+            };
             let mut binary: Vec<u8> = vec![];
             module.serialize(&mut binary)?;
             bundles.push(binary);
         }
-        assert!(
-            self.txn_options.sender_account.is_some()
-                && pkg_address == self.txn_options.sender_account.unwrap(),
-            "--sender-account required and the sender account must be the same as the package address"
-        );
+        if !(self.txn_options.sender_account.is_some()
+            && pkg_address == self.txn_options.sender_account.unwrap())
+        {
+            return Err(CliError::CommandArgumentError(
+                "--sender-account required and the sender account must be the same as the package address"
+                    .to_string(),
+            ));
+        }
         let action = MoveAction::ModuleBundle(bundles);
 
         let sender: RoochAddress = pkg_address.into();
@@ -95,14 +109,5 @@ impl Publish {
 
         self.client.submit_txn(tx).await?;
         Ok(())
-    }
-
-    pub fn order_modules(modules: Modules) -> anyhow::Result<Vec<CompiledModule>> {
-        //TODO ensure all module at same address.
-        //include all module and dependency modules
-        // let modules = self.package.all_modules_map();
-        let graph = DependencyGraph::new(modules.iter_modules());
-        let order_modules = graph.compute_topological_order()?;
-        Ok(order_modules.cloned().collect())
     }
 }

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -13,8 +13,10 @@ use move_core_types::{
     transaction_argument::TransactionArgument,
     value::MoveValue,
 };
+use moveos::moveos::TransactionOutput;
 use moveos_types::transaction::MoveAction;
 use rooch_client::Client;
+use rooch_server::response::JsonResponse;
 use rooch_types::{
     address::RoochAddress,
     cli::{CliError, CliResult, CommandAction},
@@ -100,8 +102,8 @@ pub struct RunFunction {
 }
 
 #[async_trait]
-impl CommandAction<()> for RunFunction {
-    async fn execute(self) -> CliResult<()> {
+impl CommandAction<JsonResponse<TransactionOutput>> for RunFunction {
+    async fn execute(self) -> CliResult<JsonResponse<TransactionOutput>> {
         let args = self
             .args
             .iter()
@@ -139,11 +141,9 @@ impl CommandAction<()> for RunFunction {
         let tx = tx_data
             .sign(&private_key)
             .map_err(|e| CliError::SignMessageError(e.to_string()))?;
-        let resp = self
-            .client
+        self.client
             .submit_txn(tx)
             .await
-            .map_err(|e| CliError::SubmitTxError(e.to_string()))?;
-        Ok(resp)
+            .map_err(|e| CliError::TransactionError(e.to_string()))
     }
 }

--- a/crates/rooch/src/commands/move_cli/commands/run_view_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_view_function.rs
@@ -14,6 +14,7 @@ use move_core_types::{
 };
 use moveos_types::transaction::{Function, ViewPayload};
 use rooch_client::Client;
+use rooch_server::response::JsonResponse;
 use rooch_types::cli::{CliError, CliResult, CommandAction};
 use std::str::FromStr;
 
@@ -92,8 +93,8 @@ pub struct RunViewFunction {
 }
 
 #[async_trait]
-impl CommandAction<()> for RunViewFunction {
-    async fn execute(self) -> CliResult<()> {
+impl CommandAction<JsonResponse<Vec<serde_json::Value>>> for RunViewFunction {
+    async fn execute(self) -> CliResult<JsonResponse<Vec<serde_json::Value>>> {
         let args = self
             .args
             .iter()
@@ -111,11 +112,9 @@ impl CommandAction<()> for RunViewFunction {
                 args,
             },
         };
-        let resp = self
-            .client
+        self.client
             .view(payload)
             .await
-            .map_err(|e| CliError::ViewFunctionError(e.to_string()))?;
-        Ok(resp)
+            .map_err(|e| CliError::ViewFunctionError(e.to_string()))
     }
 }

--- a/crates/rooch/src/commands/move_cli/mod.rs
+++ b/crates/rooch/src/commands/move_cli/mod.rs
@@ -12,7 +12,7 @@ use move_cli::{
     },
     Move,
 };
-use rooch_types::cli::{CliError, CliResult};
+use rooch_types::cli::{CliError, CliResult, CommandAction};
 
 pub mod commands;
 pub mod types;
@@ -43,28 +43,54 @@ pub enum MoveCommand {
     //TODO implement integration test command
 }
 
-pub async fn run_cli(move_cli: MoveCli) -> CliResult<()> {
+impl MoveCli {
+    pub async fn execute(self) -> CliResult<String> {
+        run_cli(self).await
+    }
+}
+
+async fn run_cli(move_cli: MoveCli) -> CliResult<String> {
     let move_args = move_cli.move_args;
     let cmd = move_cli.cmd;
 
     //let error_descriptions: ErrorMapping = bcs::from_bytes(moveos_stdlib::error_descriptions())?;
 
     match cmd {
-        MoveCommand::Build(c) => c.execute(move_args.package_path, move_args.build_config),
-        MoveCommand::Coverage(c) => c.execute(move_args.package_path, move_args.build_config),
-        MoveCommand::Disassemble(c) => c.execute(move_args.package_path, move_args.build_config),
-        MoveCommand::Docgen(c) => c.execute(move_args.package_path, move_args.build_config),
-        MoveCommand::Errmap(c) => c.execute(move_args.package_path, move_args.build_config),
-        MoveCommand::Info(c) => c.execute(move_args.package_path, move_args.build_config),
-        MoveCommand::New(c) => c.execute(move_args.package_path),
-        MoveCommand::Prove(c) => c.execute(move_args.package_path, move_args.build_config),
-        MoveCommand::Test(c) => c.execute(move_args.package_path, move_args.build_config),
-        MoveCommand::Publish(c) => {
-            c.execute(move_args.package_path, move_args.build_config)
-                .await
-        }
-        MoveCommand::Run(c) => c.execute().await,
-        MoveCommand::View(c) => c.execute().await,
+        MoveCommand::Build(c) => c
+            .execute(move_args.package_path, move_args.build_config)
+            .map(|_| "Success".to_string())
+            .map_err(CliError::from),
+        MoveCommand::Coverage(c) => c
+            .execute(move_args.package_path, move_args.build_config)
+            .map(|_| "Success".to_string())
+            .map_err(CliError::from),
+        MoveCommand::Disassemble(c) => c
+            .execute(move_args.package_path, move_args.build_config)
+            .map(|_| "Success".to_string())
+            .map_err(CliError::from),
+        MoveCommand::Docgen(c) => c
+            .execute(move_args.package_path, move_args.build_config)
+            .map(|_| "Success".to_string())
+            .map_err(CliError::from),
+        MoveCommand::Errmap(c) => c
+            .execute(move_args.package_path, move_args.build_config)
+            .map(|_| "Success".to_string())
+            .map_err(CliError::from),
+        MoveCommand::Info(c) => c
+            .execute(move_args.package_path, move_args.build_config)
+            .map(|_| "Success".to_string())
+            .map_err(CliError::from),
+        MoveCommand::New(c) => c.execute_serialized().await,
+        MoveCommand::Prove(c) => c
+            .execute(move_args.package_path, move_args.build_config)
+            .map(|_| "Success".to_string())
+            .map_err(CliError::from),
+        MoveCommand::Test(c) => c
+            .execute(move_args.package_path, move_args.build_config)
+            .map(|_| "Success".to_string())
+            .map_err(CliError::from),
+        MoveCommand::Publish(c) => c.execute_serialized().await,
+        MoveCommand::Run(c) => c.execute_serialized().await,
+        MoveCommand::View(c) => c.execute_serialized().await,
     }
-    .map_err(CliError::from)
 }

--- a/crates/rooch/src/commands/object.rs
+++ b/crates/rooch/src/commands/object.rs
@@ -1,7 +1,7 @@
+use async_trait::async_trait;
 use moveos_types::object::ObjectID;
 use rooch_client::Client;
-use rooch_types::cli::CliResult;
-
+use rooch_types::cli::{CliResult, CommandAction};
 #[derive(clap::Parser)]
 pub struct ObjectCommand {
     /// Object id.
@@ -13,10 +13,10 @@ pub struct ObjectCommand {
     client: Client,
 }
 
-impl ObjectCommand {
-    pub async fn execute(self) -> CliResult<()> {
+#[async_trait]
+impl CommandAction<Option<String>> for ObjectCommand {
+    async fn execute(self) -> CliResult<Option<String>> {
         let resp = self.client.object(self.id).await?;
-        println!("{:?}", resp);
-        Ok(())
+        Ok(resp)
     }
 }

--- a/crates/rooch/src/commands/resource.rs
+++ b/crates/rooch/src/commands/resource.rs
@@ -1,9 +1,10 @@
+use async_trait::async_trait;
 use move_core_types::{
     account_address::AccountAddress, language_storage::TypeTag, parser::parse_type_tag,
 };
 use moveos_types::move_types::StructId;
 use rooch_client::Client;
-use rooch_types::cli::{CliError, CliResult};
+use rooch_types::cli::{CliError, CliResult, CommandAction};
 
 #[derive(clap::Parser)]
 pub struct ResourceCommand {
@@ -32,8 +33,9 @@ pub struct ResourceCommand {
     client: Client,
 }
 
-impl ResourceCommand {
-    pub async fn execute(self) -> CliResult<()> {
+#[async_trait]
+impl CommandAction<Option<String>> for ResourceCommand {
+    async fn execute(self) -> CliResult<Option<String>> {
         let resp = self
             .client
             .resource(
@@ -44,7 +46,6 @@ impl ResourceCommand {
             )
             .await
             .map_err(CliError::from)?;
-        println!("{:?}", resp);
-        Ok(())
+        Ok(resp)
     }
 }

--- a/crates/rooch/src/lib.rs
+++ b/crates/rooch/src/lib.rs
@@ -42,19 +42,3 @@ pub async fn run_cli(opt: RoochCli) -> CliResult<String> {
         Command::Account(a) => a.execute_serialized().await,
     }
 }
-
-async fn prompt_if_no_config() -> Result<RoochConfig, anyhow::Error> {
-    let config_path = rooch_config_path().map_err(CliError::from)?;
-
-    if !config_path.exists() {
-        println!(
-            "Creating config file [{:?}] with default server and ed25519 key scheme.",
-            config_path
-        );
-
-        crate::commands::init::init().await?;
-    }
-
-    Ok(PersistedConfig::read(&config_path)
-        .map_err(|err| CliError::ConfigLoadError(format!("{:?}", config_path), err.to_string()))?)
-}

--- a/crates/rooch/src/main.rs
+++ b/crates/rooch/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     let result = rooch::run_cli(opt).await;
 
     match result {
-        Ok(_) => println!(), // TODO: unify cli output
+        Ok(s) => println!("{:?}", s),
         Err(e) => {
             println!("{}", e);
             exit(1);


### PR DESCRIPTION

Unify output types of each commands.

To fix: 

The output of transaction is not pretty enough like this:
```
"{\n  \"code\": \"Ok\",\n  \"message\": null,\n  \"data\": {\n    \"state_root\": \"0xe30674dab1f57e29849b74d470c76d21ce41871e13974677f8e8f8ec87e1ba28\",\n    \"status\": \"Executed\"\n  }\n}"
```
Try to figure out why and fix it.