### PR TITLE
When processing a module publishing request, check the private_generics attribute.

### DIFF
--- a/moveos/moveos-verifier/Cargo.toml
+++ b/moveos/moveos-verifier/Cargo.toml
@@ -11,6 +11,7 @@ once_cell = { workspace = true }
 codespan-reporting = { workspace = true }
 termcolor = { workspace = true }
 bcs = { workspace = true }
+thiserror = { workspace = true }
 
 move-core-types = { workspace = true }
 move-model = { workspace = true }

--- a/moveos/moveos/src/vm/moveos_vm.rs
+++ b/moveos/moveos/src/vm/moveos_vm.rs
@@ -166,8 +166,9 @@ where
                 let compiled_modules = deserialize_modules(&module_bundle)?;
 
                 let mut init_function_modules = vec![];
-                for module in compiled_modules {
-                    let result = Self::verify_init_function(&module);
+                for module in &compiled_modules {
+                    moveos_verifier::verifier::verify_private_generics(module)?;
+                    let result = Self::verify_init_function(module);
                     match result {
                         Ok(res) => {
                             if res {
@@ -177,6 +178,7 @@ where
                         Err(err) => return Err(err),
                     }
                 }
+
                 //TODO add more module verifier.
                 Ok(VerifiedMoveAction::ModuleBundle {
                     module_bundle,


### PR DESCRIPTION
When processing a module publishing request, check whether the generic functions called with `#[private_generics(T)]` are satisfied with the requirements.

resolve https://github.com/rooch-network/rooch/issues/235.