### PR TITLE
[MoveosStdlib] Public the `destory_empty` function in table,type_table,object_storage module

### DIFF
--- a/crates/rooch-framework-tests/tests/cases/table/test_destroy.exp
+++ b/crates/rooch-framework-tests/tests/cases/table/test_destroy.exp
@@ -1,0 +1,13 @@
+processed 5 tasks
+
+task 1 'publish'. lines 3-73:
+status EXECUTED
+
+task 2 'run'. lines 75-88:
+status EXECUTED
+
+task 3 'run'. lines 89-104:
+status EXECUTED
+
+task 4 'run'. lines 105-115:
+status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
+++ b/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
@@ -1,0 +1,115 @@
+//# init --addresses test=0x42
+
+//# publish
+module test::m {
+    use std::string::String;
+    use moveos_std::table::{Self, Table};
+    use moveos_std::tx_context;
+    use moveos_std::storage_context::{Self, StorageContext};
+    use moveos_std::object;
+    use moveos_std::object_storage;
+    use moveos_std::object_id::{ObjectID};
+    use moveos_std::account_storage;
+
+    struct KVStore has store, key {
+        table: Table<String,vector<u8>>,
+    }
+
+    public fun make_kv_store(ctx: &mut StorageContext): KVStore{
+        let tx_ctx = storage_context::tx_context_mut(ctx);
+        KVStore{
+            table: table::new(tx_ctx),
+        }
+    }
+
+    public fun add(store: &mut KVStore, key: String, value: vector<u8>) {
+        table::add(&mut store.table, key, value);
+    }
+
+    public fun contains(store: &KVStore, key: String): bool {
+        table::contains(&store.table, key)
+    }
+
+    public fun borrow(store: &KVStore, key: String): &vector<u8> {
+        table::borrow(&store.table, key)
+    }
+
+    public fun save_to_object_storage(ctx: &mut StorageContext, kv: KVStore) : ObjectID {
+        let tx_ctx = storage_context::tx_context_mut(ctx);
+        let sender = tx_context::sender(tx_ctx);
+        let object = object::new(tx_ctx, sender, kv);
+        let object_id = object::id(&object);
+        let object_storage = storage_context::object_storage_mut(ctx);
+        object_storage::add(object_storage, object);
+        object_id
+    }
+
+    public fun borrow_from_object_storage(ctx: &mut StorageContext, object_id: ObjectID): &KVStore {
+        let object_storage = storage_context::object_storage(ctx);
+        let object = object_storage::borrow(object_storage, object_id);
+        object::borrow<KVStore>(object)
+    }
+
+    public fun save_to_account_storage(ctx: &mut StorageContext, account: &signer, store: KVStore){
+        account_storage::global_move_to(ctx, account, store);
+    }
+
+    public fun borrow_from_account_storage(ctx: &StorageContext, account: address) : &KVStore{
+        account_storage::global_borrow(ctx, account)
+    }
+
+    public fun borrow_mut_from_account_storage(ctx: &mut StorageContext, account: address) : &mut KVStore{
+        account_storage::global_borrow_mut(ctx, account)
+    }
+
+    public fun move_from_account_storage(ctx: &mut StorageContext, account: address) : KVStore{
+        account_storage::global_move_from(ctx, account)
+    }
+
+    public fun destroy(kv: KVStore){
+        let KVStore{table} = kv;
+        table::destroy_empty(table);
+    }
+}
+
+//# run --signers test
+script {
+    use std::string;
+    use moveos_std::storage_context::{StorageContext};
+    use test::m;
+
+    fun main(ctx: &mut StorageContext, sender: signer) {
+        let kv = m::make_kv_store(ctx);
+        m::add(&mut kv, string::utf8(b"test"), b"value");
+        m::save_to_account_storage(ctx, &sender, kv);
+    }
+}
+
+// check contains
+//# run --signers test
+script {
+    use std::string;
+    use moveos_std::storage_context::{Self, StorageContext};
+    use test::m;
+
+    fun main(ctx: &mut StorageContext) {
+        let sender = storage_context::sender(ctx);
+        let kv = m::borrow_from_account_storage(ctx, sender);
+        assert!(m::contains(kv, string::utf8(b"test")), 1000);
+        let v = m::borrow(kv, string::utf8(b"test"));
+        assert!(v == &b"value", 1001);
+    }
+}
+
+//FIXME destroy no empty table, should failed.
+//# run --signers test
+script {
+    use moveos_std::storage_context::{Self, StorageContext};
+    use test::m;
+
+    fun main(ctx: &mut StorageContext) {
+        let sender = storage_context::sender(ctx);
+        let kv = m::move_from_account_storage(ctx, sender);
+        m::destroy(kv);
+    }
+}

