### PR TITLE
Support empty vector in `rooch move run` args

### DIFF
--- a/crates/rooch/src/cli_types.rs
+++ b/crates/rooch/src/cli_types.rs
@@ -278,7 +278,9 @@ fn parse_vector_arg<T: Serialize, F: Fn(&str) -> RoochResult<T>>(
     let mut parsed_args = vec![];
     let args = args.split(',');
     for arg in args {
-        parsed_args.push(parse(arg)?);
+        if !arg.is_empty() {
+            parsed_args.push(parse(arg)?);
+        }
     }
 
     bcs::to_bytes(&parsed_args).map_err(|err| RoochError::BcsError(err.to_string()))


### PR DESCRIPTION
Fix the crash when parsing empty vector in `rooch move run` args. Now, you can use the `vector<type>:` format to pass an empty vector:

```
rooch move run --function 0x1::rooch::counter --args "vector<u8>:" --sender-account default
```