### PR TITLE
Check function parameters before executing the function and script.

### DIFF
--- a/moveos/moveos-verifier/Cargo.toml
+++ b/moveos/moveos-verifier/Cargo.toml
@@ -9,6 +9,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 codespan-reporting = { workspace = true }
 termcolor = { workspace = true }
+bcs = { workspace = true }
 
 move-core-types = { workspace = true }
 move-model = { workspace = true }
@@ -16,4 +17,5 @@ move-binary-format = { workspace = true }
 move-package = { workspace = true }
 move-compiler = { workspace = true }
 move-command-line-common = { workspace = true }
-bcs = { workspace = true }
+move-vm-runtime = { workspace = true }
+move-vm-types = { workspace = true }

--- a/moveos/moveos-verifier/src/lib.rs
+++ b/moveos/moveos-verifier/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod build;
 pub mod metadata;
+pub mod verifier;

--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -1,11 +1,13 @@
+use crate::build::ROOCH_METADATA_KEY;
 use move_binary_format::binary_views::BinaryIndexedView;
 use move_binary_format::file_format::{Bytecode, FunctionInstantiation, SignatureToken};
 use move_core_types::language_storage::ModuleId;
-// use move_model::model::ModuleId;
+use move_core_types::metadata::Metadata;
 use move_model::ast::Attribute;
-use move_model::model::{FunctionEnv, GlobalEnv, Loc, ModuleEnv, QualifiedId, StructId};
+use move_model::model::{FunctionEnv, GlobalEnv, Loc, ModuleEnv};
 use move_model::ty::PrimitiveType;
 use move_model::ty::Type;
+use move_vm_runtime::move_vm::MoveVM;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -36,6 +38,17 @@ impl RuntimeModuleMetadataV1 {
         self.fun_attributes.is_empty()
             && self.struct_attributes.is_empty()
             && self.private_generics_indices.is_empty()
+    }
+}
+
+pub fn get_metadata(md: &Metadata) -> Option<RuntimeModuleMetadataV1> {
+    bcs::from_bytes::<RuntimeModuleMetadataV1>(&md.value).ok()
+}
+
+pub fn get_vm_metadata(vm: &MoveVM, module_id: &ModuleId) -> Option<RuntimeModuleMetadataV1> {
+    match vm.get_module_metadata(module_id.clone(), ROOCH_METADATA_KEY) {
+        None => None,
+        Some(metadata) => get_metadata(&metadata),
     }
 }
 
@@ -285,7 +298,14 @@ impl<'a> ExtendedChecker<'a> {
                 // Vectors are allowed if element type is allowed
                 self.check_transaction_input_type(loc, ety)
             }
