### PR TITLE
[rooch-server] mock eth compatible rpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ eyre = "0.6.8"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c27e87fb539c88b6fe1eac7dd82561254bb1e07a" }
 futures = "0.3"
 hex = "0.4.3"
+rustc-hex = "1.0"
 itertools = "0.10.3"
 jsonrpsee = { version = "0.16", features = ["full"] }
 jpst = "0.1.1"

--- a/crates/rooch-server/Cargo.toml
+++ b/crates/rooch-server/Cargo.toml
@@ -12,7 +12,6 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-rand = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }

--- a/crates/rooch-server/Cargo.toml
+++ b/crates/rooch-server/Cargo.toml
@@ -12,6 +12,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+rand = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }

--- a/crates/rooch-server/Cargo.toml
+++ b/crates/rooch-server/Cargo.toml
@@ -22,6 +22,7 @@ derive_builder = { workspace = true }
 ethers = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+rustc-hex = { workspace = true }
 jsonrpsee = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/rooch-server/src/api/eth_api.rs
+++ b/crates/rooch-server/src/api/eth_api.rs
@@ -1,14 +1,13 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use ethers::types::{Bytes, TransactionRequest, BlockNumber, Block, TxHash, Transaction, H160, U256};
-use crate::jsonrpc_types::eth::CallRequest;
-use jsonrpsee::core::RpcResult;
-use jsonrpsee::proc_macros::rpc;
 use rooch_types::H256;
 use std::string::String;
 use serde::{Deserialize, Serialize};
