### PR TITLE
Fix in the entry function verifier.

### DIFF
--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -354,6 +354,7 @@ pub fn is_allowed_input_struct(name: String) -> bool {
             | "0x1::object_id::ObjectID"
             | "0x1::storage_context::StorageContext"
             | "0x1::tx_context::TxContext"
+            | "0x1::ascii::String"
     )
 }
 

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -169,11 +169,11 @@ impl MoveOS {
         let tx_context = TxContext::new(sender, tx_hash);
         let execute_result = match action {
             MoveAction::Script(script) => {
-                let loaded_function =
-                    session.load_script(script.code.as_slice(), script.ty_args.clone())?;
-
                 let func = session.load_script(script.code.as_slice(), script.ty_args.clone())?;
                 moveos_verifier::verifier::verify_entry_function(func, session.runtime_session())?;
+
+                let loaded_function =
+                    session.load_script(script.code.as_slice(), script.ty_args.clone())?;
 
                 let args = session
                     .resolve_args(&tx_context, loaded_function, script.args)
@@ -188,15 +188,15 @@ impl MoveOS {
                     })
             }
             MoveAction::Function(function) => {
+                let func =
+                    session.load_function(&function.function_id, function.ty_args.as_slice())?;
+                moveos_verifier::verifier::verify_entry_function(func, session.runtime_session())?;
+
                 let loaded_function =
                     session.load_function(&function.function_id, function.ty_args.as_slice())?;
                 let args = session
                     .resolve_args(&tx_context, loaded_function, function.args)
                     .map_err(|e| e.finish(Location::Undefined))?;
-
-                let func =
-                    session.load_function(&function.function_id, function.ty_args.as_slice())?;
-                moveos_verifier::verifier::verify_entry_function(func, session.runtime_session())?;
 
                 session
                     .execute_entry_function(


### PR DESCRIPTION
1. verify_entry_function should be before the `resolve_args`.
2. Add 0x1::ascii::String to the allowed parameter types in the entry function.

Pre PR #152

resolve #202   