### PR TITLE
[moveos] Refactor MoveOS VM and Session

### DIFF
--- a/crates/rooch-client/src/lib.rs
+++ b/crates/rooch-client/src/lib.rs
@@ -4,14 +4,13 @@
 use anyhow::Result;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
-use moveos::moveos::TransactionOutput;
 use moveos_types::{access_path::AccessPath, object::ObjectID, transaction::FunctionCall};
 use rand::Rng;
 use rooch_server::{
     api::rooch_api::RoochAPIClient,
     jsonrpc_types::{
         AnnotatedFunctionReturnValueView, AnnotatedMoveStructView, AnnotatedObjectView,
-        AnnotatedStateView, StateView,
+        AnnotatedStateView, ExecuteTransactionResponse, StateView,
     },
 };
 use rooch_types::{address::RoochAddress, transaction::rooch::RoochTransaction};
@@ -84,7 +83,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub async fn execute_tx(&self, tx: RoochTransaction) -> Result<TransactionOutput> {
+    pub async fn execute_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponse> {
         let txn_payload = bcs::to_bytes(&tx)?;
         self.rpc
             .http

--- a/crates/rooch-client/src/wallet_context.rs
+++ b/crates/rooch-client/src/wallet_context.rs
@@ -2,10 +2,10 @@ use crate::client_config::{ClientConfig, DEFAULT_EXPIRATION_SECS};
 use crate::Client;
 use anyhow::anyhow;
 use move_core_types::account_address::AccountAddress;
-use moveos::moveos::TransactionOutput;
 use moveos_types::transaction::MoveAction;
 use rooch_config::{rooch_config_dir, Config, PersistedConfig, ROOCH_CLIENT_CONFIG};
 use rooch_key::keystore::AccountKeystore;
+use rooch_server::jsonrpc_types::ExecuteTransactionResponse;
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::{BuiltinScheme, Signature};
 use rooch_types::error::{RoochError, RoochResult};
@@ -80,7 +80,7 @@ impl WalletContext {
         &self,
         sender: RoochAddress,
         action: MoveAction,
-    ) -> RoochResult<TransactionOutput> {
+    ) -> RoochResult<ExecuteTransactionResponse> {
         let pk = self.config.keystore.get_key(&sender).ok().ok_or_else(|| {
             RoochError::SignMessageError(format!("Cannot find key for address: [{sender}]"))
         })?;

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -10,11 +10,12 @@ use moveos_types::access_path::AccessPath;
 use moveos_types::event_filter::{EventFilter, MoveOSEvent};
 use moveos_types::function_return_value::AnnotatedFunctionReturnValue;
 use moveos_types::state::{AnnotatedState, State};
+use moveos_types::transaction::VerifiedMoveOSTransaction;
 use moveos_types::{
     object::{AnnotatedObject, ObjectID},
-    transaction::{AuthenticatableTransaction, FunctionCall, MoveOSTransaction},
+    transaction::{AuthenticatableTransaction, FunctionCall},
 };
-use rooch_types::transaction::TransactionInfo;
+use rooch_types::transaction::TransactionExecutionInfo;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
@@ -26,17 +27,17 @@ impl<T> Message for ValidateTransactionMessage<T>
 where
     T: 'static + AuthenticatableTransaction + Send + Sync,
 {
-    type Result = Result<MoveOSTransaction>;
+    type Result = Result<VerifiedMoveOSTransaction>;
 }
 
 #[derive(Debug)]
 pub struct ExecuteTransactionMessage {
-    pub tx: MoveOSTransaction,
+    pub tx: VerifiedMoveOSTransaction,
 }
 
 pub struct ExecuteTransactionResult {
     pub output: TransactionOutput,
-    pub transaction_info: TransactionInfo,
+    pub transaction_info: TransactionExecutionInfo,
 }
 
 impl Message for ExecuteTransactionMessage {

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -14,16 +14,19 @@ use coerce::actor::ActorRef;
 use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
 use move_resource_viewer::AnnotatedMoveStruct;
 use moveos::moveos::TransactionOutput;
-use moveos_types::{access_path::AccessPath, function_return_value::AnnotatedFunctionReturnValue};
+use moveos_types::{
+    access_path::AccessPath, function_return_value::AnnotatedFunctionReturnValue,
+    transaction::VerifiedMoveOSTransaction,
+};
 use moveos_types::{
     event_filter::{EventFilter, MoveOSEvent},
     state::{AnnotatedState, State},
 };
 use moveos_types::{
     object::{AnnotatedObject, ObjectID},
-    transaction::{AuthenticatableTransaction, FunctionCall, MoveOSTransaction},
+    transaction::{AuthenticatableTransaction, FunctionCall},
 };
-use rooch_types::transaction::TransactionInfo;
+use rooch_types::transaction::TransactionExecutionInfo;
 
 #[derive(Clone)]
 pub struct ExecutorProxy {
@@ -35,7 +38,7 @@ impl ExecutorProxy {
         Self { actor }
     }
 
-    pub async fn validate_transaction<T>(&self, tx: T) -> Result<MoveOSTransaction>
+    pub async fn validate_transaction<T>(&self, tx: T) -> Result<VerifiedMoveOSTransaction>
     where
         T: 'static + AuthenticatableTransaction + Send + Sync,
     {
@@ -45,8 +48,8 @@ impl ExecutorProxy {
     //TODO ensure the execute result
     pub async fn execute_transaction(
         &self,
-        tx: MoveOSTransaction,
-    ) -> Result<(TransactionOutput, TransactionInfo)> {
+        tx: VerifiedMoveOSTransaction,
+    ) -> Result<(TransactionOutput, TransactionExecutionInfo)> {
         let result = self
             .actor
             .send(crate::actor::messages::ExecuteTransactionMessage { tx })

--- a/crates/rooch-integration-test-runner/src/lib.rs
+++ b/crates/rooch-integration-test-runner/src/lib.rs
@@ -133,11 +133,12 @@ impl<'a> MoveTestAdapter<'a> for MoveOSTestAdapter<'a> {
         let id = module.self_id();
         let sender = *id.address();
 
-        let txn = MoveOSTransaction::new_for_test(
+        let tx = MoveOSTransaction::new_for_test(
             sender,
             MoveAction::new_module_bundle(vec![module_bytes]),
         );
-        self.moveos.execute(txn)?;
+        let verified_tx = self.moveos.verify(tx)?;
+        self.moveos.execute(verified_tx)?;
         Ok((None, module))
     }
 
@@ -166,11 +167,12 @@ impl<'a> MoveTestAdapter<'a> for MoveOSTestAdapter<'a> {
             .map(|arg| arg.simple_serialize().unwrap())
             .collect::<Vec<_>>();
 
-        let txn = MoveOSTransaction::new_for_test(
+        let tx = MoveOSTransaction::new_for_test(
             signers.pop().unwrap(),
             MoveAction::new_script_call(script_bytes, type_args, args),
         );
-        self.moveos.execute(txn)?;
+        let verified_tx = self.moveos.verify(tx)?;
+        self.moveos.execute(verified_tx)?;
         //TODO return values
         let value = SerializedReturnValues {
             mutable_reference_outputs: vec![],
@@ -202,11 +204,12 @@ impl<'a> MoveTestAdapter<'a> for MoveOSTestAdapter<'a> {
             .map(|arg| arg.simple_serialize().unwrap())
             .collect::<Vec<_>>();
         let function_id = FunctionId::new(module.clone(), function.to_owned());
-        let txn = MoveOSTransaction::new_for_test(
+        let tx = MoveOSTransaction::new_for_test(
             signers.pop().unwrap(),
             MoveAction::new_function_call(function_id, type_args, args),
         );
-        self.moveos.execute(txn)?;
+        let verified_tx = self.moveos.verify(tx)?;
+        self.moveos.execute(verified_tx)?;
         //TODO return values
         let value = SerializedReturnValues {
             mutable_reference_outputs: vec![],

--- a/crates/rooch-proposer/src/actor/messages.rs
+++ b/crates/rooch-proposer/src/actor/messages.rs
@@ -3,7 +3,9 @@
 
 use anyhow::Result;
 use coerce::actor::{message::Message, scheduler::timer::TimerTick};
-use rooch_types::transaction::{TransactionInfo, TransactionSequenceInfo, TypedTransaction};
+use rooch_types::transaction::{
+    TransactionExecutionInfo, TransactionSequenceInfo, TypedTransaction,
+};
 
 /// Transaction Sequence Message
 #[derive(Debug)]
@@ -15,7 +17,7 @@ pub struct TransactionSequenceMessage {
 #[derive(Debug)]
 pub struct TransactionProposeMessage {
     pub tx: TypedTransaction,
-    pub tx_execution_info: TransactionInfo,
+    pub tx_execution_info: TransactionExecutionInfo,
     pub tx_sequence_info: TransactionSequenceInfo,
 }
 

--- a/crates/rooch-proposer/src/proxy/mod.rs
+++ b/crates/rooch-proposer/src/proxy/mod.rs
@@ -7,7 +7,9 @@ use crate::actor::{
 };
 use anyhow::Result;
 use coerce::actor::ActorRef;
-use rooch_types::transaction::{TransactionInfo, TransactionSequenceInfo, TypedTransaction};
+use rooch_types::transaction::{
+    TransactionExecutionInfo, TransactionSequenceInfo, TypedTransaction,
+};
 
 #[derive(Clone)]
 pub struct ProposerProxy {
@@ -22,7 +24,7 @@ impl ProposerProxy {
     pub async fn propose_transaction(
         &self,
         tx: TypedTransaction,
-        tx_execution_info: TransactionInfo,
+        tx_execution_info: TransactionExecutionInfo,
         tx_sequence_info: TransactionSequenceInfo,
     ) -> Result<TransactionProposeResult> {
         self.actor

--- a/crates/rooch-server/src/api/rooch_api.rs
+++ b/crates/rooch-server/src/api/rooch_api.rs
@@ -3,12 +3,12 @@
 
 use crate::jsonrpc_types::{
     AnnotatedFunctionReturnValueView, AnnotatedMoveStructView, AnnotatedObjectView,
-    AnnotatedStateView, EventView, FunctionCallView, StateView, StrView, StructTagView,
+    AnnotatedStateView, EventView, ExecuteTransactionResponse, FunctionCallView, StateView,
+    StrView, StructTagView,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use move_core_types::account_address::AccountAddress;
-use moveos::moveos::TransactionOutput;
 use moveos_types::access_path::AccessPath;
 use moveos_types::event_filter::EventFilter;
 use moveos_types::object::ObjectID;
@@ -27,7 +27,7 @@ pub trait RoochAPI {
     async fn execute_raw_transaction(
         &self,
         tx_bcs_hex: StrView<Vec<u8>>,
-    ) -> RpcResult<TransactionOutput>;
+    ) -> RpcResult<ExecuteTransactionResponse>;
 
     /// Execute a read-only function call
     /// The function do not change the state of Application

--- a/crates/rooch-server/src/jsonrpc_types/execute_tx_response.rs
+++ b/crates/rooch-server/src/jsonrpc_types/execute_tx_response.rs
@@ -1,0 +1,11 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use rooch_types::transaction::{TransactionExecutionInfo, TransactionSequenceInfo};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecuteTransactionResponse {
+    pub sequence_info: TransactionSequenceInfo,
+    pub execution_info: TransactionExecutionInfo,
+}

--- a/crates/rooch-server/src/jsonrpc_types/mod.rs
+++ b/crates/rooch-server/src/jsonrpc_types/mod.rs
@@ -4,12 +4,14 @@
 #[macro_use]
 
 mod str_view;
+mod execute_tx_response;
 mod function_return_value_view;
 mod move_types;
 mod transaction_argument_view;
 
 pub mod bytes;
 pub mod eth;
+pub use execute_tx_response::*;
 pub use function_return_value_view::*;
 pub use move_types::*;
 pub use str_view::*;

--- a/crates/rooch-server/src/server/rooch_server.rs
+++ b/crates/rooch-server/src/server/rooch_server.rs
@@ -4,7 +4,7 @@
 use crate::api::RoochRpcModule;
 use crate::jsonrpc_types::{
     AnnotatedFunctionReturnValueView, AnnotatedMoveStructView, AnnotatedStateView, EventView,
-    FunctionCallView, StateView, StrView, StructTagView,
+    ExecuteTransactionResponse, FunctionCallView, StateView, StrView, StructTagView,
 };
 use crate::service::RpcService;
 use crate::{api::rooch_api::RoochAPIServer, jsonrpc_types::AnnotatedObjectView};
@@ -13,7 +13,6 @@ use jsonrpsee::{
     RpcModule,
 };
 use move_core_types::account_address::AccountAddress;
-use moveos::moveos::TransactionOutput;
 use moveos_types::access_path::AccessPath;
 use moveos_types::event_filter::EventFilter;
 use moveos_types::{object::ObjectID, transaction::AuthenticatableTransaction};
@@ -44,7 +43,7 @@ impl RoochAPIServer for RoochServer {
     async fn execute_raw_transaction(
         &self,
         payload: StrView<Vec<u8>>,
-    ) -> RpcResult<TransactionOutput> {
+    ) -> RpcResult<ExecuteTransactionResponse> {
         let tx = bcs::from_bytes::<RoochTransaction>(&payload.0).map_err(anyhow::Error::from)?;
         Ok(self
             .rpc_service

--- a/crates/rooch-types/src/transaction/ethereum.rs
+++ b/crates/rooch-types/src/transaction/ethereum.rs
@@ -10,6 +10,7 @@ use ethers::utils::rlp::{Decodable, Rlp};
 use moveos_types::{
     h256::H256,
     transaction::{AuthenticatableTransaction, MoveAction, MoveOSTransaction},
+    tx_context::TxContext,
 };
 use serde::{Deserialize, Serialize};
 
@@ -70,10 +71,7 @@ impl AuthenticatableTransaction for EthereumTransaction {
         result: super::AuthenticatorResult,
     ) -> Result<MoveOSTransaction> {
         let action = self.decode_calldata_to_action()?;
-        Ok(MoveOSTransaction::new(
-            result.resolved_address,
-            action,
-            self.tx_hash(),
-        ))
+        let tx_ctx = TxContext::new(result.resolved_address, self.tx_hash());
+        Ok(MoveOSTransaction::new(tx_ctx, action))
     }
 }

--- a/crates/rooch-types/src/transaction/mod.rs
+++ b/crates/rooch-types/src/transaction/mod.rs
@@ -150,11 +150,9 @@ impl AuthenticatableTransaction for TypedTransaction {
     }
 }
 
-/// `TransactionInfo` represents the result of executing a transaction.
-//TODO rename to TransactionExecutionInfo?
-// #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, CryptoHash, CryptoHasher)]
+/// `TransactionExecutionInfo` represents the result of executing a transaction.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct TransactionInfo {
+pub struct TransactionExecutionInfo {
     /// The hash of this transaction.
     pub tx_hash: H256,
 
@@ -174,15 +172,15 @@ pub struct TransactionInfo {
     pub status: KeptVMStatus,
 }
 
-impl TransactionInfo {
+impl TransactionExecutionInfo {
     pub fn new(
         tx_hash: H256,
         state_root: H256,
         event_root: H256,
         gas_used: u64,
         status: KeptVMStatus,
-    ) -> TransactionInfo {
-        TransactionInfo {
+    ) -> TransactionExecutionInfo {
+        TransactionExecutionInfo {
             tx_hash,
             state_root,
             event_root,

--- a/crates/rooch-types/src/transaction/rooch.rs
+++ b/crates/rooch-types/src/transaction/rooch.rs
@@ -12,7 +12,10 @@ use crate::address::RoochAddress;
 use crate::H256;
 use anyhow::Result;
 
-use moveos_types::transaction::{AuthenticatableTransaction, MoveAction, MoveOSTransaction};
+use moveos_types::{
+    transaction::{AuthenticatableTransaction, MoveAction, MoveOSTransaction},
+    tx_context::TxContext,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
@@ -105,7 +108,8 @@ impl RoochTransaction {
 impl From<RoochTransaction> for MoveOSTransaction {
     fn from(tx: RoochTransaction) -> Self {
         let tx_hash = tx.tx_hash();
-        MoveOSTransaction::new(tx.data.sender.into(), tx.data.action, tx_hash)
+        let tx_ctx = TxContext::new(tx.data.sender.into(), tx_hash);
+        MoveOSTransaction::new(tx_ctx, tx.data.action)
     }
 }
 

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -18,6 +18,7 @@ use moveos_types::{
 };
 use rooch_client::wallet_context::WalletContext;
 use rooch_key::keystore::{AccountKeystore, Keystore};
+use rooch_server::jsonrpc_types::ExecuteTransactionResponse;
 use rooch_types::{
     address::RoochAddress,
     crypto::BuiltinScheme::Ed25519,
@@ -47,7 +48,7 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub async fn execute(self) -> RoochResult<TransactionOutput> {
+    pub async fn execute(self) -> RoochResult<ExecuteTransactionResponse> {
         let mut context = self.context_options.build().await?;
         let (new_address, phrase, scheme) = context
             .config

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -8,9 +8,9 @@ use move_binary_format::file_format::CompiledModule;
 use move_bytecode_utils::dependency_graph::DependencyGraph;
 use move_bytecode_utils::Modules;
 use move_cli::Move;
+use rooch_server::jsonrpc_types::ExecuteTransactionResponse;
 
 use crate::types::{CommandAction, TransactionOptions, WalletContextOptions};
-use moveos::moveos::TransactionOutput;
 use moveos::vm::dependency_order::sort_by_dependency_order;
 use moveos_types::transaction::MoveAction;
 use moveos_verifier::build::run_verifier;
@@ -51,8 +51,8 @@ impl Publish {
 }
 
 #[async_trait]
-impl CommandAction<TransactionOutput> for Publish {
-    async fn execute(self) -> RoochResult<TransactionOutput> {
+impl CommandAction<ExecuteTransactionResponse> for Publish {
+    async fn execute(self) -> RoochResult<ExecuteTransactionResponse> {
         let context = self.context_options.build().await?;
 
         let package_path = self.move_args.package_path;

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -5,9 +5,10 @@ use crate::types::{CommandAction, TransactionOptions, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
 use move_core_types::value::MoveValue;
-use moveos::moveos::TransactionOutput;
 use moveos_types::{move_types::FunctionId, transaction::MoveAction};
-use rooch_server::jsonrpc_types::{TransactionArgumentView, TypeTagView};
+use rooch_server::jsonrpc_types::{
+    ExecuteTransactionResponse, TransactionArgumentView, TypeTagView,
+};
 use rooch_types::{
     address::RoochAddress,
     error::{RoochError, RoochResult},
@@ -54,8 +55,8 @@ pub struct RunFunction {
 }
 
 #[async_trait]
-impl CommandAction<TransactionOutput> for RunFunction {
-    async fn execute(self) -> RoochResult<TransactionOutput> {
+impl CommandAction<ExecuteTransactionResponse> for RunFunction {
+    async fn execute(self) -> RoochResult<ExecuteTransactionResponse> {
         let args = self
             .args
             .iter()

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
@@ -41,7 +41,7 @@ use std::{
 /// The representation of a table handle. This is created from truncating a sha3-256 based
 /// hash over a transaction hash provided by the environment and a table creation counter
 /// local to the transaction.
-#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TableHandle(pub ObjectID);
 
 impl std::fmt::Display for TableHandle {
@@ -56,7 +56,7 @@ impl From<TableHandle> for ObjectID {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TableInfo {
     pub key_type: TypeTag,
 }
@@ -74,7 +74,7 @@ impl std::fmt::Display for TableInfo {
 }
 
 /// A table change set.
-#[derive(Default)]
+#[derive(Default, Clone, Debug)]
 pub struct TableChangeSet {
     pub new_tables: BTreeMap<TableHandle, TableInfo>,
     pub removed_tables: BTreeSet<TableHandle>,
@@ -88,6 +88,7 @@ pub struct TableValueBox {
 }
 
 /// A change of a single table.
+#[derive(Clone, Debug)]
 pub struct TableChange {
     pub entries: BTreeMap<Vec<u8>, Op<TableValueBox>>,
 }

--- a/moveos/moveos-types/src/tx_context.rs
+++ b/moveos/moveos-types/src/tx_context.rs
@@ -18,12 +18,12 @@ pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("TxContext");
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct TxContext {
     /// Signer/sender of the transaction
-    sender: AccountAddress,
+    pub sender: AccountAddress,
     /// Hash of the current transaction
     /// Use the type `Vec<u8>` is to keep consistency with the `TxContext` type in Move
-    tx_hash: Vec<u8>,
+    pub tx_hash: Vec<u8>,
     /// Number of `ObjectID`'s generated during execution of the current transaction
-    ids_created: u64,
+    pub ids_created: u64,
 }
 
 impl TxContext {
@@ -43,8 +43,8 @@ impl TxContext {
     }
 
     /// Return the transaction Hash, to include in new objects
-    pub fn tx_hash(&self) -> &[u8] {
-        &self.tx_hash
+    pub fn tx_hash(&self) -> H256 {
+        H256::from_slice(&self.tx_hash)
     }
 
     pub fn sender(&self) -> AccountAddress {

--- a/moveos/moveos-verifier/src/verifier.rs
+++ b/moveos/moveos-verifier/src/verifier.rs
@@ -24,7 +24,7 @@ where
     for fdef in &module.function_defs {
         let fhandle = module.function_handle_at(fdef.function);
         let fname = module.identifier_at(fhandle.name);
-        if fname == INIT_FN_NAME_IDENTIFIER.clone().as_ident_str() {
+        if fname == INIT_FN_NAME_IDENTIFIER.as_ident_str() {
             if Visibility::Private != fdef.visibility {
                 return Err(Error::msg("init function should private".to_string()));
             } else if fdef.is_entry {
@@ -86,7 +86,7 @@ where
 }
 
 pub fn verify_entry_function<S>(
-    func: LoadedFunctionInstantiation,
+    func: &LoadedFunctionInstantiation,
     session: &Session<S>,
 ) -> Result<bool>
 where

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -1,43 +1,39 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::vm::vm_status_explainer::{explain_vm_status, VmStatusExplainView};
-use crate::vm::{
-    move_vm_ext::{MoveVmExt, SessionExt},
-    MoveResolverExt,
-};
-use anyhow::{anyhow, bail, ensure, Result};
-use move_binary_format::{
-    errors::{Location, PartialVMError, VMResult},
-    CompiledModule,
-};
-
-use move_core_types::vm_status::KeptVMStatus;
+use crate::vm::move_vm_ext::MoveVmExt;
+use anyhow::{bail, Result};
+use move_binary_format::errors::vm_status_of_result;
+use move_binary_format::errors::{Location, PartialVMError};
+use move_core_types::effects::ChangeSet;
+use move_core_types::vm_status::{KeptVMStatus, VMStatus};
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
     value::MoveValue, vm_status::StatusCode,
 };
 use move_vm_types::gas::UnmeteredGasMeter;
-use moveos_stdlib::natives::moveos_stdlib::raw_table::NativeTableContext;
+use moveos_stdlib::natives::moveos_stdlib::raw_table::TableChangeSet;
 use moveos_store::MoveOSDB;
 use moveos_store::{event_store::EventStore, state_store::StateDB};
-use moveos_types::event::{Event, EventID};
+use moveos_types::event::Event;
 use moveos_types::function_return_value::FunctionReturnValue;
-use moveos_types::object::ObjectID;
-use moveos_types::transaction::{AuthenticatableTransaction, MoveAction, MoveOSTransaction};
+use moveos_types::storage_context::StorageContext;
+use moveos_types::transaction::{
+    AuthenticatableTransaction, MoveAction, MoveOSTransaction, VerifiedMoveOSTransaction,
+};
 use moveos_types::tx_context::TxContext;
 use moveos_types::{addresses::ROOCH_FRAMEWORK_ADDRESS, move_types::FunctionId};
 use moveos_types::{h256::H256, transaction::FunctionCall};
-use moveos_verifier::verifier::{verify_init_function, INIT_FN_NAME_IDENTIFIER};
 use once_cell::sync::Lazy;
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+//TODO make TransactionOutput serializable
+#[derive(Debug, Clone)]
 pub struct TransactionOutput {
-    /// The new state root after the transaction execution.
-    pub state_root: H256,
     pub status: KeptVMStatus,
-    pub status_reexplain: VmStatusExplainView,
+    pub changeset: ChangeSet,
+    pub table_changeset: TableChangeSet,
+    pub events: Vec<Event>,
+    pub gas_used: u64,
 }
 
 pub static VALIDATE_FUNCTION: Lazy<FunctionId> = Lazy::new(|| {
@@ -62,8 +58,10 @@ impl MoveOS {
         let is_genesis = db.get_state_store().is_genesis();
         let mut moveos = Self { vm, db };
         if is_genesis {
-            let genesis_txn = Self::build_genesis_txn()?;
-            moveos.execute(genesis_txn)?;
+            //TODO the genesis
+            let genesis_tx = Self::build_genesis_tx()?;
+            let verified_tx = moveos.verify(genesis_tx)?;
+            moveos.execute(verified_tx)?;
         }
         Ok(moveos)
     }
@@ -77,35 +75,26 @@ impl MoveOS {
     }
 
     //TODO move to a suitable place
-    pub fn build_genesis_txn() -> Result<MoveOSTransaction> {
-        let genesis_txn =
+    pub fn build_genesis_tx() -> Result<MoveOSTransaction> {
+        let genesis_tx =
             MoveAction::ModuleBundle(moveos_stdlib::Framework::build()?.into_module_bundles()?);
         Ok(MoveOSTransaction::new_for_test(
             *ROOCH_FRAMEWORK_ADDRESS,
-            genesis_txn,
+            genesis_tx,
         ))
     }
 
-    pub fn validate<T: AuthenticatableTransaction>(&mut self, tx: T) -> Result<MoveOSTransaction> {
-        let session = self.vm.new_session(&self.db);
-        self.validate_transaction(session, tx)
-    }
-
-    fn validate_transaction<S, T: AuthenticatableTransaction>(
-        &self,
-        mut session: SessionExt<S>,
+    pub fn validate<T: AuthenticatableTransaction>(
+        &mut self,
         tx: T,
-    ) -> Result<MoveOSTransaction>
-    where
-        S: MoveResolverExt,
-    {
-        let authenticator = tx.authenticator_info();
-
+    ) -> Result<VerifiedMoveOSTransaction> {
         //TODO ensure the validate function's sender should be the genesis address?
         let tx_context = TxContext::new(*ROOCH_FRAMEWORK_ADDRESS, tx.tx_hash());
-        let mut gas_meter = UnmeteredGasMeter;
+
+        let authenticator = tx.authenticator_info();
+
         let function_id = VALIDATE_FUNCTION.clone();
-        let function = FunctionCall::new(
+        let call = FunctionCall::new(
             function_id,
             vec![],
             vec![MoveValue::vector_u8(
@@ -114,12 +103,7 @@ impl MoveOS {
             .simple_serialize()
             .unwrap()],
         );
-        let result = Self::execute_function_bypass_visibility(
-            &mut session,
-            &tx_context,
-            &mut gas_meter,
-            function,
-        );
+        let result = self.execute_readonly_function(tx_context, call);
         match result {
             Ok(return_values) => {
                 let validate_result = &return_values
@@ -127,239 +111,76 @@ impl MoveOS {
                     .expect("the validate function should return the validate result.")
                     .value;
                 let auth_result = bcs::from_bytes::<T::AuthenticatorResult>(validate_result)?;
-                tx.construct_moveos_transaction(auth_result)
+                //TODO verify should share session with validate
+                Ok(self.verify(tx.construct_moveos_transaction(auth_result)?)?)
             }
             Err(e) => {
-                let status = explain_vm_status(self.db.get_state_store(), e.into_vm_status())?;
                 //TODO handle the abort error code
-                println!("validate failed: {:?}", status);
+                //let status = explain_vm_status(self.db.get_state_store(), e.into_vm_status())?;
+                println!("validate failed: {:?}", e);
                 // If the error code is EUnsupportedScheme, then we can try to call the sender's validate function
                 // This is the Account Abstraction.
-                bail!("validate failed: {:?}", status)
+                bail!("validate failed: {:?}", e)
             }
         }
     }
 
-    pub fn execute(&mut self, tx: MoveOSTransaction) -> Result<TransactionOutput> {
+    pub fn verify(&mut self, tx: MoveOSTransaction) -> Result<VerifiedMoveOSTransaction> {
         let MoveOSTransaction {
-            sender,
+            ctx: tx_context,
             action,
-            tx_hash,
         } = tx;
-        let session = self.vm.new_session(&self.db);
-        self.execute_transaction(session, sender, tx_hash, action)
+
+        let gas_meter = UnmeteredGasMeter;
+        let ctx = StorageContext::new(tx_context.clone());
+        let session = self.vm.new_session(&self.db, ctx, gas_meter);
+
+        let verified_action = session.verify_move_action(action)?;
+        Ok(VerifiedMoveOSTransaction {
+            ctx: tx_context,
+            action: verified_action,
+        })
     }
 
-    // TODO should be return the execute result
-    fn execute_transaction<S>(
-        &self,
-        mut session: SessionExt<S>,
-        sender: AccountAddress,
-        tx_hash: H256,
-        action: MoveAction,
-    ) -> Result<TransactionOutput>
-    where
-        S: MoveResolverExt,
-    {
-        let mut gas_meter = UnmeteredGasMeter;
-        let tx_context = TxContext::new(sender, tx_hash);
-        let execute_result = match action {
-            MoveAction::Script(script) => {
-                let func = session.load_script(script.code.as_slice(), script.ty_args.clone())?;
-                moveos_verifier::verifier::verify_entry_function(func, session.runtime_session())?;
+    pub fn execute(&mut self, tx: VerifiedMoveOSTransaction) -> Result<(H256, TransactionOutput)> {
+        let VerifiedMoveOSTransaction { ctx, action } = tx;
+        //TODO define the gas meter.
+        let gas_meter = UnmeteredGasMeter;
+        let ctx = StorageContext::new(ctx);
+        let mut session = self.vm.new_session(&self.db, ctx, gas_meter);
 
-                let loaded_function =
-                    session.load_script(script.code.as_slice(), script.ty_args.clone())?;
-
-                let args = session
-                    .resolve_args(&tx_context, &loaded_function, script.args)
-                    .map_err(|e| e.finish(Location::Undefined))?;
-                session
-                    .execute_script(script.code, script.ty_args, args, &mut gas_meter)
-                    .map(|ret| {
-                        debug_assert!(
-                            ret.return_values.is_empty(),
-                            "Script function should not return values"
-                        );
-                    })
-            }
-            MoveAction::Function(function) => {
-                let func =
-                    session.load_function(&function.function_id, function.ty_args.as_slice())?;
-                moveos_verifier::verifier::verify_entry_function(func, session.runtime_session())?;
-
-                let loaded_function =
-                    session.load_function(&function.function_id, function.ty_args.as_slice())?;
-                let args = session
-                    .resolve_args(&tx_context, &loaded_function, function.args)
-                    .map_err(|e| e.finish(Location::Undefined))?;
-
-                session
-                    .execute_entry_function(
-                        &function.function_id,
-                        function.ty_args,
-                        args,
-                        &mut gas_meter,
-                    )
-                    .map(|ret| {
-                        debug_assert!(
-                            ret.return_values.is_empty(),
-                            "Entry function should not return values"
-                        );
-                    })
-            }
-            MoveAction::ModuleBundle(modules) => {
-                // since the Move runtime does not to know about new packages created,
-                // the first deployment contract and the upgrade contract need to be handled separately
-                let compiled_modules = self.deserialize_modules(&modules)?;
-
-                //TODO check the modules package address with the sender
-                let result = session.publish_module_bundle(modules, sender, &mut gas_meter);
-                self.check_and_execute_init_modules(
-                    &mut session,
-                    &tx_context,
-                    &mut gas_meter,
-                    &compiled_modules,
-                )?;
-                result
-            }
-        };
-
-        let (change_set, raw_events, mut extensions) = session.finish_with_extensions()?;
-
-        let table_context: NativeTableContext = extensions.remove();
-        let table_change_set = table_context
-            .into_change_set()
-            .map_err(|e| e.finish(Location::Undefined))?;
-
-        let vm_status = move_binary_format::errors::vm_status_of_result(execute_result);
-        let vm_status_cloned = vm_status.clone();
-        match vm_status.keep_or_discard() {
-            Ok(status) => {
-                //TODO move apply change set to a suitable place, and make MoveOS stateless.
-                let new_state_root = self
-                    .db
-                    .get_state_store()
-                    .apply_change_set(change_set, table_change_set)
-                    .map_err(|e| {
-                        PartialVMError::new(StatusCode::STORAGE_ERROR)
-                            .with_message(e.to_string())
-                            .finish(Location::Undefined)
-                    })?;
-
-                // handle events
-                let events = raw_events
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, e)| {
-                        let event_handle_id = ObjectID::from_bytes(e.0.as_slice()).unwrap();
-                        Event::new(EventID::new(event_handle_id, e.1), e.2, e.3, i as u32)
-                    })
-                    .collect();
-
-                self.db.get_event_store().save_events(events).map_err(|e| {
-                    PartialVMError::new(StatusCode::STORAGE_ERROR)
-                        .with_message(e.to_string())
-                        .finish(Location::Undefined)
-                })?;
-
-                let vm_status_explain =
-                    explain_vm_status(self.db.get_state_store(), vm_status_cloned)?;
-
-                Ok(TransactionOutput {
-                    state_root: new_state_root,
-                    status,
-                    status_reexplain: vm_status_explain,
-                })
-            }
-            Err(discard) => {
-                bail!("VM discard the transaction: {:?}", discard)
-            }
-        }
+        let execute_result = session.execute_move_action(action);
+        let vm_status = vm_status_of_result(execute_result);
+        let (_ctx, output) = session.finish_with_extensions(vm_status)?;
+        let state_root = self.apply_transaction_output(output.clone())?;
+        Ok((state_root, output))
     }
 
-    fn deserialize_modules(&self, module_bytes: &[Vec<u8>]) -> Result<Vec<CompiledModule>> {
-        let modules = module_bytes
-            .iter()
-            .map(|b| CompiledModule::deserialize(b).map_err(|e| e.finish(Location::Undefined)))
-            .collect::<VMResult<Vec<CompiledModule>>>()
-            .map_err(|e| anyhow!("Failed to deserialize modules: {:?}", e))?;
+    fn apply_transaction_output(&self, output: TransactionOutput) -> Result<H256> {
+        //TODO move apply change set to a suitable place, and make MoveOS stateless?
+        let TransactionOutput {
+            status: _,
+            changeset,
+            table_changeset,
+            events,
+            gas_used: _,
+        } = output;
 
-        Ok(modules)
-    }
-
-    fn check_and_execute_init_modules<S>(
-        &self,
-        session: &mut SessionExt<S>,
-        tx_context: &TxContext,
-        gas_meter: &mut UnmeteredGasMeter,
-        modules: &[CompiledModule],
-    ) -> Result<()>
-    where
-        S: MoveResolverExt,
-    {
-        let mut modules_to_init = vec![];
-        for module in modules {
-            let result = verify_init_function(module, session.runtime_session());
-            match result {
-                Ok(res) => {
-                    if res {
-                        modules_to_init.push(module.self_id())
-                    }
-                }
-                Err(err) => return Err(err),
-            }
-        }
-
-        for module_id in modules_to_init {
-            let function_id = FunctionId::new(module_id.clone(), INIT_FN_NAME_IDENTIFIER.clone());
-
-            let function = FunctionCall::new(function_id, vec![], vec![]);
-            let _result =
-                Self::execute_function_bypass_visibility(session, tx_context, gas_meter, function)
-                    .map_err(|e| {
-                        anyhow!(
-                            "Failed to execute init function at {:?} err: {:?}",
-                            module_id,
-                            e
-                        )
-                    })?;
-        }
-
-        Ok(())
-    }
-
-    fn execute_function_bypass_visibility(
-        session: &mut SessionExt<impl MoveResolverExt>,
-        tx_context: &TxContext,
-        gas_meter: &mut UnmeteredGasMeter,
-        function_call: FunctionCall,
-    ) -> VMResult<Vec<FunctionReturnValue>> {
-        let loaded_function =
-            session.load_function(&function_call.function_id, function_call.ty_args.as_slice())?;
-        let args = session
-            .resolve_args(tx_context, &loaded_function, function_call.args)
-            .map_err(|e| e.finish(Location::Undefined))?;
-
-        let return_values = session.execute_function_bypass_visibility(
-            &function_call.function_id,
-            function_call.ty_args,
-            args,
-            gas_meter,
-        )?;
-        return_values
-            .return_values
-            .into_iter()
-            .zip(loaded_function.return_.iter())
-            .map(|((v, _layout), ty)| {
-                // We can not use
-                // let type_tag :TypeTag = TryInto::try_into(&layout)?
-                // to get TypeTag from MoveTypeLayout, because MoveTypeLayout::StructTag does not implement TryInto<TypeTag>
-                // Invalid MoveTypeLayout -> StructTag conversion--needed MoveLayoutType::WithTypes
-                let type_tag = session.get_type_tag(ty)?;
-                Ok(FunctionReturnValue::new(type_tag, v))
-            })
-            .collect()
+        let new_state_root = self
+            .db
+            .get_state_store()
+            .apply_change_set(changeset, table_changeset)
+            .map_err(|e| {
+                PartialVMError::new(StatusCode::STORAGE_ERROR)
+                    .with_message(e.to_string())
+                    .finish(Location::Undefined)
+            })?;
+        self.db.get_event_store().save_events(events).map_err(|e| {
+            PartialVMError::new(StatusCode::STORAGE_ERROR)
+                .with_message(e.to_string())
+                .finish(Location::Undefined)
+        })?;
+        Ok(new_state_root)
     }
 
     /// Execute readonly view function
@@ -367,37 +188,27 @@ impl MoveOS {
         &self,
         function_call: FunctionCall,
     ) -> Result<Vec<FunctionReturnValue>> {
-        let mut session = self.vm.new_session(&self.db);
-        //TODO limit the view function max gas usage
-        let mut gas_meter = UnmeteredGasMeter;
         //View function use a fix address and fix hash
         let tx_context = TxContext::new(AccountAddress::ZERO, H256::zero());
+        //TODO verify the view function
+        self.execute_readonly_function(tx_context, function_call)
+    }
 
-        let result = Self::execute_function_bypass_visibility(
-            &mut session,
-            &tx_context,
-            &mut gas_meter,
-            function_call,
-        )?;
-        let (change_set, events, mut extensions) = session.finish_with_extensions()?;
+    fn execute_readonly_function(
+        &self,
+        tx_context: TxContext,
+        function_call: FunctionCall,
+    ) -> Result<Vec<FunctionReturnValue>> {
+        let ctx = StorageContext::new(tx_context);
+        //TODO limit the view function max gas usage
+        let gas_meter = UnmeteredGasMeter;
+        let mut session = self.vm.new_readonly_session(&self.db, ctx, gas_meter);
 
-        let table_context: NativeTableContext = extensions.remove();
-        let table_change_set = table_context
-            .into_change_set()
-            .map_err(|e| e.finish(Location::Undefined))?;
+        let result = session.execute_function_bypass_visibility(function_call)?;
 
-        ensure!(
-            change_set.accounts().is_empty(),
-            "Change set should be empty when execute view function"
-        );
-        ensure!(
-            events.is_empty(),
-            "Events should be empty when execute view function"
-        );
-        ensure!(
-            table_change_set.changes.is_empty(),
-            "Table change set should be empty when execute view function"
-        );
+        // if execute success, finish the session to check if it change the state
+        let (_ctx, _output) = session.finish_with_extensions(VMStatus::Executed)?;
+
         Ok(result)
     }
 }


### PR DESCRIPTION
1. Refactor MoveOS, MoveVMExt, and SessionExt, to prepare #209
   * Open One Session for One TxContext
   * Extract the transaction finalizer logic, ensuring the failed transaction changes should be discarded, but the finalizer's changes must be kept.
3. Rename TransactionInfo to TransactionExecutionInfo.


#232 has a bug. Verifying the module before publishing raises an error because it tries to load the function from the session. @WGB5445 