### PR TITLE
[MoveosStdlib] draft a table length in TableInfo implementation

### DIFF
--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
@@ -21,6 +21,7 @@ More details about the Object can be found in [Storage Abstraction](https://gith
 -  [Function `id`](#0x2_object_id)
 -  [Function `owner`](#0x2_object_owner)
 -  [Function `unpack`](#0x2_object_unpack)
+-  [Function `unpack_internal`](#0x2_object_unpack_internal)
 
 
 <pre><code><b>use</b> <a href="">0x1::debug</a>;
@@ -278,6 +279,30 @@ Transfer object to recipient
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_unpack">unpack</a>&lt;T&gt;(obj: <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): (ObjectID, <b>address</b>, T) {
+    <a href="object.md#0x2_object_unpack_internal">unpack_internal</a>(obj)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_unpack_internal"></a>
+
+## Function `unpack_internal`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_unpack_internal">unpack_internal</a>&lt;T&gt;(obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): (<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>, <b>address</b>, T)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_unpack_internal">unpack_internal</a>&lt;T&gt;(obj: <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): (ObjectID, <b>address</b>, T) {
     <b>let</b> <a href="object.md#0x2_object_Object">Object</a>{id, owner, value} = obj;
     (id, owner, value)
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object_storage.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object_storage.md
@@ -13,9 +13,13 @@ It is used to store the objects
 -  [Function `new_with_id`](#0x2_object_storage_new_with_id)
 -  [Function `global_object_storage_handle`](#0x2_object_storage_global_object_storage_handle)
 -  [Function `borrow`](#0x2_object_storage_borrow)
+-  [Function `borrow_internal`](#0x2_object_storage_borrow_internal)
 -  [Function `borrow_mut`](#0x2_object_storage_borrow_mut)
+-  [Function `borrow_mut_internal`](#0x2_object_storage_borrow_mut_internal)
 -  [Function `remove`](#0x2_object_storage_remove)
+-  [Function `remove_internal`](#0x2_object_storage_remove_internal)
 -  [Function `add`](#0x2_object_storage_add)
+-  [Function `add_internal`](#0x2_object_storage_add_internal)
 -  [Function `contains`](#0x2_object_storage_contains)
 -  [Function `destroy_empty`](#0x2_object_storage_destroy_empty)
 
@@ -129,7 +133,7 @@ Create a new ObjectStorage with a given handle.
 The global object storage's table handle should be 0x0
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_global_object_storage_handle">global_object_storage_handle</a>(): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_global_object_storage_handle">global_object_storage_handle</a>(): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
 </code></pre>
 
 
@@ -138,7 +142,7 @@ The global object storage's table handle should be 0x0
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_global_object_storage_handle">global_object_storage_handle</a>() : ObjectID {
+<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_global_object_storage_handle">global_object_storage_handle</a>() : ObjectID {
     <a href="object_id.md#0x2_object_id_address_to_object_id">object_id::address_to_object_id</a>(<a href="object_storage.md#0x2_object_storage_GlobalObjectStorageHandle">GlobalObjectStorageHandle</a>)
 }
 </code></pre>
@@ -164,6 +168,30 @@ Borrow Object from object store with object_id
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow">borrow</a>&lt;T: key&gt;(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &Object&lt;T&gt;{
+    <a href="object_storage.md#0x2_object_storage_borrow_internal">borrow_internal</a>(self, <a href="object_id.md#0x2_object_id">object_id</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_storage_borrow_internal"></a>
+
+## Function `borrow_internal`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_internal">borrow_internal</a>&lt;T: key&gt;(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_internal">borrow_internal</a>&lt;T: key&gt;(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &Object&lt;T&gt;{
     <a href="raw_table.md#0x2_raw_table_borrow">raw_table::borrow</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
@@ -189,6 +217,30 @@ Borrow mut Object from object store with object_id
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut">borrow_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &<b>mut</b> Object&lt;T&gt;{
+    <a href="object_storage.md#0x2_object_storage_borrow_mut_internal">borrow_mut_internal</a>(self, <a href="object_id.md#0x2_object_id">object_id</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_storage_borrow_mut_internal"></a>
+
+## Function `borrow_mut_internal`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut_internal">borrow_mut_internal</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut_internal">borrow_mut_internal</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &<b>mut</b> Object&lt;T&gt;{
     <a href="raw_table.md#0x2_raw_table_borrow_mut">raw_table::borrow_mut</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
@@ -214,6 +266,30 @@ Remove object from object store
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): Object&lt;T&gt;{
+    <a href="object_storage.md#0x2_object_storage_remove_internal">remove_internal</a>(self, <a href="object_id.md#0x2_object_id">object_id</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_storage_remove_internal"></a>
+
+## Function `remove_internal`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove_internal">remove_internal</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove_internal">remove_internal</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): Object&lt;T&gt;{
     <a href="raw_table.md#0x2_raw_table_remove">raw_table::remove</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
@@ -239,6 +315,30 @@ Add object to object store
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, obj: Object&lt;T&gt;) {
+    <a href="object_storage.md#0x2_object_storage_add_internal">add_internal</a>(self, obj);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_storage_add_internal"></a>
+
+## Function `add_internal`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_add_internal">add_internal</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_add_internal">add_internal</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, obj: Object&lt;T&gt;) {
     <a href="raw_table.md#0x2_raw_table_add">raw_table::add</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object.md#0x2_object_id">object::id</a>(&obj), obj);
 }
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
@@ -10,6 +10,7 @@ This type table if for design internal global storage, so all functions are frie
 
 -  [Resource `TableInfo`](#0x2_raw_table_TableInfo)
 -  [Resource `Box`](#0x2_raw_table_Box)
+-  [Constants](#@Constants_0)
 -  [Function `add`](#0x2_raw_table_add)
 -  [Function `borrow`](#0x2_raw_table_borrow)
 -  [Function `borrow_with_default`](#0x2_raw_table_borrow_with_default)
@@ -19,6 +20,9 @@ This type table if for design internal global storage, so all functions are frie
 -  [Function `remove`](#0x2_raw_table_remove)
 -  [Function `contains`](#0x2_raw_table_contains)
 -  [Function `destroy_empty`](#0x2_raw_table_destroy_empty)
+-  [Function `new_empty_table_info`](#0x2_raw_table_new_empty_table_info)
+-  [Function `length`](#0x2_raw_table_length)
+-  [Function `unpack`](#0x2_raw_table_unpack)
 -  [Function `new_table_handle`](#0x2_raw_table_new_table_handle)
 
 
@@ -32,6 +36,7 @@ This type table if for design internal global storage, so all functions are frie
 
 ## Resource `TableInfo`
 
+TableInfo is a struct that contains the information of a table, include Table,TypeTable,ObjectStorage.
 
 
 <pre><code><b>struct</b> <a href="raw_table.md#0x2_raw_table_TableInfo">TableInfo</a> <b>has</b> key
@@ -46,6 +51,12 @@ This type table if for design internal global storage, so all functions are frie
 <dl>
 <dt>
 <code>state_root: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>length: u64</code>
 </dt>
 <dd>
 
@@ -83,6 +94,20 @@ Because the GlobalValue in MoveVM must be a resource.
 
 
 </details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_raw_table_SparseMerklePlaceHolderHash"></a>
+
+
+
+<pre><code><b>const</b> <a href="raw_table.md#0x2_raw_table_SparseMerklePlaceHolderHash">SparseMerklePlaceHolderHash</a>: <b>address</b> = 5350415253455f4d45524b4c455f504c414345484f4c4445525f484153480000;
+</code></pre>
+
+
 
 <a name="0x2_raw_table_add"></a>
 
@@ -323,6 +348,82 @@ Destroy a table. The table must be empty to succeed.
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_destroy_empty">destroy_empty</a>(table_handle: &ObjectID) {
     <a href="raw_table.md#0x2_raw_table_destroy_empty_box">destroy_empty_box</a>(table_handle)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_raw_table_new_empty_table_info"></a>
+
+## Function `new_empty_table_info`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_new_empty_table_info">new_empty_table_info</a>(): <a href="raw_table.md#0x2_raw_table_TableInfo">raw_table::TableInfo</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_new_empty_table_info">new_empty_table_info</a>(): <a href="raw_table.md#0x2_raw_table_TableInfo">TableInfo</a> {
+    <a href="raw_table.md#0x2_raw_table_TableInfo">TableInfo</a> {
+        state_root: <a href="raw_table.md#0x2_raw_table_SparseMerklePlaceHolderHash">SparseMerklePlaceHolderHash</a>,
+        length: 0u64,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_raw_table_length"></a>
+
+## Function `length`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_length">length</a>(self: &<a href="raw_table.md#0x2_raw_table_TableInfo">raw_table::TableInfo</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_length">length</a>(self: &<a href="raw_table.md#0x2_raw_table_TableInfo">TableInfo</a>) : u64{
+    self.length
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_raw_table_unpack"></a>
+
+## Function `unpack`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_unpack">unpack</a>(self: <a href="raw_table.md#0x2_raw_table_TableInfo">raw_table::TableInfo</a>): (<b>address</b>, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_unpack">unpack</a>(self: <a href="raw_table.md#0x2_raw_table_TableInfo">TableInfo</a>) : (<b>address</b>, u64){
+    <b>let</b> <a href="raw_table.md#0x2_raw_table_TableInfo">TableInfo</a> { state_root, length } = self;
+    (state_root, length)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
@@ -14,6 +14,7 @@ struct itself, while the operations are implemented as native functions. No trav
 -  [Struct `Table`](#0x2_table_Table)
 -  [Function `new`](#0x2_table_new)
 -  [Function `new_with_id`](#0x2_table_new_with_id)
+-  [Function `handle`](#0x2_table_handle)
 -  [Function `add`](#0x2_table_add)
 -  [Function `borrow`](#0x2_table_borrow)
 -  [Function `borrow_with_default`](#0x2_table_borrow_with_default)
@@ -107,6 +108,30 @@ Create a table with a given handle.
     <a href="table.md#0x2_table_Table">Table</a> {
         handle,
     }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_handle"></a>
+
+## Function `handle`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x2_table_handle">handle</a>&lt;K: <b>copy</b>, drop, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x2_table_handle">handle</a>&lt;K: <b>copy</b> + drop, V: store&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;): ObjectID {
+    <a href="table.md#0x2_table">table</a>.handle
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
@@ -11,6 +11,7 @@ module moveos_std::object {
 
     friend moveos_std::account_storage;
     friend moveos_std::events;
+    friend moveos_std::storage_context;
 
     /// Invalid access of object, the object is not owned by the signer or the object is not shared or immutable
     const EInvalidAccess: u64 = 0;
@@ -70,6 +71,10 @@ module moveos_std::object {
 
     #[private_generics(T)]
     public fun unpack<T>(obj: Object<T>): (ObjectID, address, T) {
+        unpack_internal(obj)
+    }
+
+    public(friend) fun unpack_internal<T>(obj: Object<T>): (ObjectID, address, T) {
         let Object{id, owner, value} = obj;
         (id, owner, value)
     }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object_storage.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object_storage.move
@@ -32,33 +32,49 @@ module moveos_std::object_storage {
     }
 
     /// The global object storage's table handle should be 0x0
-    public(friend) fun global_object_storage_handle() : ObjectID {
+    public fun global_object_storage_handle() : ObjectID {
         object_id::address_to_object_id(GlobalObjectStorageHandle)
     }
 
     #[private_generics(T)]
     /// Borrow Object from object store with object_id
     public fun borrow<T: key>(self: &ObjectStorage, object_id: ObjectID): &Object<T>{
+        borrow_internal(self, object_id)
+    }
+
+    public(friend) fun borrow_internal<T: key>(self: &ObjectStorage, object_id: ObjectID): &Object<T>{
         raw_table::borrow<ObjectID, Object<T>>(&self.handle, object_id)
     }
 
     #[private_generics(T)]
     /// Borrow mut Object from object store with object_id
     public fun borrow_mut<T: key>(self: &mut ObjectStorage, object_id: ObjectID): &mut Object<T>{
+        borrow_mut_internal(self, object_id)
+    }
+
+    public(friend) fun borrow_mut_internal<T: key>(self: &mut ObjectStorage, object_id: ObjectID): &mut Object<T>{
         raw_table::borrow_mut<ObjectID, Object<T>>(&self.handle, object_id)
     }
     
     #[private_generics(T)]
     /// Remove object from object store
     public fun remove<T: key>(self: &mut ObjectStorage, object_id: ObjectID): Object<T>{
+        remove_internal(self, object_id)
+    }
+
+    public(friend) fun remove_internal<T: key>(self: &mut ObjectStorage, object_id: ObjectID): Object<T>{
         raw_table::remove<ObjectID, Object<T>>(&self.handle, object_id)
     }
     
     #[private_generics(T)]
     /// Add object to object store
     public fun add<T: key>(self: &mut ObjectStorage, obj: Object<T>) {
-        raw_table::add<ObjectID, Object<T>>(&self.handle, object::id(&obj), obj);
+        add_internal(self, obj);
     } 
+
+    public(friend) fun add_internal<T: key>(self: &mut ObjectStorage, obj: Object<T>) {
+        raw_table::add<ObjectID, Object<T>>(&self.handle, object::id(&obj), obj);
+    }
 
     public fun contains(self: &ObjectStorage, object_id: ObjectID): bool{
         raw_table::contains<ObjectID>(&self.handle, object_id)

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
@@ -10,11 +10,8 @@ module moveos_std::raw_table {
     friend moveos_std::type_table;
     friend moveos_std::object_storage;
     friend moveos_std::account_storage;
+    friend moveos_std::storage_context;
 
-    struct TableInfo has key {
-        // Table SMT root
-        state_root: address,
-    }
     
     /// Add a new entry to the table. Aborts if an entry for this
     /// key already exists. The entry itself is not stored in the
@@ -86,6 +83,34 @@ module moveos_std::raw_table {
     /// Destroy a table. The table must be empty to succeed.
     public(friend) fun destroy_empty(table_handle: &ObjectID) {
         destroy_empty_box(table_handle)
+    }
+
+    // ======================================================================================================
+    // TableInfo
+
+    const SparseMerklePlaceHolderHash: address = @0x5350415253455f4d45524b4c455f504c414345484f4c4445525f484153480000;
+    
+    /// TableInfo is a struct that contains the information of a table, include Table,TypeTable,ObjectStorage.
+    struct TableInfo has key {
+        // Table SMT root, it is a 32 bytes hash, we use address to represent it.
+        state_root: address,
+        length: u64,
+    }
+
+    public(friend) fun new_empty_table_info(): TableInfo {
+        TableInfo {
+            state_root: SparseMerklePlaceHolderHash,
+            length: 0u64,
+        }
+    }
+
+    public(friend) fun length(self: &TableInfo) : u64{
+        self.length
+    }
+
+    public(friend) fun unpack(self: TableInfo) : (address, u64){
+        let TableInfo { state_root, length } = self;
+        (state_root, length)
     }
 
     // ======================================================================================================

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -11,6 +11,7 @@ module moveos_std::table {
     use moveos_std::object_id::{ObjectID};
 
     friend moveos_std::account_storage;
+    friend moveos_std::storage_context;
 
     /// Type of tables
     struct Table<phantom K: copy + drop, phantom V> has store {
@@ -29,6 +30,10 @@ module moveos_std::table {
         Table {
             handle,
         }
+    }
+
+    public(friend) fun handle<K: copy + drop, V: store>(table: &Table<K, V>): ObjectID {
+        table.handle
     }
 
     /// Add a new entry to the table. Aborts if an entry for this


### PR DESCRIPTION
Try to keep the length in TableInfo. 

But if we want to use TableInfo, we need the global object_storage, so I put the `new_table` and `destroy_empty_table` in the StorageContext.


I will try a new native implementation.