--- a/crates/rooch-framework/doc/authenticator.md
+++ b/crates/rooch-framework/doc/authenticator.md
@@ -280,7 +280,7 @@ If not, just abort
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_scheme">scheme</a>(this: &<a href="authenticator.md#0x3_authenticator_Authenticator">authenticator::Authenticator</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_scheme">scheme</a>(self: &<a href="authenticator.md#0x3_authenticator_Authenticator">authenticator::Authenticator</a>): u64
 </code></pre>
 
 
@@ -289,8 +289,8 @@ If not, just abort
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_scheme">scheme</a>(this: &<a href="authenticator.md#0x3_authenticator_Authenticator">Authenticator</a>): u64 {
-   this.scheme
+<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_scheme">scheme</a>(self: &<a href="authenticator.md#0x3_authenticator_Authenticator">Authenticator</a>): u64 {
+   self.scheme
 }
 </code></pre>
 
@@ -355,7 +355,7 @@ If not, just abort
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_ed25519_public">ed25519_public</a>(this: &<a href="authenticator.md#0x3_authenticator_Ed25519Authenticator">authenticator::Ed25519Authenticator</a>): <a href="">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_ed25519_public">ed25519_public</a>(self: &<a href="authenticator.md#0x3_authenticator_Ed25519Authenticator">authenticator::Ed25519Authenticator</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -364,11 +364,11 @@ If not, just abort
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_ed25519_public">ed25519_public</a>(this: &<a href="authenticator.md#0x3_authenticator_Ed25519Authenticator">Ed25519Authenticator</a>): <a href="">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_ed25519_public">ed25519_public</a>(self: &<a href="authenticator.md#0x3_authenticator_Ed25519Authenticator">Ed25519Authenticator</a>): <a href="">vector</a>&lt;u8&gt; {
    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
    <b>let</b> i = <a href="authenticator.md#0x3_authenticator_ED25519_SCHEME_LENGTH">ED25519_SCHEME_LENGTH</a> + <a href="authenticator.md#0x3_authenticator_ED25519_SIG_LENGTH">ED25519_SIG_LENGTH</a>;
    <b>while</b> (i &lt; <a href="authenticator.md#0x3_authenticator_ED25519_SCHEME_LENGTH">ED25519_SCHEME_LENGTH</a> + <a href="authenticator.md#0x3_authenticator_ED25519_SIG_LENGTH">ED25519_SIG_LENGTH</a> + <a href="authenticator.md#0x3_authenticator_ED25519_PUBKEY_LENGTH">ED25519_PUBKEY_LENGTH</a>) {
-      <b>let</b> value = <a href="_borrow">vector::borrow</a>(&this.signature, i);
+      <b>let</b> value = <a href="_borrow">vector::borrow</a>(&self.signature, i);
       <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
       i = i + 1;
    };
