### PR TITLE
use paths-ignore instead

### DIFF
--- a/.github/workflows/check_build_test.yml
+++ b/.github/workflows/check_build_test.yml
@@ -3,20 +3,20 @@ name: Check-Build-Test
 on:
   push:
     branches: ["main"]
-    paths:
-      - 'crates/**'
-      - 'examples/**'
-      - 'moveos/**'
-      - '.github/**'
-      - 'Cargo.toml'
+    paths-ignore:
+      - 'docs/**'
+      - 'fixtures/**'
+      - 'kube/**'
+      - 'scripts/**'
+      - '**.md'
   pull_request:
     branches: ["main"]
-    paths:
-      - 'crates/**'
-      - 'examples/**'
-      - 'moveos/**'
-      - '.github/**'
-      - 'Cargo.toml'
+    paths-ignore:
+      - 'docs/**'
+      - 'fixtures/**'
+      - 'kube/**'
+      - 'scripts/**'
+      - '**.md'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This way, docs related changes should always be passed.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks