### PR TITLE
Return more complete error messages in verify_init_function and verify_entry_function.

### DIFF
--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -316,7 +316,7 @@ impl<'a> ExtendedChecker<'a> {
                             )
                         }
 
-                        if !check_storage_context_struct_tag(&struct_tag.unwrap().to_canonical_string()){
+                        if !check_storage_context_struct_tag(struct_tag.unwrap().to_canonical_string()){
                             self.env.error(
                                 &fun.get_loc(),
                                 "module init function should not input reference structures other than storageContext"
@@ -454,13 +454,13 @@ impl<'a> ExtendedChecker<'a> {
     }
 }
 
-pub fn check_storage_context_struct_tag(struct_tag: &str) -> bool {
+pub fn check_storage_context_struct_tag(struct_tag: String) -> bool {
     let address = moveos_types::addresses::MOVEOS_STD_ADDRESS.to_string();
     let module = StorageContext::module_identifier()
         .as_ident_str()
         .to_string();
     let name = StorageContext::struct_identifier().to_string();
-    struct_tag == address + "::" + &module + "::" + &name
+    struct_tag == format!("{}::{}::{}", address, module, name)
 }
 
 fn is_defined_or_allowed_in_current_module(

--- a/moveos/moveos-verifier/src/verifier.rs
+++ b/moveos/moveos-verifier/src/verifier.rs
@@ -1,7 +1,9 @@
 use crate::metadata::{check_storage_context_struct_tag, is_allowed_input_struct};
-use anyhow::{Error, Ok, Result};
-use move_binary_format::file_format::Visibility;
+use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMError, VMResult};
+use move_binary_format::file_format::{FunctionDefinition, FunctionDefinitionIndex, Visibility};
 use move_binary_format::{access::ModuleAccess, CompiledModule};
+use move_core_types::language_storage::ModuleId;
+use move_core_types::vm_status::StatusCode;
 use move_core_types::{identifier::Identifier, resolver::MoveResolver};
 use move_vm_runtime::session::{LoadedFunctionInstantiation, Session};
 use move_vm_types::loaded_data::runtime_types::Type;
@@ -17,7 +19,7 @@ pub static INIT_FN_NAME_IDENTIFIER: Lazy<Identifier> =
 /// - Single parameter of &mut TxContext type
 /// - No return values
 /// - Private
-pub fn verify_init_function<S>(module: &CompiledModule, session: &Session<S>) -> Result<bool>
+pub fn verify_init_function<S>(module: &CompiledModule, session: &Session<S>) -> VMResult<bool>
 where
     S: MoveResolver,
 {
@@ -26,10 +28,18 @@ where
         let fname = module.identifier_at(fhandle.name);
         if fname == INIT_FN_NAME_IDENTIFIER.as_ident_str() {
             if Visibility::Private != fdef.visibility {
-                return Err(Error::msg("init function should private".to_string()));
+                return Err(vm_error_for_init_func_checking(
+                    StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE,
+                    "init function should private",
+                    fdef,
+                    module.self_id(),
+                ));
             } else if fdef.is_entry {
-                return Err(Error::msg(
-                    "init function should not entry function".to_string(),
+                return Err(vm_error_for_init_func_checking(
+                    StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE,
+                    "init function should not entry function",
+                    fdef,
+                    module.self_id(),
                 ));
             } else {
                 let function_id =
@@ -41,42 +51,51 @@ where
                 )?;
                 let parameters_usize = loaded_function.parameters.len();
                 if parameters_usize != 1 && parameters_usize != 2 {
-                    return Err(Error::msg(
-                        "init function only should have two parameter with signer or storageContext"
-                            .to_string(),
+                    return Err(vm_error_for_init_func_checking(
+                        StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
+                        "init function only should have two parameter with signer or storageContext",
+                        fdef,
+                        module.self_id(),
                     ));
                 }
                 for ref ty in loaded_function.parameters {
                     match ty {
-                        Type::Reference( bt) | Type::MutableReference(bt)=> {
-                            match bt.as_ref() {
-                                Type::Struct(s) | Type::StructInstantiation(s, _) => {
-                                    let struct_type = session.get_struct_type(*s).unwrap();
-                                    if !check_storage_context_struct_tag(
-                                        &(struct_type.module.address().to_string() + "::"
-                                            + &struct_type.module.name().to_string() + "::"
-                                            + &struct_type.name.to_string()),
-                                    ) {
-                                        return Err(Error::msg(
-                                            "init function should not input structures other than storageContext"
-                                                .to_string(),
-                                        ))
-                                    }
-                                }
-                                Type::Signer => {}
-                                _ => {
-                                    return Err(Error::msg(
-                                        "init function should only enter reference signer or mutable reference storageContext"
-                                            .to_string(),
-                                    ))
+                        Type::Reference(bt) | Type::MutableReference(bt) => match bt.as_ref() {
+                            Type::Struct(s) | Type::StructInstantiation(s, _) => {
+                                let struct_type = session.get_struct_type(*s).unwrap();
+                                if !check_storage_context_struct_tag(format!(
+                                    "{}::{}::{}",
+                                    struct_type.module.short_str_lossless(),
+                                    struct_type.module.name(),
+                                    struct_type.name
+                                )) {
+                                    return Err(vm_error_for_init_func_checking(
+                                            StatusCode::TYPE_MISMATCH,
+                                            "init function should not input structures other than storageContext",
+                                            fdef,
+                                            module.self_id(),
+                                        ));
                                 }
                             }
-                        }
+                            Type::Signer => {}
+                            _ => {
+                                return Err(vm_error_for_init_func_checking(
+                                        StatusCode::TYPE_MISMATCH,
+                                        "init function should only enter reference signer or mutable reference storageContext",
+                                        fdef,
+                                        module.self_id(),
+                                    ));
+                            }
+                        },
                         Type::Signer => {}
-                        _ => return Err(Error::msg(
-                            "init function should only enter signer or storageContext"
-                                .to_string(),
-                        ))
+                        _ => {
+                            return Err(vm_error_for_init_func_checking(
+                                StatusCode::TYPE_MISMATCH,
+                                "init function should only enter signer or storageContext",
+                                fdef,
+                                module.self_id(),
+                            ))
+                        }
                     }
                 }
             }
@@ -88,17 +107,21 @@ where
 pub fn verify_entry_function<S>(
     func: &LoadedFunctionInstantiation,
     session: &Session<S>,
-) -> Result<bool>
+) -> PartialVMResult<bool>
 where
     S: MoveResolver,
 {
     if !func.return_.is_empty() {
-        return Err(Error::msg("function should not return values".to_string()));
+        return Err(
+            PartialVMError::new(StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE)
+                .with_message("function should not return values".to_string()),
+        );
     }
 
     for ty in &func.parameters {
         if !check_transaction_input_type(ty, session) {
-            return Err(Error::msg("parameter type is not allowed".to_string()));
+            return Err(PartialVMError::new(StatusCode::TYPE_MISMATCH)
+                .with_message("parameter type is not allowed".to_string()));
         }
     }
 
@@ -160,4 +183,16 @@ where
         }
         _ => false,
     }
+}
+
+fn vm_error_for_init_func_checking(
+    status_code: StatusCode,
+    error_message: &str,
+    func_def: &FunctionDefinition,
+    module_id: ModuleId,
+) -> VMError {
+    PartialVMError::new(status_code)
+        .with_message(error_message.to_string())
+        .at_code_offset(FunctionDefinitionIndex::new(func_def.function.0), 0_u16)
+        .finish(Location::Module(module_id))
 }


### PR DESCRIPTION
Return more complete error messages when executing `verify_entry_function` and `verify_init_function`.
`verify_entry_function` returns the `PartialVMError` error type, and `verify_init_function` returns the `VMError` error type.

resolve https://github.com/rooch-network/rooch/issues/243.