-            Struct(mid, sid, _) if self.is_allowed_input_struct(mid.qualified(*sid)) => {
+
+            Struct(mid, sid, _)
+                if is_allowed_input_struct(
+                    self.env
+                        .get_struct(mid.qualified(*sid))
+                        .get_full_name_with_address(),
+                ) =>
+            {
                 // Specific struct types are allowed
             }
             Reference(false, bt)
@@ -313,7 +333,11 @@ impl<'a> ExtendedChecker<'a> {
     fn is_allowed_reference_types(&self, bt: &Type) -> bool {
         match bt {
             Type::Struct(mid, sid, _) => {
-                if self.is_allowed_input_struct(mid.qualified(*sid)) {
+                let struct_name = self
+                    .env
+                    .get_struct(mid.qualified(*sid))
+                    .get_full_name_with_address();
+                if is_allowed_input_struct(struct_name) {
                     return true;
                 }
                 false
@@ -321,17 +345,16 @@ impl<'a> ExtendedChecker<'a> {
             _ => false,
         }
     }
+}
 
-    fn is_allowed_input_struct(&self, qid: QualifiedId<StructId>) -> bool {
-        let name = self.env.get_struct(qid).get_full_name_with_address();
-        matches!(
-            name.as_str(),
-            "0x1::string::String"
-                | "0x1::object_id::ObjectID"
-                | "0x1::storage_context::StorageContext"
-                | "0x1::tx_context::TxContext"
-        )
-    }
+pub fn is_allowed_input_struct(name: String) -> bool {
+    matches!(
+        name.as_str(),
+        "0x1::string::String"
+            | "0x1::object_id::ObjectID"
+            | "0x1::storage_context::StorageContext"
+            | "0x1::tx_context::TxContext"
+    )
 }
 
 // ----------------------------------------------------------------------------------

--- a/moveos/moveos-verifier/src/verifier.rs
+++ b/moveos/moveos-verifier/src/verifier.rs
@@ -1,0 +1,83 @@
+use crate::metadata::is_allowed_input_struct;
+use anyhow::{Error, Result};
+use move_core_types::resolver::MoveResolver;
+use move_vm_runtime::session::{LoadedFunctionInstantiation, Session};
+use move_vm_types::loaded_data::runtime_types::Type;
+use std::ops::Deref;
+
+pub fn verify_entry_function<S>(
+    func: LoadedFunctionInstantiation,
+    session: &Session<S>,
+) -> Result<bool>
+where
+    S: MoveResolver,
+{
+    if !func.return_.is_empty() {
+        return Err(Error::msg("function should not return values".to_string()));
+    }
+
+    for ty in &func.parameters {
+        if !check_transaction_input_type(ty, session) {
+            return Err(Error::msg("parameter type is not allowed".to_string()));
+        }
+    }
+
+    Ok(true)
+}
+
+fn check_transaction_input_type<S>(ety: &Type, session: &Session<S>) -> bool
+where
+    S: MoveResolver,
+{
+    use Type::*;
+    match ety {
+        // Any primitive type allowed, any parameter expected to instantiate with primitive
+        Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address | Signer => true,
+        Vector(ety) => {
+            // Vectors are allowed if element type is allowed
+            check_transaction_input_type(ety.deref(), session)
+        }
+        Struct(idx) | StructInstantiation(idx, _) => {
+            if let Some(st) = session.get_struct_type(*idx) {
+                let full_name = format!("{}::{}", st.module.short_str_lossless(), st.name);
+                is_allowed_input_struct(full_name)
+            } else {
+                false
+            }
+        }
+        Reference(bt)
+            if matches!(bt.as_ref(), Signer)
+                || is_allowed_reference_types(bt.as_ref(), session) =>
+        {
+            // Immutable Reference to signer and specific types is allowed
+            true
+        }
+        MutableReference(bt) if is_allowed_reference_types(bt.as_ref(), session) => {
+            // Mutable references to specific types is allowed
+            true
+        }
+        _ => {
+            // Everything else is disallowed.
+            false
+        }
+    }
+}
+
+fn is_allowed_reference_types<S>(bt: &Type, session: &Session<S>) -> bool
+where
+    S: MoveResolver,
+{
+    match bt {
+        Type::Struct(sid) => {
+            if let Some(st) = session.get_struct_type(*sid) {
+                let full_name = format!("{}::{}", st.module.short_str_lossless(), st.name);
+                if is_allowed_input_struct(full_name) {
+                    return true;
+                }
+            }
+
+            false
+        }
+        _ => false,
+    }
+}

--- a/moveos/moveos/Cargo.toml
+++ b/moveos/moveos/Cargo.toml
@@ -34,3 +34,4 @@ move-vm-types = { workspace = true }
 moveos-types = { workspace = true }
 moveos-store = { workspace = true }
 moveos-stdlib = { workspace = true }
+moveos-verifier = { workspace = true }

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -172,6 +172,9 @@ impl MoveOS {
                 let loaded_function =
                     session.load_script(script.code.as_slice(), script.ty_args.clone())?;
 
+                let func = session.load_script(script.code.as_slice(), script.ty_args.clone())?;
+                moveos_verifier::verifier::verify_entry_function(func, session.runtime_session())?;
+
                 let args = session
                     .resolve_args(&tx_context, loaded_function, script.args)
                     .map_err(|e| e.finish(Location::Undefined))?;
@@ -190,6 +193,11 @@ impl MoveOS {
                 let args = session
                     .resolve_args(&tx_context, loaded_function, function.args)
                     .map_err(|e| e.finish(Location::Undefined))?;
+
+                let func =
+                    session.load_function(&function.function_id, function.ty_args.as_slice())?;
+                moveos_verifier::verifier::verify_entry_function(func, session.runtime_session())?;
+
                 session
                     .execute_entry_function(
                         &function.function_id,

--- a/moveos/moveos/src/vm/move_vm_ext.rs
+++ b/moveos/moveos/src/vm/move_vm_ext.rs
@@ -233,6 +233,10 @@ where
     pub fn get_native_extensions(&self) -> &NativeContextExtensions<'r> {
         self.session.get_native_extensions()
     }
+
+    pub fn runtime_session(&self) -> &Session<'r, 'l, S> {
+        self.session.borrow()
+    }
 }
 
 impl AsRef<MoveVM> for MoveVmExt {


### PR DESCRIPTION
According to issue https://github.com/rooch-network/rooch/issues/202.

When MoveOS executes functions and scripts, the verifier checks the parameters and return values of the functions before execution, in the same way as it checks the entry function during compile time.