### PR TITLE
Check if private_generics is used correctly in the integration-test.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ derive-syn-parse = "0.1.5"
 unescape = "0.1.0"
 tempfile = "3.2.0"
 regex = "1.8.4"
+walkdir = "2.3.3"
 
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.

--- a/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_invalid_struct.exp
+++ b/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_invalid_struct.exp
@@ -1,11 +1,11 @@
 processed 2 tasks
 
 task 1 'publish'. lines 3-12:
-error: type `test::Foo` is not supported as a parameter type
+Error: error: type `test::Foo` is not supported as a parameter type
   ┌─ /tmp/tempfile:8:5
   │  
 8 │ ╭     entry public fun test_entry_function_invalid_struct( _foo: Foo ){
 9 │ │     }
   │ ╰─────^
 
-status EXECUTED
+

--- a/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_valid_reference.exp
+++ b/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_valid_reference.exp
@@ -1,11 +1,11 @@
 processed 2 tasks
 
 task 1 'publish'. lines 3-33:
-error: type `&mut signer` is not supported as a parameter type
+Error: error: type `&mut signer` is not supported as a parameter type
    ┌─ /tmp/tempfile:9:5
    │  
  9 │ ╭     entry public fun test_entry_function_valid_reference_mut_signer( _: &mut signer ){
 10 │ │     }
    │ ╰─────^
 
-status EXECUTED
+

--- a/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_with_return_value.exp
+++ b/crates/rooch-framework-tests/tests/cases/entry_function/entry_function_with_return_value.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 3-54:
-error: entry function cannot return values
+Error: error: entry function cannot return values
    ┌─ /tmp/tempfile:26:5
    │  
 26 │ ╭     entry public fun test_entry_function_return_value_String():std::string::String{
@@ -81,4 +81,4 @@ error: entry function cannot return values
 7 │ │     }
   │ ╰─────^
 
-status EXECUTED
+

--- a/crates/rooch-framework-tests/tests/cases/object/object_cap.exp
+++ b/crates/rooch-framework-tests/tests/cases/object/object_cap.exp
@@ -4,7 +4,7 @@ task 1 'publish'. lines 3-21:
 status EXECUTED
 
 task 2 'run'. lines 22-38:
-error: resource type "TestObject" in function "0x2::object::new" not defined in current module or not allowed
+Error: error: resource type "TestObject" in function "0x2::object::new" not defined in current module or not allowed
    ┌─ /tmp/tempfile:31:19
    │
 31 │         let obj = object::new<TestObject>(storage_context::tx_context_mut(ctx), sender_addr, object);
@@ -22,4 +22,4 @@ error: resource type "TestObject" in function "0x2::object::unpack" not defined 
 33 │         let (_id, _owner, test_object) = object::unpack(obj);
    │                                          ^^^^^^^^^^^^^^^^^^^
 
-status EXECUTED
+

--- a/crates/rooch-integration-test-runner/Cargo.toml
+++ b/crates/rooch-integration-test-runner/Cargo.toml
@@ -20,6 +20,10 @@ bcs = { workspace = true }
 clap = { features = [ "derive",], workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+codespan-reporting = { workspace = true }
+regex = { workspace = true }
+datatest-stable = { workspace = true }
+walkdir = { workspace = true }
 
 move-binary-format = { workspace = true }
 move-bytecode-utils = { workspace = true }
@@ -40,6 +44,7 @@ moveos-stdlib = { workspace = true }
 moveos-stdlib-builder = { workspace = true }
 moveos = { workspace = true }
 moveos-types = { workspace = true }
+moveos-verifier = { workspace = true }
 
 rooch-framework = { workspace = true }
 rooch-genesis = { workspace = true }

--- a/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.exp
+++ b/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.exp
@@ -4,7 +4,7 @@ task 1 'publish'. lines 3-8:
 status EXECUTED
 
 task 2 'publish'. lines 10-48:
-error: resource type "KeyStruct" in function "0x2::object_storage::remove" not defined in current module or not allowed
+Error: error: resource type "KeyStruct" in function "0x2::object_storage::remove" not defined in current module or not allowed
    ┌─ /tmp/tempfile:37:19
    │
 37 │         let obj = object_storage::remove<KeyStruct>(object_storage, object_id);
@@ -22,4 +22,4 @@ error: resource type "KeyStruct" in function "0x2::account_storage::global_move_
 40 │         account_storage::global_move_to(ctx, &sender, value);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-status EXECUTED
+

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 bcs = { workspace = true }
 clap = { features = [ "derive",], workspace = true }
-datatest-stable = { git = "https://github.com/starcoinorg/diem-devtools", branch = "feature/pub-test-opts" }
+datatest-stable = { git = "https://github.com/rooch-network/diem-devtools", branch = "feature/pub-test-opts" }
 tokio = { features = ["full"], workspace = true }
 dirs  = { workspace = true }
 serde = { workspace = true }

--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -224,7 +224,9 @@ impl<'a> ExtendedChecker<'a> {
                     }
                 }
             }
