### PR TITLE
[rpc] AccessPath and State API

### DIFF
--- a/crates/rooch-client/src/lib.rs
+++ b/crates/rooch-client/src/lib.rs
@@ -9,12 +9,12 @@ use clap::Parser;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
 use moveos::moveos::TransactionOutput;
-use moveos_types::{object::ObjectID, transaction::FunctionCall};
+use moveos_types::{access_path::AccessPath, object::ObjectID, transaction::FunctionCall};
 use rand::Rng;
 use rooch_common::config::{rooch_config_path, PersistedConfig, RoochConfig};
 use rooch_server::{
     api::rooch_api::RoochAPIClient,
-    jsonrpc_types::{AnnotatedMoveStructView, AnnotatedObjectView},
+    jsonrpc_types::{AnnotatedMoveStructView, AnnotatedObjectView, AnnotatedStateView, StateView},
 };
 use rooch_types::{address::RoochAddress, transaction::rooch::RoochTransaction};
 
@@ -83,6 +83,17 @@ impl Client {
 
     pub async fn get_object(&self, object_id: ObjectID) -> Result<Option<AnnotatedObjectView>> {
         Ok(self.get_client()?.get_object(object_id).await?)
+    }
+
+    pub async fn get_states(&self, access_path: AccessPath) -> Result<Vec<Option<StateView>>> {
+        Ok(self.get_client()?.get_states(access_path).await?)
+    }
+
+    pub async fn get_annotated_states(
+        &self,
+        access_path: AccessPath,
+    ) -> Result<Vec<Option<AnnotatedStateView>>> {
+        Ok(self.get_client()?.get_annotated_states(access_path).await?)
     }
 
     pub async fn get_sequence_number(&self, _sender: RoochAddress) -> Result<u64> {

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -8,7 +8,9 @@ use move_core_types::{
 };
 use move_resource_viewer::AnnotatedMoveStruct;
 use moveos::moveos::TransactionOutput;
+use moveos_types::access_path::AccessPath;
 use moveos_types::event_filter::{EventFilter, MoveOSEvent};
+use moveos_types::state::{AnnotatedState, State};
 use moveos_types::{
     object::{AnnotatedObject, ObjectID},
     transaction::{AuthenticatableTransaction, FunctionCall, MoveOSTransaction},
@@ -68,6 +70,24 @@ pub struct ObjectMessage {
 
 impl Message for ObjectMessage {
     type Result = Result<Option<AnnotatedObject>>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatesMessage {
+    pub access_path: AccessPath,
+}
+
+impl Message for StatesMessage {
+    type Result = Result<Vec<Option<State>>>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AnnotatedStatesMessage {
+    pub access_path: AccessPath,
+}
+
+impl Message for AnnotatedStatesMessage {
+    type Result = Result<Vec<Option<AnnotatedState>>>;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -4,8 +4,9 @@
 use crate::actor::{
     executor::ExecutorActor,
     messages::{
-        ExecuteViewFunctionMessage, GetEventsByTxHashMessage, GetEventsMessage, GetResourceMessage,
-        ObjectMessage, ValidateTransactionMessage,
+        AnnotatedStatesMessage, ExecuteViewFunctionMessage, GetEventsByTxHashMessage,
+        GetEventsMessage, GetResourceMessage, ObjectMessage, StatesMessage,
+        ValidateTransactionMessage,
     },
 };
 use anyhow::Result;
@@ -15,7 +16,11 @@ use move_core_types::{
 };
 use move_resource_viewer::AnnotatedMoveStruct;
 use moveos::moveos::TransactionOutput;
-use moveos_types::event_filter::{EventFilter, MoveOSEvent};
+use moveos_types::access_path::AccessPath;
+use moveos_types::{
+    event_filter::{EventFilter, MoveOSEvent},
+    state::{AnnotatedState, State},
+};
 use moveos_types::{
     object::{AnnotatedObject, ObjectID},
     transaction::{AuthenticatableTransaction, FunctionCall, MoveOSTransaction},
@@ -70,6 +75,19 @@ impl ExecutorProxy {
 
     pub async fn get_object(&self, object_id: ObjectID) -> Result<Option<AnnotatedObject>> {
         self.actor.send(ObjectMessage { object_id }).await?
+    }
+
+    pub async fn get_states(&self, access_path: AccessPath) -> Result<Vec<Option<State>>> {
+        self.actor.send(StatesMessage { access_path }).await?
+    }
+
+    pub async fn get_annotated_states(
+        &self,
+        access_path: AccessPath,
+    ) -> Result<Vec<Option<AnnotatedState>>> {
+        self.actor
+            .send(AnnotatedStatesMessage { access_path })
+            .await?
     }
 
     pub async fn get_events_by_tx_hash(&self, tx_hash: H256) -> Result<Option<Vec<MoveOSEvent>>> {

--- a/crates/rooch-integration-test-runner/src/lib.rs
+++ b/crates/rooch-integration-test-runner/src/lib.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use move_command_line_common::files::verify_and_create_named_address_mapping;
 use move_command_line_common::{address::ParsedAddress, values::ParsableValue};
 use move_compiler::FullyCompiledProgram;
-use move_resource_viewer::MoveValueAnnotator;
 use move_transactional_test_runner::{
     framework::{CompiledState, MoveTestAdapter},
     tasks::{InitCommand, SyntaxChoice, TaskInput},
@@ -13,6 +12,7 @@ use move_transactional_test_runner::{
 };
 use move_vm_runtime::session::SerializedReturnValues;
 use moveos::moveos::MoveOS;
+use moveos_store::state_store::state_view::AnnotatedStateReader;
 use moveos_types::move_types::FunctionId;
 use moveos_types::object::ObjectID;
 use moveos_types::transaction::{MoveAction, MoveOSTransaction};
@@ -232,11 +232,8 @@ impl<'a> MoveTestAdapter<'a> for MoveOSTestAdapter<'a> {
         match subcommand.command {
             MoveOSSubcommands::ViewObject { object_id } => {
                 let storage = self.moveos.state();
-                let annotator = MoveValueAnnotator::new(&storage);
                 let object = storage
-                    .get(object_id)?
-                    .map(|state| state.as_annotated_object(&annotator))
-                    .transpose()?
+                    .get_annotated_object(object_id)?
                     .ok_or_else(|| anyhow::anyhow!("Object with id {} not found", object_id))?;
                 //TODO should we bring the AnnotatedObjectView from jsonrpc to test adapter for better json output formatting?
                 Ok(Some(format!("{:?}", object)))

--- a/crates/rooch-server/Cargo.toml
+++ b/crates/rooch-server/Cargo.toml
@@ -38,6 +38,7 @@ rand = { workspace = true }
 
 move-core-types = { workspace = true }
 move-resource-viewer = { workspace = true }
+move-binary-format = { workspace = true }
 
 moveos = { workspace = true }
 moveos-store = { workspace = true }

--- a/crates/rooch-server/src/api/rooch_api.rs
+++ b/crates/rooch-server/src/api/rooch_api.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::{
-    AnnotatedMoveStructView, AnnotatedObjectView, EventView, FunctionCallView, StrView,
-    StructTagView,
+    AnnotatedMoveStructView, AnnotatedObjectView, AnnotatedStateView, EventView, FunctionCallView,
+    StateView, StrView, StructTagView,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use move_core_types::account_address::AccountAddress;
 use moveos::moveos::TransactionOutput;
+use moveos_types::access_path::AccessPath;
 use moveos_types::event_filter::EventFilter;
 use moveos_types::object::ObjectID;
 use rooch_types::H256;
@@ -46,6 +47,19 @@ pub trait RoochAPI {
 
     #[method(name = "rooch_getObject")]
     async fn get_object(&self, object_id: ObjectID) -> RpcResult<Option<AnnotatedObjectView>>;
+
+    //TODO should we merge the `get_resource` and `get_object` to `get_state`?
+    /// Get the states by access_path
+    #[method(name = "rooch_getStates")]
+    async fn get_states(&self, access_path: AccessPath) -> RpcResult<Vec<Option<StateView>>>;
+
+    /// Get the annotated states by access_path
+    /// The annotated states include the decoded move value of the state
+    #[method(name = "rooch_getAnnotatedStates")]
+    async fn get_annotated_states(
+        &self,
+        access_path: AccessPath,
+    ) -> RpcResult<Vec<Option<AnnotatedStateView>>>;
 
     /// Get the events by tx_hash
     #[method(name = "rooch_getEventsByTxHash")]

--- a/crates/rooch-server/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-server/src/jsonrpc_types/move_types.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::StrView;
+use move_binary_format::file_format::AbilitySet;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
@@ -9,9 +10,12 @@ use move_core_types::{
     u256,
 };
 use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
-use moveos_types::event::Event;
 use moveos_types::event_filter::MoveOSEvent;
 use moveos_types::h256::H256;
+use moveos_types::{
+    event::Event,
+    state::{AnnotatedState, State},
+};
 use moveos_types::{
     move_types::FunctionId,
     object::{AnnotatedObject, ObjectID},
@@ -46,9 +50,30 @@ impl From<AnnotatedMoveStruct> for AnnotatedMoveStructView {
     }
 }
 
+impl TryFrom<AnnotatedMoveStructView> for AnnotatedMoveStruct {
+    type Error = anyhow::Error;
+
+    fn try_from(value: AnnotatedMoveStructView) -> Result<Self, Self::Error> {
+        Ok(Self {
+            abilities: AbilitySet::from_u8(value.abilities)
+                .ok_or_else(|| anyhow::anyhow!("invalid abilities:{}", value.abilities))?,
+            type_: value.type_.0,
+            value: value
+                .value
+                .into_iter()
+                .map(|(k, v)| {
+                    Ok::<(Identifier, AnnotatedMoveValue), anyhow::Error>((k, v.try_into()?))
+                })
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum AnnotatedMoveValueView {
     U8(u8),
+    ///u64, u128, U256 is too large to be serialized in json
+    /// so we use string to represent them
     U64(StrView<u64>),
     U128(StrView<u128>),
     Bool(bool),
@@ -56,8 +81,8 @@ pub enum AnnotatedMoveValueView {
     Vector(TypeTagView, Vec<AnnotatedMoveValueView>),
     Bytes(StrView<Vec<u8>>),
     Struct(AnnotatedMoveStructView),
-    U16(StrView<u16>),
-    U32(StrView<u32>),
+    U16(u16),
+    U32(u32),
     U256(StrView<u256::U256>),
 }
 
@@ -75,10 +100,34 @@ impl From<AnnotatedMoveValue> for AnnotatedMoveValueView {
             ),
             AnnotatedMoveValue::Bytes(data) => AnnotatedMoveValueView::Bytes(StrView(data)),
             AnnotatedMoveValue::Struct(data) => AnnotatedMoveValueView::Struct(data.into()),
-            AnnotatedMoveValue::U16(u) => AnnotatedMoveValueView::U16(StrView(u)),
-            AnnotatedMoveValue::U32(u) => AnnotatedMoveValueView::U32(StrView(u)),
+            AnnotatedMoveValue::U16(u) => AnnotatedMoveValueView::U16(u),
+            AnnotatedMoveValue::U32(u) => AnnotatedMoveValueView::U32(u),
             AnnotatedMoveValue::U256(u) => AnnotatedMoveValueView::U256(StrView(u)),
         }
+    }
+}
+
+impl TryFrom<AnnotatedMoveValueView> for AnnotatedMoveValue {
+    type Error = anyhow::Error;
+    fn try_from(value: AnnotatedMoveValueView) -> Result<Self, Self::Error> {
+        Ok(match value {
+            AnnotatedMoveValueView::U8(u8) => AnnotatedMoveValue::U8(u8),
+            AnnotatedMoveValueView::U64(u64) => AnnotatedMoveValue::U64(u64.0),
+            AnnotatedMoveValueView::U128(u128) => AnnotatedMoveValue::U128(u128.0),
+            AnnotatedMoveValueView::Bool(bool) => AnnotatedMoveValue::Bool(bool),
+            AnnotatedMoveValueView::Address(address) => AnnotatedMoveValue::Address(address),
+            AnnotatedMoveValueView::Vector(type_tag, data) => AnnotatedMoveValue::Vector(
+                type_tag.0,
+                data.into_iter()
+                    .map(AnnotatedMoveValue::try_from)
+                    .collect::<Result<Vec<_>, Self::Error>>()?,
+            ),
+            AnnotatedMoveValueView::Bytes(data) => AnnotatedMoveValue::Bytes(data.0),
+            AnnotatedMoveValueView::Struct(data) => AnnotatedMoveValue::Struct(data.try_into()?),
+            AnnotatedMoveValueView::U16(u16) => AnnotatedMoveValue::U16(u16),
+            AnnotatedMoveValueView::U32(u32) => AnnotatedMoveValue::U32(u32),
+            AnnotatedMoveValueView::U256(u256) => AnnotatedMoveValue::U256(u256.0),
+        })
     }
 }
 
@@ -187,5 +236,55 @@ impl EventView {
             event_key: key,
             event_seq_number: sequence_number.into(),
         }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StateView {
+    pub value: StrView<Vec<u8>>,
+    pub value_type: TypeTagView,
+}
+
+impl From<State> for StateView {
+    fn from(state: State) -> Self {
+        Self {
+            value: StrView(state.value),
+            value_type: state.value_type.into(),
+        }
+    }
+}
+
+impl From<StateView> for State {
+    fn from(state: StateView) -> Self {
+        Self {
+            value: state.value.0,
+            value_type: state.value_type.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AnnotatedStateView {
+    pub state: StateView,
+    pub move_value: AnnotatedMoveValueView,
+}
+
+impl From<AnnotatedState> for AnnotatedStateView {
+    fn from(state: AnnotatedState) -> Self {
+        Self {
+            state: state.state.into(),
+            move_value: state.move_value.into(),
+        }
+    }
+}
+
+impl TryFrom<AnnotatedStateView> for AnnotatedState {
+    type Error = anyhow::Error;
+
+    fn try_from(value: AnnotatedStateView) -> Result<Self, Self::Error> {
+        Ok(Self {
+            state: value.state.into(),
+            move_value: value.move_value.try_into()?,
+        })
     }
 }

--- a/crates/rooch-server/src/server/rooch_server.rs
+++ b/crates/rooch-server/src/server/rooch_server.rs
@@ -3,7 +3,8 @@
 
 use crate::api::RoochRpcModule;
 use crate::jsonrpc_types::{
-    AnnotatedMoveStructView, EventView, FunctionCallView, StrView, StructTagView,
+    AnnotatedMoveStructView, AnnotatedStateView, EventView, FunctionCallView, StateView, StrView,
+    StructTagView,
 };
 use crate::service::RpcService;
 use crate::{api::rooch_api::RoochAPIServer, jsonrpc_types::AnnotatedObjectView};
@@ -13,6 +14,7 @@ use jsonrpsee::{
 };
 use move_core_types::account_address::AccountAddress;
 use moveos::moveos::TransactionOutput;
+use moveos_types::access_path::AccessPath;
 use moveos_types::event_filter::EventFilter;
 use moveos_types::{object::ObjectID, transaction::AuthenticatableTransaction};
 use rooch_types::transaction::TypedTransaction;
@@ -74,6 +76,29 @@ impl RoochAPIServer for RoochServer {
 
     async fn get_object(&self, object_id: ObjectID) -> RpcResult<Option<AnnotatedObjectView>> {
         Ok(self.rpc_service.object(object_id).await?.map(Into::into))
+    }
+
+    async fn get_states(&self, access_path: AccessPath) -> RpcResult<Vec<Option<StateView>>> {
+        Ok(self
+            .rpc_service
+            .get_states(access_path)
+            .await?
+            .into_iter()
+            .map(|s| s.map(StateView::from))
+            .collect())
+    }
+
+    async fn get_annotated_states(
+        &self,
+        access_path: AccessPath,
+    ) -> RpcResult<Vec<Option<AnnotatedStateView>>> {
+        Ok(self
+            .rpc_service
+            .get_annotated_states(access_path)
+            .await?
+            .into_iter()
+            .map(|s| s.map(AnnotatedStateView::from))
+            .collect())
     }
 
     async fn get_events_by_tx_hash(&self, tx_hash: H256) -> RpcResult<Option<Vec<EventView>>> {

--- a/crates/rooch-server/src/service/mod.rs
+++ b/crates/rooch-server/src/service/mod.rs
@@ -5,7 +5,9 @@ use anyhow::{bail, Result};
 use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
 use move_resource_viewer::AnnotatedMoveStruct;
 use moveos::moveos::TransactionOutput;
+use moveos_types::access_path::AccessPath;
 use moveos_types::event_filter::{EventFilter, MoveOSEvent};
+use moveos_types::state::{AnnotatedState, State};
 use moveos_types::{
     object::{AnnotatedObject, ObjectID},
     transaction::FunctionCall,
@@ -82,6 +84,17 @@ impl RpcService {
 
     pub async fn object(&self, object_id: ObjectID) -> Result<Option<AnnotatedObject>> {
         self.executor.get_object(object_id).await
+    }
+
+    pub async fn get_states(&self, access_path: AccessPath) -> Result<Vec<Option<State>>> {
+        self.executor.get_states(access_path).await
+    }
+
+    pub async fn get_annotated_states(
+        &self,
+        access_path: AccessPath,
+    ) -> Result<Vec<Option<AnnotatedState>>> {
+        self.executor.get_annotated_states(access_path).await
     }
 
     /// Sign a message with the private key of the given address.

--- a/crates/rooch/src/commands/mod.rs
+++ b/crates/rooch/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod move_cli;
 pub mod object;
 pub mod resource;
 pub mod server;
+pub mod state;

--- a/crates/rooch/src/commands/state.rs
+++ b/crates/rooch/src/commands/state.rs
@@ -1,0 +1,31 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use moveos_types::access_path::AccessPath;
+use rooch_client::Client;
+use rooch_server::jsonrpc_types::AnnotatedStateView;
+use rooch_types::cli::{CliError, CliResult, CommandAction};
+
+/// Get States by AccessPath
+#[derive(clap::Parser)]
+pub struct StateCommand {
+    #[clap(long = "access-path", short = 'a')]
+    pub access_path: AccessPath,
+
+    /// RPC client options.
+    #[clap(flatten)]
+    client: Client,
+}
+
+#[async_trait]
+impl CommandAction<Vec<Option<AnnotatedStateView>>> for StateCommand {
+    async fn execute(self) -> CliResult<Vec<Option<AnnotatedStateView>>> {
+        let resp = self
+            .client
+            .get_annotated_states(self.access_path)
+            .await
+            .map_err(CliError::from)?;
+        Ok(resp)
+    }
+}

--- a/crates/rooch/src/lib.rs
+++ b/crates/rooch/src/lib.rs
@@ -9,7 +9,7 @@ use crate::commands::{
     server::ServerCommand,
 };
 
-use commands::init::Init;
+use commands::{init::Init, state::StateCommand};
 use rooch_types::cli::{CliResult, CommandAction};
 
 pub mod commands;
@@ -30,6 +30,7 @@ pub enum Command {
     Server(ServerCommand),
     Resource(ResourceCommand),
     Object(ObjectCommand),
+    State(StateCommand),
 }
 
 pub async fn run_cli(opt: RoochCli) -> CliResult<String> {
@@ -40,5 +41,6 @@ pub async fn run_cli(opt: RoochCli) -> CliResult<String> {
         Command::Object(object) => object.execute_serialized().await,
         Command::Init(c) => c.execute_serialized().await,
         Command::Account(a) => a.execute_serialized().await,
+        Command::State(s) => s.execute_serialized().await,
     }
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -13,6 +13,7 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.move[-1][0]}} == 1"
       Then cmd: "object --id {default}"
       Then cmd: "resource --address {default} --resource {default}::counter::Counter"
+      Then cmd: "state --access-path /resource/{default}/{default}::counter::Counter"
       Then cmd: "account create"
       Then cmd: "account list"
       Then cmd: "account import "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit""

--- a/moveos/moveos-store/Cargo.toml
+++ b/moveos/moveos-store/Cargo.toml
@@ -23,6 +23,7 @@ hex = { workspace = true }
 parking_lot = { workspace = true }
 
 move-core-types = { workspace = true }
+move-resource-viewer = { workspace = true }
 
 moveos-types = { workspace = true }
 moveos-stdlib = { workspace = true }

--- a/moveos/moveos-store/src/state_store/mod.rs
+++ b/moveos/moveos-store/src/state_store/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use self::state_view::StateReader;
 use crate::MoveOSDB;
 use anyhow::{ensure, Error, Result};
 use move_core_types::{
@@ -14,6 +15,7 @@ use moveos_stdlib::natives::moveos_stdlib::raw_table::{
     TableChangeSet, TableHandle, TableResolver, TableValueBox,
 };
 use moveos_types::{
+    access_path::{AccessPath, Path},
     h256::H256,
     move_module::MoveModule,
     state::{MoveState, State},
@@ -22,35 +24,16 @@ use moveos_types::{
     object::{AccountStorage, NamedTableID, Object, ObjectID, RawObject, TableInfo},
     storage_context,
 };
-use serde::{Deserialize, Serialize};
 use smt::{InMemoryNodeStore, NodeStore, SMTree, UpdateSet};
 use std::collections::BTreeMap;
 
+pub mod state_view;
 #[cfg(test)]
 mod tests;
 
-/// StateDB query path
-/// 1. /account_address/resource_type|module_id
-/// 2. /table_handle/key
-/// 3. /object_id/child_id
-pub struct AccessPath {}
-
-pub trait StateWriter {
-    //TODO define batch struct
-    fn write_batch(&self, batch: Vec<(AccessPath, Vec<u8>)>) -> Result<()>;
-}
-
-pub struct AccountStorageTables<NS> {
+struct AccountStorageTables<NS> {
     pub resources: (Object<TableInfo>, TreeTable<NS>),
     pub modules: (Object<TableInfo>, TreeTable<NS>),
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub enum StateType {
-    /// The Move module
-    MoveModule,
-    /// The Move resource, include Object and Table Resource
-    MoveResource(StructTag),
 }
 
 pub struct TreeTable<NS> {
@@ -157,6 +140,47 @@ impl StateDB {
 
     pub fn get(&self, id: ObjectID) -> Result<Option<State>> {
         self.global_table.get(id.to_bytes())
+    }
+
+    pub fn get_with_access_path(&self, access_path: &AccessPath) -> Result<Vec<Option<State>>> {
+        //TODO optimize the batch gets
+        match &access_path.0 {
+            Path::Object { object_ids } => {
+                let mut states = Vec::new();
+                for id in object_ids {
+                    states.push(self.get(*id)?);
+                }
+                Ok(states)
+            }
+            Path::Resource {
+                account,
+                resource_types,
+            } => {
+                let mut states = Vec::new();
+                for resource_type in resource_types {
+                    states.push(self.get_resource_state(account, resource_type)?);
+                }
+                Ok(states)
+            }
+            Path::Module {
+                account,
+                module_names,
+            } => {
+                let mut states = Vec::new();
+                for module_name in module_names {
+                    let module_id = ModuleId::new(*account, module_name.clone());
+                    states.push(self.get_module_state(&module_id)?);
+                }
+                Ok(states)
+            }
+            Path::Table { table_handle, keys } => {
+                let mut states = Vec::new();
+                for key in keys {
+                    states.push(self.get_with_key(*table_handle, key.clone())?);
+                }
+                Ok(states)
+            }
+        }
     }
 
     fn get_as_object<T: MoveState>(&self, id: ObjectID) -> Result<Option<Object<T>>> {
@@ -298,11 +322,11 @@ impl StateDB {
         Ok(())
     }
 
-    pub fn get_resource(
+    fn get_resource_state(
         &self,
         address: &AccountAddress,
         tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Error> {
+    ) -> Result<Option<State>> {
         let resource_table_id = NamedTableID::Resource(*address).to_object_id();
         let key = tag_to_key(tag);
         self.get_with_key(resource_table_id, key)?
@@ -313,17 +337,29 @@ impl StateDB {
                     tag,
                     s.value_type
                 );
-                Ok(s.value)
+                Ok(s)
             })
             .transpose()
     }
 
-    pub fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Error> {
+    pub fn get_resource(
+        &self,
+        address: &AccountAddress,
+        tag: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        Ok(self.get_resource_state(address, tag)?.map(|s| s.value))
+    }
+
+    fn get_module_state(&self, module_id: &ModuleId) -> Result<Option<State>, Error> {
         let module_table_id = NamedTableID::Module(*module_id.address()).to_object_id();
         let key = module_name_to_key(module_id.name());
+        self.get_with_key(module_table_id, key)
+    }
+
+    pub fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Error> {
         //We wrap the modules byte codes to `MoveModule` type when store the module.
         //So we need unwrap the MoveModule type.
-        self.get_with_key(module_table_id, key)?
+        self.get_module_state(module_id)?
             .map(|s| Ok(s.as_move_state::<MoveModule>()?.byte_codes))
             .transpose()
     }
@@ -415,5 +451,11 @@ impl TableResolver for StateDB {
         key: &[u8],
     ) -> std::result::Result<Option<TableValueBox>, Error> {
         self.resolve_table_entry(handle, key)
+    }
+}
+
+impl StateReader for StateDB {
+    fn get_states(&self, path: &AccessPath) -> Result<Vec<Option<State>>> {
+        self.get_with_access_path(path)
     }
 }

--- a/moveos/moveos-store/src/state_store/state_view.rs
+++ b/moveos/moveos-store/src/state_store/state_view.rs
@@ -1,0 +1,61 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use move_core_types::{
+    account_address::AccountAddress, language_storage::StructTag, resolver::MoveResolver,
+};
+use move_resource_viewer::MoveValueAnnotator;
+use moveos_types::{
+    access_path::AccessPath,
+    object::{AnnotatedObject, ObjectID},
+    state::{AnnotatedState, State},
+};
+
+/// StateReader provide an unify State API with AccessPath
+pub trait StateReader {
+    /// Get states by AccessPath
+    fn get_states(&self, path: &AccessPath) -> Result<Vec<Option<State>>>;
+}
+
+pub trait AnnotatedStateReader: StateReader + MoveResolver {
+    fn get_annotated_states(&self, path: &AccessPath) -> Result<Vec<Option<AnnotatedState>>> {
+        let annotator = MoveValueAnnotator::new(self);
+        self.get_states(path)?
+            .into_iter()
+            .map(|state| {
+                state
+                    .map(|state| state.into_annotated_state(&annotator))
+                    .transpose()
+            })
+            .collect()
+    }
+
+    fn get_annotated_object(&self, object_id: ObjectID) -> Result<Option<AnnotatedObject>> {
+        let annotator = MoveValueAnnotator::new(self);
+        self.get_states(&AccessPath::object(object_id))?
+            .pop()
+            .and_then(|state| state)
+            .map(|state| {
+                state
+                    .into_annotated_state(&annotator)?
+                    .into_annotated_object()
+            })
+            .transpose()
+    }
+
+    fn get_annotated_resource(
+        &self,
+        account: AccountAddress,
+        resource_type: StructTag,
+    ) -> Result<Option<AnnotatedState>> {
+        let annotator = MoveValueAnnotator::new(self);
+        self.get_states(&AccessPath::resource(account, resource_type))?
+            .pop()
+            .and_then(|state| state)
+            .map(|state| state.into_annotated_state(&annotator))
+            .transpose()
+    }
+}
+
+impl<T> AnnotatedStateReader for T where T: StateReader + MoveResolver {}

--- a/moveos/moveos-types/src/access_path.rs
+++ b/moveos/moveos-types/src/access_path.rs
@@ -1,0 +1,266 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::object::ObjectID;
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, language_storage::StructTag,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Path {
+    /// Get Object
+    Object { object_ids: Vec<ObjectID> },
+    /// Get account resources
+    Resource {
+        account: AccountAddress,
+        resource_types: Vec<StructTag>,
+    },
+    /// Get account modules
+    Module {
+        account: AccountAddress,
+        module_names: Vec<Identifier>,
+    },
+    /// Get table values by keys
+    Table {
+        table_handle: ObjectID,
+        keys: Vec<Vec<u8>>,
+    },
+}
+
+impl std::fmt::Display for Path {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Path::Object { object_ids } => {
+                write!(
+                    f,
+                    "/object/{}",
+                    object_ids
+                        .iter()
+                        .map(|object_id| object_id.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )?;
+            }
+            Path::Resource {
+                account,
+                resource_types,
+            } => {
+                write!(
+                    f,
+                    "/resource/{}/{}",
+                    account.to_hex_literal(),
+                    resource_types
+                        .iter()
+                        .map(|struct_tag| struct_tag.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )?;
+            }
+            Path::Module {
+                account,
+                module_names,
+            } => {
+                write!(
+                    f,
+                    "/module/{}/{}",
+                    account.to_hex_literal(),
+                    module_names
+                        .iter()
+                        .map(|module_name| module_name.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )?;
+            }
+            Path::Table { table_handle, keys } => {
+                write!(
+                    f,
+                    "/table/{}/{}",
+                    table_handle,
+                    keys.iter()
+                        .map(|key| {
+                            let hex_key = hex::encode(key);
+                            format!("0x{hex_key}")
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for Path {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim_start_matches('/');
+        let mut iter = s.split('/');
+        let path_type = iter.next().ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+        match path_type {
+            "object" => {
+                let object_ids = iter.next().ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+                let object_ids = object_ids
+                    .split(',')
+                    .map(ObjectID::from_str)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Path::Object { object_ids })
+            }
+            "resource" => {
+                let account = iter.next().ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+                let account = AccountAddress::from_hex_literal(account)?;
+                let resource_types = iter.next().ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+                let resource_types = resource_types
+                    .split(',')
+                    .map(StructTag::from_str)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Path::Resource {
+                    account,
+                    resource_types,
+                })
+            }
+            "module" => {
+                let account = iter.next().ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+                let account = AccountAddress::from_hex_literal(account)?;
+                let module_names = iter.next().ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+                let module_names = module_names
+                    .split(',')
+                    .map(Identifier::from_str)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Path::Module {
+                    account,
+                    module_names,
+                })
+            }
+            "table" => {
+                let table_handle = iter.next().ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+                let table_handle = ObjectID::from_str(table_handle)?;
+                let keys = iter.next().ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+                let keys = keys
+                    .split(',')
+                    .map(|key| {
+                        let key = key.trim_start_matches("0x");
+                        hex::decode(key).map_err(|_| anyhow::anyhow!("Invalid path key: {}", key))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Path::Table { table_handle, keys })
+            }
+            _ => Err(anyhow::anyhow!("Invalid path: {}", s)),
+        }
+    }
+}
+
+/// StateDB query path
+///
+/// 1. /object/$object_id1[,$object_id2]*
+/// 2. /resource/$account_address/$resource_type1[,$resource_type2]*
+/// 3. /module/$account_address/$module_name1[,$module_name2]*
+/// 4. /table/$table_handle/$key1[,$key2]*
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AccessPath(pub Path);
+
+impl AccessPath {
+    pub fn object(object_id: ObjectID) -> Self {
+        AccessPath(Path::Object {
+            object_ids: vec![object_id],
+        })
+    }
+
+    pub fn objects(object_ids: Vec<ObjectID>) -> Self {
+        AccessPath(Path::Object { object_ids })
+    }
+
+    pub fn resource(account: AccountAddress, resource_type: StructTag) -> Self {
+        AccessPath(Path::Resource {
+            account,
+            resource_types: vec![resource_type],
+        })
+    }
+
+    pub fn resources(account: AccountAddress, resource_types: Vec<StructTag>) -> Self {
+        AccessPath(Path::Resource {
+            account,
+            resource_types,
+        })
+    }
+
+    pub fn module(account: AccountAddress, module_name: Identifier) -> Self {
+        AccessPath(Path::Module {
+            account,
+            module_names: vec![module_name],
+        })
+    }
+
+    pub fn modules(account: AccountAddress, module_names: Vec<Identifier>) -> Self {
+        AccessPath(Path::Module {
+            account,
+            module_names,
+        })
+    }
+
+    pub fn table(table_handle: ObjectID, keys: Vec<Vec<u8>>) -> Self {
+        AccessPath(Path::Table { table_handle, keys })
+    }
+}
+
+impl std::fmt::Display for AccessPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)?;
+        Ok(())
+    }
+}
+
+impl FromStr for AccessPath {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let path = s.parse::<Path>()?;
+        Ok(AccessPath(path))
+    }
+}
+
+// AccessPath always serialize and deserilaize as string
+impl Serialize for AccessPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for AccessPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<AccessPath>().map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_path_roundtrip(path: &str) {
+        let path = path.parse::<Path>().unwrap();
+        let path_str = path.to_string();
+        let path2 = path_str.parse::<Path>().unwrap();
+        assert_eq!(path, path2);
+    }
+
+    #[test]
+    pub fn test_path() {
+        test_path_roundtrip("/object/0x1");
+        test_path_roundtrip("/object/0x1,0x2");
+        test_path_roundtrip("/resource/0x1/0x2::m::S");
+        test_path_roundtrip("/resource/0x1/0x2::m1::S1,0x3::m2::S2");
+        test_path_roundtrip("/module/0x2/m1");
+        test_path_roundtrip("/module/0x2/m1,m2");
+        test_path_roundtrip("/table/0x1/0x12");
+        test_path_roundtrip("/table/0x1/0x12,0x13");
+    }
+}

--- a/moveos/moveos-types/src/lib.rs
+++ b/moveos/moveos-types/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod access_path;
 pub mod addresses;
 pub mod error;
 pub mod event;

--- a/moveos/moveos/src/lib.rs
+++ b/moveos/moveos/src/lib.rs
@@ -5,15 +5,3 @@ pub mod moveos;
 #[cfg(test)]
 mod tests;
 pub mod vm;
-
-pub struct ValidatorResult {}
-
-pub struct ExecutorResult {}
-
-pub trait TransactionValidator {
-    fn validate_transaction<T>(&self, transaction: T) -> ValidatorResult;
-}
-
-pub trait TransactionExecutor {
-    fn execute_transaction<T>(&self, transaction: T) -> ExecutorResult;
-}

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -1,13 +1,10 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    vm::{
-        move_vm_ext::{MoveVmExt, SessionExt},
-        tx_argument_resolver::{as_struct_no_panic, is_storage_context},
-        MoveResolverExt,
-    },
-    TransactionExecutor, TransactionValidator,
+use crate::vm::{
+    move_vm_ext::{MoveVmExt, SessionExt},
+    tx_argument_resolver::{as_struct_no_panic, is_storage_context},
+    MoveResolverExt,
 };
 use anyhow::{anyhow, bail, ensure, Result};
 use move_binary_format::access::ModuleAccess;
@@ -26,9 +23,8 @@ use move_core_types::{
 use move_vm_runtime::session::SerializedReturnValues;
 use move_vm_types::gas::UnmeteredGasMeter;
 use moveos_stdlib::natives::moveos_stdlib::raw_table::NativeTableContext;
-use moveos_store::event_store::EventStore;
-use moveos_store::state_store::StateDB;
 use moveos_store::MoveOSDB;
+use moveos_store::{event_store::EventStore, state_store::StateDB};
 use moveos_types::event::Event;
 use moveos_types::object::ObjectID;
 use moveos_types::transaction::{AuthenticatableTransaction, MoveAction, MoveOSTransaction};
@@ -432,17 +428,5 @@ impl MoveOS {
             "Table change set should be empty when execute view function"
         );
         Ok(result)
-    }
-}
-
-impl TransactionValidator for MoveOS {
-    fn validate_transaction<T>(&self, _transaction: T) -> crate::ValidatorResult {
-        todo!()
-    }
-}
-
-impl TransactionExecutor for MoveOS {
-    fn execute_transaction<T>(&self, _transaction: T) -> crate::ExecutorResult {
-        todo!()
     }
 }

--- a/moveos/moveos/src/vm/tx_argument_resolver.rs
+++ b/moveos/moveos/src/vm/tx_argument_resolver.rs
@@ -112,12 +112,6 @@ where
     }
 }
 
-// fn is_object(t: &StructType) -> bool {
-//     *t.module.address() == *moveos_types::addresses::MOVEOS_STD_ADDRESS
-//         && t.module.name() == object::OBJECT_MODULE_NAME
-//         && t.name.as_ident_str() == object::OBJECT_STRUCT_NAME
-// }
-
 fn is_tx_context(t: &StructType) -> bool {
     *t.module.address() == *moveos_types::addresses::MOVEOS_STD_ADDRESS
         && t.module.name() == TxContext::module_identifier().as_ident_str()


### PR DESCRIPTION
Implement AccessPath and State API

resolve #58 #12 


### AccessPath format

1. /object/$object_id1[,$object_id2]*
2. /resource/$account_address/$resource_type1[,$resource_type2]*
3. /module/$account_address/$module_name1[,$module_name2]*
4. /table/$table_handle/$key1[,$key2]*


### Add two RPC API:

```rust
    /// Get the states by access_path
    #[method(name = "rooch_getStates")]
    async fn get_states(&self, access_path: AccessPath) -> RpcResult<Vec<Option<StateView>>>;

    /// Get the annotated states by access_path
    /// The annotated states include the decoded move value of the state
    #[method(name = "rooch_getAnnotatedStates")]
    async fn get_annotated_states(
        &self,
        access_path: AccessPath,
    ) -> RpcResult<Vec<Option<AnnotatedStateView>>>;
```

### Add a `state` command:

```
rooch state --access-path /resource/0x40ad744b6a3cd57d800e595b0aa9bf29ae0d2c1dadc78860a2c57df3cea5da91/0x40ad744b6a3cd57d800e595b0aa9bf29ae0d2c1dadc78860a2c57df3cea5da91::counter::Counter        
[
  {
    "state": {
      "value": "0x0000000000000000",
      "value_type": "0x40ad744b6a3cd57d800e595b0aa9bf29ae0d2c1dadc78860a2c57df3cea5da91::counter::Counter"
    },
    "move_value": {
      "Struct": {
        "abilities": 12,
        "type_": "0x40ad744b6a3cd57d800e595b0aa9bf29ae0d2c1dadc78860a2c57df3cea5da91::counter::Counter",
        "value": [
          [
            "value",
            {
              "U64": "0"
            }
          ]
        ]
      }
    }
  }
]
```

### Discussion: 

https://discord.com/channels/1078938449974935592/1113442482357805076

1. Currently, AccessPath only supports getting state with multi-key and does not support iter access to the resources or tables. Are we need the feature?
2. Should we remove the `rooch_getObject` and `rooch_getResource` API?
3. Do not plan to support the field or subpath described in #58.