-
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
+use ethers::types::{Bytes, TransactionRequest, BlockNumber, Block, TxHash, Transaction, H160, U256};
+use crate::jsonrpc_types::eth::{CallRequest, EthFeeHistory};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub enum TransactionType {
@@ -26,7 +25,6 @@ impl Default for TransactionType {
 #[rpc(server, client)]
 pub trait EthAPI {
     
-
     /// Returns the network version.
     #[method(name = "net_version")]
     async fn net_version(&self) -> RpcResult<String>;
@@ -50,6 +48,21 @@ pub trait EthAPI {
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
     #[method(name = "eth_estimateGas")]
     async fn estimate_gas(&self, request: CallRequest, num: Option<BlockNumber>) -> RpcResult<U256>;
+
+    /// Transaction fee history
+    #[method(name = "eth_feeHistory")]
+    async fn fee_history(&self, 
+        block_count: U256,
+        newest_block: BlockNumber,
+        reward_percentiles: Option<Vec<f64>>,) -> RpcResult<EthFeeHistory>;
+
+    /// Returns the current price per gas in wei.
+    #[method(name = "eth_gasPrice")]
+    async fn gas_price(&self) -> RpcResult<U256>;
+        
+    /// Returns the number of transactions sent from an address.
+    #[method(name = "eth_getTransactionCount")]
+    async fn transaction_count(&self, address: H160, num: Option<BlockNumber>) -> RpcResult<U256>;
 
     /// Sends transaction; will block waiting for signer to return the
     /// transaction hash.

--- a/crates/rooch-server/src/api/eth_api.rs
+++ b/crates/rooch-server/src/api/eth_api.rs
@@ -1,13 +1,15 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use rooch_types::H256;
-use std::string::String;
-use serde::{Deserialize, Serialize};
+use crate::jsonrpc_types::eth::{CallRequest, EthFeeHistory};
+use ethers::types::{
+    Block, BlockNumber, Bytes, Transaction, TransactionRequest, TxHash, H160, U256,
+};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
-use ethers::types::{Bytes, TransactionRequest, BlockNumber, Block, TxHash, Transaction, H160, U256};
-use crate::jsonrpc_types::eth::{CallRequest, EthFeeHistory};
+use rooch_types::H256;
+use serde::{Deserialize, Serialize};
+use std::string::String;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub enum TransactionType {
@@ -24,7 +26,6 @@ impl Default for TransactionType {
 // Define a rpc server api
 #[rpc(server, client)]
 pub trait EthAPI {
-    
     /// Returns the network version.
     #[method(name = "net_version")]
     async fn net_version(&self) -> RpcResult<String>;
@@ -39,7 +40,11 @@ pub trait EthAPI {
 
     /// Returns information about a block by number.
     #[method(name = "eth_getBlockByNumber")]
-    async fn get_block_by_number(&self, num: BlockNumber, include_txs: bool) -> RpcResult<Block<TransactionType>>;
+    async fn get_block_by_number(
+        &self,
+        num: BlockNumber,
+        include_txs: bool,
+    ) -> RpcResult<Block<TransactionType>>;
 
     /// Returns the balance of the account of given address.
     #[method(name = "eth_getBalance")]
@@ -47,19 +52,22 @@ pub trait EthAPI {
 
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
     #[method(name = "eth_estimateGas")]
-    async fn estimate_gas(&self, request: CallRequest, num: Option<BlockNumber>) -> RpcResult<U256>;
+    async fn estimate_gas(&self, request: CallRequest, num: Option<BlockNumber>)
+        -> RpcResult<U256>;
 
     /// Transaction fee history
     #[method(name = "eth_feeHistory")]
-    async fn fee_history(&self, 
+    async fn fee_history(
+        &self,
         block_count: U256,
         newest_block: BlockNumber,
-        reward_percentiles: Option<Vec<f64>>,) -> RpcResult<EthFeeHistory>;
+        reward_percentiles: Option<Vec<f64>>,
+    ) -> RpcResult<EthFeeHistory>;
 
     /// Returns the current price per gas in wei.
     #[method(name = "eth_gasPrice")]
     async fn gas_price(&self) -> RpcResult<U256>;
-        
+
     /// Returns the number of transactions sent from an address.
     #[method(name = "eth_getTransactionCount")]
     async fn transaction_count(&self, address: H160, num: Option<BlockNumber>) -> RpcResult<U256>;

--- a/crates/rooch-server/src/api/eth_api.rs
+++ b/crates/rooch-server/src/api/eth_api.rs
@@ -1,14 +1,40 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use ethers::types::{Bytes, TransactionRequest};
+use ethers::types::{Bytes, TransactionRequest, BlockNumber, Block, TxHash, Transaction};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use rooch_types::H256;
+use std::string::String;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub enum TransactionType {
+    Full(Transaction),
+    Hash(TxHash),
+}
+
+impl Default for TransactionType {
+    fn default() -> Self {
+        TransactionType::Hash(H256::zero())
+    }
+}
 
 // Define a rpc server api
 #[rpc(server, client)]
 pub trait EthAPI {
+    /// Returns the chain ID of the current network.
+    #[method(name = "eth_chainId")]
+    async fn get_chain_id(&self) -> RpcResult<String>;
+
+    /// Returns the number of most recent block.
+    #[method(name = "eth_blockNumber")]
+    async fn get_block_number(&self) -> RpcResult<String>;
+
+    /// Returns information about a block by number.
+    #[method(name = "eth_getBlockByNumber")]
+    async fn get_block_by_number(&self, num: BlockNumber, include_txs: bool) -> RpcResult<Block<TransactionType>>;
+
     /// Sends transaction; will block waiting for signer to return the
     /// transaction hash.
     #[method(name = "eth_sendTransaction")]

--- a/crates/rooch-server/src/api/eth_api.rs
+++ b/crates/rooch-server/src/api/eth_api.rs
@@ -1,12 +1,14 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use ethers::types::{Bytes, TransactionRequest, BlockNumber, Block, TxHash, Transaction};
+use ethers::types::{Bytes, TransactionRequest, BlockNumber, Block, TxHash, Transaction, H160, U256};
+use crate::jsonrpc_types::eth::CallRequest;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use rooch_types::H256;
 use std::string::String;
 use serde::{Deserialize, Serialize};
+
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub enum TransactionType {
@@ -23,6 +25,12 @@ impl Default for TransactionType {
 // Define a rpc server api
 #[rpc(server, client)]
 pub trait EthAPI {
+    
+
+    /// Returns the network version.
+    #[method(name = "net_version")]
+    async fn net_version(&self) -> RpcResult<String>;
+
     /// Returns the chain ID of the current network.
     #[method(name = "eth_chainId")]
     async fn get_chain_id(&self) -> RpcResult<String>;
@@ -34,6 +42,14 @@ pub trait EthAPI {
     /// Returns information about a block by number.
     #[method(name = "eth_getBlockByNumber")]
     async fn get_block_by_number(&self, num: BlockNumber, include_txs: bool) -> RpcResult<Block<TransactionType>>;
+
+    /// Returns the balance of the account of given address.
+    #[method(name = "eth_getBalance")]
+    async fn get_balance(&self, address: H160, num: Option<BlockNumber>) -> RpcResult<U256>;
+
+    /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
+    #[method(name = "eth_estimateGas")]
+    async fn estimate_gas(&self, request: CallRequest, num: Option<BlockNumber>) -> RpcResult<U256>;
 
     /// Sends transaction; will block waiting for signer to return the
     /// transaction hash.

--- a/crates/rooch-server/src/jsonrpc_types/bytes.rs
+++ b/crates/rooch-server/src/jsonrpc_types/bytes.rs
@@ -23,18 +23,6 @@ impl Bytes {
     }
 }
 
-impl From<Vec<u8>> for Bytes {
-    fn from(bytes: Vec<u8>) -> Bytes {
-        Bytes(bytes)
-    }
-}
-
-impl Into<Vec<u8>> for Bytes {
-    fn into(self) -> Vec<u8> {
-        self.0
-    }
-}
-
 impl Serialize for Bytes {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/rooch-server/src/jsonrpc_types/bytes.rs
+++ b/crates/rooch-server/src/jsonrpc_types/bytes.rs
@@ -1,0 +1,122 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use rustc_hex::{FromHex, ToHex};
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::fmt;
+
+/// Wrapper structure around vector of bytes.
+#[derive(Debug, PartialEq, Eq, Default, Hash, Clone)]
+pub struct Bytes(pub Vec<u8>);
+
+impl Bytes {
+    /// Simple constructor.
+    pub fn new(bytes: Vec<u8>) -> Bytes {
+        Bytes(bytes)
+    }
+    /// Convert back to vector
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl From<Vec<u8>> for Bytes {
+    fn from(bytes: Vec<u8>) -> Bytes {
+        Bytes(bytes)
+    }
+}
+
+impl Into<Vec<u8>> for Bytes {
+    fn into(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl Serialize for Bytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serialized = "0x".to_owned();
+        serialized.push_str(self.0.to_hex().as_ref());
+        serializer.serialize_str(serialized.as_ref())
+    }
+}
+
+impl<'a> Deserialize<'a> for Bytes {
+    fn deserialize<D>(deserializer: D) -> Result<Bytes, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_any(BytesVisitor)
+    }
+}
+
+struct BytesVisitor;
+
+impl<'a> Visitor<'a> for BytesVisitor {
+    type Value = Bytes;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a 0x-prefixed, hex-encoded vector of bytes")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if value.len() >= 2 && value.starts_with("0x") && value.len() & 1 == 0 {
+            Ok(Bytes::new(FromHex::from_hex(&value[2..]).map_err(|e| {
+                Error::custom(format!("Invalid hex: {}", e))
+            })?))
+        } else {
+            Err(Error::custom(
+                "Invalid bytes format. Expected a 0x-prefixed hex string with even length",
+            ))
+        }
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_str(value.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustc_hex::FromHex;
+    use serde_json;
+
+    #[test]
+    fn test_bytes_serialize() {
+        let bytes = Bytes("0123456789abcdef".from_hex().unwrap());
+        let serialized = serde_json::to_string(&bytes).unwrap();
+        assert_eq!(serialized, r#""0x0123456789abcdef""#);
+    }
+
+    #[test]
+    fn test_bytes_deserialize() {
+        let bytes0: Result<Bytes, serde_json::Error> = serde_json::from_str(r#""∀∂""#);
+        let bytes1: Result<Bytes, serde_json::Error> = serde_json::from_str(r#""""#);
+        let bytes2: Result<Bytes, serde_json::Error> = serde_json::from_str(r#""0x123""#);
+        let bytes3: Result<Bytes, serde_json::Error> = serde_json::from_str(r#""0xgg""#);
+
+        let bytes4: Bytes = serde_json::from_str(r#""0x""#).unwrap();
+        let bytes5: Bytes = serde_json::from_str(r#""0x12""#).unwrap();
+        let bytes6: Bytes = serde_json::from_str(r#""0x0123""#).unwrap();
+
+        assert!(bytes0.is_err());
+        assert!(bytes1.is_err());
+        assert!(bytes2.is_err());
+        assert!(bytes3.is_err());
+        assert_eq!(bytes4, Bytes(vec![]));
+        assert_eq!(bytes5, Bytes(vec![0x12]));
+        assert_eq!(bytes6, Bytes(vec![0x1, 0x23]));
+    }
+}

--- a/crates/rooch-server/src/jsonrpc_types/eth/call_request.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/call_request.rs
@@ -1,0 +1,41 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use ethers::types::{H160, U256, U64};
+use crate::jsonrpc_types::bytes::Bytes;
+use crate::jsonrpc_types::eth::AccessList;
+use serde::{Deserialize};
+
+/// Call request
+#[derive(Debug, Default, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct CallRequest {
+    /// transaction type. Defaults to legacy type.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub transaction_type: Option<U64>,
+    /// From
+    pub from: Option<H160>,
+    /// To
+    pub to: Option<H160>,
+    /// Gas Price
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_price: Option<U256>,
+    /// Max fee per gas
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_fee_per_gas: Option<U256>,
+    /// Gas
+    pub gas: Option<U256>,
+    /// Value
+    pub value: Option<U256>,
+    /// Data
+    pub data: Option<Bytes>,
+    /// Nonce
+    pub nonce: Option<U256>,
+    /// Access list
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_list: Option<AccessList>,
+    /// Miner bribe
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_priority_fee_per_gas: Option<U256>,
+}

--- a/crates/rooch-server/src/jsonrpc_types/eth/call_request.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/call_request.rs
@@ -1,10 +1,10 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{Serialize, Deserialize};
-use ethers::types::{H160, U256, U64};
 use crate::jsonrpc_types::bytes::Bytes;
 use crate::jsonrpc_types::eth::AccessList;
+use ethers::types::{H160, U256, U64};
+use serde::{Deserialize, Serialize};
 
 /// Call request
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/crates/rooch-server/src/jsonrpc_types/eth/call_request.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/call_request.rs
@@ -1,13 +1,13 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Serialize, Deserialize};
 use ethers::types::{H160, U256, U64};
 use crate::jsonrpc_types::bytes::Bytes;
 use crate::jsonrpc_types::eth::AccessList;
-use serde::{Deserialize};
 
 /// Call request
-#[derive(Debug, Default, PartialEq, Deserialize)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct CallRequest {

--- a/crates/rooch-server/src/jsonrpc_types/eth/fee_history.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/fee_history.rs
@@ -1,0 +1,15 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Serialize, Deserialize};
+use ethers::types::{U256, BlockNumber};
+
+/// Account information.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EthFeeHistory {
+    pub oldest_block: BlockNumber,
+    pub base_fee_per_gas: Vec<U256>,
+    pub gas_used_ratio: Vec<f64>,
+    pub reward: Option<Vec<Vec<U256>>>,
+}

--- a/crates/rooch-server/src/jsonrpc_types/eth/fee_history.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/fee_history.rs
@@ -1,8 +1,8 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{Serialize, Deserialize};
-use ethers::types::{U256, BlockNumber};
+use ethers::types::{BlockNumber, U256};
+use serde::{Deserialize, Serialize};
 
 /// Account information.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/rooch-server/src/jsonrpc_types/eth/mod.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod call_request;
+pub mod transaction_access_list;
+
+pub use self::{
+  transaction_access_list::{AccessList, AccessListItem},
+};

--- a/crates/rooch-server/src/jsonrpc_types/eth/mod.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/mod.rs
@@ -3,7 +3,10 @@
 
 pub mod call_request;
 pub mod transaction_access_list;
+pub mod fee_history;
 
 pub use self::{
   transaction_access_list::{AccessList, AccessListItem},
+  call_request::CallRequest,
+  fee_history::EthFeeHistory
 };

--- a/crates/rooch-server/src/jsonrpc_types/eth/mod.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/mod.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod call_request;
-pub mod transaction_access_list;
 pub mod fee_history;
+pub mod transaction_access_list;
 
 pub use self::{
-  transaction_access_list::{AccessList, AccessListItem},
-  call_request::CallRequest,
-  fee_history::EthFeeHistory
+    call_request::CallRequest,
+    fee_history::EthFeeHistory,
+    transaction_access_list::{AccessList, AccessListItem},
 };

--- a/crates/rooch-server/src/jsonrpc_types/eth/transaction_access_list.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/transaction_access_list.rs
@@ -1,9 +1,9 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use std::vec::Vec;
-use serde::{Deserialize, Serialize};
 use ethers::types::{H160, H256};
+use serde::{Deserialize, Serialize};
+use std::vec::Vec;
 
 pub type AccessList = Vec<AccessListItem>;
 

--- a/crates/rooch-server/src/jsonrpc_types/eth/transaction_access_list.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/transaction_access_list.rs
@@ -1,9 +1,9 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use ethers::types::{H160, H256};
-use serde::{Deserialize, Serialize};
 use std::vec::Vec;
+use serde::{Deserialize, Serialize};
+use ethers::types::{H160, H256};
 
 pub type AccessList = Vec<AccessListItem>;
 

--- a/crates/rooch-server/src/jsonrpc_types/eth/transaction_access_list.rs
+++ b/crates/rooch-server/src/jsonrpc_types/eth/transaction_access_list.rs
@@ -1,0 +1,24 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use ethers::types::{H160, H256};
+use serde::{Deserialize, Serialize};
+use std::vec::Vec;
+
+pub type AccessList = Vec<AccessListItem>;
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccessListItem {
+    address: H160,
+    storage_keys: Vec<H256>,
+}
+
+impl AccessListItem {
+    pub fn new(address: H160, storage_keys: Vec<H256>) -> Self {
+        Self {
+            address,
+            storage_keys,
+        }
+    }
+}

--- a/crates/rooch-server/src/jsonrpc_types/mod.rs
+++ b/crates/rooch-server/src/jsonrpc_types/mod.rs
@@ -6,5 +6,7 @@
 mod str_view;
 mod move_types;
 
+pub mod eth;
+pub mod bytes;
 pub use move_types::*;
 pub use str_view::*;

--- a/crates/rooch-server/src/jsonrpc_types/mod.rs
+++ b/crates/rooch-server/src/jsonrpc_types/mod.rs
@@ -6,7 +6,7 @@
 mod str_view;
 mod move_types;
 
-pub mod eth;
 pub mod bytes;
+pub mod eth;
 pub use move_types::*;
 pub use str_view::*;

--- a/crates/rooch-server/src/server/eth_server.rs
+++ b/crates/rooch-server/src/server/eth_server.rs
@@ -1,20 +1,24 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
+
+use std::iter;
 use std::time::SystemTime;
 use std::str::FromStr;
+use rand::{Rng, SeedableRng};
+use rand::rngs::StdRng;
 use ethers::types::{
     transaction::eip2930::AccessList, Block, BlockNumber, Bytes, OtherFields, Transaction,
     Withdrawal, H160, U256, U64,
 };
 use jsonrpsee::{
-    core::{async_trait, RpcResult},
+    core::{async_trait, RpcResult, Error as JsonRpcError},
     RpcModule,
 };
 use rooch_types::{
     transaction::{ethereum::EthereumTransaction, AbstractTransaction, TypedTransaction},
     H256,
 };
-use crate::jsonrpc_types::eth::CallRequest;
+use crate::jsonrpc_types::eth::{CallRequest, EthFeeHistory};
 use crate::{
     api::{
         eth_api::{EthAPIServer, TransactionType},
@@ -135,11 +139,71 @@ impl EthAPIServer for EthServer {
     
 
     async fn get_balance(&self, _address: H160, _num: Option<BlockNumber>) -> RpcResult<U256> {
-        Ok(U256::from(10_000_000))
+        Ok(U256::from(100) * U256::from(10_u64.pow(18)))
     }
 
     async fn estimate_gas(&self, _request: CallRequest, _num: Option<BlockNumber>) -> RpcResult<U256> {
         Ok(U256::from(10_000_000))
+    }
+
+    async fn fee_history(&self, 
+        block_count: U256,
+        newest_block: BlockNumber,
+        reward_percentiles: Option<Vec<f64>>,) -> RpcResult<EthFeeHistory> {
+        let mut rng = rand::thread_rng();
+
+        let base_fee_per_gas: Vec<U256> = iter::repeat_with(|| {
+            let random_value = rng.gen_range(1..100);
+            U256::from(random_value)
+        })
+        .take(block_count.as_usize())
+        .collect();
+    
+        let gas_used_ratio: Vec<f64> = iter::repeat_with(|| rng.gen_range(0.0..1.0))
+            .take(block_count.as_usize())
+            .collect();
+    
+        let reward = match reward_percentiles {
+            Some(percentiles) => {
+                let rewards: Vec<Vec<U256>> = (0..block_count.as_usize())
+                    .map(|_| {
+                        percentiles
+                            .iter()
+                            .map(|_| {
+                                let random_value = rng.gen_range(1..100);
+                                U256::from(random_value)
+                            })
+                            .collect()
+                    })
+                    .collect();
+                Some(rewards)
+            }
+            None => None,
+        };
+    
+        match newest_block.as_number() {
+            Some(newest_block_num) => {
+                let oldest_block_num = newest_block_num - block_count.low_u64();
+                Ok(EthFeeHistory {
+                    oldest_block: BlockNumber::Number(oldest_block_num.into()),
+                    base_fee_per_gas,
+                    gas_used_ratio,
+                    reward,
+                })
+            }
+            None => {
+                return Err(JsonRpcError::Custom(String::from("newest_block not a number")))
+            }
+        }
+    }
+
+    async fn gas_price(&self) -> RpcResult<U256> {
+        Ok(U256::from(20 * (10_u64.pow(9))))
+    }
+
+    async fn transaction_count(&self, _address: H160, _num: Option<BlockNumber>) -> RpcResult<U256> {
+        let mut rng = StdRng::from_entropy();
+        Ok(U256::from(rng.gen_range(0..10000)))
     }
 
     async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<H256> {

--- a/crates/rooch-server/src/server/eth_server.rs
+++ b/crates/rooch-server/src/server/eth_server.rs
@@ -2,10 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    api::{eth_api::EthAPIServer, RoochRpcModule},
+    api::{
+        eth_api::{EthAPIServer, TransactionType},
+        RoochRpcModule,
+    },
     service::RpcService,
 };
-use ethers::types::Bytes;
+use ethers::types::{
+    Block, BlockNumber, Bytes, OtherFields, Transaction, Withdrawal, transaction::eip2930::AccessList, H160, H256 as EtherH256, U256,
+    U64
+};
+
 use jsonrpsee::{
     core::{async_trait, RpcResult},
     RpcModule,
@@ -27,6 +34,88 @@ impl EthServer {
 
 #[async_trait]
 impl EthAPIServer for EthServer {
+    async fn get_chain_id(&self) -> RpcResult<String> {
+        Ok(format!("0x{:X}", 10001))
+    }
+
+    async fn get_block_number(&self) -> RpcResult<String> {
+        Ok(format!("0x{:X}", 100))
+    }
+
+    async fn get_block_by_number(
+        &self,
+        num: BlockNumber,
+        include_txs: bool,
+    ) -> RpcResult<Block<TransactionType>> {
+        let block_number = num.as_number().unwrap();
+        let parent_hash = EtherH256::zero();
+        let gas_limit = U256::from(10_000_000);
+        let gas_used = U256::from(5_000_000);
+
+        let txs = if include_txs {
+            vec![TransactionType::Full(Transaction {
+                hash: EtherH256::zero(),
+                nonce: U256::zero(),
+                block_hash: Some(H256::zero()),
+                block_number: Some(block_number),
+                transaction_index: Some(U64::from(0)),
+                from: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+                    .parse()
+                    .unwrap(),
+                to: Some(
+                    "0x832daF8DDe81fA5186EF2D04b3099251c508D5A1"
+                        .parse()
+                        .unwrap(),
+                ),
+                value: U256::from(1_000_000),
+                gas_price: Some(U256::from(20_000_000_000u64)),
+                gas: U256::from(21_000),
+                input: vec![].into(),
+                r: U256::zero(),
+                s: U256::zero(),
+                v: U64::zero(),
+                transaction_type: Default::default(),
+                access_list: Some(AccessList::default()),
+                max_priority_fee_per_gas: Default::default(),
+                max_fee_per_gas: Default::default(),
+                chain_id: Some(U256::from(10001)),
+                other: OtherFields::default(),
+            })]
+        } else {
+            vec![TransactionType::Hash(H256::zero())]
+        };
+
+        let block = Block {
+            hash: Some(H256::zero()),
+            parent_hash,
+            uncles_hash: H256::zero(),
+            author: Some(H160::zero()),
+            state_root: H256::zero(),
+            transactions_root: H256::zero(),
+            receipts_root: H256::zero(),
+            number: Some(block_number),
+            gas_used,
+            gas_limit,
+            extra_data: Bytes::default(),
+            logs_bloom: None,
+            timestamp: U256::from(1_620_000_000),
+            difficulty: U256::from(1_000_000),
+            total_difficulty: Some(U256::from(10_000_000)),
+            seal_fields: vec![],
+            uncles: vec![],
+            transactions: txs,
+            size: None,
+            mix_hash: None,
+            nonce: None,
+            base_fee_per_gas: Some(U256::zero()),
+            withdrawals_root: Some(H256::zero()),
+            withdrawals: Some(vec![Withdrawal::default()]),
+            other: OtherFields::default(),
+        };
+
+        Ok(block)
+    }
+
     async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<H256> {
         let tx = TypedTransaction::Ethereum(EthereumTransaction::decode(&bytes)?);
         let hash = tx.hash();

--- a/crates/rooch-server/src/server/eth_server.rs
+++ b/crates/rooch-server/src/server/eth_server.rs
@@ -1,23 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use std::iter;
-use std::time::SystemTime;
-use std::str::FromStr;
-use rand::{Rng, SeedableRng};
-use rand::rngs::StdRng;
-use ethers::types::{
-    transaction::eip2930::AccessList, Block, BlockNumber, Bytes, OtherFields, Transaction,
-    Withdrawal, H160, U256, U64,
-};
-use jsonrpsee::{
-    core::{async_trait, RpcResult, Error as JsonRpcError},
-    RpcModule,
-};
-use rooch_types::{
-    transaction::{ethereum::EthereumTransaction, AbstractTransaction, TypedTransaction},
-    H256,
-};
 use crate::jsonrpc_types::eth::{CallRequest, EthFeeHistory};
 use crate::{
     api::{
@@ -26,6 +9,23 @@ use crate::{
     },
     service::RpcService,
 };
+use ethers::types::{
+    transaction::eip2930::AccessList, Block, BlockNumber, Bytes, OtherFields, Transaction,
+    Withdrawal, H160, U256, U64,
+};
+use jsonrpsee::{
+    core::{async_trait, Error as JsonRpcError, RpcResult},
+    RpcModule,
+};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use rooch_types::{
+    transaction::{ethereum::EthereumTransaction, AbstractTransaction, TypedTransaction},
+    H256,
+};
+use std::iter;
+use std::str::FromStr;
+use std::time::SystemTime;
 
 pub struct EthServer {
     rpc_service: RpcService,
@@ -62,13 +62,17 @@ impl EthAPIServer for EthServer {
         include_txs: bool,
     ) -> RpcResult<Block<TransactionType>> {
         let block_number = num.as_number().unwrap();
-        let parent_hash = "0xe5ece23ec875db0657f964cbc74fa34439eef3ab3dc8664e7f4ae8b5c5c963e1".parse().unwrap();
+        let parent_hash = "0xe5ece23ec875db0657f964cbc74fa34439eef3ab3dc8664e7f4ae8b5c5c963e1"
+            .parse()
+            .unwrap();
         let gas_limit = U256::from_str("0x1c9c380").unwrap();
         let gas_used = U256::from_str("0xf4954d").unwrap();
-    
+
         let txs = if include_txs {
             vec![TransactionType::Full(Transaction {
-                hash: "0x96c133e6ee7966ee28e6a3b4abd38d1feb15bfcb9e3a36257bd4818ad679c26e".parse().unwrap(),
+                hash: "0x96c133e6ee7966ee28e6a3b4abd38d1feb15bfcb9e3a36257bd4818ad679c26e"
+                    .parse()
+                    .unwrap(),
                 nonce: U256::zero(),
                 block_hash: Some(parent_hash),
                 block_number: Some(block_number),
@@ -96,21 +100,44 @@ impl EthAPIServer for EthServer {
                 other: OtherFields::default(),
             })]
         } else {
-            vec![TransactionType::Hash("0x96c133e6ee7966ee28e6a3b4abd38d1feb15bfcb9e3a36257bd4818ad679c26e".parse().unwrap())]
+            vec![TransactionType::Hash(
+                "0x96c133e6ee7966ee28e6a3b4abd38d1feb15bfcb9e3a36257bd4818ad679c26e"
+                    .parse()
+                    .unwrap(),
+            )]
         };
-    
+
         let block = Block {
-            hash: Some("0xa4161cc321054df6e370776f19a958950ce4237fca4aff57605efdcdd3b802f4".parse().unwrap()),
+            hash: Some(
+                "0xa4161cc321054df6e370776f19a958950ce4237fca4aff57605efdcdd3b802f4"
+                    .parse()
+                    .unwrap(),
+            ),
             parent_hash,
-            uncles_hash: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347".parse().unwrap(),
-            author: Some("0xbaf6dc2e647aeb6f510f9e318856a1bcd66c5e19".parse().unwrap()),
-            state_root: "0xde1cdf9816313c105a75eaaedab04815b1b7aa5650bf91b69749d71a36497243".parse().unwrap(),
-            transactions_root: "0xdc8c2a8825fbbe669360d351e34f3ad09d320db83539c98e92bb18ea5fa93773".parse().unwrap(),
-            receipts_root: "0x31814320e99d27d63448b25b122870e70427d8261bbaa3674e96dd686bcb507a".parse().unwrap(),
+            uncles_hash: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                .parse()
+                .unwrap(),
+            author: Some(
+                "0xbaf6dc2e647aeb6f510f9e318856a1bcd66c5e19"
+                    .parse()
+                    .unwrap(),
+            ),
+            state_root: "0xde1cdf9816313c105a75eaaedab04815b1b7aa5650bf91b69749d71a36497243"
+                .parse()
+                .unwrap(),
+            transactions_root: "0xdc8c2a8825fbbe669360d351e34f3ad09d320db83539c98e92bb18ea5fa93773"
+                .parse()
+                .unwrap(),
+            receipts_root: "0x31814320e99d27d63448b25b122870e70427d8261bbaa3674e96dd686bcb507a"
+                .parse()
+                .unwrap(),
             number: Some(block_number),
             gas_used,
             gas_limit,
-            extra_data: Bytes::from_str("0x4d616465206f6e20746865206d6f6f6e20627920426c6f636b6e6174697665").unwrap(),
+            extra_data: Bytes::from_str(
+                "0x4d616465206f6e20746865206d6f6f6e20627920426c6f636b6e6174697665",
+            )
+            .unwrap(),
             logs_bloom: None,
             timestamp: U256::from_str("0x64731653").unwrap(),
             difficulty: U256::zero(),
@@ -122,34 +149,43 @@ impl EthAPIServer for EthServer {
             mix_hash: None,
             nonce: None,
             base_fee_per_gas: Some(U256::from_str("0x52e0ce91c").unwrap()),
-            withdrawals_root: Some("0xdc8c2a8825fbbe669360d351e34f3ad09d320db83539c98e92bb18ea5fa93773".parse().unwrap()),
-            withdrawals: Some(vec![
-                Withdrawal {
-                    address: "0xb9d7934878b5fb9610b3fe8a5e441e8fad7e293f".parse().unwrap(),
-                    amount: U256::from_str("0xc7a3fa").unwrap(),
-                    index: U64::from_str("0x4e81dc").unwrap(),
-                    validator_index: U64::from_str("0x5be41").unwrap(),
-                },
-            ]),
+            withdrawals_root: Some(
+                "0xdc8c2a8825fbbe669360d351e34f3ad09d320db83539c98e92bb18ea5fa93773"
+                    .parse()
+                    .unwrap(),
+            ),
+            withdrawals: Some(vec![Withdrawal {
+                address: "0xb9d7934878b5fb9610b3fe8a5e441e8fad7e293f"
+                    .parse()
+                    .unwrap(),
+                amount: U256::from_str("0xc7a3fa").unwrap(),
+                index: U64::from_str("0x4e81dc").unwrap(),
+                validator_index: U64::from_str("0x5be41").unwrap(),
+            }]),
             other: OtherFields::default(),
         };
-    
+
         Ok(block)
     }
-    
 
     async fn get_balance(&self, _address: H160, _num: Option<BlockNumber>) -> RpcResult<U256> {
         Ok(U256::from(100) * U256::from(10_u64.pow(18)))
     }
 
-    async fn estimate_gas(&self, _request: CallRequest, _num: Option<BlockNumber>) -> RpcResult<U256> {
+    async fn estimate_gas(
+        &self,
+        _request: CallRequest,
+        _num: Option<BlockNumber>,
+    ) -> RpcResult<U256> {
         Ok(U256::from(10_000_000))
     }
 
-    async fn fee_history(&self, 
+    async fn fee_history(
+        &self,
         block_count: U256,
         newest_block: BlockNumber,
-        reward_percentiles: Option<Vec<f64>>,) -> RpcResult<EthFeeHistory> {
+        reward_percentiles: Option<Vec<f64>>,
+    ) -> RpcResult<EthFeeHistory> {
         let mut rng = rand::thread_rng();
 
         let base_fee_per_gas: Vec<U256> = iter::repeat_with(|| {
@@ -158,11 +194,11 @@ impl EthAPIServer for EthServer {
         })
         .take(block_count.as_usize())
         .collect();
-    
+
         let gas_used_ratio: Vec<f64> = iter::repeat_with(|| rng.gen_range(0.0..1.0))
             .take(block_count.as_usize())
             .collect();
-    
+
         let reward = match reward_percentiles {
             Some(percentiles) => {
                 let rewards: Vec<Vec<U256>> = (0..block_count.as_usize())
@@ -180,19 +216,21 @@ impl EthAPIServer for EthServer {
             }
             None => None,
         };
-    
+
         match newest_block.as_number() {
             Some(newest_block_num) => {
                 let oldest_block_num = newest_block_num - block_count.low_u64();
                 Ok(EthFeeHistory {
-                    oldest_block: BlockNumber::Number(oldest_block_num.into()),
+                    oldest_block: BlockNumber::Number(oldest_block_num),
                     base_fee_per_gas,
                     gas_used_ratio,
                     reward,
                 })
             }
             None => {
-                return Err(JsonRpcError::Custom(String::from("newest_block not a number")))
+                return Err(JsonRpcError::Custom(String::from(
+                    "newest_block not a number",
+                )))
             }
         }
     }
@@ -201,7 +239,11 @@ impl EthAPIServer for EthServer {
         Ok(U256::from(20 * (10_u64.pow(9))))
     }
 
-    async fn transaction_count(&self, _address: H160, _num: Option<BlockNumber>) -> RpcResult<U256> {
+    async fn transaction_count(
+        &self,
+        _address: H160,
+        _num: Option<BlockNumber>,
+    ) -> RpcResult<U256> {
         let mut rng = StdRng::from_entropy();
         Ok(U256::from(rng.gen_range(0..10000)))
     }

--- a/crates/rooch-server/src/server/eth_server.rs
+++ b/crates/rooch-server/src/server/eth_server.rs
@@ -1,18 +1,11 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
-
-use crate::{
-    api::{
-        eth_api::{EthAPIServer, TransactionType},
-        RoochRpcModule,
-    },
-    service::RpcService,
-};
+use std::time::SystemTime;
+use std::str::FromStr;
 use ethers::types::{
-    Block, BlockNumber, Bytes, OtherFields, Transaction, Withdrawal, transaction::eip2930::AccessList, H160, H256 as EtherH256, U256,
-    U64
+    transaction::eip2930::AccessList, Block, BlockNumber, Bytes, OtherFields, Transaction,
+    Withdrawal, H160, U256, U64,
 };
-
 use jsonrpsee::{
     core::{async_trait, RpcResult},
     RpcModule,
@@ -20,6 +13,14 @@ use jsonrpsee::{
 use rooch_types::{
     transaction::{ethereum::EthereumTransaction, AbstractTransaction, TypedTransaction},
     H256,
+};
+use crate::jsonrpc_types::eth::CallRequest;
+use crate::{
+    api::{
+        eth_api::{EthAPIServer, TransactionType},
+        RoochRpcModule,
+    },
+    service::RpcService,
 };
 
 pub struct EthServer {
@@ -34,12 +35,21 @@ impl EthServer {
 
 #[async_trait]
 impl EthAPIServer for EthServer {
+    async fn net_version(&self) -> RpcResult<String> {
+        Ok(String::from("1"))
+    }
+
     async fn get_chain_id(&self) -> RpcResult<String> {
         Ok(format!("0x{:X}", 10001))
     }
 
     async fn get_block_number(&self) -> RpcResult<String> {
-        Ok(format!("0x{:X}", 100))
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards");
+
+        let block_number = now.as_secs();
+        Ok(format!("0x{:X}", block_number))
     }
 
     async fn get_block_by_number(
@@ -48,15 +58,15 @@ impl EthAPIServer for EthServer {
         include_txs: bool,
     ) -> RpcResult<Block<TransactionType>> {
         let block_number = num.as_number().unwrap();
-        let parent_hash = EtherH256::zero();
-        let gas_limit = U256::from(10_000_000);
-        let gas_used = U256::from(5_000_000);
-
+        let parent_hash = "0xe5ece23ec875db0657f964cbc74fa34439eef3ab3dc8664e7f4ae8b5c5c963e1".parse().unwrap();
+        let gas_limit = U256::from_str("0x1c9c380").unwrap();
+        let gas_used = U256::from_str("0xf4954d").unwrap();
+    
         let txs = if include_txs {
             vec![TransactionType::Full(Transaction {
-                hash: EtherH256::zero(),
+                hash: "0x96c133e6ee7966ee28e6a3b4abd38d1feb15bfcb9e3a36257bd4818ad679c26e".parse().unwrap(),
                 nonce: U256::zero(),
-                block_hash: Some(H256::zero()),
+                block_hash: Some(parent_hash),
                 block_number: Some(block_number),
                 transaction_index: Some(U64::from(0)),
                 from: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
@@ -73,7 +83,7 @@ impl EthAPIServer for EthServer {
                 input: vec![].into(),
                 r: U256::zero(),
                 s: U256::zero(),
-                v: U64::zero(),
+                v: U64::one(),
                 transaction_type: Default::default(),
                 access_list: Some(AccessList::default()),
                 max_priority_fee_per_gas: Default::default(),
@@ -82,38 +92,54 @@ impl EthAPIServer for EthServer {
                 other: OtherFields::default(),
             })]
         } else {
-            vec![TransactionType::Hash(H256::zero())]
+            vec![TransactionType::Hash("0x96c133e6ee7966ee28e6a3b4abd38d1feb15bfcb9e3a36257bd4818ad679c26e".parse().unwrap())]
         };
-
+    
         let block = Block {
-            hash: Some(H256::zero()),
+            hash: Some("0xa4161cc321054df6e370776f19a958950ce4237fca4aff57605efdcdd3b802f4".parse().unwrap()),
             parent_hash,
-            uncles_hash: H256::zero(),
-            author: Some(H160::zero()),
-            state_root: H256::zero(),
-            transactions_root: H256::zero(),
-            receipts_root: H256::zero(),
+            uncles_hash: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347".parse().unwrap(),
+            author: Some("0xbaf6dc2e647aeb6f510f9e318856a1bcd66c5e19".parse().unwrap()),
+            state_root: "0xde1cdf9816313c105a75eaaedab04815b1b7aa5650bf91b69749d71a36497243".parse().unwrap(),
+            transactions_root: "0xdc8c2a8825fbbe669360d351e34f3ad09d320db83539c98e92bb18ea5fa93773".parse().unwrap(),
+            receipts_root: "0x31814320e99d27d63448b25b122870e70427d8261bbaa3674e96dd686bcb507a".parse().unwrap(),
             number: Some(block_number),
             gas_used,
             gas_limit,
-            extra_data: Bytes::default(),
+            extra_data: Bytes::from_str("0x4d616465206f6e20746865206d6f6f6e20627920426c6f636b6e6174697665").unwrap(),
             logs_bloom: None,
-            timestamp: U256::from(1_620_000_000),
-            difficulty: U256::from(1_000_000),
-            total_difficulty: Some(U256::from(10_000_000)),
+            timestamp: U256::from_str("0x64731653").unwrap(),
+            difficulty: U256::zero(),
+            total_difficulty: Some(U256::from_str("0xc70d815d562d3cfa955").unwrap()),
             seal_fields: vec![],
             uncles: vec![],
             transactions: txs,
             size: None,
             mix_hash: None,
             nonce: None,
-            base_fee_per_gas: Some(U256::zero()),
-            withdrawals_root: Some(H256::zero()),
-            withdrawals: Some(vec![Withdrawal::default()]),
+            base_fee_per_gas: Some(U256::from_str("0x52e0ce91c").unwrap()),
+            withdrawals_root: Some("0xdc8c2a8825fbbe669360d351e34f3ad09d320db83539c98e92bb18ea5fa93773".parse().unwrap()),
+            withdrawals: Some(vec![
+                Withdrawal {
+                    address: "0xb9d7934878b5fb9610b3fe8a5e441e8fad7e293f".parse().unwrap(),
+                    amount: U256::from_str("0xc7a3fa").unwrap(),
+                    index: U64::from_str("0x4e81dc").unwrap(),
+                    validator_index: U64::from_str("0x5be41").unwrap(),
+                },
+            ]),
             other: OtherFields::default(),
         };
-
+    
         Ok(block)
+    }
+    
+
+    async fn get_balance(&self, _address: H160, _num: Option<BlockNumber>) -> RpcResult<U256> {
+        Ok(U256::from(10_000_000))
+    }
+
+    async fn estimate_gas(&self, _request: CallRequest, _num: Option<BlockNumber>) -> RpcResult<U256> {
+        Ok(U256::from(10_000_000))
     }
 
     async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<H256> {


### PR DESCRIPTION
I have mocked some APIs required by MetaMask, now we can configure the rooch server RPC address to MetaMask and initiate transactions.

Ref https://github.com/rooch-network/rooch/issues/108