### PR TITLE
Introduce fuzzing proptest for test struct serialize and deserialize

### DIFF
--- a/crates/rooch-key/Cargo.toml
+++ b/crates/rooch-key/Cargo.toml
@@ -31,3 +31,16 @@ tiny-bip39 = { workspace = true }
 rooch-types = { workspace = true }
 move-core-types = { workspace = true }
 moveos-types = { workspace = true }
+proptest = { default-features = false, optional = true, workspace = true }
+proptest-derive = { default-features = false, optional = true, workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+proptest-derive = { workspace = true }
+
+[features]
+default = []
+fuzzing = [
+    "proptest",
+    "proptest-derive",
+]

--- a/crates/rooch-key/src/keystore.rs
+++ b/crates/rooch-key/src/keystore.rs
@@ -6,6 +6,10 @@ use anyhow::anyhow;
 use bip32::DerivationPath;
 use bip39::{Language, Mnemonic, Seed};
 use enum_dispatch::enum_dispatch;
+// #[cfg(any(test, feature = "fuzzing"))]
+// use proptest::{collection::btree_map, prelude::*};
+// #[cfg(any(test, feature = "fuzzing"))]
+// use proptest_derive::Arbitrary;
 use rand::{rngs::StdRng, SeedableRng};
 use rooch_types::account::{
     get_key_pair_from_rng, EncodeDecodeBase64, PublicKey, RoochKeyPair, SignatureScheme,
@@ -84,7 +88,7 @@ impl Display for Keystore {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct FileBasedKeystore {
     keys: BTreeMap<RoochAddress, RoochKeyPair>,
     path: Option<PathBuf>,
@@ -115,6 +119,28 @@ impl<'de> Deserialize<'de> for FileBasedKeystore {
             .map_err(D::Error::custom)
     }
 }
+
+// #[cfg(any(test, feature = "fuzzing"))]
+// impl Arbitrary for FileBasedKeystore {
+//     type Parameters = ();
+//     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+//         arb_file_based_keystore().boxed()
+//     }
+//     type Strategy = BoxedStrategy<Self>;
+// }
+
+// #[cfg(any(test, feature = "fuzzing"))]
+// prop_compose! {
+//     fn arb_file_based_keystore()(
+//         key in btree_map(any::<RoochAddress>(), any::<RoochKeyPair>(), 1..100),
+//         path in any::<PathBuf>(),
+//     ) -> FileBasedKeystore {
+//         FileBasedKeystore {
+//             keys: key,
+//             path: Some(path),
+//         }
+//     }
+// }
 
 impl AccountKeystore for FileBasedKeystore {
     fn add_key(&mut self, keypair: RoochKeyPair) -> Result<(), anyhow::Error> {

--- a/crates/rooch-types/proptest-regressions/transaction/authenticator.txt
+++ b/crates/rooch-types/proptest-regressions/transaction/authenticator.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 5109663404bc3d9988d137bc9db8ab99b65453ba295a2249f346ee092af00b0b # shrinks to authenticator = Secp256k1Authenticator { signature: Signature { r: 0, s: 0, v: 256 } }

--- a/crates/rooch-types/proptest-regressions/transaction/authenticator.txt
+++ b/crates/rooch-types/proptest-regressions/transaction/authenticator.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5109663404bc3d9988d137bc9db8ab99b65453ba295a2249f346ee092af00b0b # shrinks to authenticator = Secp256k1Authenticator { signature: Signature { r: 0, s: 0, v: 256 } }

--- a/crates/rooch-types/src/account.rs
+++ b/crates/rooch-types/src/account.rs
@@ -111,8 +111,8 @@ impl Arbitrary for RoochKeyPair {
 
 #[cfg(any(test, feature = "fuzzing"))]
 prop_compose! {
-    fn arb_rooch_keypair()(_ in 1..10) -> RoochKeyPair {
-        let mut rng = rand::thread_rng();
+    pub fn arb_rooch_keypair()(seed in any::<u64>()) -> RoochKeyPair {
+        let mut rng = StdRng::seed_from_u64(seed);
         let ed25519_keypair: Ed25519KeyPair = Ed25519KeyPair::generate(&mut rng);
         prop_oneof![
             RoochKeyPair::Ed25519(ed25519_keypair),

--- a/crates/rooch-types/src/account.rs
+++ b/crates/rooch-types/src/account.rs
@@ -17,6 +17,8 @@ pub use fastcrypto::traits::{
     VerifyingKey,
 };
 use moveos_types::h256::H256;
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest::prelude::*;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use schemars::JsonSchema;
@@ -98,7 +100,27 @@ impl<'de> Deserialize<'de> for RoochKeyPair {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, From, JsonSchema)]
+#[cfg(any(test, feature = "fuzzing"))]
+impl Arbitrary for RoochKeyPair {
+    type Parameters = ();
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        arb_rooch_keypair().boxed()
+    }
+    type Strategy = BoxedStrategy<Self>;
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+prop_compose! {
+    fn arb_rooch_keypair()(_ in 1..10) -> RoochKeyPair {
+        let mut rng = rand::thread_rng();
+        let ed25519_keypair: Ed25519KeyPair = Ed25519KeyPair::generate(&mut rng);
+        prop_oneof![
+            RoochKeyPair::Ed25519(ed25519_keypair),
+        ]
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, From, JsonSchema)]
 pub enum PublicKey {
     #[schemars(with = "Base64")]
     Ed25519(Ed25519PublicKey),
@@ -185,6 +207,15 @@ impl From<&PublicKey> for RoochAddress {
         let g_arr = hasher.finalize();
         RoochAddress(H256(g_arr.digest))
     }
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl Arbitrary for PublicKey {
+    type Parameters = ();
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        arb_rooch_keypair().prop_map(|kp| kp.public()).boxed()
+    }
+    type Strategy = BoxedStrategy<Self>;
 }
 
 #[derive(Deserialize, Serialize, Debug, EnumString, strum_macros::Display)]
@@ -300,4 +331,26 @@ where
         kp,
     )
     //    (kp.public().into(), kp)
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn test_rooch_keypair_serialize_deserialize(keypair in any::<RoochKeyPair>()) {
+            let serialized = serde_json::to_string(&keypair).unwrap();
+            let deserialized: RoochKeyPair = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(keypair, deserialized);
+        }
+
+        #[test]
+        fn test_rooch_publickey_serialize_deserialize(publickey in any::<PublicKey>()) {
+            let serialized = serde_json::to_string(&publickey).unwrap();
+            let deserialized: PublicKey = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(publickey, deserialized);
+        }
+    }
 }

--- a/crates/rooch-types/src/coin_id.rs
+++ b/crates/rooch-types/src/coin_id.rs
@@ -1,12 +1,15 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
 /// The coin id standard is defined in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
 /// The rooch's ID do not add to the slip-0044 yet.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[repr(u32)]
 pub enum CoinID {
     BTC = 0,

--- a/crates/rooch-types/src/transaction/authenticator.rs
+++ b/crates/rooch-types/src/transaction/authenticator.rs
@@ -17,6 +17,8 @@ use proptest::{collection::vec, prelude::*};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};
+#[cfg(any(test, feature = "fuzzing"))]
+use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 #[cfg(any(test, feature = "fuzzing"))]
 use starcoin_crypto::ed25519::keypair_strategy;
@@ -211,9 +213,10 @@ impl Arbitrary for MultiEd25519Authenticator {
 #[cfg(any(test, feature = "fuzzing"))]
 prop_compose! {
     fn arb_multied25519_authenticator()(
+        seed in any::<u64>(),
         message in vec(any::<u8>(), 1..1000)
     ) -> MultiEd25519Authenticator {
-        let mut rng = rand::thread_rng();
+        let mut rng = StdRng::seed_from_u64(seed);
         let private_key = MultiEd25519PrivateKey::generate(&mut rng);
         MultiEd25519Authenticator {
             public_key: MultiEd25519PublicKey::from(&private_key),


### PR DESCRIPTION
part of #160

To fix:

Encountering problem when impl Arbitrary trait for FileBasedKeystore struct.
```
pub struct FileBasedKeystore {
    keys: BTreeMap<RoochAddress, RoochKeyPair>,
    path: Option<PathBuf>,
}
```
When using ` btree_map(any::<RoochAddress>(), any::<RoochKeyPair>(), 1..100)` to generate a Strategy, it shows "the trait `Arbitrary` is not implemented for `RoochAddress`" and "the trait `Arbitrary` is not implemented for `RoochKeyPair`" but they are actually implemented.