### PR TITLE
remove ci cache

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -13,15 +13,6 @@ runs:
       with:
         override: true
         components: rustfmt, clippy
-    # https://github.com/Mozilla-Actions/sccache-action
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
-      env:
-        SCCACHE_GHA_ENABLED: "true"
-        RUSTC_WRAPPER: "sccache"
-        SCCACHE_BUCKET: "rooch-gha-cache"
-        SCCACHE_REGION: "ap-northeast-1"
-        SCCACHE_S3_USE_SSL: "true"
 
     - name: install protoc and related tools
       shell: bash

--- a/.github/workflows/check_build_test.yml
+++ b/.github/workflows/check_build_test.yml
@@ -16,11 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: ap-northeast-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - uses: rooch-network/rooch/.github/actions/rust-setup@main
       #  with:
       #    fetch-depth: 0


### PR DESCRIPTION
After discussion, we have temporarily removed the CI rust cache. We will observe the effects in the future.