@@ -387,7 +387,7 @@ If not, just abort
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_ed25519_signature">ed25519_signature</a>(this: &<a href="authenticator.md#0x3_authenticator_Ed25519Authenticator">authenticator::Ed25519Authenticator</a>): <a href="">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_ed25519_signature">ed25519_signature</a>(self: &<a href="authenticator.md#0x3_authenticator_Ed25519Authenticator">authenticator::Ed25519Authenticator</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -396,11 +396,11 @@ If not, just abort
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_ed25519_signature">ed25519_signature</a>(this: &<a href="authenticator.md#0x3_authenticator_Ed25519Authenticator">Ed25519Authenticator</a>): <a href="">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_ed25519_signature">ed25519_signature</a>(self: &<a href="authenticator.md#0x3_authenticator_Ed25519Authenticator">Ed25519Authenticator</a>): <a href="">vector</a>&lt;u8&gt; {
    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
    <b>let</b> i = <a href="authenticator.md#0x3_authenticator_ED25519_SCHEME_LENGTH">ED25519_SCHEME_LENGTH</a>;
    <b>while</b> (i &lt; <a href="authenticator.md#0x3_authenticator_ED25519_SIG_LENGTH">ED25519_SIG_LENGTH</a> + 1) {
-      <b>let</b> value = <a href="_borrow">vector::borrow</a>(&this.signature, i);
+      <b>let</b> value = <a href="_borrow">vector::borrow</a>(&self.signature, i);
       <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
       i = i + 1;
    };
@@ -469,7 +469,7 @@ If not, just abort
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_secp256k1_signature">secp256k1_signature</a>(this: &<a href="authenticator.md#0x3_authenticator_Secp256k1Authenticator">authenticator::Secp256k1Authenticator</a>): <a href="">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_secp256k1_signature">secp256k1_signature</a>(self: &<a href="authenticator.md#0x3_authenticator_Secp256k1Authenticator">authenticator::Secp256k1Authenticator</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -478,8 +478,8 @@ If not, just abort
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_secp256k1_signature">secp256k1_signature</a>(this: &<a href="authenticator.md#0x3_authenticator_Secp256k1Authenticator">Secp256k1Authenticator</a>): <a href="">vector</a>&lt;u8&gt; {
-   this.signature
+<pre><code><b>public</b> <b>fun</b> <a href="authenticator.md#0x3_authenticator_secp256k1_signature">secp256k1_signature</a>(self: &<a href="authenticator.md#0x3_authenticator_Secp256k1Authenticator">Secp256k1Authenticator</a>): <a href="">vector</a>&lt;u8&gt; {
+   self.signature
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
@@ -146,7 +146,7 @@ The private generic is indicate the T should be defined in the same module as th
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow">borrow</a>&lt;T&gt;(this: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): &T
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow">borrow</a>&lt;T&gt;(self: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): &T
 </code></pre>
 
 
@@ -155,8 +155,8 @@ The private generic is indicate the T should be defined in the same module as th
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow">borrow</a>&lt;T&gt;(this: &<a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): &T {
-    &this.value
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow">borrow</a>&lt;T&gt;(self: &<a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): &T {
+    &self.value
 }
 </code></pre>
 
@@ -171,7 +171,7 @@ The private generic is indicate the T should be defined in the same module as th
 Borrow the object mutable value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_mut">borrow_mut</a>&lt;T&gt;(this: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): &<b>mut</b> T
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_mut">borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): &<b>mut</b> T
 </code></pre>
 
 
@@ -180,8 +180,8 @@ Borrow the object mutable value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_mut">borrow_mut</a>&lt;T&gt;(this: &<b>mut</b> <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): &<b>mut</b> T {
-    &<b>mut</b> this.value
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_mut">borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): &<b>mut</b> T {
+    &<b>mut</b> self.value
 }
 </code></pre>
 
@@ -196,7 +196,7 @@ Borrow the object mutable value
 Transfer object to recipient
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_transfer">transfer</a>&lt;T: key&gt;(this: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, recipient: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_transfer">transfer</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, recipient: <b>address</b>)
 </code></pre>
 
 
