### PR TITLE
Add test_only attribute to integration test functions.

### DIFF
--- a/crates/rooch/src/commands/move_cli/commands/integration_test.rs
+++ b/crates/rooch/src/commands/move_cli/commands/integration_test.rs
@@ -10,7 +10,7 @@ use move_compiler::diagnostics::report_diagnostics;
 use move_compiler::shared::unique_map::UniqueMap;
 use move_compiler::shared::{NamedAddressMapIndex, NamedAddressMaps};
 use move_compiler::{
-    cfgir, expansion, hlir, naming, parser, typing, Compiler, FullyCompiledProgram,
+    cfgir, expansion, hlir, naming, parser, typing, Compiler, Flags, FullyCompiledProgram,
 };
 use move_package::compilation::build_plan::BuildPlan;
 use move_package::source_package::layout::SourcePackageLayout;
@@ -196,6 +196,8 @@ impl IntegrationTest {
                 &mut std::io::stdout(),
                 Some(6),
                 |compiler: Compiler| {
+                    let compiler =
+                        compiler.set_flags(Flags::empty().set_keep_testing_functions(true));
                     let full_program = match construct_pre_compiled_lib_from_compiler(compiler)? {
                         Ok(full_program) => full_program,
                         Err((file, s)) => report_diagnostics(&file, s),

--- a/examples/counter/sources/counter.move
+++ b/examples/counter/sources/counter.move
@@ -6,6 +6,7 @@ module rooch_examples::counter {
       value:u64,
    }
 
+   #[test_only]
    public fun init_for_test(ctx: &mut StorageContext, account: &signer) {
       account_storage::global_move_to(ctx, account, Counter { value: 0 });
    }


### PR DESCRIPTION
Add the `#[test_only]` attribute to integration test functions to prevent them from being compiled into the Move Package.