### PR TITLE
[gh-296] Add example integration test for private generics.

### DIFF
--- a/examples/private_generics/Move.toml
+++ b/examples/private_generics/Move.toml
@@ -3,7 +3,6 @@ name = "private_generics"
 version = "0.0.1"
 
 [dependencies]
-#MoveosStdlib = { git = "https://github.com/rooch-network/rooch.git", subdir = "moveos/moveos-stdlib/moveos-stdlib", rev = "main" }
 MoveosStdlib = { local = "../../moveos/moveos-stdlib/moveos-stdlib" }
 
 [addresses]

--- a/examples/private_generics/integration-tests/private_generics.exp
+++ b/examples/private_generics/integration-tests/private_generics.exp
@@ -1,4 +1,10 @@
-processed 2 tasks
+processed 4 tasks
 
-task 1 'run'. lines 3-15:
+task 1 'run'. lines 3-10:
+status EXECUTED
+
+task 2 'run'. lines 12-19:
+status EXECUTED
+
+task 3 'run'. lines 21-29:
 status EXECUTED

--- a/examples/private_generics/integration-tests/private_generics.exp
+++ b/examples/private_generics/integration-tests/private_generics.exp
@@ -1,10 +1,59 @@
+warning: unused alias
+   ┌─ /tmp/tempfile.move:33:32
+   │
+33 │     use rooch_examples::Test1::Box;
+   │                                ^^^ Unused 'use' of alias 'Box'. Consider removing it
+
+warning: unused alias
+   ┌─ /Users/system/Downloads/rooch/examples/private_generics/sources/private_generics.move:35:32
+   │
+35 │     use rooch_examples::Test1::box_value;
+   │                                ^^^^^^^^^ Unused 'use' of alias 'box_value'. Consider removing it
+
+warning: unused alias
+   ┌─ /Users/system/Downloads/rooch/examples/private_generics/sources/private_generics.move:34:32
+   │
+34 │     use rooch_examples::Test1::create_box;
+   │                                ^^^^^^^^^^ Unused 'use' of alias 'create_box'. Consider removing it
+
+error: resource type "Data" in function "0x34141::Test1::create_box" not defined in current module or not allowed
+   ┌─ /Users/system/Downloads/rooch/examples/private_generics/sources/private_generics.move:64:23
+   │
+64 │         let box_val = create_box<Data, Data, Box<u32>>(data);
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
 processed 4 tasks
 
 task 1 'run'. lines 3-10:
-status EXECUTED
+Error: error[E03003]: unbound module member
+  ┌─ /tmp/tempfile:7:9
+  │
+7 │         Test1::test();
+  │         ^^^^^^^^^^^ Invalid module access. Unbound function 'test' in module '(rooch_examples=0x34141)::Test1'
+
+
 
 task 2 'run'. lines 12-19:
-status EXECUTED
+Error: error[E03003]: unbound module member
+   ┌─ /tmp/tempfile:16:9
+   │
+16 │         Test2::run();
+   │         ^^^^^^^^^^ Invalid module access. Unbound function 'run' in module '(rooch_examples=0x34141)::Test2'
+
+
 
 task 3 'run'. lines 21-29:
