### PR TITLE
[MoveOS] Execute `pre_execute` function before transaction execute 

### DIFF
--- a/crates/rooch-framework/doc/account.md
+++ b/crates/rooch-framework/doc/account.md
@@ -465,10 +465,6 @@ Return the current sequence number at <code>addr</code>
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_increment_sequence_number">increment_sequence_number</a>(ctx: &<b>mut</b> StorageContext) {
    <b>let</b> sender = <a href="_sender">storage_context::sender</a>(ctx);
-   //Auto create <a href="account.md#0x3_account">account</a> <b>if</b> not exist
-   <b>if</b> (!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, sender)) {
-      <a href="account.md#0x3_account_create_account_unchecked">create_account_unchecked</a>(ctx, sender);
-   };
 
    <b>let</b> sequence_number = &<b>mut</b> <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, sender).sequence_number;
 
@@ -595,7 +591,7 @@ Return the current TokenType balance of the account at <code>addr</code>.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_exists_at">exists_at</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_exists_at">exists_at</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -604,7 +600,7 @@ Return the current TokenType balance of the account at <code>addr</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_exists_at">exists_at</a>(ctx: &<b>mut</b> StorageContext, addr: <b>address</b>): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_exists_at">exists_at</a>(ctx: &StorageContext, addr: <b>address</b>): bool {
    <b>if</b>(<a href="_exist_account_storage">account_storage::exist_account_storage</a>(ctx, addr)){
       <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, addr)
    } <b>else</b> {

--- a/crates/rooch-framework/doc/address_mapping.md
+++ b/crates/rooch-framework/doc/address_mapping.md
@@ -10,7 +10,9 @@
 -  [Constants](#@Constants_0)
 -  [Function `is_rooch_address`](#0x3_address_mapping_is_rooch_address)
 -  [Function `resolve`](#0x3_address_mapping_resolve)
--  [Function `binding`](#0x3_address_mapping_binding)
+-  [Function `exists_mapping`](#0x3_address_mapping_exists_mapping)
+-  [Function `bind`](#0x3_address_mapping_bind)
+-  [Function `bind_no_check`](#0x3_address_mapping_bind_no_check)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -175,15 +177,14 @@ Resolve a multi-chain address to a rooch address
 
 </details>
 
-<a name="0x3_address_mapping_binding"></a>
+<a name="0x3_address_mapping_exists_mapping"></a>
 
-## Function `binding`
+## Function `exists_mapping`
 
-Binding a multi-chain address to a rooch address
-The caller need to ensure the relationship between the multi-chain address and the rooch address
+Check if a multi-chain address is bound to a rooch address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_binding">binding</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, sender: &<a href="">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_exists_mapping">exists_mapping</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): bool
 </code></pre>
 
 
@@ -192,10 +193,68 @@ The caller need to ensure the relationship between the multi-chain address and t
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_binding">binding</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_exists_mapping">exists_mapping</a>(ctx: &StorageContext, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>): bool {
+    <b>if</b> (<a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(&maddress)) {
+        <b>return</b> <b>true</b>
+    };
+    <b>let</b> am = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
+    <a href="_contains">table::contains</a>(&am.mapping, maddress)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_address_mapping_bind"></a>
+
+## Function `bind`
+
+Bind a multi-chain address to the sender's rooch address
+The caller need to ensure the relationship between the multi-chain address and the rooch address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, sender: &<a href="">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) {
+    <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx, <a href="_address_of">signer::address_of</a>(sender), maddress);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_address_mapping_bind_no_check"></a>
+
+## Function `bind_no_check`
+
+Bind a rooch address to a multi-chain address
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, rooch_address: <b>address</b>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx: &<b>mut</b> StorageContext, rooch_address: <b>address</b>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) {
+    <b>if</b>(<a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(&maddress)){
+        //Do nothing <b>if</b> the multi-chain <b>address</b> is a rooch <b>address</b>
+        <b>return</b>
+    };
     <b>let</b> am = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
-    <b>let</b> sender_addr = <a href="_address_of">signer::address_of</a>(sender);
-    <a href="_add">table::add</a>(&<b>mut</b> am.mapping, maddress, sender_addr);
+    <a href="_add">table::add</a>(&<b>mut</b> am.mapping, maddress, rooch_address);
     //TODO matienance the reverse mapping rooch_address -&gt; <a href="">vector</a>&lt;<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>&gt;
 }
 </code></pre>

--- a/crates/rooch-framework/doc/transaction_validator.md
+++ b/crates/rooch-framework/doc/transaction_validator.md
@@ -10,8 +10,10 @@
 
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account.md#0x3_account">0x3::account</a>;
+<b>use</b> <a href="address_mapping.md#0x3_address_mapping">0x3::address_mapping</a>;
 <b>use</b> <a href="authenticator.md#0x3_authenticator">0x3::authenticator</a>;
 <b>use</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1">0x3::ecdsa_k1</a>;
 <b>use</b> <a href="ed25519.md#0x3_ed25519">0x3::ed25519</a>;

--- a/crates/rooch-framework/sources/account.move
+++ b/crates/rooch-framework/sources/account.move
@@ -141,10 +141,6 @@ module rooch_framework::account{
 
    public(friend) fun increment_sequence_number(ctx: &mut StorageContext) {
       let sender = storage_context::sender(ctx);
-      //Auto create account if not exist
-      if (!account_storage::global_exists<Account>(ctx, sender)) {
-         create_account_unchecked(ctx, sender); 
-      };
 
       let sequence_number = &mut account_storage::global_borrow_mut<Account>(ctx, sender).sequence_number;
 
@@ -188,7 +184,7 @@ module rooch_framework::account{
 
 
    #[view]
-   public fun exists_at(ctx: &mut StorageContext, addr: address): bool {
+   public fun exists_at(ctx: &StorageContext, addr: address): bool {
       if(account_storage::exist_account_storage(ctx, addr)){
          account_storage::global_exists<Account>(ctx, addr)
       } else {

--- a/crates/rooch-framework/src/bindings/transaction_validator.rs
+++ b/crates/rooch-framework/src/bindings/transaction_validator.rs
@@ -21,7 +21,8 @@ pub struct TransactionValidator<'a> {
 
 impl<'a> TransactionValidator<'a> {
     const VALIDATE_FUNCTION_NAME: &'static IdentStr = ident_str!("validate");
-    const FINALIZE_FUNCTION_NAME: &IdentStr = ident_str!("finalize");
+    const PRE_EXECUTE_FUNCTION_NAME: &IdentStr = ident_str!("pre_execute");
+    const POST_EXECUTE_FUNCTION_NAME: &IdentStr = ident_str!("post_execute");
 
     pub fn validate(&self, ctx: &TxContext, auth: AuthenticatorInfo) -> Result<()> {
         let call = FunctionCall::new(
@@ -38,8 +39,12 @@ impl<'a> TransactionValidator<'a> {
         })
     }
 
-    pub fn finalize_function_id() -> FunctionId {
-        Self::function_id(Self::FINALIZE_FUNCTION_NAME)
+    pub fn pre_execute_function_id() -> FunctionId {
+        Self::function_id(Self::PRE_EXECUTE_FUNCTION_NAME)
+    }
+
+    pub fn post_execute_function_id() -> FunctionId {
+        Self::function_id(Self::POST_EXECUTE_FUNCTION_NAME)
     }
 }
 

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -51,7 +51,6 @@ impl RoochGenesis {
             pre_execute_function: Some(
                 transaction_validator::TransactionValidator::pre_execute_function_id(),
             ),
-            //We do not execute the finalize function in the test.
             post_execute_function: Some(
                 transaction_validator::TransactionValidator::post_execute_function_id(),
             ),

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -38,15 +38,23 @@ impl RoochGenesis {
             .collect();
         let config = MoveOSConfig {
             vm_config: VMConfig::default(),
-            finalize_function: Some(
-                transaction_validator::TransactionValidator::finalize_function_id(),
+            pre_execute_function: Some(
+                transaction_validator::TransactionValidator::pre_execute_function_id(),
+            ),
+            post_execute_function: Some(
+                transaction_validator::TransactionValidator::post_execute_function_id(),
             ),
         };
 
         let config_for_test = MoveOSConfig {
             vm_config: VMConfig::default(),
+            pre_execute_function: Some(
+                transaction_validator::TransactionValidator::pre_execute_function_id(),
+            ),
             //We do not execute the finalize function in the test.
-            finalize_function: None,
+            post_execute_function: Some(
+                transaction_validator::TransactionValidator::post_execute_function_id(),
+            ),
         };
 
         let gas_params = rooch_framework::natives::GasParameters::zeros();

--- a/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.exp
+++ b/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
-task 1 'publish'. lines 3-17:
+task 1 'publish'. lines 3-19:
 status EXECUTED
 
-task 2 'run'. lines 19-26:
+task 2 'run'. lines 21-29:
 status EXECUTED

--- a/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.move
+++ b/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.move
@@ -2,25 +2,28 @@
 
 //# publish
 module creator::test {
+    use moveos_std::storage_context::{StorageContext};
+    use moveos_std::account_storage;
     struct Foo has key {
         x: u64,
     }
 
     #[private(T1)]
-    public fun publish_foo<T1>(s: &signer) {
-        move_to<Foo>(s, Foo { x: 500 })
+    public fun publish_foo<T1>(ctx: &mut StorageContext, s: &signer) {
+        account_storage::global_move_to<Foo>(ctx, s, Foo { x: 500 })
     }
 
-    public fun run(s: &signer) {
-        publish_foo<u64>(s)
+    public fun run(ctx: &mut StorageContext, s: &signer) {
+        publish_foo<u64>(ctx, s)
     }
 }
 
 //# run --signers creator
 script {
     use creator::test;
+    use moveos_std::storage_context::{StorageContext};
 
-    fun main(s: signer) {
-        test::run(&s);
+    fun main(ctx: &mut StorageContext, s: signer) {
+        test::run(ctx, &s);
     }
 }

--- a/crates/rooch-integration-test-runner/tests/cases/publish_cmd.exp
+++ b/crates/rooch-integration-test-runner/tests/cases/publish_cmd.exp
@@ -1,12 +1,12 @@
 processed 4 tasks
 
-task 1 'publish'. lines 3-12:
+task 1 'publish'. lines 3-14:
 status EXECUTED
 
-task 2 'run'. lines 14-21:
+task 2 'run'. lines 16-24:
 status EXECUTED
 
-task 3 'view'. lines 23-25:
+task 3 'view'. lines 26-28:
 key 0x42::test::Foo {
     x: 500
 }

--- a/crates/rooch-integration-test-runner/tests/cases/publish_cmd.move
+++ b/crates/rooch-integration-test-runner/tests/cases/publish_cmd.move
@@ -2,21 +2,24 @@
 
 //# publish
 module creator::test {
+    use moveos_std::storage_context::{StorageContext};
+    use moveos_std::account_storage;
     struct Foo has key {
         x: u64,
     }
 
-    public fun publish_foo(s: &signer) {
-        move_to<Foo>(s, Foo { x: 500 })
+    public fun publish_foo(ctx: &mut StorageContext, s: &signer) {
+        account_storage::global_move_to<Foo>(ctx, s, Foo { x: 500 })
     }
 }
 
 //# run --signers creator
 script {
     use creator::test;
+    use moveos_std::storage_context::{StorageContext};
 
-    fun main(s: signer) {
-        test::publish_foo(&s);
+    fun main(ctx: &mut StorageContext, s: signer) {
+        test::publish_foo(ctx, &s);
     }
 }
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md
@@ -17,9 +17,12 @@ and let developers can customize the storage
 -  [Function `fresh_address`](#0x2_storage_context_fresh_address)
 -  [Function `fresh_object_id`](#0x2_storage_context_fresh_object_id)
 -  [Function `tx_hash`](#0x2_storage_context_tx_hash)
+-  [Function `add`](#0x2_storage_context_add)
+-  [Function `get`](#0x2_storage_context_get)
 
 
-<pre><code><b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
 <b>use</b> <a href="object_storage.md#0x2_object_storage">0x2::object_storage</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
@@ -250,6 +253,56 @@ Wrap functions for TxContext
 
 <pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_tx_hash">tx_hash</a>(this: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): <a href="">vector</a>&lt;u8&gt; {
     <a href="tx_context.md#0x2_tx_context_tx_hash">tx_context::tx_hash</a>(&this.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_storage_context_add"></a>
+
+## Function `add`
+
+Add a value to the context map
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_add">add</a>&lt;T: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, value: T)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_add">add</a>&lt;T: drop + store + <b>copy</b>&gt;(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>, value: T) {
+    <a href="tx_context.md#0x2_tx_context_add">tx_context::add</a>(&<b>mut</b> self.<a href="tx_context.md#0x2_tx_context">tx_context</a>, value);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_storage_context_get"></a>
+
+## Function `get`
+
+Get a value from the context map
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_get">get</a>&lt;T: <b>copy</b>, drop, store&gt;(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="_Option">option::Option</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_get">get</a>&lt;T: drop + store + <b>copy</b>&gt;(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): Option&lt;T&gt; {
+    <a href="tx_context.md#0x2_tx_context_get">tx_context::get</a>(&self.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
@@ -3,6 +3,8 @@
 /// and let developers can customize the storage
 
 module moveos_std::storage_context {
+
+    use std::option::Option;
     use moveos_std::object_storage::{ObjectStorage};
     use moveos_std::tx_context::{Self, TxContext};
     use moveos_std::object_id::{ObjectID};
@@ -56,6 +58,16 @@ module moveos_std::storage_context {
     public fun tx_hash(this: &StorageContext): vector<u8> {
         tx_context::tx_hash(&this.tx_context)
     } 
+
+    /// Add a value to the context map
+    public fun add<T: drop + store + copy>(self: &mut StorageContext, value: T) {
+        tx_context::add(&mut self.tx_context, value); 
+    }
+
+    /// Get a value from the context map
+    public fun get<T: drop + store + copy>(self: &StorageContext): Option<T> {
+        tx_context::get(&self.tx_context)
+    }
 
     #[test_only]
     /// Create a StorageContext and AccountStorage for unit test

--- a/moveos/moveos-types/src/move_any.rs
+++ b/moveos/moveos-types/src/move_any.rs
@@ -18,17 +18,39 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 /// `Any` is represented `moveos_std::any::Any` in Move.
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Any {
     pub type_name: MoveString,
     pub data: Vec<u8>,
 }
 
+impl std::fmt::Debug for Any {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Any {{ type_name: {}, data: {} }}",
+            self.type_name,
+            hex::encode(&self.data)
+        )
+    }
+}
+
 /// `CopyableAny` is represented `moveos_std::copyable_any::Any` in Move.
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Deserialize, Serialize, Eq, PartialEq)]
 pub struct CopyableAny {
     pub type_name: MoveString,
     pub data: Vec<u8>,
+}
+
+impl std::fmt::Debug for CopyableAny {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CopyableAny {{ type_name: {}, data: {} }}",
+            self.type_name,
+            hex::encode(&self.data)
+        )
+    }
 }
 
 pub trait AnyTrait {

--- a/moveos/moveos-types/src/move_string.rs
+++ b/moveos/moveos-types/src/move_string.rs
@@ -18,9 +18,15 @@ use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Eq, PartialEq, Clone, PartialOrd, Ord, Hash, JsonSchema)]
+#[derive(Eq, PartialEq, Clone, PartialOrd, Ord, Hash, JsonSchema)]
 pub struct MoveString {
     bytes: Vec<u8>,
+}
+
+impl std::fmt::Debug for MoveString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
 }
 
 impl std::fmt::Display for MoveString {

--- a/moveos/moveos-types/src/storage_context.rs
+++ b/moveos/moveos-types/src/storage_context.rs
@@ -2,10 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    addresses::MOVEOS_STD_ADDRESS, object::ObjectID, state::MoveStructType, state_resolver,
+    addresses::MOVEOS_STD_ADDRESS,
+    object::ObjectID,
+    state::{MoveStructState, MoveStructType},
+    state_resolver,
     tx_context::TxContext,
 };
-use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use anyhow::Result;
+use move_core_types::{
+    account_address::AccountAddress,
+    ident_str,
+    identifier::IdentStr,
+    value::{MoveStructLayout, MoveTypeLayout},
+};
 use serde::{Deserialize, Serialize};
 
 pub const GLOBAL_OBJECT_STORAGE_HANDLE: ObjectID = state_resolver::GLOBAL_OBJECT_STORAGE_HANDLE;
@@ -13,6 +22,18 @@ pub const GLOBAL_OBJECT_STORAGE_HANDLE: ObjectID = state_resolver::GLOBAL_OBJECT
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ObjectStorage {
     pub handle: ObjectID,
+}
+
+impl MoveStructType for ObjectStorage {
+    const ADDRESS: AccountAddress = MOVEOS_STD_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = ident_str!("object_storage");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ObjectStorage");
+}
+
+impl MoveStructState for ObjectStorage {
+    fn struct_layout() -> MoveStructLayout {
+        MoveStructLayout::new(vec![MoveTypeLayout::Struct(ObjectID::struct_layout())])
+    }
 }
 
 pub const STORAGE_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("storage_context");
@@ -35,8 +56,12 @@ impl StorageContext {
         }
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self).unwrap()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(bcs::from_bytes(bytes)?)
     }
 }
 
@@ -44,4 +69,13 @@ impl MoveStructType for StorageContext {
     const ADDRESS: AccountAddress = MOVEOS_STD_ADDRESS;
     const MODULE_NAME: &'static IdentStr = STORAGE_CONTEXT_MODULE_NAME;
     const STRUCT_NAME: &'static IdentStr = STORAGE_CONTEXT_STRUCT_NAME;
+}
+
+impl MoveStructState for StorageContext {
+    fn struct_layout() -> MoveStructLayout {
+        MoveStructLayout::new(vec![
+            MoveTypeLayout::Struct(TxContext::struct_layout()),
+            MoveTypeLayout::Struct(ObjectStorage::struct_layout()),
+        ])
+    }
 }

--- a/moveos/moveos-types/src/tx_context.rs
+++ b/moveos/moveos-types/src/tx_context.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("tx_context");
 pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("TxContext");
 
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Deserialize, Serialize, Eq, PartialEq)]
 pub struct TxContext {
     /// Signer/sender of the transaction
     pub sender: AccountAddress,
@@ -32,11 +32,32 @@ pub struct TxContext {
     pub map: SimpleMap<MoveString, CopyableAny>,
 }
 
+impl std::fmt::Debug for TxContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TxContext")
+            .field("sender", &self.sender)
+            .field("tx_hash", &hex::encode(&self.tx_hash))
+            .field("ids_created", &self.ids_created)
+            .field("map", &self.map)
+            .finish()
+    }
+}
+
 impl TxContext {
     pub fn new(sender: AccountAddress, tx_hash: H256) -> Self {
         Self {
             sender,
             tx_hash: tx_hash.0.to_vec(),
+            ids_created: 0,
+            map: SimpleMap::create(),
+        }
+    }
+
+    /// Spawn a new TxContext with a new `ids_created` counter and empty map
+    pub fn spawn(self) -> Self {
+        Self {
+            sender: self.sender,
+            tx_hash: self.tx_hash,
             ids_created: 0,
             map: SimpleMap::create(),
         }

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -19,16 +19,16 @@ use moveos_types::function_return_value::FunctionReturnValue;
 use moveos_types::module_binding::MoveFunctionCaller;
 use moveos_types::move_types::FunctionId;
 use moveos_types::state_resolver::MoveOSResolverProxy;
-use moveos_types::storage_context::StorageContext;
 use moveos_types::transaction::{MoveOSTransaction, TransactionOutput, VerifiedMoveOSTransaction};
 use moveos_types::tx_context::TxContext;
 use moveos_types::{h256::H256, transaction::FunctionCall};
 
 pub struct MoveOSConfig {
     pub vm_config: VMConfig,
-    /// if the finalize_function is set, the MoveOS will call the function after the transaction is executed.
-    /// otherwise, the MoveOS will not call the function.
-    pub finalize_function: Option<FunctionId>,
+    /// if the pre_execute_function is set, the MoveOS will call the function before the transaction is executed.
+    pub pre_execute_function: Option<FunctionId>,
+    /// if the post_execute_function is set, the MoveOS will call the function after the transaction is executed.
+    pub post_execute_function: Option<FunctionId>,
 }
 
 //TODO make VMConfig cloneable
@@ -40,7 +40,8 @@ impl Clone for MoveOSConfig {
                 max_binary_format_version: self.vm_config.max_binary_format_version,
                 paranoid_type_checks: self.vm_config.paranoid_type_checks,
             },
-            finalize_function: self.finalize_function.clone(),
+            pre_execute_function: self.pre_execute_function.clone(),
+            post_execute_function: self.post_execute_function.clone(),
         }
     }
 }
@@ -56,7 +57,12 @@ impl MoveOS {
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
         config: MoveOSConfig,
     ) -> Result<Self> {
-        let vm = MoveOSVM::new(natives, config.vm_config, config.finalize_function)?;
+        let vm = MoveOSVM::new(
+            natives,
+            config.vm_config,
+            config.pre_execute_function,
+            config.post_execute_function,
+        )?;
         Ok(Self {
             vm,
             db: MoveOSResolverProxy(db),
@@ -78,12 +84,8 @@ impl MoveOS {
     }
 
     fn verify_and_execute_genesis_tx(&mut self, tx: MoveOSTransaction) -> Result<()> {
-        let MoveOSTransaction {
-            ctx: tx_context,
-            action,
-        } = tx;
+        let MoveOSTransaction { ctx, action } = tx;
 
-        let ctx = StorageContext::new(tx_context);
         let mut session = self.vm.new_genesis_session(&self.db, ctx);
         let verified_action = session.verify_move_action(action)?;
         let execute_result = session.execute_move_action(verified_action);
@@ -113,19 +115,17 @@ impl MoveOS {
     }
 
     pub fn verify(&self, tx: MoveOSTransaction) -> Result<VerifiedMoveOSTransaction> {
-        let MoveOSTransaction {
-            ctx: tx_context,
-            action,
-        } = tx;
+        let MoveOSTransaction { ctx, action } = tx;
 
         let gas_meter = UnmeteredGasMeter;
-        let ctx = StorageContext::new(tx_context.clone());
-        let session = self.vm.new_readonly_session(&self.db, ctx, gas_meter);
+        let session = self
+            .vm
+            .new_readonly_session(&self.db, ctx.clone(), gas_meter);
 
         let verified_action = session.verify_move_action(action)?;
         let (_, _) = session.finish_with_extensions(VMStatus::Executed)?;
         Ok(VerifiedMoveOSTransaction {
-            ctx: tx_context,
+            ctx,
             action: verified_action,
         })
     }
@@ -143,7 +143,6 @@ impl MoveOS {
         }
         //TODO define the gas meter.
         let gas_meter = UnmeteredGasMeter;
-        let ctx = StorageContext::new(ctx);
         let mut session = self.vm.new_session(&self.db, ctx, gas_meter);
         let execute_result = session.execute_move_action(action);
         if execute_result.is_err() {
@@ -204,10 +203,11 @@ impl MoveOS {
         tx_context: &TxContext,
         function_call: FunctionCall,
     ) -> Result<Vec<FunctionReturnValue>> {
-        let ctx = StorageContext::new(tx_context.clone());
         //TODO limit the view function max gas usage
         let gas_meter = UnmeteredGasMeter;
-        let mut session = self.vm.new_readonly_session(&self.db, ctx, gas_meter);
+        let mut session = self
+            .vm
+            .new_readonly_session(&self.db, tx_context.clone(), gas_meter);
 
         let result = session.execute_function_bypass_visibility(function_call)?;
 

--- a/moveos/moveos/src/vm/moveos_vm.rs
+++ b/moveos/moveos/src/vm/moveos_vm.rs
@@ -88,7 +88,7 @@ impl MoveOSVM {
     ) -> MoveOSSession<'r, '_, S, UnmeteredGasMeter> {
         //Do not charge gas for genesis session
         let gas_meter = UnmeteredGasMeter;
-        // Genesis session do not need to execute finalize function
+        // Genesis session do not need to execute pre_execute and post_execute function
         MoveOSSession::new(&self.inner, remote, ctx, None, None, gas_meter, false)
     }
 

--- a/moveos/moveos/src/vm/tx_argument_resolver.rs
+++ b/moveos/moveos/src/vm/tx_argument_resolver.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 
 /// Transaction Argument Resolver will implemented by the Move Extension
 /// to auto fill transaction argument or do type conversion.
-// TODO: Try to push to Move upstream if possible.
 pub trait TxArgumentResolver {
     fn resolve_argument<S>(
         &self,
@@ -45,20 +44,13 @@ impl TxArgumentResolver for StorageContext {
                         .simple_serialize()
                         .expect("serialize signer should success"),
                 );
-            }
-            //Should we remove TxContext as entry function or view function argument?
-            if as_struct(session, t)
-                .map(|t| is_tx_context(&t))
-                .unwrap_or(false)
-            {
-                args.insert(i, self.tx_context.to_bytes());
-            }
+            } 
 
             if as_struct(session, t)
                 .map(|t| is_storage_context(&t))
                 .unwrap_or(false)
             {
-                args.insert(i, self.to_vec());
+                args.insert(i, self.to_bytes());
             }
         });
         Ok(args)
@@ -98,14 +90,8 @@ where
     }
 }
 
-fn is_tx_context(t: &StructType) -> bool {
-    t.module.address() == &moveos_types::addresses::MOVEOS_STD_ADDRESS
-        && t.module.name() == TxContext::module_identifier().as_ident_str()
-        && t.name == TxContext::struct_identifier()
-}
-
 pub fn is_storage_context(t: &StructType) -> bool {
-    t.module.address() == &moveos_types::addresses::MOVEOS_STD_ADDRESS
+    t.module.address() == &StorageContext::ADDRESS
         && t.module.name() == StorageContext::module_identifier().as_ident_str()
         && t.name == StorageContext::struct_identifier()
 }

--- a/moveos/moveos/src/vm/tx_argument_resolver.rs
+++ b/moveos/moveos/src/vm/tx_argument_resolver.rs
@@ -8,7 +8,6 @@ use move_vm_runtime::session::{LoadedFunctionInstantiation, Session};
 use move_vm_types::loaded_data::runtime_types::{StructType, Type};
 use moveos_types::{
     state::MoveStructType, state_resolver::MoveOSResolver, storage_context::StorageContext,
-    tx_context::TxContext,
 };
 use std::sync::Arc;
 
@@ -44,7 +43,7 @@ impl TxArgumentResolver for StorageContext {
                         .simple_serialize()
                         .expect("serialize signer should success"),
                 );
-            } 
+            }
 
             if as_struct(session, t)
                 .map(|t| is_storage_context(&t))


### PR DESCRIPTION
Resolve #302 

1. [rooch-framework] transaction_validator add pre_execute, rename finalize to post_execute
2. [moveos] Refactor MoveOS: execute pre_execute_function before transaction execute
3. [moveos] Remove TxContext from the tx argument resolver
4. [integration-test] fix integration test

TODO:
1. #323
2. Finish the transaction flow document #126 
3. How to test the ethereum signature and address from cli? @wow-sven @yubing744 
    