### PR TITLE
unify next_cursor as the cursor corresponding to the last object in the returned result

### DIFF
--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -71,7 +71,7 @@ impl Message for AnnotatedStatesMessage {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetEventsByEventHandleMessage {
     pub event_handle_type: StructTag,
-    pub cursor: u64,
+    pub cursor: Option<u64>,
     pub limit: u64,
 }
 

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -76,7 +76,7 @@ impl ExecutorProxy {
     pub async fn get_events_by_event_handle(
         &self,
         event_handle_type: StructTag,
-        cursor: u64,
+        cursor: Option<u64>,
         limit: u64,
     ) -> Result<Vec<Option<AnnotatedMoveOSEvent>>> {
         self.actor

--- a/crates/rooch-server/src/server/rooch_server.rs
+++ b/crates/rooch-server/src/server/rooch_server.rs
@@ -98,17 +98,17 @@ impl RoochAPIServer for RoochServer {
         let u_limit = limit.unwrap_or(MAX_RESULT_LIMIT);
         let mut result: Vec<Option<AnnotatedEventView>> = self
             .rpc_service
-            .get_events_by_event_handle(event_handle_type.into(), cursor.unwrap_or(0), u_limit + 1)
+            .get_events_by_event_handle(event_handle_type.into(), cursor, u_limit + 1)
             .await?
             .into_iter()
             .map(|event| event.map(AnnotatedEventView::from))
             .collect();
 
         let has_next_page = (result.len() as u64) > u_limit;
+        result.truncate(u_limit as usize);
         let next_cursor = result.last().map_or(cursor, |event| {
             Some(event.clone().unwrap().event.event_id.event_seq)
         });
-        result.truncate(u_limit as usize);
 
         Ok(EventPage {
             data: result,

--- a/crates/rooch-server/src/service/mod.rs
+++ b/crates/rooch-server/src/service/mod.rs
@@ -98,7 +98,7 @@ impl RpcService {
     pub async fn get_events_by_event_handle(
         &self,
         event_handle_type: StructTag,
-        cursor: u64,
+        cursor: Option<u64>,
         limit: u64,
     ) -> Result<Vec<Option<AnnotatedMoveOSEvent>>> {
         let resp = self

--- a/moveos/moveos-store/src/event_store/mod.rs
+++ b/moveos/moveos-store/src/event_store/mod.rs
@@ -69,16 +69,21 @@ impl EventStore {
     pub fn get_events_by_event_handle_id(
         &self,
         event_handle_id: &ObjectID,
-        cursor: u64,
+        cursor: Option<u64>,
         limit: u64,
     ) -> Result<Vec<Event>, Error> {
         //  will not cross the boundary even if the size exceeds the storage capacity,
-        let end = cursor + limit;
+        let u_cursor = cursor.unwrap_or(0);
+        let end = u_cursor + limit;
         let rw_locks = self.store.read();
         let data = rw_locks
             .iter()
             .filter(|((handle_id, event_seq), _)| {
-                *handle_id == *event_handle_id && (*event_seq >= cursor && *event_seq < end)
+                if Option::is_some(&cursor) {
+                    *handle_id == *event_handle_id && (*event_seq > u_cursor && *event_seq <= end)
+                } else {
+                    *handle_id == *event_handle_id && (*event_seq >= u_cursor && *event_seq < end)
+                }
             })
             .map(|(_, e)| e.clone())
             .collect::<Vec<_>>();


### PR DESCRIPTION
1) If the cursor is empty, return the first page of results from the beginning
2) If the cursor is not empty, skip the cursor and return the result from the next position

```
curl --location 'http://localhost:50051' \
--header 'Content-Type: application/json' \
--data '{
    "id": 101,
    "jsonrpc": "2.0",
    "method": "rooch_getEventsByEventHandle",
    "params": [
        "0xb4321fa441b5d9fdefb71f82856a56447451f7b1ba9478747b07e9f26b34c87::something::SomethingCreated", null, 1
    ]
}'
```

```
{
    "jsonrpc": "2.0",
    "result": {
        "data": [
            {
                "event": {
                    "event_id": {
                        "event_handle_id": "0xebe6b25007d2d52a8245b21d654b015726ae6f5edff9001ec4a529322885588e",
                        "event_seq": 0
                    },
                    "type_tag": "0xb4321fa441b5d9fdefb71f82856a56447451f7b1ba9478747b07e9f26b34c87::something::SomethingCreated",
                    "event_data": "0xc8e70b6230d7113043aef70a0ce9e748beda3fa0703a058c39e887a2772701bb0100000002000000000000000000000000000000",
                    "event_index": 3
                },
                "sender": "0000000000000000000000000000000000000000000000000000000000000000",
                "tx_hash": null,
                "timestamp_ms": null,
                "parsed_event_data": {
                    "abilities": 8,
                    "type": "0xb4321fa441b5d9fdefb71f82856a56447451f7b1ba9478747b07e9f26b34c87::something::SomethingCreated",
                    "value": {
                        "i": 1,
                        "j": "2",
                        "obj_id": "0xc8e70b6230d7113043aef70a0ce9e748beda3fa0703a058c39e887a2772701bb"
                    }
                }
            }
        ],
        "next_cursor": 0,
        "has_next_page": true
    },
    "id": 101
}
```