### PR TITLE
Ci cache

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -20,6 +20,9 @@ runs:
       env:
         SCCACHE_GHA_ENABLED: "true"
         RUSTC_WRAPPER: "sccache"
+        SCCACHE_BUCKET: "rooch-gha-cache"
+        SCCACHE_REGION: "ap-northeast-1"
+        SCCACHE_S3_USE_SSL: "true"
 
     - name: install protoc and related tools
       shell: bash

--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -17,6 +17,9 @@ runs:
     # https://github.com/Mozilla-Actions/sccache-action
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+        RUSTC_WRAPPER: "sccache"
 
     - name: install protoc and related tools
       shell: bash

--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -14,10 +14,9 @@ runs:
         override: true
         components: rustfmt, clippy
 
-    # rust-cache action will cache ~/.cargo and ./target
-    # https://github.com/Swatinem/rust-cache#cache-details
-    - name: Run cargo cache
-      uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # pin@v2.2.0
+    # https://github.com/Mozilla-Actions/sccache-action
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: install protoc and related tools
       shell: bash


### PR DESCRIPTION
Backgroud:
https://github.com/rooch-network/rooch/actions/runs/5253703423/jobs/9491367820?pr=270

Considering the 10GB limit of GitHub cache, and occasional network issues leading to timeouts, using sccache with support for S3 might be a better choice.

```
Received 4290772990 of 6318484518 (67.9%), 1.1 MBs/sec
Received 4290772990 of 6318484518 (67.9%), 1.1 MBs/sec
Received 4290772990 of 6318484518 (67.9%), 1.1 MBs/sec
Warning: Failed to restore: Aborting cache download as the download time exceeded the timeout.
No cache found.
```
