### PR TITLE
refactor event storage and event handle base on object id

### DIFF
--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -3,7 +3,7 @@
 
 use super::messages::{
     ExecuteTransactionMessage, ExecuteTransactionResult, ExecuteViewFunctionMessage,
-    GetEventsByTxHashMessage, GetEventsMessage, GetResourceMessage, ObjectMessage,
+    GetEventsByEventHandleMessage, GetEventsMessage, GetResourceMessage, ObjectMessage,
     ValidateTransactionMessage,
 };
 use anyhow::Result;
@@ -124,22 +124,22 @@ impl Handler<ObjectMessage> for ExecutorActor {
 }
 
 #[async_trait]
-impl Handler<GetEventsByTxHashMessage> for ExecutorActor {
+impl Handler<GetEventsByEventHandleMessage> for ExecutorActor {
     async fn handle(
         &mut self,
-        msg: GetEventsByTxHashMessage,
+        msg: GetEventsByEventHandleMessage,
         _ctx: &mut ActorContext,
     ) -> Result<Option<Vec<MoveOSEvent>>> {
-        let GetEventsByTxHashMessage { tx_hash } = msg;
+        let GetEventsByEventHandleMessage { event_handle_id } = msg;
         let event_store = self.moveos.event_store();
 
         let mut result: Vec<MoveOSEvent> = Vec::new();
         for ev in event_store
-            .get_events_by_tx_hash(&tx_hash)?
+            .get_events_by_event_handle_id(&event_handle_id)?
             .unwrap()
             .into_iter()
             .enumerate()
-            .map(|(_i, event)| MoveOSEvent::try_from(event, tx_hash, None, None))
+            .map(|(_i, event)| MoveOSEvent::try_from(event, None, None, None))
             .collect::<Vec<_>>()
         {
             result.push(ev.unwrap());
@@ -169,7 +169,7 @@ impl Handler<GetEventsMessage> for ExecutorActor {
             .unwrap()
             .into_iter()
             .enumerate()
-            .map(|(_i, event)| MoveOSEvent::try_from(event, H256::zero(), None, None))
+            .map(|(_i, event)| MoveOSEvent::try_from(event, None, None, None))
             .collect::<Vec<_>>()
         {
             result.push(ev.unwrap());

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -13,7 +13,7 @@ use moveos_types::{
     object::{AnnotatedObject, ObjectID},
     transaction::{AuthenticatableTransaction, FunctionCall, MoveOSTransaction},
 };
-use rooch_types::{transaction::TransactionInfo, H256};
+use rooch_types::transaction::TransactionInfo;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
@@ -71,11 +71,11 @@ impl Message for ObjectMessage {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct GetEventsByTxHashMessage {
-    pub tx_hash: H256,
+pub struct GetEventsByEventHandleMessage {
+    pub event_handle_id: ObjectID,
 }
 
-impl Message for GetEventsByTxHashMessage {
+impl Message for GetEventsByEventHandleMessage {
     type Result = Result<Option<Vec<MoveOSEvent>>>;
 }
 

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -4,8 +4,8 @@
 use crate::actor::{
     executor::ExecutorActor,
     messages::{
-        ExecuteViewFunctionMessage, GetEventsByTxHashMessage, GetEventsMessage, GetResourceMessage,
-        ObjectMessage, ValidateTransactionMessage,
+        ExecuteViewFunctionMessage, GetEventsByEventHandleMessage, GetEventsMessage,
+        GetResourceMessage, ObjectMessage, ValidateTransactionMessage,
     },
 };
 use anyhow::Result;
@@ -20,7 +20,7 @@ use moveos_types::{
     object::{AnnotatedObject, ObjectID},
     transaction::{AuthenticatableTransaction, FunctionCall, MoveOSTransaction},
 };
-use rooch_types::{transaction::TransactionInfo, H256};
+use rooch_types::transaction::TransactionInfo;
 
 #[derive(Clone)]
 pub struct ExecutorProxy {
@@ -72,9 +72,12 @@ impl ExecutorProxy {
         self.actor.send(ObjectMessage { object_id }).await?
     }
 
-    pub async fn get_events_by_tx_hash(&self, tx_hash: H256) -> Result<Option<Vec<MoveOSEvent>>> {
+    pub async fn get_events_by_event_handle(
+        &self,
+        event_handle_id: ObjectID,
+    ) -> Result<Option<Vec<MoveOSEvent>>> {
         self.actor
-            .send(GetEventsByTxHashMessage { tx_hash })
+            .send(GetEventsByEventHandleMessage { event_handle_id })
             .await?
     }
 

--- a/crates/rooch-server/src/api/rooch_api.rs
+++ b/crates/rooch-server/src/api/rooch_api.rs
@@ -47,9 +47,12 @@ pub trait RoochAPI {
     #[method(name = "rooch_getObject")]
     async fn get_object(&self, object_id: ObjectID) -> RpcResult<Option<AnnotatedObjectView>>;
 
-    /// Get the events by tx_hash
-    #[method(name = "rooch_getEventsByTxHash")]
-    async fn get_events_by_tx_hash(&self, tx_hash: H256) -> RpcResult<Option<Vec<EventView>>>;
+    /// Get the events by event handle id
+    #[method(name = "rooch_getEventsByEventHandle")]
+    async fn get_events_by_event_handle(
+        &self,
+        event_handle_id: ObjectID,
+    ) -> RpcResult<Option<Vec<EventView>>>;
 
     /// Get the events by event filter
     #[method(name = "rooch_getEvents")]

--- a/crates/rooch-server/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-server/src/jsonrpc_types/move_types.rs
@@ -9,7 +9,7 @@ use move_core_types::{
     u256,
 };
 use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
-use moveos_types::event::Event;
+use moveos_types::event::{Event, EventID};
 use moveos_types::event_filter::MoveOSEvent;
 use moveos_types::h256::H256;
 use moveos_types::{
@@ -136,20 +136,20 @@ pub struct EventView {
     pub type_tag: TypeTagView,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_index: Option<u32>,
-    pub event_key: ObjectID,
-    pub event_seq_number: StrView<u64>,
+    pub event_id: EventID,
+    // pub event_seq_number: StrView<u64>,
 }
 
 impl From<Event> for EventView {
     fn from(event: Event) -> Self {
         EventView {
             tx_hash: None,
-            sender: AccountAddress::ZERO, //TODO fill event sender
+            sender: AccountAddress::ZERO, //Reserved as an extension field
             event_data: StrView(event.event_data().to_vec()),
             type_tag: event.type_tag().clone().into(),
             event_index: Some(event.event_index),
-            event_key: *event.key(),
-            event_seq_number: event.sequence_number().into(),
+            event_id: *event.event_id(),
+            // event_seq_number: event.sequence_number().into(),
         }
     }
 }
@@ -157,13 +157,13 @@ impl From<Event> for EventView {
 impl From<MoveOSEvent> for EventView {
     fn from(event: MoveOSEvent) -> Self {
         EventView {
-            tx_hash: Some(event.tx_hash),
-            sender: AccountAddress::ZERO, //TODO fill event sender
+            tx_hash: event.tx_hash,
+            sender: AccountAddress::ZERO, //Reserved as an extension field
             event_data: StrView(event.event_data.to_vec()),
             type_tag: event.type_tag.clone().into(),
             event_index: Some(event.event_index),
-            event_key: event.key,
-            event_seq_number: event.sequence_number.into(),
+            event_id: event.event_id,
+            // event_seq_number: event.sequence_number.into(),
         }
     }
 }
@@ -171,8 +171,8 @@ impl From<MoveOSEvent> for EventView {
 impl EventView {
     pub fn try_from(event: Event, tx_hash: H256) -> Self {
         let Event {
-            key,
-            sequence_number,
+            event_id,
+            // sequence_number,
             type_tag,
             event_data,
             event_index,
@@ -180,12 +180,12 @@ impl EventView {
 
         EventView {
             tx_hash: Some(tx_hash),
-            sender: AccountAddress::ZERO, //TODO fill event sender
+            sender: AccountAddress::ZERO, //Reserved as an extension field
             event_data: StrView(event_data.to_vec()),
             type_tag: type_tag.into(),
             event_index: Some(event_index),
-            event_key: key,
-            event_seq_number: sequence_number.into(),
+            event_id,
+            // event_seq_number: sequence_number.into(),
         }
     }
 }

--- a/crates/rooch-server/src/server/rooch_server.rs
+++ b/crates/rooch-server/src/server/rooch_server.rs
@@ -76,11 +76,14 @@ impl RoochAPIServer for RoochServer {
         Ok(self.rpc_service.object(object_id).await?.map(Into::into))
     }
 
-    async fn get_events_by_tx_hash(&self, tx_hash: H256) -> RpcResult<Option<Vec<EventView>>> {
+    async fn get_events_by_event_handle(
+        &self,
+        event_handle_id: ObjectID,
+    ) -> RpcResult<Option<Vec<EventView>>> {
         let mut result: Vec<EventView> = Vec::new();
         for ev in self
             .rpc_service
-            .get_events_by_tx_hash(tx_hash)
+            .get_events_by_event_handle(event_handle_id)
             .await?
             .unwrap()
             .iter()

--- a/crates/rooch-server/src/service/mod.rs
+++ b/crates/rooch-server/src/service/mod.rs
@@ -13,7 +13,7 @@ use moveos_types::{
 use rooch_executor::proxy::ExecutorProxy;
 use rooch_proposer::proxy::ProposerProxy;
 use rooch_sequencer::proxy::SequencerProxy;
-use rooch_types::{address::RoochAddress, transaction::TypedTransaction, H256};
+use rooch_types::{address::RoochAddress, transaction::TypedTransaction};
 
 /// RpcService is the implementation of the RPC service.
 /// It is the glue between the RPC server(EthAPIServer,RoochApiServer) and the rooch's actors.
@@ -97,8 +97,14 @@ impl RpcService {
         bail!("Not implemented")
     }
 
-    pub async fn get_events_by_tx_hash(&self, tx_hash: H256) -> Result<Option<Vec<MoveOSEvent>>> {
-        let resp = self.executor.get_events_by_tx_hash(tx_hash).await?;
+    pub async fn get_events_by_event_handle(
+        &self,
+        event_handle_id: ObjectID,
+    ) -> Result<Option<Vec<MoveOSEvent>>> {
+        let resp = self
+            .executor
+            .get_events_by_event_handle(event_handle_id)
+            .await?;
         Ok(resp)
     }
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/events.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/events.move
@@ -1,7 +1,114 @@
-/// events emit events to the event store.
+/// `EventHandle`s with unique GUIDs. It contains a counter for the number
+/// of `EventHandle`s it generates. An `EventHandle` is used to count the number of
+/// events emitted to a handle and emit events to the event store.
 module moveos_std::events {
-    use moveos_std::tx_context::{Self, TxContext};
-    use moveos_std::object_id::ObjectID;
+    use std::error;
+    use std::bcs;
+    use std::signer;
+    use moveos_std::storage_context::{Self, StorageContext};
+    use moveos_std::tx_context::{Self};
+    use moveos_std::object_storage::{Self, ObjectStorage};
+    use moveos_std::object_id::{Self, ObjectID};
+    use moveos_std::object;
+    use moveos_std::type_table::{Self, TypeTable};
+
+    const NamedTableEventHandler: u64 = 2;
+
+    /// The address/account did not correspond to the moveos_std address
+    const ENotMoveOSStdAddress: u64 = 0;
+    /// The event hander table resource already exists
+    const EEventHandlerTableAlreadyExists: u64 = 1;
+    /// The event handle with the given type already exists
+    const EEventHandleAlreadyExists: u64 = 2;
+
+    struct EventStorage has key {
+        event_handle: TypeTable,
+    }
+
+    /// A handle for an event such that:
+    /// 1. Other modules can emit events to this handle.
+    /// 2. Storage can use this handle to prove the total number of events that happened in the past.
+    struct EventHandle<phantom T: drop + store> has key, store {
+        /// Total number of events emitted to this event stream.
+        counter: u64,
+        /// A globally unique ID for this event stream.
+        guid: ObjectID,
+        sender: address,
+    }
+
+    /// Can only execute by moveos_std account
+    fun init(ctx: &mut StorageContext, account: &signer) {
+        let account_addr = signer::address_of(account);
+        assert!(account_addr == @moveos_std, error::permission_denied(ENotMoveOSStdAddress));
+        create_event_storage(ctx, account_addr)
+    }
+
+    /// Create a new event storage space
+    fun create_event_storage(ctx: &mut StorageContext, account_addr: address) {
+        let object_id = derive_event_object_id(account_addr);
+        let event_storage = EventStorage {
+            event_handle: type_table::new_with_id(object_id),
+        };
+
+        let object_storage = storage_context::object_storage_mut(ctx);
+        assert!(!object_storage::contains(object_storage, object_id), EEventHandlerTableAlreadyExists);
+        let object = object::new_with_id(object_id, account_addr, event_storage);
+        object_storage::add(object_storage, object);
+    }
+
+    fun derive_event_object_id(account_addr: address): ObjectID{
+        object_id::address_to_object_id(tx_context::derive_id(bcs::to_bytes(&account_addr), NamedTableEventHandler))
+    }
+
+    //TODO if we create the table every time, how to drop the table?
+    fun derive_event_table_handle(object_id: ObjectID): TypeTable{
+        // let account_addr = @moveos_std;
+        type_table::new_with_id(object_id)
+    }
+
+    fun borrow_event_storage<T: key>(object_storage: &ObjectStorage) : &EventStorage {
+        let object_id = derive_event_object_id(@moveos_std);
+        let object = object_storage::borrow<EventStorage>(object_storage, object_id);
+        object::borrow(object)
+    }
+
+    fun borrow_mut_event_storage<T: key>(object_storage: &mut ObjectStorage) : &mut EventStorage {
+        let object_id = derive_event_object_id(@moveos_std);
+        let object = object_storage::borrow_mut<EventStorage>(object_storage, object_id);
+        object::borrow_mut(object)
+    }
+
+    /// Add a event handle to the event storage
+    fun add_event_handle_to_event_storage<T: key>(object_storage: &mut ObjectStorage, event_handle_resource: T){
+        // let event_table_handle = derive_event_table_handle();
+        let event_storage = borrow_mut_event_storage<T>(object_storage);
+        assert!(!type_table::contains_internal<T>(&event_storage.event_handle), EEventHandleAlreadyExists);
+        type_table::add_internal(&mut event_storage.event_handle, event_handle_resource);
+    }
+
+    fun exists_event_handle_at_event_storage<T: key>(object_storage: &ObjectStorage) : bool {
+        // let event_table_handle = derive_event_table_handle();
+        let event_storage = borrow_event_storage<T>(object_storage);
+        type_table::contains<T>(&event_storage.event_handle)
+    }
+
+    /// Borrow a mut event handle from the event storage
+    fun borrow_mut_event_handle_from_event_storage<T: key>(object_storage: &mut ObjectStorage): &mut T {
+        let event_storage = borrow_mut_event_storage<T>(object_storage);
+        type_table::borrow_mut_internal<T>(&mut event_storage.event_handle)
+    }
+
+    /// Use EventHandle to generate a unique event handle
+    public fun new_event_handle<T: drop + store>(ctx: &mut StorageContext, account: &signer) {
+        let account_addr = signer::address_of(account);
+        let guid = tx_context::fresh_object_id(storage_context::tx_context_mut(ctx));
+        let event_handle = EventHandle<T> {
+            counter: 0,
+            guid,
+            sender: account_addr,
+        };
+        add_event_handle_to_event_storage<EventHandle<T>>(storage_context::object_storage_mut(ctx), event_handle)
+    }
 
     /// Emit a custom Move event, sending the data offchain.
     ///
@@ -10,14 +117,21 @@ module moveos_std::events {
     ///
     /// The type T is the main way to index the event, and can contain
     /// phantom parameters, eg emit(MyEvent<phantom T>).
-    public fun emit_event<T: drop + store>(ctx: &mut TxContext, event: T) {
-        let guid = tx_context::fresh_object_id(ctx);
+    public fun emit_event<T: drop + store>(ctx: &mut StorageContext, event: T) {
+        let event_handle_ref = borrow_mut_event_handle_from_event_storage<EventHandle<T>>(storage_context::object_storage_mut(ctx));
 
-        //!Notice that: count now just for For placeholder, and value is always 0
-        write_to_event_store<T>(&guid, 0,  event);
+        let guid = *&event_handle_ref.guid;
+        write_to_event_store<T>(&guid, event_handle_ref.counter, event);
+        event_handle_ref.counter = event_handle_ref.counter + 1;
     }
 
     /// Native procedure that writes to the actual event stream in Event store
     /// This will replace the "native" portion of EmitEvent bytecode
     native fun write_to_event_store<T: drop + store>(guid: &ObjectID, count: u64, data: T);
+
+
+    /// Destroy a unique handle.
+    public fun destroy_handle<T: drop + store>(handle: EventHandle<T>) {
+        EventHandle<T> { counter: _, guid: _, sender: _} = handle;
+    }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
@@ -10,7 +10,8 @@ module moveos_std::object {
     use moveos_std::object_id::ObjectID;
 
     friend moveos_std::account_storage;
-    
+    friend moveos_std::events;
+
     /// Invalid access of object, the object is not owned by the signer or the object is not shared or immutable
     const EInvalidAccess: u64 = 0;
    

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object_id.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object_id.move
@@ -5,6 +5,7 @@ module moveos_std::object_id {
     friend moveos_std::raw_table;
     friend moveos_std::object_storage;
     friend moveos_std::account_storage;
+    friend moveos_std::events;
 
     struct ObjectID has store, copy, drop {
         //TODO should use u256 to replace address?

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
@@ -44,7 +44,6 @@ module moveos_std::storage_context {
     /// Create a StorageContext and AccountStorage for unit test
     public fun new_test_context(sender: address): StorageContext {
         let tx_context = tx_context::new_test_context(sender);
-        // let object_storage = object_storage::new(&mut tx_context);
         let object_storage = object_storage::new_with_id(object_storage::global_object_storage_handle());
         StorageContext {
             tx_context,

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/tx_context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/tx_context.move
@@ -11,6 +11,7 @@ module moveos_std::tx_context {
     friend moveos_std::object;
     friend moveos_std::raw_table;
     friend moveos_std::account_storage;
+    friend moveos_std::events;
 
     /// Number of bytes in an tx hash (which will be the transaction digest)
     const TX_HASH_LENGTH: u64 = 32;

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
@@ -8,6 +8,7 @@ module moveos_std::type_table {
     use moveos_std::object_id::ObjectID;
 
     friend moveos_std::account_storage;
+    friend moveos_std::events;
 
     struct TypeTable has store {
         handle: ObjectID,

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/events.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/events.rs
@@ -50,7 +50,6 @@ pub fn native_write_to_event_store(
     let ty = ty_args.pop().unwrap();
     let msg = args.pop_back().unwrap();
     let seq_num = pop_arg!(args, u64);
-    // let guid = pop_arg!(args, ObjectID);
     let raw_guid = pop_arg!(args, StructRef);
     let guid = helpers::get_object_id(raw_guid)?;
 

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/events.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/events.rs
@@ -50,11 +50,12 @@ pub fn native_write_to_event_store(
     let ty = ty_args.pop().unwrap();
     let msg = args.pop_back().unwrap();
     let seq_num = pop_arg!(args, u64);
-    let raw_guid = pop_arg!(args, StructRef);
-    let guid = helpers::get_object_id(raw_guid)?;
+    let raw_event_handler_id = pop_arg!(args, StructRef);
+    // event_handler_id equal to guid
+    let event_handler_id = helpers::get_object_id(raw_event_handler_id)?;
 
     let _result = context
-        .save_event(guid.to_bytes(), seq_num, ty, msg)
+        .save_event(event_handler_id.to_bytes(), seq_num, ty, msg)
         .map_err(|e| {
             PartialVMError::new(StatusCode::ABORTED)
                 .with_message(e.to_string())

--- a/moveos/moveos-store/src/event_store/mod.rs
+++ b/moveos/moveos-store/src/event_store/mod.rs
@@ -2,19 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Error, Result};
-// use anyhow::{bail, ensure, format_err, Result, Error};
-use moveos_types::event::Event;
-use moveos_types::h256::H256;
-// use std::collections::BTreeMap;
 use move_core_types::language_storage::TypeTag;
+use moveos_types::event::{Event, EventID};
 use moveos_types::event_filter::EventFilter;
+use moveos_types::h256::H256;
 use moveos_types::move_types::type_tag_match;
+use moveos_types::object::ObjectID;
 use parking_lot::RwLock;
+use std::ops::Not;
 use std::{collections::HashMap, sync::Arc};
 
 #[derive(Debug)]
 pub struct EventStore {
-    store: Arc<RwLock<HashMap<H256, Vec<Event>>>>,
+    store: Arc<RwLock<HashMap<(ObjectID, u64), Event>>>,
+    indexer_store: Arc<RwLock<HashMap<(H256, u64), Event>>>,
     // store: Arc<RwLock<BTreeMap<H256, Vec<u8>>>>,
 }
 
@@ -24,47 +25,61 @@ impl EventStore {
         Self {
             // store: Arc::new(RwLock::new(BTreeMap::new())),
             store: Arc::new(RwLock::new(HashMap::new())),
+            indexer_store: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
-    pub fn save_events(&self, tx_hash: H256, events: Vec<Event>) -> Result<(), Error> {
+    pub fn save_event(&self, event: Event) -> Result<(), Error> {
         let mut locked = self.store.write();
-        if locked.contains_key(&tx_hash) {
-            let _old_events = locked.remove(&tx_hash);
-        }
-        // let raw_value = bcs::to_bytes(&events)?;
-        locked.insert(tx_hash, events);
+        let key = (event.event_id.event_handle_id, event.event_id.event_seq);
+        locked.insert(key, event);
         Ok(())
     }
 
-    pub fn get_events_by_tx_hash(&self, tx_hash: &H256) -> Result<Option<Vec<Event>>, Error> {
+    pub fn save_events(&self, events: Vec<Event>) -> Result<(), Error> {
+        let mut locked = self.store.write();
+        let data = events
+            .into_iter()
+            .map(|event| {
+                (
+                    (event.event_id.event_handle_id, event.event_id.event_seq),
+                    event,
+                )
+            })
+            .collect::<Vec<_>>();
+        locked.extend(data);
+        Ok(())
+    }
+
+    pub fn get_event(&self, event_id: &EventID) -> Result<Option<Event>, Error> {
         let rw_locks = self.store.read();
-        let result = rw_locks.get(tx_hash);
-        // Ok(result.map(|raw_value| bcs::from_bytes(raw_value).ok().unwrap()))
-        // Ok(result.map(|raw_value| raw_value.clone()))
+        let key = (event_id.event_handle_id, event_id.event_seq);
+        let result = rw_locks.get(&key);
         Ok(result.cloned())
     }
 
-    pub fn multi_get_events_by_tx_hash(
-        &self,
-        tx_hashes: &[H256],
-    ) -> Result<Option<Vec<Event>>, Error> {
-        let mut result: Vec<Event> = Vec::new();
-        for ev in tx_hashes
+    //TODO implement event indexer for query by tx hash
+    pub fn get_events_by_tx_hash(&self, tx_hash: &H256) -> Result<Option<Vec<Event>>, Error> {
+        let rw_locks = self.indexer_store.read();
+        let data = rw_locks
             .iter()
-            .map(|tx_hash| self.get_events_by_tx_hash(tx_hash).unwrap())
-            .collect::<Vec<_>>()
-        {
-            if Option::is_some(&ev) {
-                result.append(&mut ev.unwrap());
-            }
-        }
+            .take_while(|((tx_hash_key, _), _)| tx_hash_key == tx_hash)
+            .map(|(_, e)| e.clone())
+            .collect::<Vec<_>>();
+        Ok(data.is_empty().not().then_some(data))
+    }
 
-        if !result.is_empty() {
-            Ok(Some(result))
-        } else {
-            Ok(None)
-        }
+    pub fn get_events_by_event_handle_id(
+        &self,
+        event_handle_id: &ObjectID,
+    ) -> Result<Option<Vec<Event>>, Error> {
+        let rw_locks = self.store.read();
+        let data = rw_locks
+            .iter()
+            .take_while(|((handle_id, _), _)| handle_id == event_handle_id)
+            .map(|(_, e)| e.clone())
+            .collect::<Vec<_>>();
+        Ok(data.is_empty().not().then_some(data))
     }
 
     pub fn get_events_by_move_event_type(
@@ -73,41 +88,26 @@ impl EventStore {
     ) -> Result<Option<Vec<Event>>, Error> {
         let rw_locks = self.store.read();
 
-        let mut result: Vec<Event> = Vec::new();
-        for ev in rw_locks
+        let data = rw_locks
             .iter()
-            .map(|(_tx_hash, events)| {
-                for event in events {
-                    if type_tag_match(event.type_tag(), move_event_type) {
-                        return Some(event.clone());
-                        // result_events.push(event);
-                    }
+            .filter_map(|((_event_handle_id, _event_seq), event)| {
+                if type_tag_match(event.type_tag(), move_event_type) {
+                    return Some(event.clone());
                 }
                 None
             })
-            .collect::<Vec<_>>()
-        {
-            if Option::is_some(&ev) {
-                // events.pop(&mut ev.unwrap());
-                result.push(ev.unwrap());
-            }
-        }
-
-        if !result.is_empty() {
-            Ok(Some(result))
-        } else {
-            Ok(None)
-        }
+            .collect::<Vec<_>>();
+        Ok(data.is_empty().not().then_some(data))
     }
 
     // TODO The complete event filter implementation depends on Indexer
     pub fn get_events_with_filter(&self, filter: EventFilter) -> Result<Option<Vec<Event>>, Error> {
         let result = match filter {
-            // EventFilter::All(filters) => {
-            //     return Err(anyhow!(
-            //         "This type does not currently support filter combinations."
-            //     ));
-            // }
+            EventFilter::All(_filters) => {
+                return Err(anyhow!(
+                    "This type does not currently support filter combinations."
+                ));
+            }
             EventFilter::Transaction(tx_hash) => self.get_events_by_tx_hash(&tx_hash)?,
             EventFilter::MoveEventType(move_event_type) => {
                 self.get_events_by_move_event_type(&move_event_type)?

--- a/moveos/moveos-types/src/event.rs
+++ b/moveos/moveos-types/src/event.rs
@@ -1,179 +1,110 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright (c) The Starcoin Core Contributors
-// SPDX-License-Identifier: Apache-2.0
-
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::object::ObjectID;
 use anyhow::{ensure, Error, Result};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::{language_storage::TypeTag, move_resource::MoveResource};
-#[cfg(any(test, feature = "fuzzing"))]
-use rand::{rngs::OsRng, RngCore};
-use schemars::{self, JsonSchema};
+// #[cfg(any(test, feature = "fuzzing"))]
+// use rand::{rngs::OsRng, RngCore};
 use serde::de::DeserializeOwned;
-use serde::{de, ser, Deserialize, Serialize};
-// use serde_json::Value;
-// use serde_with::serde_as;
-// use serde_with::Bytes;
-use crate::object::ObjectID;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use std::str::FromStr;
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt,
-};
 
 /// A struct that represents a globally unique id for an Event stream that a user can listen to.
-/// By design, the lower part of EventKey is the same as account address.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, JsonSchema)]
-pub struct EventKey(#[schemars(with = "String")] [u8; EventKey::LENGTH]);
-
-impl EventKey {
-    /// Construct a new EventKey from a byte array slice.
-    pub fn new(key: [u8; Self::LENGTH]) -> Self {
-        EventKey(key)
-    }
-
-    /// The number of bytes in an EventKey.
-    pub const LENGTH: usize = AccountAddress::LENGTH + 8;
-
-    /// Get the byte representation of the event key.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-
-    /// Convert event key into a byte array.
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-
-    /// Get the account address part in this event key
-    pub fn get_creator_address(&self) -> AccountAddress {
-        let mut arr = [0u8; AccountAddress::LENGTH];
-        arr.copy_from_slice(&self.0[EventKey::LENGTH - AccountAddress::LENGTH..]);
-
-        AccountAddress::new(arr)
-    }
-
-    /// If this is the `ith` EventKey` created by `get_creator_address()`, return `i`
-    pub fn get_creation_number(&self) -> u64 {
-        u64::from_le_bytes(self.0[0..8].try_into().unwrap())
-    }
-
-    #[cfg(any(test, feature = "fuzzing"))]
-    /// Create a random event key for testing
-    pub fn random() -> Self {
-        let mut rng = OsRng;
-        let salt = rng.next_u64();
-        EventKey::new_from_address(&AccountAddress::random(), salt)
-    }
-
-    /// Create a unique handle by using an AccountAddress and a counter.
-    pub fn new_from_address(addr: &AccountAddress, salt: u64) -> Self {
-        let mut output = [0; Self::LENGTH];
-        let (lhs, rhs) = output.split_at_mut(8);
-        lhs.copy_from_slice(&salt.to_le_bytes());
-        rhs.copy_from_slice(addr.as_ref());
-        EventKey(output)
-    }
+/// the Unique ID is a combination of event handle id and event seq number.
+/// the ID is local to this particular fullnode and will be different from other fullnode.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct EventID {
+    /// each event handle corresponds to a unique event handle id. event handler id equal to guid.
+    pub event_handle_id: ObjectID,
+    /// For expansion: The number of messages that have been emitted to the path previously
+    pub event_seq: u64,
 }
 
-impl From<EventKey> for [u8; EventKey::LENGTH] {
-    fn from(event_key: EventKey) -> Self {
-        event_key.0
-    }
-}
-
-impl From<&EventKey> for [u8; EventKey::LENGTH] {
-    fn from(event_key: &EventKey) -> Self {
-        event_key.0
-    }
-}
-
-impl ser::Serialize for EventKey {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        if serializer.is_human_readable() {
-            self.to_string().serialize(serializer)
-        } else {
-            // In order to preserve the Serde data model and help analysis tools,
-            // make sure to wrap our value in a container with the same name
-            // as the original type.
-            serializer.serialize_newtype_struct("EventKey", serde_bytes::Bytes::new(&self.0))
+impl From<(ObjectID, u64)> for EventID {
+    fn from((event_handle_id, event_seq): (ObjectID, u64)) -> Self {
+        Self {
+            event_handle_id,
+            event_seq,
         }
     }
 }
 
-impl<'de> de::Deserialize<'de> for EventKey {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            let s = <String>::deserialize(deserializer)?;
-            Self::from_str(s.as_str()).map_err(<D::Error as ::serde::de::Error>::custom)
-        } else {
-            // See comment in serialize.
-            #[derive(::serde::Deserialize)]
-            #[serde(rename = "EventKey")]
-            struct Value<'a>(&'a [u8]);
-
-            let value = Value::deserialize(deserializer)?;
-            Self::try_from(value.0).map_err(<D::Error as ::serde::de::Error>::custom)
-        }
+impl From<EventID> for String {
+    fn from(id: EventID) -> Self {
+        format!("{:?}:{}", id.event_handle_id, id.event_seq)
     }
 }
 
-impl TryFrom<&[u8]> for EventKey {
+impl TryFrom<String> for EventID {
     type Error = Error;
 
-    /// Tries to convert the provided byte array into Event Key.
-    fn try_from(bytes: &[u8]) -> Result<EventKey> {
-        ensure!(
-            bytes.len() == Self::LENGTH,
-            "The Event Key {:?} is of invalid length",
-            bytes
-        );
-        let mut addr = [0u8; Self::LENGTH];
-        addr.copy_from_slice(bytes);
-        Ok(EventKey(addr))
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let values = value.split(':').collect::<Vec<_>>();
+        ensure!(values.len() == 2, "Malformed EventID : {value}");
+        Ok((ObjectID::from_str(values[0])?, u64::from_str(values[1])?).into())
     }
 }
 
-impl FromStr for EventKey {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.strip_prefix("0x").unwrap_or(s);
-        let data = hex::decode(s)?;
-        Self::try_from(data.as_slice())
+impl EventID {
+    /// Construct a new EventID.
+    pub fn new(event_handle_id: ObjectID, event_seq: u64) -> Self {
+        EventID {
+            event_handle_id,
+            event_seq,
+        }
     }
 }
 
-impl fmt::LowerHex for EventKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.as_bytes()))
-    }
-}
-
-impl fmt::Display for EventKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        // Forward to the LowerHex impl with a "0x" prepended (the # flag).
-        write!(f, "0x{:#x}", self)
-    }
-}
+// impl ser::Serialize for EventID {
+//     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+//     where
+//         S: ser::Serializer,
+//     {
+//         if serializer.is_human_readable() {
+//             self.to_string().serialize(serializer)
+//         } else {
+//             // In order to preserve the Serde data model and help analysis tools,
+//             // make sure to wrap our value in a container with the same name
+//             // as the original type.
+//             serializer.serialize_newtype_struct("EventID", serde_bytes::Bytes::new(&self.0))
+//         }
+//     }
+// }
+//
+// impl<'de> de::Deserialize<'de> for EventID {
+//     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+//     where
+//         D: de::Deserializer<'de>,
+//     {
+//         if deserializer.is_human_readable() {
+//             let s = <String>::deserialize(deserializer)?;
+//             Self::from_str(s.as_str()).map_err(<D::Error as ::serde::de::Error>::custom)
+//         } else {
+//             // See comment in serialize.
+//             #[derive(::serde::Deserialize)]
+//             #[serde(rename = "EventID")]
+//             struct Value<'a>(&'a [u8]);
+//
+//             let value = Value::deserialize(deserializer)?;
+//             Self::try_from(value.0).map_err(<D::Error as ::serde::de::Error>::custom)
+//         }
+//     }
+// }
+//
 
 /// Entry produced via a call to the `emit_event` builtin.
 #[derive(Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Event {
-    /// The unique key that the event was emitted to
-    pub key: ObjectID,
-    /// For expansion: The number of messages that have been emitted to the path previously
-    pub sequence_number: u64,
+    /// The unique event_id that the event was emitted to
+    pub event_id: EventID,
+    // /// For expansion: The number of messages that have been emitted to the path previously
+    // pub sequence_number: u64,
     /// The type of the data
     pub type_tag: TypeTag,
     /// The data payload of the event
@@ -185,28 +116,28 @@ pub struct Event {
 
 impl Event {
     pub fn new(
-        key: ObjectID,
-        sequence_number: u64,
+        event_id: EventID,
+        // sequence_number: u64,
         type_tag: TypeTag,
         event_data: Vec<u8>,
         event_index: u32,
     ) -> Self {
         Self {
-            key,
-            sequence_number,
+            event_id,
+            // sequence_number,
             type_tag,
             event_data,
             event_index,
         }
     }
 
-    pub fn key(&self) -> &ObjectID {
-        &self.key
+    pub fn event_id(&self) -> &EventID {
+        &self.event_id
     }
 
-    pub fn sequence_number(&self) -> u64 {
-        self.sequence_number
-    }
+    // pub fn sequence_number(&self) -> u64 {
+    //     self.sequence_number
+    // }s
 
     pub fn event_data(&self) -> &[u8] {
         &self.event_data
@@ -230,9 +161,9 @@ impl std::fmt::Debug for Event {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Event {{ key: {:?}, index: {:?}, type: {:?}, event_data: {:?} }}",
-            self.key,
-            self.sequence_number,
+            "Event {{ event_id: {:?}, type: {:?}, event_data: {:?} }}",
+            self.event_id,
+            // self.sequence_number,
             self.type_tag,
             hex::encode(&self.event_data)
         )
@@ -246,23 +177,29 @@ impl std::fmt::Display for Event {
 }
 
 /// A Rust representation of an Event Handle Resource.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EventHandle {
     /// Number of events in the event stream.
     count: u64,
-    /// The associated globally unique key that is used as the key to the EventStore.
-    key: EventKey,
+    /// each event handle corresponds to a unique event handle id
+    event_handle_id: ObjectID,
+    /// event handle create address
+    sender: AccountAddress,
 }
 
 impl EventHandle {
     /// Constructs a new Event Handle
-    pub fn new(key: EventKey, count: u64) -> Self {
-        EventHandle { key, count }
+    pub fn new(event_handle_id: ObjectID, count: u64, sender: AccountAddress) -> Self {
+        EventHandle {
+            event_handle_id,
+            count,
+            sender,
+        }
     }
 
-    /// Return the key to where this event is stored in EventStore.
-    pub fn key(&self) -> &EventKey {
-        &self.key
+    /// Return the event_id to where this event is stored in EventStore.
+    pub fn event_handle_id(&self) -> &ObjectID {
+        &self.event_handle_id
     }
     /// Return the counter for the handle
     pub fn count(&self) -> u64 {
@@ -274,20 +211,20 @@ impl EventHandle {
         &mut self.count
     }
 
-    #[cfg(any(test, feature = "fuzzing"))]
-    /// Create a random event handle for testing
-    pub fn random_handle(count: u64) -> Self {
-        Self {
-            key: EventKey::random(),
-            count,
-        }
-    }
+    // #[cfg(any(test, feature = "fuzzing"))]
+    // /// Create a random event handle for testing
+    // pub fn random_handle(count: u64) -> Self {
+    //     Self {
+    //         event_id: EventID::random(),
+    //         count,
+    //     }
+    // }
 
-    /// Derive a unique handle by using an AccountAddress and a counter.
-    pub fn new_from_address(addr: &AccountAddress, salt: u64) -> Self {
-        Self {
-            key: EventKey::new_from_address(addr, salt),
-            count: 0,
-        }
-    }
+    // /// Derive a unique handle by using an AccountAddress and a counter.
+    // pub fn new_from_address(addr: &AccountAddress, salt: u64) -> Self {
+    //     Self {
+    //         event_id: EventID::new_from_address(addr, salt),
+    //         count: 0,
+    //     }
+    // }
 }

--- a/moveos/moveos-types/src/event_filter.rs
+++ b/moveos/moveos-types/src/event_filter.rs
@@ -4,17 +4,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
-// use move_bytecode_utils::module_cache::GetModule;
-use move_core_types::account_address::AccountAddress;
-// use move_core_types::identifier::Identifier;
-// use move_core_types::language_storage::StructTag;
-use crate::event::Event;
+use crate::event::{Event, EventID};
 use crate::h256::H256;
 use crate::move_types::type_tag_match;
+use anyhow::Result;
+use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::TypeTag;
-// use schemars::JsonSchema;
-use crate::object::ObjectID;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::serde_as;
@@ -24,13 +19,13 @@ use serde_with::serde_as;
 #[derive(Eq, PartialEq, Clone, Debug)]
 // #[serde(rename = "Event", rename_all = "camelCase")]
 pub struct MoveOSEvent {
-    pub key: ObjectID,
+    pub event_id: EventID,
     /// Sender's address.
     pub sender: AccountAddress,
     /// Transaction hash
-    pub tx_hash: H256,
+    pub tx_hash: Option<H256>,
     /// The number of messages that have been emitted to the path previously
-    pub sequence_number: u64,
+    // pub sequence_number: u64,
     // #[schemars(with = "String")]
     // #[serde_as(as = "TypeTag")]
     /// Move event type.
@@ -56,13 +51,13 @@ pub struct MoveOSEvent {
 impl MoveOSEvent {
     pub fn try_from(
         event: Event,
-        tx_hash: H256,
+        tx_hash: Option<H256>,
         timestamp_ms: Option<u64>,
         block_height: Option<u64>,
     ) -> Result<Self> {
         let Event {
-            key,
-            sequence_number,
+            event_id,
+            // sequence_number,
             type_tag,
             event_data,
             event_index,
@@ -70,14 +65,11 @@ impl MoveOSEvent {
 
         //TODO how to store and derive sender address ?
         let sender = AccountAddress::ZERO;
-        // let move_struct = Event::move_event_to_move_struct(&type_, &contents, resolver)?;
-        // let (type_, field) = type_and_fields_from_move_struct(&type_, move_struct);
         //TODO deserilize field from event_data
         let parsed_json = serde_json::to_value(event_data.clone()).unwrap();
 
         Ok(MoveOSEvent {
-            key,
-            sequence_number,
+            event_id,
             sender,
             tx_hash,
             type_tag,
@@ -158,8 +150,9 @@ impl EventFilter {
             EventFilter::Or(f1, f2) => {
                 EventFilter::Any(vec![*(*f1).clone(), *(*f2).clone()]).matches(item)
             }
-            EventFilter::Transaction(tx_hash) => tx_hash == &item.tx_hash,
-
+            EventFilter::Transaction(tx_hash) => {
+                Option::is_some(&item.tx_hash) && (tx_hash == &item.tx_hash.unwrap())
+            }
             EventFilter::TimeRange {
                 start_time,
                 end_time,


### PR DESCRIPTION
This pr further improve event implementation involve https://github.com/rooch-network/rooch/issues/91.

The design of the event handle is retained, and the event handle contains guid and event serial number, where the guid is generated based on the Object ID. The event handle is stored in the type table, so developers don't actually need to care about the event handle, they can directly emit the event, and the contract will implicitly create and maintain the event handle.