### PR TITLE
add `rooch account switch` command

### DIFF
--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -53,6 +53,8 @@ pub enum RoochError {
     ViewFunctionError(String),
     #[error("Import account error: {0}")]
     ImportAccountError(String),
+    #[error("Switch account error: {0}")]
+    SwitchAccountError(String),
     #[error("Update account error: {0}")]
     UpdateAccountError(String),
     #[error("Generate key error: {0}")]

--- a/crates/rooch/src/commands/account/commands/mod.rs
+++ b/crates/rooch/src/commands/account/commands/mod.rs
@@ -4,4 +4,5 @@
 pub mod create;
 pub mod import;
 pub mod list;
+pub mod switch;
 pub mod update;

--- a/crates/rooch/src/commands/account/commands/switch.rs
+++ b/crates/rooch/src/commands/account/commands/switch.rs
@@ -1,0 +1,46 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::{CommandAction, WalletContextOptions};
+use async_trait::async_trait;
+use clap::Parser;
+use rooch_key::keystore::AccountKeystore;
+use rooch_types::{
+    address::RoochAddress,
+    error::{RoochError, RoochResult},
+};
+use std::{fmt::Debug, str::FromStr};
+
+/// Switch the active Rooch account
+#[derive(Debug, Parser)]
+pub struct SwitchCommand {
+    #[clap(flatten)]
+    pub context_options: WalletContextOptions,
+    /// The address of the Rooch account to be set as active
+    #[clap(short = 'a', long = "address")]
+    address: String,
+}
+
+#[async_trait]
+impl CommandAction<()> for SwitchCommand {
+    async fn execute(self) -> RoochResult<()> {
+        let mut context = self.context_options.build().await?;
+        let rooch_address = RoochAddress::from_str(self.address.as_str()).map_err(|e| {
+            RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))
+        })?;
+
+        if !context.config.keystore.addresses().contains(&rooch_address) {
+            RoochError::CommandArgumentError(format!(
+                "Address {} not found in keystore",
+                self.address
+            ));
+        }
+
+        context.config.active_address = Some(rooch_address);
+        context.config.save()?;
+
+        println!("Active account successfully switched to {}", self.address);
+
+        Ok(())
+    }
+}

--- a/crates/rooch/src/commands/account/commands/switch.rs
+++ b/crates/rooch/src/commands/account/commands/switch.rs
@@ -30,16 +30,19 @@ impl CommandAction<()> for SwitchCommand {
         })?;
 
         if !context.config.keystore.addresses().contains(&rooch_address) {
-            RoochError::CommandArgumentError(format!(
-                "Address {} not found in keystore",
+            return Err(RoochError::SwitchAccountError(format!(
+                "Address `{}` does not in the Rooch keystore",
                 self.address
-            ));
+            )));
         }
 
         context.config.active_address = Some(rooch_address);
         context.config.save()?;
 
-        println!("Active account successfully switched to {}", self.address);
+        println!(
+            "The active account was successfully switched to `{}`",
+            self.address
+        );
 
         Ok(())
     }

--- a/crates/rooch/src/commands/account/mod.rs
+++ b/crates/rooch/src/commands/account/mod.rs
@@ -9,6 +9,8 @@ use commands::{
 use rooch_types::error::{RoochError, RoochResult};
 use std::path::PathBuf;
 
+use self::commands::switch::SwitchCommand;
+
 pub mod commands;
 
 /// Tool for interacting with accounts
@@ -31,6 +33,7 @@ impl CommandAction<String> for Account {
             AccountCommand::List(list) => list.execute().await.map(|_| "".to_owned()),
             AccountCommand::Import(import) => import.execute().await.map(|_| "".to_owned()),
             AccountCommand::Update(update) => update.execute().await.map(|_| "".to_owned()),
+            AccountCommand::Switch(switch) => switch.execute().await.map(|_| "".to_owned()),
         }
         .map_err(RoochError::from)
     }
@@ -43,4 +46,5 @@ pub enum AccountCommand {
     List(ListCommand),
     Import(ImportCommand),
     Update(UpdateCommand),
+    Switch(SwitchCommand),
 }


### PR DESCRIPTION
Resolves #508 

Example usage:
```sh
rooch account switch --address <address>
```

Example output:
```txt
Active account successfully switched to <address>
```