+        }
 
+        for ref fun in module.get_functions() {
             // Inspect the bytecode of every function, and if an instruction is CallGeneric,
             // verify that it calls a function with the private_generics attribute as detected earlier.
             // Then, ensure that the generic parameters of the CallGeneric instruction are valid.

--- a/moveos/moveos/src/moveos_test_runner.rs
+++ b/moveos/moveos/src/moveos_test_runner.rs
@@ -230,6 +230,14 @@ fn merge_output(left: Option<String>, right: Option<String>) -> Option<String> {
     }
 }
 
+fn filter_temp_path(input: String) -> String {
+    let re = Regex::new("/tmp/.[0-9a-zA-Z]+").unwrap();
+    let re1 = Regex::new("/var/.*tmp[0-9a-zA-Z]+").unwrap();
+    let re_output = re.replace_all(input.as_str(), FIXED_TEMP_PATH).to_string();
+    re1.replace_all(re_output.as_str(), FIXED_TEMP_PATH)
+        .to_string()
+}
+
 fn compile_source_unit(
     pre_compiled_deps: Option<&FullyCompiledProgram>,
     named_address_mapping: BTreeMap<String, NumericalAddress>,
@@ -253,16 +261,7 @@ fn compile_source_unit(
         if global_env.diag_count(Severity::Warning) > 0 {
             let mut buffer = Buffer::no_color();
             global_env.report_diag(&mut buffer, Severity::Warning);
-            let warn_msg = String::from_utf8_lossy(buffer.as_slice()).to_string();
-            let re = Regex::new("/tmp/.[0-9a-zA-Z]+").unwrap();
-            let re1 = Regex::new("/var/.*tmp[0-9a-zA-Z]+").unwrap();
-            let output = re
-                .replace_all(warn_msg.as_str(), FIXED_TEMP_PATH)
-                .to_string();
-            Some(
-                re1.replace_all(output.as_str(), FIXED_TEMP_PATH)
-                    .to_string(),
-            )
+            Some(String::from_utf8_lossy(buffer.as_slice()).to_string())
         } else {
             None
         }
@@ -301,17 +300,25 @@ fn compile_source_unit(
                 }
             }
 
-            Err(anyhow!(rendered_diags(&files, diags).unwrap()))
+            Err(anyhow!(filter_temp_path(
+                rendered_diags(&files, diags).unwrap()
+            )))
         }
         Ok((mut units, warnings)) => {
             let warnings = rendered_diags(&files, warnings);
+            let merged_output = merge_output(extended_checks_error, warnings);
+
+            let modified_merged_error = merged_output.map(filter_temp_path);
+
+            if let Some(merged_error_message) = modified_merged_error {
+                return Err(anyhow::Error::msg(merged_error_message));
+            }
             let len = units.len();
             if len != 1 {
                 panic!("Invalid input. Expected 1 compiled unit but got {}", len)
             }
             let unit = units.pop().unwrap();
-            let merged_output = merge_output(extended_checks_error, warnings);
-            Ok((unit, merged_output))
+            Ok((unit, modified_merged_error))
         }
     }
 }
@@ -671,6 +678,7 @@ fn display_return_values(return_values: SerializedReturnValues) -> Option<String
 pub fn run_test_impl<'a, Adapter>(
     path: &Path,
     fully_compiled_program_opt: Option<&'a FullyCompiledProgram>,
+    additional_output: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     Adapter: MoveOSTestAdapter<'a>,
@@ -688,6 +696,10 @@ where
         SyntaxChoice::Source
     };
     let mut output = String::new();
+    if let Some(value) = additional_output {
+        writeln!(output, "{}", value).unwrap();
+    }
+
     let mut tasks = taskify::<
         TaskCommand<
             Adapter::ExtraInitArgs,


### PR DESCRIPTION
The issue of not checking `private_generics` when executing the command `rooch move integration-test -p private_generics/ --named-addresses rooch_examples=0x1234` in the `examples/private_generics` directory has been resolved.

However, there are still some remaining issues:

1. The `datatest_stable::runner_with_opts` invocation is bypassed, and the test cases are executed directly. This means that some additional options, such as `rooch move test --list` to view the current test projects, will not be executed (but it does not affect the testing process).

2. Because the `integration-test` depends on a complete Move package, and it is itself a separate Move file, it is not possible to compile them together. Instead, the dependent Move package is compiled first, followed by the compilation of the individual Move file. Finally, the result of compiling the Move package is injected into the checking process of the individual Move file.

resolve https://github.com/rooch-network/rooch/issues/350.