### PR TITLE
add unit tests for moveos_stdlib::table and  moveos_stdlib::type_table

### DIFF
--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
@@ -600,10 +600,10 @@ fn native_destroy_empty_box(
     let mut table_data = table_context.table_data.borrow_mut();
 
     let handle = get_table_handle(pop_arg!(args, StructRef))?;
-    if table_data.tables.contains_key(&handle) {
-        if table_data.tables.get(&handle).unwrap().content.len() > 0 {
-            return Ok(NativeResult::err(gas_params.base, NOT_EMPTY));
-        }
+    if table_data.tables.contains_key(&handle)
+        && !table_data.tables.get(&handle).unwrap().content.is_empty()
+    {
+        return Ok(NativeResult::err(gas_params.base, NOT_EMPTY));
     }
     assert!(table_data.removed_tables.insert(handle));
 

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
@@ -58,7 +58,7 @@ const ALREADY_EXISTS: u64 = (100 << 8) + ECATEGORY_INVALID_ARGUMENT as u64;
 const NOT_FOUND: u64 = (101 << 8) + ECATEGORY_INVALID_ARGUMENT as u64;
 // Move side raises this
 //26112
-const _NOT_EMPTY: u64 = (102 << 8) + _ECATEGORY_INVALID_STATE as u64;
+const NOT_EMPTY: u64 = (102 << 8) + _ECATEGORY_INVALID_STATE as u64;
 
 // ===========================================================================================
 // Private Data Structures and Constants
@@ -600,6 +600,11 @@ fn native_destroy_empty_box(
     let mut table_data = table_context.table_data.borrow_mut();
 
     let handle = get_table_handle(pop_arg!(args, StructRef))?;
+    if table_data.tables.contains_key(&handle) {
+        if table_data.tables.get(&handle).unwrap().content.len() > 0 {
+            return Ok(NativeResult::err(gas_params.base, NOT_EMPTY));
+        }
+    }
     assert!(table_data.removed_tables.insert(handle));
 
     Ok(NativeResult::ok(gas_params.base, smallvec![]))


### PR DESCRIPTION
There are two failed cases:
- `table::test_destroy_nonempty_table`: it should aborts when destroy a non-empty table however not.
- `table::test_nested_table_destroy`: destroy the parent table of a nested table, the child table should not be accessable how not.

Please help review the test cases. @jolestar 