### PR TITLE
[gh-438] add btc address supports for random() case.

### DIFF
--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -310,7 +310,7 @@ pub struct BitcoinAddress(pub Address);
 impl RoochSupportedAddress for BitcoinAddress {
     fn random() -> Self {
         // Generate a random public key hash
-        let pubkey_hash = hash160::Hash::from_slice(&H160::random().as_bytes()).unwrap();
+        let pubkey_hash = hash160::Hash::from_slice(H160::random().as_bytes()).unwrap();
         // Create a P2PKH address using the public key hash
         let p2pkh_address = Address::new(Network::Bitcoin, Payload::PubkeyHash(pubkey_hash.into()));
         // Create a redeem script from the P2PKH address
@@ -319,7 +319,7 @@ impl RoochSupportedAddress for BitcoinAddress {
         // Create a P2SH address using the redeem script
         let p2sh_address = Address::new(
             Network::Bitcoin,
-            Payload::ScriptHash(redeem_script.script_hash().into()),
+            Payload::ScriptHash(redeem_script.script_hash()),
         );
         // Create a witness program for the SegWit address
         let witness_program = vec![0x00]

--- a/crates/rooch-types/src/transaction/rooch.rs
+++ b/crates/rooch-types/src/transaction/rooch.rs
@@ -73,14 +73,18 @@ impl RoochTransaction {
     //TODO use protest Arbitrary to generate mock data
     #[cfg(test)]
     pub fn mock() -> RoochTransaction {
-        use crate::address::RoochSupportedAddress;
+        use crate::address::{Protocols, RoochSupportedAddress};
         use crate::crypto::Signature;
         use fastcrypto::ed25519::Ed25519KeyPair;
         use fastcrypto::traits::KeyPair;
         use move_core_types::{identifier::Identifier, language_storage::ModuleId};
         use moveos_types::move_types::FunctionId;
 
-        let sender = RoochAddress::random();
+        // Randomly select a bitcoin protocol
+        let bitcoin_protocols = [Protocols::P2PKH, Protocols::P2SH, Protocols::SegWit];
+        let selected_protocol =
+            &bitcoin_protocols[rand::random::<usize>() % bitcoin_protocols.len()];
+        let sender: RoochAddress = RoochAddress::random(selected_protocol);
         let sequence_number = 0;
         let payload = MoveAction::new_function_call(
             FunctionId::new(

--- a/crates/rooch-types/src/transaction/rooch.rs
+++ b/crates/rooch-types/src/transaction/rooch.rs
@@ -73,18 +73,14 @@ impl RoochTransaction {
     //TODO use protest Arbitrary to generate mock data
     #[cfg(test)]
     pub fn mock() -> RoochTransaction {
-        use crate::address::{Protocols, RoochSupportedAddress};
+        use crate::address::RoochSupportedAddress;
         use crate::crypto::Signature;
         use fastcrypto::ed25519::Ed25519KeyPair;
         use fastcrypto::traits::KeyPair;
         use move_core_types::{identifier::Identifier, language_storage::ModuleId};
         use moveos_types::move_types::FunctionId;
 
-        // Randomly select a bitcoin protocol
-        let bitcoin_protocols = [Protocols::P2PKH, Protocols::P2SH, Protocols::SegWit];
-        let selected_protocol =
-            &bitcoin_protocols[rand::random::<usize>() % bitcoin_protocols.len()];
-        let sender: RoochAddress = RoochAddress::random(selected_protocol);
+        let sender: RoochAddress = RoochAddress::random();
         let sequence_number = 0;
         let payload = MoveAction::new_function_call(
             FunctionId::new(


### PR DESCRIPTION
resolves #438 

Tests should generate and pass all BTC address versions.

This is to ensure the assumed addresses are correctly mapped for all Bitcoin address versions.