### PR TITLE
Add the type_info.spec.move file to solve the problem of the missing spec_is_struct function.

### DIFF
--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_info.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_info.move
@@ -118,7 +118,7 @@ module moveos_std::type_info {
         let module_name = module_name(&type_info);
         let struct_name = struct_name(&type_info);
         spec {
-            assert account_address == @aptos_std;
+            assert account_address == @moveos_std;
             assert module_name == b"type_info";
             assert struct_name == b"TypeInfo";
         };

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_info.spec.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_info.spec.move
@@ -1,0 +1,16 @@
+spec moveos_std::type_info {
+
+    spec native fun spec_is_struct<T>(): bool;
+
+    spec type_of<T>(): TypeInfo {
+        // Move Prover natively supports this function.
+        // This function will abort if `T` is not a struct type.
+    }
+
+    spec type_name<T>(): string::String {
+        // Move Prover natively supports this function.
+    }
+
+    // The chain ID is modeled as an uninterpreted function.
+    spec fun spec_chain_id_internal(): u8;
+}


### PR DESCRIPTION
In issue https://github.com/rooch-network/rooch/issues/181, the reported problem is: `error: no function named spec_is_struct found`.

Because in Rooch's code, the function `build_config.compile_package_no_exit(&package_path, &mut stderr())` is used to compile the Move Package, while the code of moveos_verifier uses `build_model(package_path.as_path(), additional_named_address, None)`. The difference between these two functions is that the first one does not compile code in `spec`, while the second one does, so the `spec` code will report that the function cannot be found.

So I added a new file named `type_info.spec.move`, and its contents are as follows:

```move
spec moveos_std::type_info {

    spec native fun spec_is_struct<T>(): bool;

    spec type_of<T>(): TypeInfo {
        // Move Prover natively supports this function.
        // This function will abort if `T` is not a struct type.
    }

    spec type_name<T>(): string::String {
        // Move Prover natively supports this function.
    }

    // The chain ID is modeled as an uninterpreted function.
    spec fun spec_chain_id_internal(): u8;
}
```

The problem of `no function named spec_is_struct found` mentioned earlier no longer occurs.

However, there is still content like `@aptos_std` in the `type_info.move` file, so I changed it to `@moveos_std` to avoid address not found errors, as mentioned in this issue: https://github.com/rooch-network/rooch/issues/167.
