### PR TITLE
Private generics attribute and other extended checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,8 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.8", features = ["gzip"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-
+codespan-reporting = "0.11.1"
+termcolor = "1.1.2"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -27,6 +27,8 @@ serde_json = { workspace = true }
 once_cell = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
+codespan-reporting = { workspace = true }
+termcolor = { workspace = true }
 
 
 move-bytecode-utils = { workspace = true }
@@ -43,6 +45,7 @@ move-package = { workspace = true }
 move-unit-test = { workspace = true }
 move-vm-runtime = { workspace = true }
 move-vm-test-utils = { workspace = true }
+move-model = { workspace = true }
 
 moveos-stdlib = { workspace = true }
 moveos-types = { workspace = true }

--- a/crates/rooch/src/commands/move_cli/commands/build.rs
+++ b/crates/rooch/src/commands/move_cli/commands/build.rs
@@ -1,11 +1,28 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::extended_checks::build::build_model;
+use crate::extended_checks::build::BYTECODE_VERSION;
+use crate::extended_checks::metadata::{run_extended_checks, RuntimeModuleMetadataV1};
 use crate::move_cli::types::AccountAddressWrapper;
 use clap::*;
+use codespan_reporting::diagnostic::Severity;
 use move_cli::base::reroot_path;
+use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
+use move_compiler::compiled_unit::CompiledUnit;
+use move_core_types::language_storage::ModuleId;
+use move_core_types::metadata::Metadata;
+use move_package::compilation::compiled_package::CompiledPackage;
+use move_package::compilation::package_layout::CompiledPackageLayout;
 use move_package::BuildConfig;
 use std::{collections::BTreeMap, path::PathBuf};
+use termcolor::ColorChoice;
+use termcolor::StandardStream;
+
+/// The keys used to identify the metadata in the metadata section of the module bytecode.
+/// This is more or less arbitrary, besides we should use some unique key to identify
+/// Rooch specific metadata (`rooch::` here).
+pub static ROOCH_METADATA_KEY: &[u8] = "rooch::metadata_v0".as_bytes();
 
 /// Build the package at `path`. If no path is provided defaults to current directory.
 #[derive(Parser)]
@@ -29,6 +46,8 @@ impl Build {
             .map(|(key, value)| (key, value.account_address))
             .collect();
 
+        let additional_named_address = config.additional_named_addresses.clone();
+
         let rerooted_path = reroot_path(path)?;
         if config.fetch_deps_only {
             if config.test_mode {
@@ -38,8 +57,65 @@ impl Build {
             return Ok(());
         }
 
-        config.compile_package_no_exit(&rerooted_path, &mut std::io::stdout())?;
+        let mut package = config.compile_package_no_exit(&rerooted_path, &mut std::io::stdout())?;
+
+        let model = &build_model(rerooted_path.as_path(), additional_named_address, None)?;
+
+        let runtime_metadata = run_extended_checks(model);
+        // println!("runtime metadata {:?}", runtime_metadata);
+
+        if model.diag_count(Severity::Warning) > 0 {
+            let mut error_writer = StandardStream::stderr(ColorChoice::Auto);
+            model.report_diag(&mut error_writer, Severity::Warning);
+            if model.has_errors() {
+                eprintln!("extended checks failed")
+            }
+        }
+
+        inject_runtime_metadata(
+            rerooted_path
+                .join(CompiledPackageLayout::Root.path())
+                .join(package.compiled_package_info.package_name.as_str()),
+            &mut package,
+            runtime_metadata,
+        );
 
         Ok(())
+    }
+}
+
+fn inject_runtime_metadata(
+    package_path: PathBuf,
+    pack: &mut CompiledPackage,
+    metadata: BTreeMap<ModuleId, RuntimeModuleMetadataV1>,
+) {
+    for unit_with_source in pack.root_compiled_units.iter_mut() {
+        match &mut unit_with_source.unit {
+            CompiledUnit::Module(named_module) => {
+                if let Some(module_metadata) = metadata.get(&named_module.module.self_id()) {
+                    if !module_metadata.is_empty() {
+                        let serialized_metadata =
+                            bcs::to_bytes(&module_metadata).expect("BCS for RuntimeModuleMetadata");
+                        named_module.module.metadata.push(Metadata {
+                            key: ROOCH_METADATA_KEY.to_vec(),
+                            value: serialized_metadata,
+                        });
+
+                        // Also need to update the .mv file on disk.
+                        let path = package_path
+                            .join(CompiledPackageLayout::CompiledModules.path())
+                            .join(named_module.name.as_str())
+                            .with_extension(MOVE_COMPILED_EXTENSION);
+                        if path.is_file() {
+                            let bytes = unit_with_source
+                                .unit
+                                .serialize(Option::from(BYTECODE_VERSION));
+                            std::fs::write(path, bytes).unwrap();
+                        }
+                    }
+                }
+            }
+            CompiledUnit::Script(_) => {}
+        }
     }
 }

--- a/crates/rooch/src/commands/move_cli/commands/new.rs
+++ b/crates/rooch/src/commands/move_cli/commands/new.rs
@@ -22,7 +22,7 @@ pub struct New {
     pub new: new::New,
 
     /// Path of the new package to create.
-    #[clap(long = "path", short = 'p', global = true, parse(from_os_str))]
+    #[clap(long = "mpath", short = 'm', global = true, parse(from_os_str))]
     pub path: Option<PathBuf>,
 }
 

--- a/crates/rooch/src/extended_checks/build.rs
+++ b/crates/rooch/src/extended_checks/build.rs
@@ -1,0 +1,35 @@
+use move_core_types::account_address::AccountAddress;
+use move_model::model::GlobalEnv;
+use move_package::{BuildConfig, ModelConfig};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+pub(crate) const BYTECODE_VERSION: u32 = 6;
+
+pub fn build_model(
+    package_path: &Path,
+    additional_named_addresses: BTreeMap<String, AccountAddress>,
+    target_filter: Option<String>,
+) -> anyhow::Result<GlobalEnv> {
+    let build_config = BuildConfig {
+        dev_mode: false,
+        additional_named_addresses,
+        architecture: None,
+        generate_abis: false,
+        generate_docs: false,
+        install_dir: None,
+        test_mode: false,
+        force_recompilation: false,
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: true,
+        bytecode_version: Some(BYTECODE_VERSION),
+        lock_file: None,
+    };
+    build_config.move_model_for_package(
+        package_path,
+        ModelConfig {
+            target_filter,
+            all_files_as_targets: false,
+        },
+    )
+}

--- a/crates/rooch/src/extended_checks/metadata.rs
+++ b/crates/rooch/src/extended_checks/metadata.rs
@@ -1,0 +1,274 @@
+use move_binary_format::binary_views::BinaryIndexedView;
+use move_binary_format::file_format::{Bytecode, FunctionInstantiation, SignatureToken};
+use move_core_types::language_storage::ModuleId;
+use move_model::ast::Attribute;
+use move_model::model::{FunctionEnv, GlobalEnv, ModuleEnv};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+const PRIVATE_GENERICS_ATTRIBUTE: &str = "private_generics";
+
+/// Enumeration of potentially known attributes
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct KnownAttribute {
+    kind: u8,
+    args: Vec<String>,
+}
+
+/// V1 of Aptos specific metadata attached to the metadata section of file_format.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RuntimeModuleMetadataV1 {
+    /// Attributes attached to structs.
+    pub struct_attributes: BTreeMap<String, Vec<KnownAttribute>>,
+
+    /// Attributes attached to functions, by definition index.
+    pub fun_attributes: BTreeMap<String, Vec<KnownAttribute>>,
+
+    /// The correspondence between private generics and their type parameters.
+    pub private_generics_indices: BTreeMap<String, Vec<usize>>,
+}
+
+impl RuntimeModuleMetadataV1 {
+    pub fn is_empty(&self) -> bool {
+        self.fun_attributes.is_empty()
+            && self.struct_attributes.is_empty()
+            && self.private_generics_indices.is_empty()
+    }
+}
+
+/// Run the extended context checker on target modules in the environment and returns a map
+/// from module to extended runtime metadata. Any errors during context checking are reported to
+/// `env`. This is invoked after general build succeeds.
+pub fn run_extended_checks(env: &GlobalEnv) -> BTreeMap<ModuleId, RuntimeModuleMetadataV1> {
+    let mut checker = ExtendedChecker::new(env);
+    checker.run();
+    checker.output
+}
+
+#[derive(Debug)]
+struct ExtendedChecker<'a> {
+    env: &'a GlobalEnv,
+    /// Computed runtime metadata
+    output: BTreeMap<ModuleId, RuntimeModuleMetadataV1>,
+}
+
+impl<'a> ExtendedChecker<'a> {
+    fn new(env: &'a GlobalEnv) -> Self {
+        Self {
+            env,
+            output: BTreeMap::default(),
+        }
+    }
+
+    fn run(&mut self) {
+        for ref module in self.env.get_modules() {
+            if module.is_target() {
+                self.check_private_generics_functions(module);
+                //self.check_entry_functions(module);
+                //self.check_init_module(module);
+            }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------
+// Private Generic Functions
+
+impl<'a> ExtendedChecker<'a> {
+    fn check_private_generics_functions(&mut self, module: &ModuleEnv) {
+        let mut type_name_indices: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+
+        // Check every function and if a function has the private_generics attribute,
+        // ensure that the function name and the types defined in the private_generics attribute match,
+        // for example: #[private_generics(T1, T2)].
+        for ref fun in module.get_functions() {
+            if !self.has_attribute(fun, PRIVATE_GENERICS_ATTRIBUTE) {
+                continue;
+            }
+
+            let mut func_type_params_name_list = vec![];
+            let type_params = fun.get_named_type_parameters();
+            for t in type_params {
+                let type_name = self.env.symbol_pool().string(t.0).as_str().to_string();
+                func_type_params_name_list.push(type_name);
+            }
+
+            if func_type_params_name_list.is_empty() {
+                self.env
+                    .error(&fun.get_loc(), "Function do not has type parameter.");
+            }
+
+            let attributes = fun.get_attributes();
+
+            for attr in attributes {
+                if let Attribute::Apply(_, _, types) = attr {
+                    if types.is_empty() {
+                        self.env.error(
+                            &fun.get_loc(),
+                            "A type name is needed for private generics.",
+                        );
+                    }
+
+                    let mut attribute_type_index = vec![];
+                    let mut attribute_type_names = vec![];
+                    for (idx, type_name) in func_type_params_name_list.iter().enumerate() {
+                        let _ = types
+                            .iter()
+                            .map(|attr| {
+                                if let Attribute::Apply(_, name, _) = attr {
+                                    let attribute_type_name =
+                                        self.env.symbol_pool().string(*name).as_str().to_string();
+
+                                    if attribute_type_name == type_name.as_str() {
+                                        attribute_type_index.push(idx);
+                                        attribute_type_names.push(attribute_type_name);
+                                    }
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                    }
+
+                    let _ = types
+                        .iter()
+                        .map(|attr| {
+                            if let Attribute::Apply(_, name, _) = attr {
+                                let attribute_type_name =
+                                    self.env.symbol_pool().string(*name).as_str().to_string();
+                                if !attribute_type_names.contains(&attribute_type_name) {
+                                    let func_name = self
+                                        .env
+                                        .symbol_pool()
+                                        .string(fun.get_name())
+                                        .as_str()
+                                        .to_string();
+
+                                    self.env.error(
+                                        &fun.get_loc(),
+                                        format!(
+                                            "type name {:?} not defined in function {:?}",
+                                            attribute_type_name, func_name
+                                        )
+                                        .as_str(),
+                                    );
+                                }
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    type_name_indices.insert(
+                        self.env
+                            .symbol_pool()
+                            .string(fun.get_name())
+                            .as_str()
+                            .to_string(),
+                        attribute_type_index.clone(),
+                    );
+                }
+            }
+        }
+
+        let module = module.get_verified_module();
+        let view = BinaryIndexedView::Module(module);
+
+        // Inspect the bytecode of every function, and if an instruction is CallGeneric,
+        // verify that it calls a function with the private_generics attribute as detected earlier.
+        // Then, ensure that the generic parameters of the CallGeneric instruction are valid.
+        for func_def in &module.function_defs {
+            let code = match func_def.code.clone() {
+                None => continue,
+                Some(code) => code,
+            };
+
+            for instr in code.code {
+                if let Bytecode::CallGeneric(finst_idx) = instr {
+                    let FunctionInstantiation {
+                        handle,
+                        type_parameters,
+                    } = view.function_instantiation_at(finst_idx);
+
+                    let fhandle = view.function_handle_at(*handle);
+                    let func_name = view.identifier_at(fhandle.name).to_string();
+
+                    let type_arguments = &view.signature_at(*type_parameters).0;
+                    let private_generics_types = type_name_indices.get(func_name.as_str());
+
+                    if let Some(private_generics_types_indices) = private_generics_types {
+                        for generic_type_index in private_generics_types_indices {
+                            let type_arg = type_arguments.get(*generic_type_index).unwrap();
+                            let (defined_in_current_module, struct_name) =
+                                is_defined_in_current_module(&view, type_arg);
+
+                            if !defined_in_current_module {
+                                panic!(
+                                    "{}",
+                                    format!(
+                                        "resource struct {:?} not defined in current module",
+                                        struct_name
+                                    )
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        for (private_generics_func_name, types_list) in type_name_indices {
+            let type_params_idicies = self
+                .output
+                .entry(module.self_id().clone())
+                .or_default()
+                .private_generics_indices
+                .entry(private_generics_func_name)
+                .or_default();
+
+            let _ = types_list
+                .iter()
+                .map(|index| type_params_idicies.push(*index))
+                .collect::<Vec<_>>();
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------
+// Helpers
+
+impl<'a> ExtendedChecker<'a> {
+    fn has_attribute(&self, fun: &FunctionEnv, attr_name: &str) -> bool {
+        fun.get_attributes().iter().any(|attr| {
+            if let Attribute::Apply(_, name, _) = attr {
+                self.env.symbol_pool().string(*name).as_str() == attr_name
+            } else {
+                false
+            }
+        })
+    }
+}
+
+fn is_defined_in_current_module(
+    view: &BinaryIndexedView,
+    type_arg: &SignatureToken,
+) -> (bool, String) {
+    match type_arg {
+        SignatureToken::Struct(idx) | SignatureToken::StructInstantiation(idx, _) => {
+            let shandle = view.struct_handle_at(*idx);
+            (
+                view.self_handle_idx() == Some(shandle.module),
+                view.identifier_at(shandle.name).to_string(),
+            )
+        }
+        SignatureToken::TypeParameter(_)
+        | SignatureToken::Bool
+        | SignatureToken::U8
+        | SignatureToken::U16
+        | SignatureToken::U32
+        | SignatureToken::U64
+        | SignatureToken::U128
+        | SignatureToken::U256
+        | SignatureToken::Address
+        | SignatureToken::Vector(_)
+        | SignatureToken::Signer
+        | SignatureToken::Reference(_)
+        | SignatureToken::MutableReference(_) => (false, "".to_string()),
+    }
+}

--- a/crates/rooch/src/extended_checks/mod.rs
+++ b/crates/rooch/src/extended_checks/mod.rs
@@ -1,0 +1,2 @@
+pub mod build;
+pub mod metadata;

--- a/crates/rooch/src/lib.rs
+++ b/crates/rooch/src/lib.rs
@@ -13,6 +13,7 @@ use commands::init::Init;
 use rooch_types::cli::{CliResult, CommandAction};
 
 pub mod commands;
+pub mod extended_checks;
 
 #[derive(clap::Parser)]
 #[clap(author, version, about, long_about = None)]

--- a/examples/private_generics/Move.toml
+++ b/examples/private_generics/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "private_generics"
+version = "0.0.1"
+
+[dependencies]
+#MoveosStdLib = { git = "https://github.com/rooch-network/rooch.git", subdir = "moveos/moveos-stdlib/moveos-stdlib", rev = "main" }
+
+[addresses]
+rooch_examples = "0x123"
+moveos_std =  "0x1"
+rooch_framework =  "0x1"

--- a/examples/private_generics/sources/private_generics.move
+++ b/examples/private_generics/sources/private_generics.move
@@ -1,0 +1,24 @@
+module rooch_examples::Data {
+    struct Box<T: store> has key, store, drop {
+        value: T
+    }
+
+    struct Data has key, store, drop, copy {
+        v: u64,
+    }
+
+    #[private_generics(T3, T2)]
+    public fun create_box<T1: store, T2, T3>(value: T1): Box<T1> {
+        Box<T1> { value: value }
+    }
+
+    public fun box_value<T: copy+store>(box: &Box<T>): T {
+        *&box.value
+    }
+
+    public fun run() {
+        let data = Data{ v: 123 };
+        let box_val = create_box<Data, Data, Box<u32>>(data);
+        let _ = box_value(&box_val);
+    }
+}


### PR DESCRIPTION
According to the content of this issue, https://github.com/move-language/move/issues/1043, the `#[private_generics(T1, T2)]` function attribute feature has been implemented in the Rooch project, which checks that `T1` and `T2` are defined as types in the current module.

resolve #64 

Here is an example code:

```move
module rooch_examples::Data {
    struct Box<T: store> has key, store, drop {
        value: T
    }

    struct Data1 has key, store, drop, copy {
        v: u64,
    }

    struct Data2 has key, store, drop, copy {
        v: u64,
    }

    #[private_generics(T3, T2)]
    public fun create_box<T1: store, T2, T3>(value: T1): Box<T1> {
        Box<T1> { value: value }
    }

    public fun box_value<T: copy+store>(box: &Box<T>): T {
        *&box.value
    }

    public fun run() {
        let data = Data1{ v: 123 };
        let box_val = create_box<Data1, Data2, Box<u32>>(data);
        let _ = box_value(&box_val);
    }
}
```

In the above code, we are checking the following items:

- `private_generics` needs to define at least one type `T` and cannot be empty.
- `T2` and `T3` in `#[private_generics(T3, T2)]` must exist in the generic parameters of the `create_box` function.
- When calling the function `create_box<Data1, Data2, Box<u32>>(data)`, according to the attribute `#[private_generics(T3, T2)]` checks that `Data2` and `Box<u32>` must be defined as types in the current module.

There is still have unfinished issue that will be completed at a later time:

- entry function verifier https://github.com/rooch-network/rooch/issues/152
- initial function of a module