### PR TITLE
Fix issues with rooch move build in development mode.

### DIFF
--- a/crates/rooch-integration-test-runner/src/lib.rs
+++ b/crates/rooch-integration-test-runner/src/lib.rs
@@ -351,7 +351,7 @@ pub fn run_integration_test_with_extended_check(
         })
         .collect::<Vec<_>>();
 
-    let global_env = build_model(dep_package_path, named_account_address_map, None).unwrap();
+    let global_env = build_model(dep_package_path, named_account_address_map, false, None).unwrap();
 
     let _ = run_extended_checks(&global_env);
 

--- a/crates/rooch/src/commands/move_cli/commands/build.rs
+++ b/crates/rooch/src/commands/move_cli/commands/build.rs
@@ -38,8 +38,6 @@ impl Build {
         let mut config = config;
         config.additional_named_addresses = context.parse_account_args(self.named_addresses)?;
 
-        let additional_named_address = config.additional_named_addresses.clone();
-
         let rerooted_path = reroot_path(path)?;
         if config.fetch_deps_only {
             if config.test_mode {
@@ -49,9 +47,11 @@ impl Build {
             return Ok(());
         }
 
+        let config_cloned = config.clone();
+
         let mut package = config.compile_package_no_exit(&rerooted_path, &mut std::io::stdout())?;
 
-        run_verifier(rerooted_path, additional_named_address, &mut package)?;
+        run_verifier(rerooted_path, config_cloned, &mut package)?;
 
         Ok(())
     }

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -60,8 +60,7 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
         let mut config = config.clone();
 
         config.additional_named_addresses = context.parse_account_args(self.named_addresses)?;
-
-        let additional_named_address = config.additional_named_addresses.clone();
+        let config_cloned = config.clone();
 
         let package_path = match package_path {
             Some(package_path) => package_path,
@@ -69,7 +68,7 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
         };
         let mut package = config.compile_package_no_exit(&package_path, &mut stderr())?;
 
-        run_verifier(package_path, additional_named_address, &mut package)?;
+        run_verifier(package_path, config_cloned, &mut package)?;
 
         // let modules = package.root_modules_map().iter_modules_owned();
         let modules = package.root_modules_map();

--- a/moveos/moveos-stdlib-builder/src/lib.rs
+++ b/moveos/moveos-stdlib-builder/src/lib.rs
@@ -110,12 +110,7 @@ impl Stdlib {
             .clone()
             .compile_package_no_exit(&package_path, &mut stderr())?;
 
-        let additional_named_address = options.named_addresses;
-        run_verifier(
-            &package_path,
-            additional_named_address,
-            &mut compiled_package,
-        )?;
+        run_verifier(&package_path, build_config.clone(), &mut compiled_package)?;
         let module_map = compiled_package.root_modules_map();
         let mut modules = module_map.iter_modules().into_iter();
 

--- a/moveos/moveos-verifier/src/build.rs
+++ b/moveos/moveos-verifier/src/build.rs
@@ -244,10 +244,11 @@ pub static ROOCH_METADATA_KEY: &[u8] = "rooch::metadata_v0".as_bytes();
 pub fn build_model(
     package_path: &Path,
     additional_named_addresses: BTreeMap<String, AccountAddress>,
+    dev_mode: bool,
     target_filter: Option<String>,
 ) -> anyhow::Result<GlobalEnv> {
     let build_config = BuildConfig {
-        dev_mode: false,
+        dev_mode,
         additional_named_addresses,
         architecture: None,
         generate_abis: false,
@@ -299,10 +300,16 @@ pub fn build_model_with_test_attr(
 
 pub fn run_verifier<P: AsRef<Path>>(
     package_path: P,
-    additional_named_address: BTreeMap<String, AccountAddress>,
+    build_config: BuildConfig,
     package: &mut CompiledPackage,
 ) -> anyhow::Result<bool> {
-    let model = build_model(package_path.as_ref(), additional_named_address, None).unwrap();
+    let model = build_model(
+        package_path.as_ref(),
+        build_config.additional_named_addresses,
+        build_config.dev_mode,
+        None,
+    )
+    .unwrap();
 
     let runtime_metadata = run_extended_checks(&model);
 


### PR DESCRIPTION
When executing "rooch move build -d", the private_generics are compiled and checked. Now, add a check for dev_mode.

resolve https://github.com/rooch-network/rooch/issues/441.