### PR TITLE
Allow the use of external libraries in integration-test.

### DIFF
--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -32,6 +32,7 @@ termcolor = { workspace = true }
 itertools = { workspace = true }
 hex = { workspace = true }
 regex = { workspace = true }
+walkdir = { workspace = true }
 
 move-bytecode-utils = { workspace = true }
 move-binary-format = { workspace = true }

--- a/examples/counter/integration-tests/counter.move
+++ b/examples/counter/integration-tests/counter.move
@@ -6,6 +6,6 @@ script {
     use rooch_examples::counter;
 
     fun main(sender: &signer) {
-        counter::init_(sender);
+        counter::test_init(sender);
     }
 }

--- a/examples/counter/sources/counter.move
+++ b/examples/counter/sources/counter.move
@@ -1,9 +1,25 @@
+module rooch_examples::C1 {
+   struct Data has key, store {
+      value:u64,
+   }
+
+   #[private_generics(T2)]
+   public fun f1<T1, T2>() {
+
+   }
+}
+
 module rooch_examples::counter {
    use moveos_std::account_storage;
    use moveos_std::storage_context::{StorageContext};
+   use rooch_examples::C1::f1;
 
    struct Counter has key, store {
       value:u64,
+   }
+
+   public fun test_init(_account: &signer) {
+      f1<Counter, Counter>();
    }
 
    fun init(ctx: &mut StorageContext, account: &signer){

--- a/moveos/moveos/src/moveos_test_model_builder.rs
+++ b/moveos/moveos/src/moveos_test_model_builder.rs
@@ -24,6 +24,21 @@ pub fn build_file_to_module_env(
     let mut env = GlobalEnv::new();
     env.set_extension(options);
 
+    if let Some(fully_compiled_prog) = pre_compiled_deps {
+        for package_def in fully_compiled_prog.parser.source_definitions.iter() {
+            let fhash = package_def.def.file_hash();
+            let (fname, fsrc) = fully_compiled_prog.files.get(&fhash).unwrap();
+            let aliases = fully_compiled_prog
+                .parser
+                .named_address_maps
+                .get(package_def.named_address_map)
+                .iter()
+                .map(|(symbol, addr)| (env.symbol_pool().make(symbol.as_str()), *addr))
+                .collect();
+            env.add_source(fhash, Rc::new(aliases), fname.as_str(), fsrc, false);
+        }
+    }
+
     use move_compiler::command_line::compiler::PASS_PARSER;
 
     // Step 1: parse the program to get comments and a separation of targets and dependencies.


### PR DESCRIPTION
In `rooch move integration-test`, allow the use of the `moveos-stdlib` library in the move source code.

resolve https://github.com/rooch-network/rooch/issues/404.