### PR TITLE
Fix error message printing when checking private_generics.

### DIFF
--- a/examples/private_generics/sources/private_generics.move
+++ b/examples/private_generics/sources/private_generics.move
@@ -18,7 +18,7 @@ module rooch_examples::Data {
 
     public fun run() {
         let data = Data{ v: 123 };
-        let box_val = create_box<Data, Data, Box<u32>>(data);
+        let box_val = create_box<Data, u64, Box<u32>>(data);
         let _ = box_value(&box_val);
     }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/bcd.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/bcd.move
@@ -30,7 +30,7 @@ module moveos_std::bcd{
     //1. The caller of from_bytes is the module that defines the `T`. This is ensured by private_generics.
     //2. The fields contained in `T` are either primitive types or are defined by the module that calls from_bytes. 
     //We need to find a solution to this problem. If we cannot solve it, then we cannot set from_bytes to public.
-    #[private_generics(T)]
+    // #[private_generics(MoveValue)]
     /// Function to deserialize a type T.
     /// Note the `private_generics` ensure only the `MoveValue`'s owner module can call this function
     public native fun from_bytes<MoveValue>(bytes: vector<u8>): MoveValue;

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
@@ -36,7 +36,7 @@ module moveos_std::type_table {
         name_string
     }
 
-    #[private_generics(T)]
+    #[private_generics(V)]
     /// Add a new entry to the table. Aborts if an entry for this
     /// key already exists. The entry itself is not stored in the
     /// table, and cannot be discovered from it.
@@ -48,7 +48,7 @@ module moveos_std::type_table {
         raw_table::add<String, V>(&table.handle, key<V>(), val)
     }
 
-    #[private_generics(T)]
+    #[private_generics(V)]
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
     public fun borrow<V: key>(table: &TypeTable): &V {
@@ -59,7 +59,7 @@ module moveos_std::type_table {
         raw_table::borrow<String, V>(&table.handle, key<V>())
     }
 
-    #[private_generics(T)]
+    #[private_generics(V)]
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
     public fun borrow_mut<V: key>(table: &mut TypeTable): &mut V {
@@ -70,7 +70,7 @@ module moveos_std::type_table {
         raw_table::borrow_mut<String, V>(&table.handle, key<V>())
     }
 
-    #[private_generics(T)]
+    #[private_generics(V)]
     /// Remove from `table` and return the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
     public fun remove<V: key>(table: &mut TypeTable): V {
@@ -81,7 +81,7 @@ module moveos_std::type_table {
         raw_table::remove<String, V>(&table.handle, key<V>())
     }
 
-    #[private_generics(T)]
+    #[private_generics(V)]
     /// Returns true if `table` contains an entry for `key`.
     public fun contains<V: key>(table: &TypeTable): bool {
         raw_table::contains<String>(&table.handle, key<V>())


### PR DESCRIPTION
resolve https://github.com/rooch-network/rooch/issues/204

1. If a function decorated with `#[private_generics(T)]` is called with a generic parameter type that is not allowed, print the code where the `CallGeneric` instruction is located, instead of the called function.
2. In `moveos-stdlib`, some `#[private_generics(T)`] have `T` that is not defined in the current function.