### PR TITLE
[FrameworkDoc] Rename the overview.md to README.md

### DIFF
--- a/crates/rooch-framework/doc/README.md
+++ b/crates/rooch-framework/doc/README.md
@@ -20,3 +20,13 @@ This is the reference documentation of the Rooch Framework.
 -  [`0x3::ed25519`](ed25519.md#0x3_ed25519)
 -  [`0x3::hash`](hash.md#0x3_hash)
 -  [`0x3::transaction_validator`](transaction_validator.md#0x3_transaction_validator)
+
+
+
+<a name="@Reference_2"></a>
+
+## Reference
+
+
+* [MoveStdlib](https://github.com/rooch-network/rooch/tree/main/moveos/moveos-stdlib/move-stdlib/doc)
+* [MoveosStdlib](https://github.com/rooch-network/rooch/tree/main/moveos/moveos-stdlib/moveos-stdlib/doc)

--- a/crates/rooch-framework/doc_template/README.md
+++ b/crates/rooch-framework/doc_template/README.md
@@ -1,0 +1,12 @@
+# Rooch Framework
+
+This is the reference documentation of the Rooch Framework.
+
+## Index
+
+> {{move-index}}
+
+## Reference
+
+* [MoveStdlib](https://github.com/rooch-network/rooch/tree/main/moveos/moveos-stdlib/move-stdlib/doc)
+* [MoveosStdlib](https://github.com/rooch-network/rooch/tree/main/moveos/moveos-stdlib/moveos-stdlib/doc)

--- a/crates/rooch-framework/doc_template/overview.md
+++ b/crates/rooch-framework/doc_template/overview.md
@@ -1,7 +1,0 @@
-# Rooch Framework
-
-This is the reference documentation of the Rooch Framework.
-
-## Index
-
-> {{move-index}}

--- a/moveos/moveos-stdlib-builder/src/lib.rs
+++ b/moveos/moveos-stdlib-builder/src/lib.rs
@@ -126,7 +126,7 @@ impl Stdlib {
             toc_depth: Option::None,
             no_collapsed_sections: false,
             output_directory: None,
-            template: vec!["doc_template/overview.md".to_string()],
+            template: vec!["doc_template/README.md".to_string()],
             references_file: Option::None,
             include_dep_diagrams: false,
             include_call_diagrams: false,

--- a/moveos/moveos-stdlib/move-stdlib/doc/README.md
+++ b/moveos/moveos-stdlib/move-stdlib/doc/README.md
@@ -25,3 +25,13 @@ This is the reference documentation of the Move standard library.
 -  [`0x1::string`](string.md#0x1_string)
 -  [`0x1::type_name`](type_name.md#0x1_type_name)
 -  [`0x1::vector`](vector.md#0x1_vector)
+
+
+
+<a name="@Reference_2"></a>
+
+## Reference
+
+
+* [MoveosStdlib](https://github.com/rooch-network/rooch/tree/main/moveos/moveos-stdlib/moveos-stdlib/doc)
+* [RoochFramework](https://github.com/rooch-network/rooch/tree/main/crates/rooch-framework/doc)

--- a/moveos/moveos-stdlib/move-stdlib/doc_template/README.md
+++ b/moveos/moveos-stdlib/move-stdlib/doc_template/README.md
@@ -1,0 +1,12 @@
+# Move standard library
+
+This is the reference documentation of the Move standard library.
+
+## Index
+
+> {{move-index}}
+
+## Reference
+
+* [MoveosStdlib](https://github.com/rooch-network/rooch/tree/main/moveos/moveos-stdlib/moveos-stdlib/doc)
+* [RoochFramework](https://github.com/rooch-network/rooch/tree/main/crates/rooch-framework/doc)

--- a/moveos/moveos-stdlib/move-stdlib/doc_template/overview.md
+++ b/moveos/moveos-stdlib/move-stdlib/doc_template/overview.md
@@ -1,7 +1,0 @@
-# Move standard library
-
-This is the reference documentation of the Move standard library.
-
-## Index
-
-> {{move-index}}

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/README.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/README.md
@@ -31,3 +31,13 @@ This is the reference documentation of the MoveOS standard library.
 -  [`0x2::tx_context`](tx_context.md#0x2_tx_context)
 -  [`0x2::type_info`](type_info.md#0x2_type_info)
 -  [`0x2::type_table`](type_table.md#0x2_type_table)
+
+
+
+<a name="@Reference_2"></a>
+
+## Reference
+
+
+* [MoveStdlib](https://github.com/rooch-network/rooch/tree/main/moveos/moveos-stdlib/move-stdlib/doc)
+* [RoochFramework](https://github.com/rooch-network/rooch/tree/main/crates/rooch-framework/doc)

--- a/moveos/moveos-stdlib/moveos-stdlib/doc_template/README.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc_template/README.md
@@ -1,0 +1,12 @@
+# MoveOS standard library
+
+This is the reference documentation of the MoveOS standard library.
+
+## Index
+
+> {{move-index}}
+
+## Reference
+
+* [MoveStdlib](https://github.com/rooch-network/rooch/tree/main/moveos/moveos-stdlib/move-stdlib/doc)
+* [RoochFramework](https://github.com/rooch-network/rooch/tree/main/crates/rooch-framework/doc)

--- a/moveos/moveos-stdlib/moveos-stdlib/doc_template/overview.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc_template/overview.md
@@ -1,7 +1,0 @@
-# MoveOS standard library
-
-This is the reference documentation of the MoveOS standard library.
-
-## Index
-
-> {{move-index}}


### PR DESCRIPTION
Rename the template overview.md to README.md for a better view of the document on GitHub.