-status EXECUTED
+Error: error: unresolved spec target
+    ┌─ /Users/system/Downloads/rooch/examples/private_generics/../../moveos/moveos-stdlib/moveos-stdlib/sources/type_info.move:140:10
+    │
+140 │     spec verify_type_of_generic {
+    │          ^^^^^^^^^^^^^^^^^^^^^^
+
+error: resource type "Data" in function "0x34141::Test1::create_box" not defined in current module or not allowed
+   ┌─ /Users/system/Downloads/rooch/examples/private_generics/sources/private_generics.move:64:23
+   │
+64 │         let box_val = create_box<Data, Data, Box<u32>>(data);
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/examples/private_generics/integration-tests/private_generics.exp
+++ b/examples/private_generics/integration-tests/private_generics.exp
@@ -1,49 +1,13 @@
-warning: unused alias
-   ┌─ /tmp/tempfile.move:33:32
-   │
-33 │     use rooch_examples::Test1::Box;
-   │                                ^^^ Unused 'use' of alias 'Box'. Consider removing it
-
-warning: unused alias
-   ┌─ /Users/system/Downloads/rooch/examples/private_generics/sources/private_generics.move:35:32
-   │
-35 │     use rooch_examples::Test1::box_value;
-   │                                ^^^^^^^^^ Unused 'use' of alias 'box_value'. Consider removing it
-
-warning: unused alias
-   ┌─ /Users/system/Downloads/rooch/examples/private_generics/sources/private_generics.move:34:32
-   │
-34 │     use rooch_examples::Test1::create_box;
-   │                                ^^^^^^^^^^ Unused 'use' of alias 'create_box'. Consider removing it
-
 error: resource type "Data" in function "0x34141::Test1::create_box" not defined in current module or not allowed
-   ┌─ /Users/system/Downloads/rooch/examples/private_generics/sources/private_generics.move:64:23
+   ┌─ /tmp/tempfile.move:62:23
    │
-64 │         let box_val = create_box<Data, Data, Box<u32>>(data);
+62 │         let box_val = create_box<Data, Data, Box<u32>>(data);
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-processed 4 tasks
+processed 2 tasks
 
-task 1 'run'. lines 3-10:
-Error: error[E03003]: unbound module member
-  ┌─ /tmp/tempfile:7:9
-  │
-7 │         Test1::test();
-  │         ^^^^^^^^^^^ Invalid module access. Unbound function 'test' in module '(rooch_examples=0x34141)::Test1'
-
-
-
-task 2 'run'. lines 12-19:
-Error: error[E03003]: unbound module member
-   ┌─ /tmp/tempfile:16:9
-   │
-16 │         Test2::run();
-   │         ^^^^^^^^^^ Invalid module access. Unbound function 'run' in module '(rooch_examples=0x34141)::Test2'
-
-
-
-task 3 'run'. lines 21-29:
+task 1 'run'. lines 3-14:
 Error: error: unresolved spec target
     ┌─ /Users/system/Downloads/rooch/examples/private_generics/../../moveos/moveos-stdlib/moveos-stdlib/sources/type_info.move:140:10
     │
@@ -51,9 +15,9 @@ Error: error: unresolved spec target
     │          ^^^^^^^^^^^^^^^^^^^^^^
 
 error: resource type "Data" in function "0x34141::Test1::create_box" not defined in current module or not allowed
-   ┌─ /Users/system/Downloads/rooch/examples/private_generics/sources/private_generics.move:64:23
+   ┌─ /Users/system/Downloads/rooch/examples/private_generics/sources/private_generics.move:62:23
    │
-64 │         let box_val = create_box<Data, Data, Box<u32>>(data);
+62 │         let box_val = create_box<Data, Data, Box<u32>>(data);
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 

--- a/examples/private_generics/integration-tests/private_generics.exp
+++ b/examples/private_generics/integration-tests/private_generics.exp
@@ -1,5 +1,0 @@
-processed 2 tasks
-
-// TODO should be panic after checking scripts at the verifier level
-task 1 'run'. lines 3-10:
-status EXECUTED

--- a/examples/private_generics/integration-tests/private_generics.exp
+++ b/examples/private_generics/integration-tests/private_generics.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+// TODO should be panic after checking scripts at the verifier level
+task 1 'run'. lines 3-10:
+status EXECUTED

--- a/examples/private_generics/integration-tests/private_generics.exp
+++ b/examples/private_generics/integration-tests/private_generics.exp
@@ -1,4 +1,4 @@
 processed 2 tasks
 
-task 1 'run'. lines 3-12:
+task 1 'run'. lines 3-15:
 status EXECUTED

--- a/examples/private_generics/integration-tests/private_generics.exp
+++ b/examples/private_generics/integration-tests/private_generics.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+
+task 1 'run'. lines 3-12:
+status EXECUTED

--- a/examples/private_generics/integration-tests/private_generics.move
+++ b/examples/private_generics/integration-tests/private_generics.move
@@ -3,27 +3,12 @@
 //# run --signers test
 script {
     use rooch_examples::Test1;
-
-    fun main() {
-        Test1::test();
-    }
-}
-
-//# run --signers test
-script {
     use rooch_examples::Test2;
-
-    fun main() {
-        Test2::run();
-    }
-}
-
-//# run --signers test
-script {
     use rooch_examples::Test3;
 
     fun main() {
-        // FIXME: expected failure
-        Test3::run();
+        Test1::test();
+        Test2::run();
+        Test3::run(); // this test will report error!
     }
 }

--- a/examples/private_generics/integration-tests/private_generics.move
+++ b/examples/private_generics/integration-tests/private_generics.move
@@ -5,7 +5,7 @@ script {
     use rooch_examples::Test1;
     use rooch_examples::Test2;
 
-    fun main() {
+    fun main(_s: &signer) {
         Test1::test();
         Test2::run();
     }

--- a/examples/private_generics/integration-tests/private_generics.move
+++ b/examples/private_generics/integration-tests/private_generics.move
@@ -1,0 +1,10 @@
+//# init --addresses test=0x42
+
+//# run --signers test
+script {
+    use rooch_examples::Data;
+
+    fun main() {
+        Data::run();
+    }
+}

--- a/examples/private_generics/integration-tests/private_generics.move
+++ b/examples/private_generics/integration-tests/private_generics.move
@@ -3,12 +3,26 @@
 //# run --signers test
 script {
     use rooch_examples::Test1;
+
+    fun main() {
+        Test1::test();
+    }
+}
+
+//# run --signers test
+script {
     use rooch_examples::Test2;
+
+    fun main() {
+        Test2::run();
+    }
+}
+
+//# run --signers test
+script {
     use rooch_examples::Test3;
 
-    fun main(_s: &signer) {
-        Test1::test();
-        Test2::run();
+    fun main() {
         // FIXME: expected failure
         Test3::run();
     }

--- a/examples/private_generics/integration-tests/private_generics.move
+++ b/examples/private_generics/integration-tests/private_generics.move
@@ -2,9 +2,11 @@
 
 //# run --signers test
 script {
-    use rooch_examples::Data;
+    use rooch_examples::Test1;
+    use rooch_examples::Test2;
 
     fun main() {
-        Data::run();
+        Test1::test();
+        Test2::run();
     }
 }

--- a/examples/private_generics/integration-tests/private_generics.move
+++ b/examples/private_generics/integration-tests/private_generics.move
@@ -4,9 +4,12 @@
 script {
     use rooch_examples::Test1;
     use rooch_examples::Test2;
+    use rooch_examples::Test3;
 
     fun main(_s: &signer) {
         Test1::test();
         Test2::run();
+        // FIXME: expected failure
+        Test3::run();
     }
 }

--- a/examples/private_generics/sources/private_generics.move
+++ b/examples/private_generics/sources/private_generics.move
@@ -20,7 +20,6 @@ module rooch_examples::Test1 {
         *&box.value
     }
 
-    #[test]
     public fun test() {
         let data = Data{ v: 123 };
 
@@ -38,7 +37,6 @@ module rooch_examples::Test2 {
         v: u64,
     }
 
-    #[test]
     public fun run() {
         let data = InnerData { v: 789 };
 

--- a/examples/private_generics/sources/private_generics.move
+++ b/examples/private_generics/sources/private_generics.move
@@ -29,7 +29,7 @@ module rooch_examples::Test1 {
     }
 }
 
-module rooch_examples::Test3 {
+module rooch_examples::Test2 {
     use rooch_examples::Test1::Box;
     use rooch_examples::Test1::create_box;
     use rooch_examples::Test1::box_value;

--- a/examples/private_generics/sources/private_generics.move
+++ b/examples/private_generics/sources/private_generics.move
@@ -40,7 +40,7 @@ module rooch_examples::Test2 {
 
     #[test]
     public fun run() {
-        let data = InnerData{ v: 789 };
+        let data = InnerData { v: 789 };
 
         // Here is correct because the InnerData type is defined within the current module.
         let box_val = create_box<InnerData, InnerData, Box<u32>>(data);
@@ -49,3 +49,20 @@ module rooch_examples::Test2 {
     }
 }
 
+module rooch_examples::Test3 {
+    use rooch_examples::Test1::Data;
+    use rooch_examples::Test1::Box;
+    use rooch_examples::Test1::new_data;
+    use rooch_examples::Test1::create_box;
+    use rooch_examples::Test1::box_value;
+
+    public fun run() {
+        let data = new_data(789);
+
+        // Here, it will report that `Data` is not defined within the current module,
+        // because `Data` is imported from the `Test1` module.
+        let box_val = create_box<Data, Data, Box<u32>>(data);
+
+        let _ = box_value(&box_val);
+    }
+}

--- a/examples/private_generics/sources/private_generics.move
+++ b/examples/private_generics/sources/private_generics.move
@@ -21,7 +21,7 @@ module rooch_examples::Test1 {
     }
 
     #[test]
-    fun test() {
+    public fun test() {
         let data = Data{ v: 123 };
 
         let box_val = create_box<Data, Data, Box<u32>>(data);


### PR DESCRIPTION
Test case for example private generics referred to #282 

Resolves #296 

Should be erroring once the verifier added checks for script in a move test file.