### PR TITLE
[rpc] Refactor the execute_view_function return value and support string key in Table AccessPath

### DIFF
--- a/crates/rooch-client/src/lib.rs
+++ b/crates/rooch-client/src/lib.rs
@@ -9,7 +9,10 @@ use moveos_types::{access_path::AccessPath, object::ObjectID, transaction::Funct
 use rand::Rng;
 use rooch_server::{
     api::rooch_api::RoochAPIClient,
-    jsonrpc_types::{AnnotatedMoveStructView, AnnotatedObjectView, AnnotatedStateView, StateView},
+    jsonrpc_types::{
+        AnnotatedFunctionReturnValueView, AnnotatedMoveStructView, AnnotatedObjectView,
+        AnnotatedStateView, StateView,
+    },
 };
 use rooch_types::{address::RoochAddress, transaction::rooch::RoochTransaction};
 
@@ -93,7 +96,7 @@ impl Client {
     pub async fn execute_view_function(
         &self,
         function_call: FunctionCall,
-    ) -> Result<Vec<serde_json::Value>> {
+    ) -> Result<Vec<AnnotatedFunctionReturnValueView>> {
         self.rpc
             .http
             .execute_view_function(function_call.into())

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -3,13 +3,12 @@
 
 use anyhow::Result;
 use coerce::actor::message::Message;
-use move_core_types::{
-    account_address::AccountAddress, language_storage::StructTag, value::MoveValue,
-};
+use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
 use move_resource_viewer::AnnotatedMoveStruct;
 use moveos::moveos::TransactionOutput;
 use moveos_types::access_path::AccessPath;
 use moveos_types::event_filter::{EventFilter, MoveOSEvent};
+use moveos_types::function_return_value::AnnotatedFunctionReturnValue;
 use moveos_types::state::{AnnotatedState, State};
 use moveos_types::{
     object::{AnnotatedObject, ObjectID},
@@ -50,7 +49,7 @@ pub struct ExecuteViewFunctionMessage {
 }
 
 impl Message for ExecuteViewFunctionMessage {
-    type Result = Result<Vec<MoveValue>, anyhow::Error>;
+    type Result = Result<Vec<AnnotatedFunctionReturnValue>, anyhow::Error>;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -11,12 +11,10 @@ use crate::actor::{
 };
 use anyhow::Result;
 use coerce::actor::ActorRef;
-use move_core_types::{
-    account_address::AccountAddress, language_storage::StructTag, value::MoveValue,
-};
+use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
 use move_resource_viewer::AnnotatedMoveStruct;
 use moveos::moveos::TransactionOutput;
-use moveos_types::access_path::AccessPath;
+use moveos_types::{access_path::AccessPath, function_return_value::AnnotatedFunctionReturnValue};
 use moveos_types::{
     event_filter::{EventFilter, MoveOSEvent},
     state::{AnnotatedState, State},
@@ -56,7 +54,10 @@ impl ExecutorProxy {
         Ok((result.output, result.transaction_info))
     }
 
-    pub async fn execute_view_function(&self, call: FunctionCall) -> Result<Vec<MoveValue>> {
+    pub async fn execute_view_function(
+        &self,
+        call: FunctionCall,
+    ) -> Result<Vec<AnnotatedFunctionReturnValue>> {
         self.actor.send(ExecuteViewFunctionMessage { call }).await?
     }
 

--- a/crates/rooch-server/src/api/rooch_api.rs
+++ b/crates/rooch-server/src/api/rooch_api.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::{
-    AnnotatedMoveStructView, AnnotatedObjectView, AnnotatedStateView, EventView, FunctionCallView,
-    StateView, StrView, StructTagView,
+    AnnotatedFunctionReturnValueView, AnnotatedMoveStructView, AnnotatedObjectView,
+    AnnotatedStateView, EventView, FunctionCallView, StateView, StrView, StructTagView,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -35,7 +35,7 @@ pub trait RoochAPI {
     async fn execute_view_function(
         &self,
         function_call: FunctionCallView,
-    ) -> RpcResult<Vec<serde_json::Value>>;
+    ) -> RpcResult<Vec<AnnotatedFunctionReturnValueView>>;
 
     /// Get the resource of an account by address and type
     #[method(name = "rooch_getResource")]

--- a/crates/rooch-server/src/jsonrpc_types/function_return_value_view.rs
+++ b/crates/rooch-server/src/jsonrpc_types/function_return_value_view.rs
@@ -1,0 +1,37 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{AnnotatedMoveValueView, TypeTagView};
+use crate::jsonrpc_types::StrView;
+use moveos_types::function_return_value::{AnnotatedFunctionReturnValue, FunctionReturnValue};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionReturnValueView {
+    pub type_tag: TypeTagView,
+    pub value: StrView<Vec<u8>>,
+}
+
+impl From<FunctionReturnValue> for FunctionReturnValueView {
+    fn from(value: FunctionReturnValue) -> Self {
+        Self {
+            type_tag: value.type_tag.into(),
+            value: StrView(value.value),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnotatedFunctionReturnValueView {
+    pub value: FunctionReturnValueView,
+    pub move_value: AnnotatedMoveValueView,
+}
+
+impl From<AnnotatedFunctionReturnValue> for AnnotatedFunctionReturnValueView {
+    fn from(value: AnnotatedFunctionReturnValue) -> Self {
+        Self {
+            value: value.value.into(),
+            move_value: value.move_value.into(),
+        }
+    }
+}

--- a/crates/rooch-server/src/jsonrpc_types/mod.rs
+++ b/crates/rooch-server/src/jsonrpc_types/mod.rs
@@ -4,9 +4,13 @@
 #[macro_use]
 
 mod str_view;
+mod function_return_value_view;
 mod move_types;
+mod transaction_argument_view;
 
 pub mod bytes;
 pub mod eth;
+pub use function_return_value_view::*;
 pub use move_types::*;
 pub use str_view::*;
+pub use transaction_argument_view::*;

--- a/crates/rooch-server/src/jsonrpc_types/transaction_argument_view.rs
+++ b/crates/rooch-server/src/jsonrpc_types/transaction_argument_view.rs
@@ -1,0 +1,27 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::jsonrpc_types::StrView;
+use move_core_types::{
+    parser::parse_transaction_argument, transaction_argument::TransactionArgument, value::MoveValue,
+};
+use std::str::FromStr;
+
+pub type TransactionArgumentView = StrView<TransactionArgument>;
+
+impl std::fmt::Display for StrView<TransactionArgument> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", MoveValue::from(self.0.clone()))
+    }
+}
+
+impl FromStr for TransactionArgumentView {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        //TODO support more argument types
+        // vector<address>, vector<std::string::String>, etc.
+        let arg = parse_transaction_argument(s)?;
+        Ok(Self(arg))
+    }
+}

--- a/crates/rooch-server/src/server/rooch_server.rs
+++ b/crates/rooch-server/src/server/rooch_server.rs
@@ -3,8 +3,8 @@
 
 use crate::api::RoochRpcModule;
 use crate::jsonrpc_types::{
-    AnnotatedMoveStructView, AnnotatedStateView, EventView, FunctionCallView, StateView, StrView,
-    StructTagView,
+    AnnotatedFunctionReturnValueView, AnnotatedMoveStructView, AnnotatedStateView, EventView,
+    FunctionCallView, StateView, StrView, StructTagView,
 };
 use crate::service::RpcService;
 use crate::{api::rooch_api::RoochAPIServer, jsonrpc_types::AnnotatedObjectView};
@@ -55,11 +55,14 @@ impl RoochAPIServer for RoochServer {
     async fn execute_view_function(
         &self,
         function_call: FunctionCallView,
-    ) -> RpcResult<Vec<serde_json::Value>> {
+    ) -> RpcResult<Vec<AnnotatedFunctionReturnValueView>> {
         Ok(self
             .rpc_service
             .execute_view_function(function_call.into())
-            .await?)
+            .await?
+            .into_iter()
+            .map(AnnotatedFunctionReturnValueView::from)
+            .collect())
     }
 
     async fn get_resource(

--- a/crates/rooch-server/src/service/mod.rs
+++ b/crates/rooch-server/src/service/mod.rs
@@ -7,6 +7,7 @@ use move_resource_viewer::AnnotatedMoveStruct;
 use moveos::moveos::TransactionOutput;
 use moveos_types::access_path::AccessPath;
 use moveos_types::event_filter::{EventFilter, MoveOSEvent};
+use moveos_types::function_return_value::AnnotatedFunctionReturnValue;
 use moveos_types::state::{AnnotatedState, State};
 use moveos_types::{
     object::{AnnotatedObject, ObjectID},
@@ -64,12 +65,8 @@ impl RpcService {
     pub async fn execute_view_function(
         &self,
         function_call: FunctionCall,
-    ) -> Result<Vec<serde_json::Value>> {
-        let output_values = self.executor.execute_view_function(function_call).await?;
-        let mut resp = vec![];
-        for v in output_values {
-            resp.push(serde_json::to_value(v)?);
-        }
+    ) -> Result<Vec<AnnotatedFunctionReturnValue>> {
+        let resp = self.executor.execute_view_function(function_call).await?;
         Ok(resp)
     }
 

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -109,7 +109,7 @@ impl CommandAction<TransactionOutput> for Publish {
         let action = MoveAction::ModuleBundle(bundles);
 
         let sender: RoochAddress = pkg_address.into();
-
+        eprintln!("Publish modules to address: {:?}", sender);
         context.sign_and_execute(sender, action).await
     }
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -2,17 +2,34 @@ Feature: Rooch CLI integration tests
     Scenario: Init
       Then cmd: "init"
 
-    Scenario: move and account
-      Given a server
-      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default}"
-      Then cmd: "move run --function {default}::counter::init --sender-account {default}"
-      Then cmd: "move view --function {default}::counter::value"
-      Then assert: "{{$.move[-1][0]}} == 0"
-      Then cmd: "move run --function {default}::counter::increase --sender-account {default}"
-      Then cmd: "move view --function {default}::counter::value"
-      Then assert: "{{$.move[-1][0]}} == 1"
+    Scenario: account
+      Given the server
+
       Then cmd: "object --id {default}"
-      Then cmd: "resource --address {default} --resource {default}::counter::Counter"
       Then cmd: "account create"
       Then cmd: "account list"
       Then cmd: "account import "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit""
+    
+      # TODO split Scenario for every example
+      # counter example
+      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default}"
+      Then cmd: "move run --function {default}::counter::init --sender-account {default}"
+      Then cmd: "move view --function {default}::counter::value"
+      Then assert: "{{$.move[-1][0].move_value}} == 0"
+      Then cmd: "move run --function {default}::counter::increase --sender-account {default}"
+      Then cmd: "move view --function {default}::counter::value"
+      Then assert: "{{$.move[-1][0].move_value}} == 1"
+      Then cmd: "resource --address {default} --resource {default}::counter::Counter"
+
+
+      # kv store example
+      Then cmd: "move publish -p ../../examples/kv_store --sender-account {default} --named-addresses rooch_examples={default}"
+      #FIXME how to pass args at here.
+      #Then cmd: "move run --function {default}::kv_store::add_value --args 'b\"key1\"' 'b\"value1\"' --sender-account default"
+      #Then cmd: "move view --function {default}::kv_store::get_value --args 'b\"key1\"' "
+      #Then assert: "{{$.move[-1][0].move_value}} == "value1""
+      #Then cmd: "state --access-path /resource/{default}/{default}::kv_store::KVStore
+      #Then cmd: "state --access-path /table/{{$.move[-1][0].move_value.value.table.value.handle}}/key1"
+      #Then assert: "{{$.move[-1][0].move_value}} == "value1""
+            
+      

--- a/crates/testsuite/tests/integration.rs
+++ b/crates/testsuite/tests/integration.rs
@@ -16,12 +16,27 @@ struct World {
     tpl_ctx: Option<TemplateContext>,
 }
 
-#[given(expr = "a server")] // Cucumber Expression
+#[given(expr = "the server")] // Cucumber Expression
 async fn start_server(w: &mut World) {
     let mut service = Service::new();
     service.start().await.unwrap();
 
     w.service = Some(service);
+}
+
+#[then(expr = "stop the server")] // Cucumber Expression
+async fn stop_server(w: &mut World) {
+    println!("stop server");
+    match w.service.take() {
+        Some(service) => {
+            service.stop().unwrap();
+            info!("Shutdown Sever");
+        }
+        None => {
+            info!("service is none");
+        }
+    }
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 }
 
 #[then(regex = r#"cmd: "(.*)?""#)]

--- a/examples/complex_struct/README.md
+++ b/examples/complex_struct/README.md
@@ -1,6 +1,6 @@
 # Complex Struct example
  
-The purpose of this example is mainly to test how different types of MoveValue are displayed in the JSON-RPC output
+The purpose of this example is mainly to test how types of MoveValue are displayed in the JSON-RPC output
 
 ## Getting started
 

--- a/examples/kv_store/Move.toml
+++ b/examples/kv_store/Move.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kv_store"
+version = "0.0.1"
+
+[dependencies]
+#MoveosStdLib = { git = "https://github.com/rooch-network/rooch.git", subdir = "moveos/moveos-stdlib/moveos-stdlib", rev = "main" }
+MoveosStdLib = { local = "../../moveos/moveos-stdlib/moveos-stdlib" }
+
+[addresses]
+rooch_examples =  "_"
+moveos_std =  "0x1"
+rooch_framework =  "0x1"
+
+[dev-addresses]
+rooch_examples = "0x42"

--- a/examples/kv_store/README.md
+++ b/examples/kv_store/README.md
@@ -1,0 +1,85 @@
+# KV store example
+ 
+The purpose of this example is mainly to show use table as a KV store
+
+## Getting started
+
+> `0xbbfc33692c7d57839fde9643681fb64c83b377e4c70b1e4b76aa35ff1e410d01` is a example address. When executing, please replace it with your own local address.
+
+### Publish and init
+
+```bash
+rooch move publish -p examples/kv_store --sender-account default --named-addresses rooch_examples=default
+```
+
+### Add value
+
+```bash
+rooch move run --function 0xbbfc33692c7d57839fde9643681fb64c83b377e4c70b1e4b76aa35ff1e410d01::kv_store::add_value --args "b\"key1\"" "b\"value1\"" --sender-account default
+```
+
+### Get value
+
+```bash
+rooch move view --function 0xbbfc33692c7d57839fde9643681fb64c83b377e4c70b1e4b76aa35ff1e410d01::kv_store::get_value --args "b\"key1\""
+```
+```json
+[
+  {
+    "value": {
+      "type_tag": "0x1::string::String",
+      "value": "0x0676616c756531"
+    },
+    "move_value": "value1"
+  }
+]
+```
+
+### Get KVStore resource
+
+```bash
+rooch state --access-path /resource/0xbbfc33692c7d57839fde9643681fb64c83b377e4c70b1e4b76aa35ff1e410d01/0xbbfc33692c7d57839fde9643681fb64c83b377e4c70b1e4b76aa35ff1e410d01::kv_store::KVStore
+```
+```json
+[
+  {
+    "state": {
+      "value": "0x7bffff7301cbcafe87a12a5a4e0f3798e9062743df6330eaa0ba2e92dd685a1e",
+      "value_type": "0xbbfc33692c7d57839fde9643681fb64c83b377e4c70b1e4b76aa35ff1e410d01::kv_store::KVStore"
+    },
+    "move_value": {
+      "abilities": 12,
+      "type": "0xbbfc33692c7d57839fde9643681fb64c83b377e4c70b1e4b76aa35ff1e410d01::kv_store::KVStore",
+      "value": {
+        "table": {
+          "abilities": 4,
+          "type": "0x1::table::Table<0x1::string::String, 0x1::string::String>",
+          "value": {
+            "handle": "0x7bffff7301cbcafe87a12a5a4e0f3798e9062743df6330eaa0ba2e92dd685a1e"
+          }
+        }
+      }
+    }
+  }
+]
+```
+
+### Get Table Items by key
+
+> Table AccessPath: `/table/$table_handle`
+> The table_handle from previous output. 
+
+```bash
+rooch state --access-path /table/0x7bffff7301cbcafe87a12a5a4e0f3798e9062743df6330eaa0ba2e92dd685a1e/key1
+```
+```json
+[
+  {
+    "state": {
+      "value": "0x0676616c756531",
+      "value_type": "0x1::string::String"
+    },
+    "move_value": "value1"
+  }
+]
+```

--- a/examples/kv_store/sources/kv_store.move
+++ b/examples/kv_store/sources/kv_store.move
@@ -1,0 +1,62 @@
+module rooch_examples::kv_store {
+
+   use moveos_std::storage_context::{Self, StorageContext};
+   use moveos_std::account_storage;
+   use moveos_std::table::{Self, Table};
+   use std::string::{String};
+
+   struct KVStore has store, key {
+      table: Table<String, String>,
+   }
+
+   public fun add(store: &mut KVStore, key: String, value: String) {
+      table::add(&mut store.table, key, value);
+   }
+
+   public fun remove(store: &mut KVStore, key: String) {
+      table::remove(&mut store.table, key);
+   }
+
+   public fun contains(store: &KVStore, key: String): bool {
+      table::contains(&store.table, key)
+   }
+
+   public fun borrow(store: &KVStore, key: String): &String {
+      table::borrow(&store.table, key)
+   }
+
+   public fun borrow_kv_store(ctx: &mut StorageContext): &KVStore {
+      account_storage::global_borrow(ctx, @rooch_examples)
+   }
+
+   public fun borrow_kv_store_mut(ctx: &mut StorageContext): &mut KVStore {
+      account_storage::global_borrow_mut(ctx, @rooch_examples)
+   }
+
+   //init when module publish
+   fun init(ctx: &mut StorageContext, sender: signer) {
+      let tx_ctx = storage_context::tx_context_mut(ctx);
+      let kv = KVStore{
+         table: table::new(tx_ctx),
+      };
+      account_storage::global_move_to(ctx, &sender, kv);
+   }
+
+   public entry fun add_value(ctx: &mut StorageContext, key: String, value: String) {
+      let kv = borrow_kv_store_mut(ctx);
+      add(kv, key, value);
+   }
+
+   public entry fun remove_value(ctx: &mut StorageContext, key: String) {
+      let kv = borrow_kv_store_mut(ctx);
+      remove(kv, key);
+   }
+
+   #[view]
+   public fun get_value(ctx: &mut StorageContext, key: String): String {
+      let kv = borrow_kv_store(ctx);
+      let value = borrow(kv, key);
+      *value
+   }
+
+}

--- a/moveos/moveos-stdlib/tests/cases/table/basic.exp
+++ b/moveos/moveos-stdlib/tests/cases/table/basic.exp
@@ -1,1 +1,1 @@
-processed 3 tasks
+processed 4 tasks

--- a/moveos/moveos-stdlib/tests/cases/table/basic.move
+++ b/moveos/moveos-stdlib/tests/cases/table/basic.move
@@ -4,15 +4,20 @@
 module test::m {
     use std::string::String;
     use moveos_std::table::{Self, Table};
-    use moveos_std::tx_context::{TxContext};
+    use moveos_std::tx_context;
+    use moveos_std::storage_context::{Self, StorageContext};
+    use moveos_std::object;
+    use moveos_std::object_storage;
+    use moveos_std::object_id::{ObjectID};
 
     struct KVStore has store, key {
         table: Table<String,vector<u8>>,
     }
 
-    public fun make_kv_store(ctx: &mut TxContext): KVStore {
+    public fun make_kv_store(ctx: &mut StorageContext): KVStore {
+        let tx_ctx = storage_context::tx_context_mut(ctx);
         KVStore{
-            table: table::new(ctx),
+            table: table::new(tx_ctx),
         }
     }
 
@@ -20,31 +25,56 @@ module test::m {
         table::add(&mut store.table, key, value);
     }
 
-    public fun contains(store: &mut KVStore, key: String): bool {
-        table::contains(&mut store.table, key)
+    public fun contains(store: &KVStore, key: String): bool {
+        table::contains(&store.table, key)
     }
 
+    public fun borrow(store: &KVStore, key: String): &vector<u8> {
+        table::borrow(&store.table, key)
+    }
+
+    public fun save_to_object_storage(ctx: &mut StorageContext, kv: KVStore) : ObjectID {
+        let tx_ctx = storage_context::tx_context_mut(ctx);
+        let sender = tx_context::sender(tx_ctx);
+        let object = object::new(tx_ctx, sender, kv);
+        let object_id = object::id(&object);
+        let object_storage = storage_context::object_storage_mut(ctx);
+        object_storage::add(object_storage, object);
+        object_id
+    }
+
+    public fun borrow_from_object_storage(ctx: &mut StorageContext, object_id: ObjectID): &KVStore {
+        let object_storage = storage_context::object_storage(ctx);
+        let object = object_storage::borrow(object_storage, object_id);
+        object::borrow<KVStore>(object)
+    }
 }
 
-//check module exists
 //# run --signers test
 script {
     use std::string;
-    use moveos_std::storage_context::{Self, StorageContext};
-    use moveos_std::object;
-    use moveos_std::object_storage;
-    use moveos_std::tx_context;
+    use moveos_std::storage_context::{StorageContext};
     use test::m;
 
     fun main(ctx: &mut StorageContext) {
-        let tx_ctx = storage_context::tx_context_mut(ctx);
-        let kv = m::make_kv_store(tx_ctx);
+        let kv = m::make_kv_store(ctx);
         m::add(&mut kv, string::utf8(b"test"), b"value");
-        assert!(m::contains(&mut kv, string::utf8(b"test")), 1000);
-        let sender = tx_context::sender(tx_ctx);
-        let object = object::new(tx_ctx, sender, kv);
-        let object_storage = storage_context::object_storage_mut(ctx);
-        object_storage::add(object_storage, object);
+        let object_id = m::save_to_object_storage(ctx, kv);
+        std::debug::print(&object_id);
     }
 }
 
+//# run --signers test --args 0x3e9909ac8516729bf47d8cdcba9180c07ab76a3ca770ae2ea0466acbc8fca3f8
+script {
+    use std::string;
+    use moveos_std::storage_context::{StorageContext};
+    use moveos_std::object_id::{ObjectID};
+    use test::m;
+
+    fun main(ctx: &mut StorageContext, object_id: ObjectID) {
+        let kv = m::borrow_from_object_storage(ctx, object_id);
+        assert!(m::contains(kv, string::utf8(b"test")), 1000);
+        let v = m::borrow(kv, string::utf8(b"test"));
+        assert!(v == &b"value", 1001);
+    }
+}

--- a/moveos/moveos-types/src/function_return_value.rs
+++ b/moveos/moveos-types/src/function_return_value.rs
@@ -1,0 +1,25 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::language_storage::TypeTag;
+use move_resource_viewer::AnnotatedMoveValue;
+use serde::{Deserialize, Serialize};
+
+/// The `view` function return value in MoveOS
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionReturnValue {
+    pub type_tag: TypeTag,
+    pub value: Vec<u8>,
+}
+
+impl FunctionReturnValue {
+    pub fn new(type_tag: TypeTag, value: Vec<u8>) -> Self {
+        Self { type_tag, value }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AnnotatedFunctionReturnValue {
+    pub value: FunctionReturnValue,
+    pub move_value: AnnotatedMoveValue,
+}

--- a/moveos/moveos-types/src/lib.rs
+++ b/moveos/moveos-types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod addresses;
 pub mod error;
 pub mod event;
 pub mod event_filter;
+pub mod function_return_value;
 pub mod h256;
 pub mod move_module;
 pub mod move_string;

--- a/moveos/moveos/src/tests/mod.rs
+++ b/moveos/moveos/src/tests/mod.rs
@@ -24,7 +24,7 @@ pub fn test_check_account() {
         .unwrap();
 
     assert_eq!(
-        result.return_values[0].0,
+        result[0].value,
         serialize_values(&vec![MoveValue::Bool(false)])[0]
     );
 }

--- a/moveos/moveos/src/vm/move_vm_ext.rs
+++ b/moveos/moveos/src/vm/move_vm_ext.rs
@@ -81,10 +81,10 @@ where
     pub fn resolve_args(
         &self,
         tx_context: &TxContext,
-        func: LoadedFunctionInstantiation,
+        func: &LoadedFunctionInstantiation,
         args: Vec<Vec<u8>>,
     ) -> Result<Vec<Vec<u8>>, PartialVMError> {
-        tx_context.resolve_argument(self, &func, args)
+        tx_context.resolve_argument(self, func, args)
     }
 
     /************** Proxy function */


### PR DESCRIPTION
1. Refactor execute_view_function return value, follow #221 
2. Table AccessPath key supports hex and original string. `/table/$table_handle/0xabc,key1`
3. Write a KVStore example for the table test case.


TODO:

1. @pause125  How to pass the `b"key1"` argument in the `cmd.feature` tests.