@@ -205,8 +205,8 @@ Transfer object to recipient
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_transfer">transfer</a>&lt;T: key&gt;(this: &<b>mut</b> <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;, recipient: <b>address</b>) {
-    this.owner = recipient;
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_transfer">transfer</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;, recipient: <b>address</b>) {
+    self.owner = recipient;
 }
 </code></pre>
 
@@ -220,7 +220,7 @@ Transfer object to recipient
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id">id</a>&lt;T&gt;(this: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id">id</a>&lt;T&gt;(self: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
 </code></pre>
 
 
@@ -229,8 +229,8 @@ Transfer object to recipient
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id">id</a>&lt;T&gt;(this: &<a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): ObjectID {
-    this.id
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_id">id</a>&lt;T&gt;(self: &<a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): ObjectID {
+    self.id
 }
 </code></pre>
 
@@ -244,7 +244,7 @@ Transfer object to recipient
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_owner">owner</a>&lt;T&gt;(this: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_owner">owner</a>&lt;T&gt;(self: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): <b>address</b>
 </code></pre>
 
 
@@ -253,8 +253,8 @@ Transfer object to recipient
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_owner">owner</a>&lt;T&gt;(this: &<a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): <b>address</b> {
-    this.owner
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_owner">owner</a>&lt;T&gt;(self: &<a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): <b>address</b> {
+    self.owner
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object_storage.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object_storage.md
@@ -17,6 +17,7 @@ It is used to store the objects
 -  [Function `remove`](#0x2_object_storage_remove)
 -  [Function `add`](#0x2_object_storage_add)
 -  [Function `contains`](#0x2_object_storage_contains)
+-  [Function `destroy_empty`](#0x2_object_storage_destroy_empty)
 
 
 <pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
@@ -153,7 +154,7 @@ The global object storage's table handle should be 0x0
 Borrow Object from object store with object_id
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow">borrow</a>&lt;T: key&gt;(this: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow">borrow</a>&lt;T: key&gt;(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
 </code></pre>
 
 
@@ -162,8 +163,8 @@ Borrow Object from object store with object_id
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow">borrow</a>&lt;T: key&gt;(this: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &Object&lt;T&gt;{
-    <a href="raw_table.md#0x2_raw_table_borrow">raw_table::borrow</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&this.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow">borrow</a>&lt;T: key&gt;(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &Object&lt;T&gt;{
+    <a href="raw_table.md#0x2_raw_table_borrow">raw_table::borrow</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
 
@@ -178,7 +179,7 @@ Borrow Object from object store with object_id
 Borrow mut Object from object store with object_id
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut">borrow_mut</a>&lt;T: key&gt;(this: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut">borrow_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
 </code></pre>
 
 
@@ -187,8 +188,8 @@ Borrow mut Object from object store with object_id
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut">borrow_mut</a>&lt;T: key&gt;(this: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &<b>mut</b> Object&lt;T&gt;{
-    <a href="raw_table.md#0x2_raw_table_borrow_mut">raw_table::borrow_mut</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&this.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut">borrow_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &<b>mut</b> Object&lt;T&gt;{
+    <a href="raw_table.md#0x2_raw_table_borrow_mut">raw_table::borrow_mut</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
 
@@ -203,7 +204,7 @@ Borrow mut Object from object store with object_id
 Remove object from object store
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove">remove</a>&lt;T: key&gt;(this: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
 </code></pre>
 
 
@@ -212,8 +213,8 @@ Remove object from object store
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove">remove</a>&lt;T: key&gt;(this: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): Object&lt;T&gt;{
-    <a href="raw_table.md#0x2_raw_table_remove">raw_table::remove</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&this.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): Object&lt;T&gt;{
+    <a href="raw_table.md#0x2_raw_table_remove">raw_table::remove</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
 
@@ -228,7 +229,7 @@ Remove object from object store
 Add object to object store
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_add">add</a>&lt;T: key&gt;(this: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -237,8 +238,8 @@ Add object to object store
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_add">add</a>&lt;T: key&gt;(this: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, obj: Object&lt;T&gt;) {
-    <a href="raw_table.md#0x2_raw_table_add">raw_table::add</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&this.handle, <a href="object.md#0x2_object_id">object::id</a>(&obj), obj);
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, obj: Object&lt;T&gt;) {
+    <a href="raw_table.md#0x2_raw_table_add">raw_table::add</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object.md#0x2_object_id">object::id</a>(&obj), obj);
 }
 </code></pre>
 
@@ -252,7 +253,7 @@ Add object to object store
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_contains">contains</a>(this: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_contains">contains</a>(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): bool
 </code></pre>
 
 
@@ -261,8 +262,34 @@ Add object to object store
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_contains">contains</a>(this: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): bool{
-    <a href="raw_table.md#0x2_raw_table_contains">raw_table::contains</a>&lt;ObjectID&gt;(&this.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_contains">contains</a>(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): bool{
+    <a href="raw_table.md#0x2_raw_table_contains">raw_table::contains</a>&lt;ObjectID&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_storage_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroy a ObjectStroage. The ObjectStorage must be empty to succeed.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_destroy_empty">destroy_empty</a>(self: <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_destroy_empty">destroy_empty</a>(self: <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>) {
+    <b>let</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>{handle} = self;
+    <a href="raw_table.md#0x2_raw_table_destroy_empty">raw_table::destroy_empty</a>(&handle)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
@@ -18,7 +18,7 @@ This type table if for design internal global storage, so all functions are frie
 -  [Function `upsert`](#0x2_raw_table_upsert)
 -  [Function `remove`](#0x2_raw_table_remove)
 -  [Function `contains`](#0x2_raw_table_contains)
--  [Function `destroy`](#0x2_raw_table_destroy)
+-  [Function `destroy_empty`](#0x2_raw_table_destroy_empty)
 -  [Function `new_table_handle`](#0x2_raw_table_new_table_handle)
 
 
@@ -305,13 +305,14 @@ Returns true if <code><a href="table.md#0x2_table">table</a></code> contains an 
 
 </details>
 
-<a name="0x2_raw_table_destroy"></a>
+<a name="0x2_raw_table_destroy_empty"></a>
 
-## Function `destroy`
+## Function `destroy_empty`
+
+Destroy a table. The table must be empty to succeed.
 
 
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_destroy">destroy</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_destroy_empty">destroy_empty</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>)
 </code></pre>
 
 
@@ -320,9 +321,8 @@ Returns true if <code><a href="table.md#0x2_table">table</a></code> contains an 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_destroy">destroy</a>(table_handle: &ObjectID) {
-    <a href="raw_table.md#0x2_raw_table_destroy_empty_box">destroy_empty_box</a>(table_handle);
-    <a href="raw_table.md#0x2_raw_table_drop_unchecked_box">drop_unchecked_box</a>(table_handle)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_destroy_empty">destroy_empty</a>(table_handle: &ObjectID) {
+    <a href="raw_table.md#0x2_raw_table_destroy_empty_box">destroy_empty_box</a>(table_handle)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md
@@ -73,7 +73,7 @@ The StorageContext can not be <code>drop</code> or <code>store</code>, so develo
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context">tx_context</a>(this: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context">tx_context</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>
 </code></pre>
 
 
@@ -82,8 +82,8 @@ The StorageContext can not be <code>drop</code> or <code>store</code>, so develo
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context">tx_context</a>(this: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &TxContext {
-    &this.<a href="tx_context.md#0x2_tx_context">tx_context</a>
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context">tx_context</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &TxContext {
+    &self.<a href="tx_context.md#0x2_tx_context">tx_context</a>
 }
 </code></pre>
 
@@ -97,7 +97,7 @@ The StorageContext can not be <code>drop</code> or <code>store</code>, so develo
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_tx_context_mut">tx_context_mut</a>(this: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_tx_context_mut">tx_context_mut</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>
 </code></pre>
 
 
@@ -106,8 +106,8 @@ The StorageContext can not be <code>drop</code> or <code>store</code>, so develo
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_tx_context_mut">tx_context_mut</a>(this: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &<b>mut</b> TxContext {
-    &<b>mut</b> this.<a href="tx_context.md#0x2_tx_context">tx_context</a>
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_tx_context_mut">tx_context_mut</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &<b>mut</b> TxContext {
+    &<b>mut</b> self.<a href="tx_context.md#0x2_tx_context">tx_context</a>
 }
 </code></pre>
 
@@ -121,7 +121,7 @@ The StorageContext can not be <code>drop</code> or <code>store</code>, so develo
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage">object_storage</a>(this: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage">object_storage</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>
 </code></pre>
 
 
@@ -130,8 +130,8 @@ The StorageContext can not be <code>drop</code> or <code>store</code>, so develo
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage">object_storage</a>(this: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &ObjectStorage {
-    &this.<a href="object_storage.md#0x2_object_storage">object_storage</a>
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage">object_storage</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &ObjectStorage {
+    &self.<a href="object_storage.md#0x2_object_storage">object_storage</a>
 }
 </code></pre>
 
@@ -145,7 +145,7 @@ The StorageContext can not be <code>drop</code> or <code>store</code>, so develo
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_object_storage_mut">object_storage_mut</a>(this: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_object_storage_mut">object_storage_mut</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>
 </code></pre>
 
 
@@ -154,8 +154,8 @@ The StorageContext can not be <code>drop</code> or <code>store</code>, so develo
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_object_storage_mut">object_storage_mut</a>(this: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &<b>mut</b> ObjectStorage {
-    &<b>mut</b> this.<a href="object_storage.md#0x2_object_storage">object_storage</a>
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_object_storage_mut">object_storage_mut</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &<b>mut</b> ObjectStorage {
+    &<b>mut</b> self.<a href="object_storage.md#0x2_object_storage">object_storage</a>
 }
 </code></pre>
 
@@ -170,7 +170,7 @@ The StorageContext can not be <code>drop</code> or <code>store</code>, so develo
 Wrap functions for TxContext
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_sender">sender</a>(this: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_sender">sender</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <b>address</b>
 </code></pre>
 
 
@@ -179,8 +179,8 @@ Wrap functions for TxContext
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_sender">sender</a>(this: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): <b>address</b> {
-    <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(&this.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_sender">sender</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): <b>address</b> {
+    <a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(&self.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
 }
 </code></pre>
 
@@ -194,7 +194,7 @@ Wrap functions for TxContext
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_fresh_address">fresh_address</a>(this: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_fresh_address">fresh_address</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <b>address</b>
 </code></pre>
 
 
@@ -203,8 +203,8 @@ Wrap functions for TxContext
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_fresh_address">fresh_address</a>(this: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): <b>address</b> {
-    <a href="tx_context.md#0x2_tx_context_fresh_address">tx_context::fresh_address</a>(&<b>mut</b> this.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_fresh_address">fresh_address</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): <b>address</b> {
+    <a href="tx_context.md#0x2_tx_context_fresh_address">tx_context::fresh_address</a>(&<b>mut</b> self.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
 }
 </code></pre>
 
@@ -218,7 +218,7 @@ Wrap functions for TxContext
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_fresh_object_id">fresh_object_id</a>(this: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_fresh_object_id">fresh_object_id</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
 </code></pre>
 
 
@@ -227,8 +227,8 @@ Wrap functions for TxContext
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_fresh_object_id">fresh_object_id</a>(this: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): ObjectID {
-    <a href="tx_context.md#0x2_tx_context_fresh_object_id">tx_context::fresh_object_id</a>(&<b>mut</b> this.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_fresh_object_id">fresh_object_id</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): ObjectID {
+    <a href="tx_context.md#0x2_tx_context_fresh_object_id">tx_context::fresh_object_id</a>(&<b>mut</b> self.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
 }
 </code></pre>
 
@@ -242,7 +242,7 @@ Wrap functions for TxContext
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_tx_hash">tx_hash</a>(this: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_tx_hash">tx_hash</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -251,8 +251,8 @@ Wrap functions for TxContext
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_tx_hash">tx_hash</a>(this: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): <a href="">vector</a>&lt;u8&gt; {
-    <a href="tx_context.md#0x2_tx_context_tx_hash">tx_context::tx_hash</a>(&this.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_tx_hash">tx_hash</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): <a href="">vector</a>&lt;u8&gt; {
+    <a href="tx_context.md#0x2_tx_context_tx_hash">tx_context::tx_hash</a>(&self.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
@@ -22,7 +22,7 @@ struct itself, while the operations are implemented as native functions. No trav
 -  [Function `upsert`](#0x2_table_upsert)
 -  [Function `remove`](#0x2_table_remove)
 -  [Function `contains`](#0x2_table_contains)
--  [Function `destroy`](#0x2_table_destroy)
+-  [Function `destroy_empty`](#0x2_table_destroy_empty)
 
 
 <pre><code><b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
@@ -322,14 +322,14 @@ Returns true if <code><a href="table.md#0x2_table">table</a></code> contains an 
 
 </details>
 
-<a name="0x2_table_destroy"></a>
+<a name="0x2_table_destroy_empty"></a>
 
-## Function `destroy`
+## Function `destroy_empty`
 
-TODO should open the destroy function to public?
+Destroy a table. The table must be empty to succeed.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x2_table_destroy">destroy</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -338,9 +338,9 @@ TODO should open the destroy function to public?
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x2_table_destroy">destroy</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;) {
     <b>let</b> <a href="table.md#0x2_table_Table">Table</a> { handle } = <a href="table.md#0x2_table">table</a>;
-    <a href="raw_table.md#0x2_raw_table_destroy">raw_table::destroy</a>(&handle)
+    <a href="raw_table.md#0x2_raw_table_destroy_empty">raw_table::destroy_empty</a>(&handle)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md
@@ -19,7 +19,7 @@ TypeTable is a table use struct Type as Key, struct as Value
 -  [Function `remove_internal`](#0x2_type_table_remove_internal)
 -  [Function `contains`](#0x2_type_table_contains)
 -  [Function `contains_internal`](#0x2_type_table_contains_internal)
--  [Function `destroy`](#0x2_type_table_destroy)
+-  [Function `destroy_empty`](#0x2_type_table_destroy_empty)
 
 
 <pre><code><b>use</b> <a href="">0x1::ascii</a>;
@@ -362,14 +362,14 @@ Returns true if <code><a href="table.md#0x2_table">table</a></code> contains an 
 
 </details>
 
-<a name="0x2_type_table_destroy"></a>
+<a name="0x2_type_table_destroy_empty"></a>
 
-## Function `destroy`
+## Function `destroy_empty`
 
-TODO should open the destroy function to public?
+Destroy a table. The table must be empty to succeed.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="type_table.md#0x2_type_table_destroy">destroy</a>(<a href="table.md#0x2_table">table</a>: <a href="type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_destroy_empty">destroy_empty</a>(<a href="table.md#0x2_table">table</a>: <a href="type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a>)
 </code></pre>
 
 
@@ -378,9 +378,9 @@ TODO should open the destroy function to public?
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="type_table.md#0x2_type_table_destroy">destroy</a>(<a href="table.md#0x2_table">table</a>: <a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_destroy_empty">destroy_empty</a>(<a href="table.md#0x2_table">table</a>: <a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a>) {
     <b>let</b> <a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a>{handle} = <a href="table.md#0x2_table">table</a>;
-    <a href="raw_table.md#0x2_raw_table_destroy">raw_table::destroy</a>(&handle)
+    <a href="raw_table.md#0x2_raw_table_destroy_empty">raw_table::destroy_empty</a>(&handle)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object_storage.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object_storage.move
@@ -64,6 +64,12 @@ module moveos_std::object_storage {
         raw_table::contains<ObjectID>(&self.handle, object_id)
     }
 
+    /// Destroy a ObjectStroage. The ObjectStorage must be empty to succeed.
+    public fun destroy_empty(self: ObjectStorage) {
+        let ObjectStorage{handle} = self;
+        raw_table::destroy_empty(&handle)
+    }
+
     #[test_only]
     /// Testing only: allow to drop oject storage
     public fun drop_object_storage(self: ObjectStorage) {

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
@@ -82,10 +82,10 @@ module moveos_std::raw_table {
     public(friend) fun drop_unchecked(table_handle: &ObjectID) {
         drop_unchecked_box(table_handle)
     }
-
-    public(friend) fun destroy(table_handle: &ObjectID) {
-        destroy_empty_box(table_handle);
-        drop_unchecked_box(table_handle)
+    
+    /// Destroy a table. The table must be empty to succeed.
+    public(friend) fun destroy_empty(table_handle: &ObjectID) {
+        destroy_empty_box(table_handle)
     }
 
     // ======================================================================================================

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -235,7 +235,7 @@ module moveos_std::table {
         let key: u64 = 100;
         add(&mut t, key, 1);
 
-        destroy(t);
+        destroy_empty(t);
     }
 
     #[test(account = @0x1)]
@@ -252,7 +252,7 @@ module moveos_std::table {
         add(&mut t2, t2_key, 32u32);
         add(&mut t1, t1_key, t2);
 
-        destroy(t1);
+        destroy_empty(t1);
 
         let t2 = new_with_id<u8, u32>(t2_id);
         assert!(*borrow(&t2, t2_key) == 32u32, 1);

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -86,10 +86,10 @@ module moveos_std::table {
         raw_table::drop_unchecked(&handle)
     }
 
-    ///TODO should open the destroy function to public?
-    public(friend) fun destroy<K: copy + drop, V>(table: Table<K, V>) {
+    /// Destroy a table. The table must be empty to succeed.
+    public fun destroy_empty<K: copy + drop, V>(table: Table<K, V>) {
         let Table { handle } = table;
-        raw_table::destroy(&handle)
+        raw_table::destroy_empty(&handle)
     }
 
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
@@ -99,10 +99,10 @@ module moveos_std::type_table {
         raw_table::drop_unchecked(&handle)
     }
 
-    ///TODO should open the destroy function to public?
-    public(friend) fun destroy(table: TypeTable) {
+    /// Destroy a table. The table must be empty to succeed.
+    public fun destroy_empty(table: TypeTable) {
         let TypeTable{handle} = table;
-        raw_table::destroy(&handle)
+        raw_table::destroy_empty(&handle)
     }
 
     #[test_only]
@@ -201,6 +201,6 @@ module moveos_std::type_table {
         };
         add<TestType>(&mut table, t);
 
-        destroy(table);
+        destroy_empty(table);
     }
 }

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
@@ -630,7 +630,7 @@ fn native_drop_unchecked_box(
     args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     assert_eq!(args.len(), 1);
-
+    //TODO remove the droped table from the table_data
     Ok(NativeResult::ok(gas_params.base, smallvec![]))
 }
 


### PR DESCRIPTION
Part of #342 

1. Provide destory_empty in table,type_table,object_storage module
2. There is a bug in the native implementation of `destory_empty`. I give a test example.

The bug will be resolved in the future PR, based on Table's `length` solution.