### PR TITLE
Update installation.en-US.mdx and installation.zh-CN.mdx

### DIFF
--- a/docs/website/pages/docs/developer/installation.en-US.mdx
+++ b/docs/website/pages/docs/developer/installation.en-US.mdx
@@ -32,7 +32,7 @@ cd rooch && cargo build && cp target/debug/rooch ~/.cargo/bin/
 
 TODO
 
-### mocOS
+### macOS
 
 TODO
 

--- a/docs/website/pages/docs/developer/installation.zh-CN.mdx
+++ b/docs/website/pages/docs/developer/installation.zh-CN.mdx
@@ -32,7 +32,7 @@ cd rooch && cargo build && cp target/debug/rooch ~/.cargo/bin/
 
 TODO
 
-### mocOS
+### macOS
 
 TODO
 


### PR DESCRIPTION
fixed typo error on installation page