### PR TITLE
[transaction-validate] Refactor transaction validate and transaction construct flow

### DIFF
--- a/crates/rooch-server/src/actor/executor.rs
+++ b/crates/rooch-server/src/actor/executor.rs
@@ -16,7 +16,6 @@ use moveos::moveos::{MoveOS, TransactionOutput};
 use moveos_types::object::RawObject;
 use moveos_types::transaction::ViewPayload;
 use rooch_types::transaction::rooch::RoochTransaction;
-use rooch_types::transaction::AbstractTransaction;
 
 pub struct ServerActor {
     moveos: MoveOS,
@@ -50,8 +49,7 @@ impl Handler<SubmitTransactionMessage> for ServerActor {
         let tx = bcs::from_bytes::<RoochTransaction>(&msg.payload)?;
         println!("sender: {:?}", tx.sender());
         //First, validate the transactin
-        let authenticator_info = tx.authenticator();
-        let moveos_tx = self.moveos.validate(tx, authenticator_info)?;
+        let moveos_tx = self.moveos.validate(tx)?;
         // TODO Write to DA
         // Then execute
         self.moveos.execute(moveos_tx)

--- a/crates/rooch-types/src/transaction/ethereum.rs
+++ b/crates/rooch-types/src/transaction/ethereum.rs
@@ -1,33 +1,35 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{
+    authenticator::Authenticator, AbstractTransaction, AuthenticatorInfo, AuthenticatorResult,
+};
 use crate::address::EthereumAddress;
-
-use super::{authenticator::Authenticator, AbstractTransaction, AuthenticatorInfo};
 use anyhow::Result;
 use ethers::utils::rlp::{Decodable, Rlp};
-use moveos_types::{h256::H256, transaction::MoveOSTransaction};
+use moveos_types::{
+    h256::H256,
+    transaction::{AuthenticatableTransaction, MoveAction, MoveOSTransaction},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EthereumTransaction(pub ethers::core::types::Transaction);
+
+impl EthereumTransaction {
+    //This function is just a demo, we should define the Ethereum calldata's MoveAction standard
+    pub fn decode_calldata_to_action(&self) -> Result<MoveAction> {
+        //Maybe we should use RLP to encode the MoveAction
+        bcs::from_bytes(&self.0.input)
+            .map_err(|e| anyhow::anyhow!("decode calldata to action failed: {}", e))
+    }
+}
 
 impl AbstractTransaction for EthereumTransaction {
     type Hash = H256;
 
     fn transaction_type(&self) -> super::TransactionType {
         super::TransactionType::Ethereum
-    }
-
-    fn authenticator(&self) -> AuthenticatorInfo {
-        AuthenticatorInfo {
-            sender: EthereumAddress(self.0.from).into(),
-            authenticator: Authenticator::secp256k1(ethers::core::types::Signature {
-                r: self.0.r,
-                s: self.0.s,
-                v: self.0.v.as_u64(),
-            }),
-        }
     }
 
     fn decode(bytes: &[u8]) -> Result<Self> {
@@ -40,14 +42,38 @@ impl AbstractTransaction for EthereumTransaction {
     fn encode(&self) -> Vec<u8> {
         self.0.rlp().to_vec()
     }
-
-    fn tx_hash(&self) -> Self::Hash {
-        self.0.hash()
-    }
 }
 
-impl From<EthereumTransaction> for MoveOSTransaction {
-    fn from(_tx: EthereumTransaction) -> Self {
-        todo!("convert ethereum transaction to moveos transaction")
+impl AuthenticatableTransaction for EthereumTransaction {
+    type AuthenticatorInfo = AuthenticatorInfo;
+    type AuthenticatorResult = AuthenticatorResult;
+
+    fn tx_hash(&self) -> H256 {
+        self.0.hash()
+    }
+
+    fn authenticator_info(&self) -> AuthenticatorInfo {
+        AuthenticatorInfo {
+            sender: EthereumAddress(self.0.from).into(),
+            //TODO should change the seqence_number to u256?
+            seqence_number: self.0.nonce.as_u64(),
+            authenticator: Authenticator::secp256k1(ethers::core::types::Signature {
+                r: self.0.r,
+                s: self.0.s,
+                v: self.0.v.as_u64(),
+            }),
+        }
+    }
+
+    fn construct_moveos_transaction(
+        &self,
+        result: super::AuthenticatorResult,
+    ) -> Result<MoveOSTransaction> {
+        let action = self.decode_calldata_to_action()?;
+        Ok(MoveOSTransaction::new(
+            result.resolved_address,
+            action,
+            self.tx_hash(),
+        ))
     }
 }

--- a/moveos/moveos-stdlib/rooch-framework/sources/account.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/account.move
@@ -11,7 +11,7 @@ module rooch_framework::account{
    use std::debug;
    #[test_only]
    use moveos_std::storage_context;
-   use rooch_framework::authenticator;
+   use rooch_framework::authenticator::{Self, AuthenticatorResult};
 
    friend rooch_framework::genesis;
    friend rooch_framework::transaction_validator;
@@ -273,8 +273,8 @@ module rooch_framework::account{
 
    /// This function is for MoveOS to validate the transaction sender's authenticator.
    /// Return the sender's address if the authenticator is valid, auto resolve multi-chain address to rooch address.
-   fun validate(ctx: &mut StorageContext, authenticator_info_bytes: vector<u8>) : address {
-      let (sender_maddr, authenticator) = authenticator::decode_authenticator_info(authenticator_info_bytes);
+   fun validate(ctx: &mut StorageContext, authenticator_info_bytes: vector<u8>) : AuthenticatorResult {
+      let (sender_maddr, _sequence_number, authenticator) = authenticator::decode_authenticator_info(authenticator_info_bytes);
       //std::debug::print(&authenticator);
       authenticator::check_authenticator(&authenticator);
       //TODO decode by the scheme id
@@ -282,7 +282,8 @@ module rooch_framework::account{
       //TODO verify signature
       //TODO verify authenicator info with account's auth key
       let addr_opt = rooch_framework::address_mapping::resolve(ctx, sender_maddr);
-      std::option::extract(&mut addr_opt)
+      let resolved_address = std::option::extract(&mut addr_opt);
+      authenticator::new_authenticator_result(resolved_address)
    }
 
    #[test_only]

--- a/moveos/moveos-stdlib/rooch-framework/sources/authenticator.move
+++ b/moveos/moveos-stdlib/rooch-framework/sources/authenticator.move
@@ -10,7 +10,12 @@ module rooch_framework::authenticator{
 
     struct AuthenticatorInfo has copy, store, drop {
         sender: MultiChainAddress,
+        sequence_number: u64,
         authenticator: Authenticator,
+    }
+
+    struct AuthenticatorResult has copy, store, drop {
+        resolved_address: address,
     }
 
     struct Authenticator has copy, store, drop {
@@ -42,10 +47,10 @@ module rooch_framework::authenticator{
         assert!(is_builtin_scheme(authenticator.scheme), EUnsupportedScheme);
     }
 
-    public fun decode_authenticator_info(data: vector<u8>) : (MultiChainAddress, Authenticator) {
+    public fun decode_authenticator_info(data: vector<u8>) : (MultiChainAddress, u64, Authenticator) {
         let info = moveos_std::bcd::from_bytes<AuthenticatorInfo>(data);
-        let AuthenticatorInfo{sender, authenticator} = info;
-        (sender, authenticator)
+        let AuthenticatorInfo{sender, sequence_number, authenticator} = info;
+        (sender, sequence_number, authenticator)
     }
 
     public fun decode_ed25519_authenticator(authenticator: Authenticator) : Ed25519Authenticator {
@@ -61,5 +66,11 @@ module rooch_framework::authenticator{
     public fun decode_secp256k1_authenticator(authenticator: Authenticator) : Secp256k1Authenticator {
         assert!(authenticator.scheme == SCHEME_SECP256K1, EUnsupportedScheme);
         moveos_std::bcd::from_bytes<Secp256k1Authenticator>(authenticator.payload)
+    }
+
+    public fun new_authenticator_result(resolved_address: address): AuthenticatorResult {
+        AuthenticatorResult{
+            resolved_address
+        }
     }
 }

--- a/moveos/moveos-types/src/transaction.rs
+++ b/moveos/moveos-types/src/transaction.rs
@@ -1,15 +1,14 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::h256::H256;
+use crate::h256::{self, H256};
+use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
 };
-use serde::{Deserialize, Serialize};
-
-use crate::h256;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Script {
@@ -79,6 +78,18 @@ impl MoveAction {
             args,
         })
     }
+}
+
+pub trait AuthenticatableTransaction {
+    type AuthenticatorInfo: Serialize;
+    type AuthenticatorResult: DeserializeOwned;
+
+    fn tx_hash(&self) -> H256;
+    fn authenticator_info(&self) -> Self::AuthenticatorInfo;
+    fn construct_moveos_transaction(
+        &self,
+        result: Self::AuthenticatorResult,
+    ) -> Result<MoveOSTransaction>;
 }
 
 #[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -28,7 +28,7 @@ use move_vm_types::gas::UnmeteredGasMeter;
 use moveos_statedb::StateDB;
 use moveos_stdlib::addresses::ROOCH_FRAMEWORK_ADDRESS;
 use moveos_stdlib::natives::moveos_stdlib::raw_table::NativeTableContext;
-use moveos_types::transaction::{MoveAction, MoveOSTransaction};
+use moveos_types::transaction::{AuthenticatableTransaction, MoveAction, MoveOSTransaction};
 use moveos_types::tx_context::TxContext;
 use moveos_types::{h256::H256, transaction::Function};
 use once_cell::sync::Lazy;
@@ -88,35 +88,34 @@ impl MoveOS {
         ))
     }
 
-    pub fn validate<T: Into<MoveOSTransaction>, A: Into<Vec<u8>>>(
-        &mut self,
-        tx: T,
-        authenticator: A,
-    ) -> Result<MoveOSTransaction> {
+    pub fn validate<T: AuthenticatableTransaction>(&mut self, tx: T) -> Result<MoveOSTransaction> {
         let session = self.vm.new_session(&self.db);
-        self.validate_transaction(session, tx, authenticator)
+        self.validate_transaction(session, tx)
     }
 
-    fn validate_transaction<S, T: Into<MoveOSTransaction>, A: Into<Vec<u8>>>(
+    fn validate_transaction<S, T: AuthenticatableTransaction>(
         &self,
         mut session: SessionExt<S>,
         tx: T,
-        authenticator: A,
     ) -> Result<MoveOSTransaction>
     where
         S: MoveResolverExt,
     {
-        let moveos_tx: MoveOSTransaction = tx.into();
-        let tx_context = TxContext::new(moveos_tx.sender, moveos_tx.tx_hash);
+        let authenticator = tx.authenticator_info();
+
+        //TODO ensure the validate function's sender should be the genesis address?
+        let tx_context = TxContext::new(*ROOCH_FRAMEWORK_ADDRESS, tx.tx_hash());
         let mut gas_meter = UnmeteredGasMeter;
         let (module, function_name) = VALIDATE_FUNCTION.clone();
         let function = Function::new(
             module,
             function_name,
             vec![],
-            vec![MoveValue::vector_u8(authenticator.into())
-                .simple_serialize()
-                .unwrap()],
+            vec![MoveValue::vector_u8(
+                bcs::to_bytes(&authenticator).expect("serialize authenticator should success"),
+            )
+            .simple_serialize()
+            .unwrap()],
         );
         let result = Self::execute_function_bypass_visibility(
             &mut session,
@@ -125,17 +124,22 @@ impl MoveOS {
             function,
         );
         match result {
-            Ok(_) => {
-                //TODO handle the return address
+            Ok(return_values) => {
+                let (validate_result, _layout) = return_values
+                    .return_values
+                    .get(0)
+                    .expect("the validate function should return the validate result.");
+                let auth_result = bcs::from_bytes::<T::AuthenticatorResult>(validate_result)?;
+                tx.construct_moveos_transaction(auth_result)
             }
             Err(e) => {
                 //TODO handle the abort error code
                 println!("validate failed: {:?}", e);
                 // If the error code is EUnsupportedScheme, then we can try to call the sender's validate function
                 // This is the Account Abstraction.
+                bail!("validate failed: {:?}", e)
             }
         }
-        Ok(moveos_tx)
     }
 
     pub fn execute(&mut self, tx: MoveOSTransaction) -> Result<TransactionOutput> {


### PR DESCRIPTION
resolve #72 

The transaction validates flow:

Multi-chain transaction -> AuthenticatableTransaction -> Validate transaction in MoveOS -> Get the AuthenticatorResult -> Construct MoveOSTransaciton -> Execute transaction

TODO:

1. Write a document to describe the validate move function ( part of #45 )
2. Refactor the validate function call, and make it an extension to MoveOS.
3. Implement the validate in Move.
