### PR TITLE
Fix the issue of not throwing an error during compilation of the private_generics module.

### DIFF
--- a/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_invalid_struct.exp
+++ b/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_invalid_struct.exp
@@ -1,11 +1,11 @@
 processed 2 tasks
 
 task 1 'publish'. lines 3-12:
-error: type `test::Foo` is not supported as a parameter type
+Error: error: type `test::Foo` is not supported as a parameter type
   ┌─ /tmp/tempfile:8:5
   │  
 8 │ ╭     entry public fun test_entry_function_invalid_struct( _foo: Foo ){
 9 │ │     }
   │ ╰─────^
 
-status EXECUTED
+

--- a/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_valid_reference.exp
+++ b/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_valid_reference.exp
@@ -1,11 +1,11 @@
 processed 2 tasks
 
 task 1 'publish'. lines 3-33:
-error: type `&mut signer` is not supported as a parameter type
+Error: error: type `&mut signer` is not supported as a parameter type
    ┌─ /tmp/tempfile:9:5
    │  
  9 │ ╭     entry public fun test_entry_function_valid_reference_mut_signer( _: &mut signer ){
 10 │ │     }
    │ ╰─────^
 
-status EXECUTED
+

--- a/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_with_return_value.exp
+++ b/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_with_return_value.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 3-54:
-error: entry function cannot return values
+Error: error: entry function cannot return values
    ┌─ /tmp/tempfile:26:5
    │  
 26 │ ╭     entry public fun test_entry_function_return_value_String():std::string::String{
@@ -81,4 +81,4 @@ error: entry function cannot return values
 7 │ │     }
   │ ╰─────^
 
-status EXECUTED
+

--- a/crates/rooch-framework-tests/tests/cases/object/object_cap.exp
+++ b/crates/rooch-framework-tests/tests/cases/object/object_cap.exp
@@ -4,7 +4,7 @@ task 1 'publish'. lines 3-21:
 status EXECUTED
 
 task 2 'run'. lines 22-38:
-error: resource type "TestObject" in function "0x2::object::new" not defined in current module or not allowed
+Error: error: resource type "TestObject" in function "0x2::object::new" not defined in current module or not allowed
    ┌─ /tmp/tempfile:31:19
    │
 31 │         let obj = object::new<TestObject>(storage_context::tx_context_mut(ctx), sender_addr, object);
@@ -22,4 +22,4 @@ error: resource type "TestObject" in function "0x2::object::unpack" not defined 
 33 │         let (_id, _owner, test_object) = object::unpack(obj);
    │                                          ^^^^^^^^^^^^^^^^^^^
 
-status EXECUTED
+

--- a/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.exp
+++ b/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.exp
@@ -4,7 +4,7 @@ task 1 'publish'. lines 3-8:
 status EXECUTED
 
 task 2 'publish'. lines 10-48:
-error: resource type "KeyStruct" in function "0x2::object_storage::remove" not defined in current module or not allowed
+Error: error: resource type "KeyStruct" in function "0x2::object_storage::remove" not defined in current module or not allowed
    ┌─ /tmp/tempfile:37:19
    │
 37 │         let obj = object_storage::remove<KeyStruct>(object_storage, object_id);
@@ -22,4 +22,4 @@ error: resource type "KeyStruct" in function "0x2::account_storage::global_move_
 40 │         account_storage::global_move_to(ctx, &sender, value);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-status EXECUTED
+

--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -224,7 +224,9 @@ impl<'a> ExtendedChecker<'a> {
                     }
                 }
             }
+        }
 
+        for ref fun in module.get_functions() {
             // Inspect the bytecode of every function, and if an instruction is CallGeneric,
             // verify that it calls a function with the private_generics attribute as detected earlier.
             // Then, ensure that the generic parameters of the CallGeneric instruction are valid.


### PR DESCRIPTION
1. Fix the issue of illegal invocation of private_generics in the module without throwing an error. @feliciss 
2. In the testing framework, do not print 'EXECUTED' when there is a compilation error.