### PR TITLE
Refactor the rooch move integration-test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,39 +185,39 @@ rust_secp256k1 = { version = "0.27.0", package = "secp256k1", features = ["recov
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-binary-format = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-bytecode-verifier = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-bytecode-utils = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-cli = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-command-line-common = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-compiler ={ git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-core-types = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c", features = ["address32"] }
-move-coverage = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-disassembler = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-docgen = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-errmapgen = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-ir-compiler = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-model = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-package = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-prover = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-prover-boogie-backend = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-stackless-bytecode = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-prover-test-utils = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-resource-viewer = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-stdlib = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c", features = ["address32", "testing"] }
-move-symbol-pool = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-#move-table-extension = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-transactional-test-runner = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-unit-test = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c", features = ["lazy_natives"] }
-move-vm-test-utils = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-read-write-set = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-read-write-set-dynamic = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-bytecode-source-map  = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
-move-ir-types = { git = "https://github.com/rooch-network/move", rev = "5597bcfd78d952f428360ba2eae81f2f79d2627c" }
+move-abigen = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-binary-format = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-bytecode-verifier = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-bytecode-utils = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-cli = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-command-line-common = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-compiler ={ git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-core-types = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756", features = ["address32"] }
+move-coverage = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-disassembler = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-docgen = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-errmapgen = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-ir-compiler = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-model = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-package = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-prover = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-prover-boogie-backend = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-stackless-bytecode = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-prover-test-utils = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-resource-viewer = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-stdlib = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756", features = ["address32", "testing"] }
+move-symbol-pool = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+#move-table-extension = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-transactional-test-runner = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-unit-test = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756", features = ["lazy_natives"] }
+move-vm-test-utils = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+read-write-set = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+read-write-set-dynamic = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-bytecode-source-map  = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
+move-ir-types = { git = "https://github.com/rooch-network/move", rev = "cbc2bf4d1420e324d6b40bd8f65490993fec5756" }
 # END MOVE DEPENDENCIES
 
 # keep this for convenient debug Move in local repo

--- a/crates/rooch/src/commands/move_cli/mod.rs
+++ b/crates/rooch/src/commands/move_cli/mod.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use commands::{
-    build::Build, /* integration_test::IntegrationTest ,*/ new::New, publish::Publish,
+    build::Build, integration_test::IntegrationTest, new::New, publish::Publish,
     run_function::RunFunction, run_view_function::RunViewFunction, unit_test::Test,
 };
 use move_cli::{
@@ -42,7 +42,7 @@ pub enum MoveCommand {
     Publish(Publish),
     Run(RunFunction),
     View(RunViewFunction),
-    // IntegrationTest(IntegrationTest),
+    IntegrationTest(IntegrationTest),
 }
 
 #[async_trait]
@@ -91,12 +91,10 @@ impl CommandAction<String> for MoveCli {
             MoveCommand::Publish(c) => c.execute_serialized().await,
             MoveCommand::Run(c) => c.execute_serialized().await,
             MoveCommand::View(c) => c.execute_serialized().await,
-            /*
             MoveCommand::IntegrationTest(c) => c
                 .execute(move_args)
                 .map(|_| "Success".to_owned())
                 .map_err(RoochError::from),
-             */
         }
     }
 }

--- a/examples/counter/integration-tests/counter.exp
+++ b/examples/counter/integration-tests/counter.exp
@@ -1,4 +1,4 @@
 processed 2 tasks
 
-task 1 'run'. lines 4-11:
+task 1 'run'. lines 4-12:
 status EXECUTED

--- a/examples/counter/integration-tests/counter.move
+++ b/examples/counter/integration-tests/counter.move
@@ -3,9 +3,10 @@
 //create account by bob self
 //# run --signers genesis
 script {
+    use moveos_std::storage_context::StorageContext;
     use rooch_examples::counter;
 
-    fun main(sender: &signer) {
-        counter::init_(sender);
+    fun main(ctx: &mut StorageContext, sender: &signer) {
+        counter::init_for_test(ctx, sender);
     }
 }

--- a/examples/counter/sources/counter.move
+++ b/examples/counter/sources/counter.move
@@ -6,8 +6,12 @@ module rooch_examples::counter {
       value:u64,
    }
 
-   fun init(ctx: &mut StorageContext, account: &signer){
-      account_storage::global_move_to(ctx, account, Counter{value:0});
+   public fun init_for_test(ctx: &mut StorageContext, account: &signer) {
+      account_storage::global_move_to(ctx, account, Counter { value: 0 });
+   }
+
+   fun init(ctx: &mut StorageContext, account: &signer) {
+      account_storage::global_move_to(ctx, account, Counter { value: 0 });
    }
 
    public fun increase_(ctx: &mut StorageContext) {


### PR DESCRIPTION
Refactor the integration-test to allow it to import moveos_stdlib and other third-party Move Packages.

resolve https://github.com/rooch-network/rooch/issues/452.