### PR TITLE
Update blog example

### DIFF
--- a/examples/blog/dddml/blog.yaml
+++ b/examples/blog/dddml/blog.yaml
@@ -75,6 +75,7 @@ aggregates:
 
 singletonObjects:
   Blog:
+    friends: [ "Article.Create", "Article.Delete" ]
     metadata:
       Preprocessors: [ "MOVE_CRUD_IT" ]
     properties:
@@ -85,12 +86,18 @@ singletonObjects:
         itemType: ObjectID
     methods:
       AddArticle:
+        isInternal: true
+        metadata:
+          NoSigner: true
         event:
           name: ArticleAddedToBlog
         parameters:
           ArticleId:
             type: ObjectID
       RemoveArticle:
+        isInternal: true
+        metadata:
+          NoSigner: true
         event:
           name: ArticleRemovedFromBlog
         parameters:

--- a/examples/blog/sources/article_aggregate.move
+++ b/examples/blog/sources/article_aggregate.move
@@ -44,7 +44,6 @@ module rooch_examples::article_aggregate {
         article::emit_comment_updated(storage_ctx, comment_updated);
     }
 
-
     public entry fun remove_comment(
         storage_ctx: &mut StorageContext,
         account: &signer,
@@ -67,7 +66,6 @@ module rooch_examples::article_aggregate {
         article::update_version_and_add(storage_ctx, updated_article_obj);
         article::emit_comment_removed(storage_ctx, comment_removed);
     }
-
 
     public entry fun add_comment(
         storage_ctx: &mut StorageContext,
@@ -96,7 +94,6 @@ module rooch_examples::article_aggregate {
         article::emit_comment_added(storage_ctx, comment_added);
     }
 
-
     public entry fun create(
         storage_ctx: &mut StorageContext,
         account: &signer,
@@ -118,7 +115,6 @@ module rooch_examples::article_aggregate {
         article::add_article(storage_ctx, article_obj);
         article::emit_article_created(storage_ctx, article_created);
     }
-
 
     public entry fun update(
         storage_ctx: &mut StorageContext,
@@ -144,7 +140,6 @@ module rooch_examples::article_aggregate {
         article::update_version_and_add(storage_ctx, updated_article_obj);
         article::emit_article_updated(storage_ctx, article_updated);
     }
-
 
     public entry fun delete(
         storage_ctx: &mut StorageContext,

--- a/examples/blog/sources/article_create_logic.move
+++ b/examples/blog/sources/article_create_logic.move
@@ -35,7 +35,7 @@ module rooch_examples::article_create_logic {
             body,
         );
         // ///////////////////////////
-        blog_aggregate::add_article(storage_ctx, _account, article::id(&article_obj));
+        blog_aggregate::add_article(storage_ctx, article::id(&article_obj));
         // ///////////////////////////
         article_obj
     }

--- a/examples/blog/sources/article_delete_logic.move
+++ b/examples/blog/sources/article_delete_logic.move
@@ -25,7 +25,7 @@ module rooch_examples::article_delete_logic {
         article_obj: Object<article::Article>,
     ): Object<article::Article> {
         let _ = article_deleted;
-        blog_aggregate::remove_article(storage_ctx, _account, article::id(&article_obj));
+        blog_aggregate::remove_article(storage_ctx, article::id(&article_obj));
         article_obj
     }
 

--- a/examples/blog/sources/blog.move
+++ b/examples/blog/sources/blog.move
@@ -163,6 +163,7 @@ module rooch_examples::blog {
 
     public(friend) fun update_version_and_add(storage_ctx: &mut StorageContext, account: &signer, blog: Blog) {
         assert!(signer::address_of(account) == @rooch_examples, error::invalid_argument(ENOT_GENESIS_ACCOUNT));
+        blog.version = blog.version + 1;
         private_add_blog(storage_ctx, account, blog);
     }
 
@@ -195,6 +196,10 @@ module rooch_examples::blog {
 
     public fun borrow_blog(storage_ctx: &mut StorageContext): &Blog {
         account_storage::global_borrow<Blog>(storage_ctx, @rooch_examples)
+    }
+
+    public(friend) fun update_version(blog: &mut Blog) {
+        blog.version = blog.version + 1;
     }
 
     public(friend) fun emit_article_added_to_blog(storage_ctx: &mut StorageContext, article_added_to_blog: ArticleAddedToBlog) {

--- a/examples/blog/sources/blog_add_article_logic.move
+++ b/examples/blog/sources/blog_add_article_logic.move
@@ -2,20 +2,17 @@ module rooch_examples::blog_add_article_logic {
     use std::vector;
 
     use moveos_std::object_id::ObjectID;
-    use moveos_std::storage_context::StorageContext;
     use rooch_examples::article_added_to_blog;
     use rooch_examples::blog;
 
     friend rooch_examples::blog_aggregate;
 
     public(friend) fun verify(
-        storage_ctx: &mut StorageContext,
-        account: &signer,
+        //storage_ctx: &mut StorageContext,
         article_id: ObjectID,
         blog: &blog::Blog,
     ): blog::ArticleAddedToBlog {
-        let _ = storage_ctx;
-        let _ = account;
+        //let _ = storage_ctx;
         blog::new_article_added_to_blog(
             blog,
             article_id,
@@ -23,18 +20,16 @@ module rooch_examples::blog_add_article_logic {
     }
 
     public(friend) fun mutate(
-        storage_ctx: &mut StorageContext,
-        _account: &signer,
+        //storage_ctx: &mut StorageContext,
         article_added_to_blog: &blog::ArticleAddedToBlog,
-        blog: blog::Blog,
-    ): blog::Blog {
-        let _ = storage_ctx;
+        blog: &mut blog::Blog,
+    ) {
+        //let _ = storage_ctx;
         let article_id = article_added_to_blog::article_id(article_added_to_blog);
-        let articles = blog::articles(&blog);
+        let articles = blog::articles(blog);
         if (!vector::contains(&articles, &article_id)) {
             vector::push_back(&mut articles, article_id);
-            blog::set_articles(&mut blog, articles);
+            blog::set_articles(blog, articles);
         };
-        blog
     }
 }

--- a/examples/blog/sources/blog_aggregate.move
+++ b/examples/blog/sources/blog_aggregate.move
@@ -14,51 +14,44 @@ module rooch_examples::blog_aggregate {
     use rooch_examples::blog_update_logic;
     use std::string::String;
 
-    public entry fun add_article(
+    friend rooch_examples::article_create_logic;
+    friend rooch_examples::article_delete_logic;
+
+    public(friend) fun add_article(
         storage_ctx: &mut StorageContext,
-        account: &signer,
         article_id: ObjectID,
     ) {
-        let blog = blog::remove_blog(storage_ctx);
+        let blog = blog::borrow_blog(storage_ctx);
         let article_added_to_blog = blog_add_article_logic::verify(
-            storage_ctx,
-            account,
             article_id,
-            &blog,
-        );
-        let updated_blog = blog_add_article_logic::mutate(
-            storage_ctx,
-            account,
-            &article_added_to_blog,
             blog,
         );
-        blog::update_version_and_add(storage_ctx, account, updated_blog);
+        let mut_blog = blog::borrow_mut_blog(storage_ctx);
+        blog_add_article_logic::mutate(
+            &article_added_to_blog,
+            mut_blog,
+        );
+        blog::update_version(mut_blog);
         blog::emit_article_added_to_blog(storage_ctx, article_added_to_blog);
     }
 
-
-    public entry fun remove_article(
+    public(friend) fun remove_article(
         storage_ctx: &mut StorageContext,
-        account: &signer,
         article_id: ObjectID,
     ) {
-        let blog = blog::remove_blog(storage_ctx);
+        let blog = blog::borrow_blog(storage_ctx);
         let article_removed_from_blog = blog_remove_article_logic::verify(
-            storage_ctx,
-            account,
             article_id,
-            &blog,
-        );
-        let updated_blog = blog_remove_article_logic::mutate(
-            storage_ctx,
-            account,
-            &article_removed_from_blog,
             blog,
         );
-        blog::update_version_and_add(storage_ctx, account, updated_blog);
+        let mut_blog = blog::borrow_mut_blog(storage_ctx);
+        blog_remove_article_logic::mutate(
+            &article_removed_from_blog,
+            mut_blog,
+        );
+        blog::update_version(mut_blog);
         blog::emit_article_removed_from_blog(storage_ctx, article_removed_from_blog);
     }
-
 
     public entry fun create(
         storage_ctx: &mut StorageContext,
@@ -80,7 +73,6 @@ module rooch_examples::blog_aggregate {
         blog::add_blog(storage_ctx, account, blog);
         blog::emit_blog_created(storage_ctx, blog_created);
     }
-
 
     public entry fun update(
         storage_ctx: &mut StorageContext,
@@ -105,7 +97,6 @@ module rooch_examples::blog_aggregate {
         blog::update_version_and_add(storage_ctx, account, updated_blog);
         blog::emit_blog_updated(storage_ctx, blog_updated);
     }
-
 
     public entry fun delete(
         storage_ctx: &mut StorageContext,

--- a/examples/blog/sources/blog_remove_article_logic.move
+++ b/examples/blog/sources/blog_remove_article_logic.move
@@ -1,21 +1,17 @@
 module rooch_examples::blog_remove_article_logic {
     use std::vector;
-
     use moveos_std::object_id::ObjectID;
-    use moveos_std::storage_context::StorageContext;
     use rooch_examples::article_removed_from_blog;
     use rooch_examples::blog;
 
     friend rooch_examples::blog_aggregate;
 
     public(friend) fun verify(
-        storage_ctx: &mut StorageContext,
-        account: &signer,
+        //storage_ctx: &mut StorageContext,
         article_id: ObjectID,
         blog: &blog::Blog,
     ): blog::ArticleRemovedFromBlog {
-        let _ = storage_ctx;
-        let _ = account;
+        //let _ = storage_ctx;
         blog::new_article_removed_from_blog(
             blog,
             article_id,
@@ -23,19 +19,17 @@ module rooch_examples::blog_remove_article_logic {
     }
 
     public(friend) fun mutate(
-        storage_ctx: &mut StorageContext,
-        _account: &signer,
+        //storage_ctx: &mut StorageContext,
         article_removed_from_blog: &blog::ArticleRemovedFromBlog,
-        blog: blog::Blog,
-    ): blog::Blog {
-        let _ = storage_ctx;
+        blog: &mut blog::Blog,
+    ) {
+        //let _ = storage_ctx;
         let article_id = article_removed_from_blog::article_id(article_removed_from_blog);
-        let articles = blog::articles(&blog);
+        let articles = blog::articles(blog);
         let (found, idx) = vector::index_of(&articles, &article_id);
         if (found) {
             vector::remove(&mut articles, idx);
-            blog::set_articles(&mut blog, articles);
+            blog::set_articles(blog, articles);
         };
-        blog
     }
 }


### PR DESCRIPTION
原来的 CLI 对于类型为 vector<T> 的参数不支持传入空的 vector。在原来的 README 中，测试应用碰到这个情况时先随意传入了一个元素，让 vector 不为空，避免出错。这个地方做了修改。

上一个版本改进后的示例应用还有一些“用户需求”可能没有满足。

比如说，不支持不同的账户（用户）在同一个博客中创作文章（Getting Started 文章示例的 simple blog 也存在同样问题）。

在本次更新的示例中，我们演示了如何解决这些问题。

---

The previous CLI did not support passing an empty vector for arguments of type vector<T>. In the previous README, when testing applications that encountered this situation, an arbitrary element was passed in so that the vector would not be empty, to avoid the error. This has been changed.

There are still some "user requirements" that may not have been met in the previous version of the improved example application.

For example, there was no support for different accounts (users) to create articles in the same blog (the same problem existed in the "simple blog" version of the Getting Started article).

In this updated example, we demonstrate how to solve these issues.