### PR TITLE
Multi environment support

### DIFF
--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -69,6 +69,9 @@ pub enum RoochError {
     #[error("Key Conversion Error: {0}")]
     KeyConversionError(String),
 
+    #[error("Switch env error: {0}")]
+    SwitchEnvError(String),
+
     // Signature verification
     #[error("Signature is not valid: {}", error)]
     InvalidSignature { error: String },

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -71,6 +71,8 @@ pub enum RoochError {
 
     #[error("Switch env error: {0}")]
     SwitchEnvError(String),
+    #[error("Remove env error: {0}")]
+    RemoveEnvError(String),
 
     // Signature verification
     #[error("Signature is not valid: {}", error)]

--- a/crates/rooch/src/commands/env/commands/add.rs
+++ b/crates/rooch/src/commands/env/commands/add.rs
@@ -1,0 +1,42 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::WalletContextOptions;
+use clap::{Parser, ValueHint};
+use rooch_rpc_client::client_config::Env;
+use rooch_types::error::RoochResult;
+use std::time::Duration;
+
+/// Add a new Rooch environment
+#[derive(Debug, Parser)]
+pub struct AddCommand {
+    #[clap(flatten)]
+    pub context_options: WalletContextOptions,
+    #[clap(long)]
+    pub alias: String,
+    #[clap(long, value_hint = ValueHint::Url)]
+    pub rpc: String,
+    #[clap(long, value_hint = ValueHint::Url)]
+    pub ws: Option<String>,
+}
+
+impl AddCommand {
+    pub async fn execute(self) -> RoochResult<()> {
+        let mut context = self.context_options.build().await?;
+        let AddCommand { alias, rpc, ws, .. } = self;
+        let env = Env {
+            ws,
+            rpc,
+            alias: alias.clone(),
+        };
+
+        // TODO: is this request timeout okay?
+        env.create_rpc_client(Duration::from_secs(5), None).await?;
+        context.config.add_env(env);
+        context.config.save()?;
+
+        println!("Environment `{} was successfully added", alias);
+
+        Ok(())
+    }
+}

--- a/crates/rooch/src/commands/env/commands/list.rs
+++ b/crates/rooch/src/commands/env/commands/list.rs
@@ -1,0 +1,40 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use rooch_types::error::RoochResult;
+
+use crate::cli_types::WalletContextOptions;
+
+#[derive(Debug, Parser)]
+pub struct ListCommand {
+    #[clap(flatten)]
+    pub context_options: WalletContextOptions,
+}
+
+impl ListCommand {
+    pub async fn execute(self) -> RoochResult<()> {
+        let context = self.context_options.build().await?;
+
+        println!(
+            "{:^24} | {:^48} | {:^48} | {:^12}",
+            "Env Alias", "RPC URL", "Websocket URL", "Active Env"
+        );
+        println!("{}", ["-"; 153].join(""));
+
+        for env in context.config.envs.iter() {
+            let mut active = "";
+            if context.config.active_env == Some(env.alias.clone()) {
+                active = "True"
+            }
+
+            let ws = env.ws.clone().unwrap_or("Null".to_owned());
+            println!(
+                "{:^24} | {:^48} | {:^48} | {:^12}",
+                env.alias, env.rpc, ws, active
+            )
+        }
+
+        Ok(())
+    }
+}

--- a/crates/rooch/src/commands/env/commands/mod.rs
+++ b/crates/rooch/src/commands/env/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod add;

--- a/crates/rooch/src/commands/env/commands/mod.rs
+++ b/crates/rooch/src/commands/env/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod add;
+pub mod list;

--- a/crates/rooch/src/commands/env/commands/mod.rs
+++ b/crates/rooch/src/commands/env/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod add;
 pub mod list;
+pub mod switch;

--- a/crates/rooch/src/commands/env/commands/mod.rs
+++ b/crates/rooch/src/commands/env/commands/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod add;
 pub mod list;
 pub mod remove;

--- a/crates/rooch/src/commands/env/commands/mod.rs
+++ b/crates/rooch/src/commands/env/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod add;
 pub mod list;
+pub mod remove;
 pub mod switch;

--- a/crates/rooch/src/commands/env/commands/remove.rs
+++ b/crates/rooch/src/commands/env/commands/remove.rs
@@ -1,0 +1,35 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use rooch_types::error::{RoochError, RoochResult};
+
+use crate::cli_types::WalletContextOptions;
+
+#[derive(Debug, Parser)]
+pub struct RemoveCommand {
+    #[clap(flatten)]
+    pub context_options: WalletContextOptions,
+    #[clap(long)]
+    env: String,
+}
+
+impl RemoveCommand {
+    pub async fn execute(self) -> RoochResult<()> {
+        let mut context = self.context_options.build().await?;
+        if let Some(active_env) = &context.config.active_env {
+            if active_env == &self.env {
+                return Err(RoochError::RemoveEnvError(
+                    "Cannot remove the currently active environment. Please switch to another environment and try again".to_owned()
+                ));
+            }
+        }
+
+        context.config.envs.retain(|env| env.alias != self.env);
+        context.config.save()?;
+
+        println!("Environment `{}` was successfully removed", self.env);
+
+        Ok(())
+    }
+}

--- a/crates/rooch/src/commands/env/commands/switch.rs
+++ b/crates/rooch/src/commands/env/commands/switch.rs
@@ -1,0 +1,39 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use rooch_types::error::{RoochError, RoochResult};
+
+use crate::cli_types::WalletContextOptions;
+
+#[derive(Debug, Parser)]
+pub struct SwitchCommand {
+    #[clap(flatten)]
+    pub context_options: WalletContextOptions,
+    #[clap(long)]
+    env: String,
+}
+
+impl SwitchCommand {
+    pub async fn execute(self) -> RoochResult<()> {
+        let mut context = self.context_options.build().await?;
+        let env = Some(self.env.clone());
+
+        if context.config.get_env(&env).is_none() {
+            return Err(RoochError::SwitchEnvError(format!(
+                "The environment config for `{}` does not exist",
+                self.env
+            )));
+        }
+
+        context.config.active_env = env;
+        context.config.save()?;
+
+        println!(
+            "The active environment was successfully switched to `{}`",
+            self.env
+        );
+
+        Ok(())
+    }
+}

--- a/crates/rooch/src/commands/env/mod.rs
+++ b/crates/rooch/src/commands/env/mod.rs
@@ -6,7 +6,9 @@ use async_trait::async_trait;
 use rooch_types::error::{RoochError, RoochResult};
 use std::path::PathBuf;
 
-use self::commands::{add::AddCommand, list::ListCommand, switch::SwitchCommand};
+use self::commands::{
+    add::AddCommand, list::ListCommand, remove::RemoveCommand, switch::SwitchCommand,
+};
 
 pub mod commands;
 
@@ -27,6 +29,7 @@ impl CommandAction<String> for Env {
             EnvCommand::Add(add) => add.execute().await.map(|_| "".to_owned()),
             EnvCommand::List(list) => list.execute().await.map(|_| "".to_owned()),
             EnvCommand::Switch(switch) => switch.execute().await.map(|_| "".to_owned()),
+            EnvCommand::Remove(remove) => remove.execute().await.map(|_| "".to_owned()),
         }
         .map_err(RoochError::from)
     }
@@ -38,4 +41,5 @@ pub enum EnvCommand {
     Add(AddCommand),
     List(ListCommand),
     Switch(SwitchCommand),
+    Remove(RemoveCommand),
 }

--- a/crates/rooch/src/commands/env/mod.rs
+++ b/crates/rooch/src/commands/env/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use rooch_types::error::{RoochError, RoochResult};
 use std::path::PathBuf;
 
-use self::commands::{add::AddCommand, list::ListCommand};
+use self::commands::{add::AddCommand, list::ListCommand, switch::SwitchCommand};
 
 pub mod commands;
 
@@ -26,6 +26,7 @@ impl CommandAction<String> for Env {
         match self.cmd {
             EnvCommand::Add(add) => add.execute().await.map(|_| "".to_owned()),
             EnvCommand::List(list) => list.execute().await.map(|_| "".to_owned()),
+            EnvCommand::Switch(switch) => switch.execute().await.map(|_| "".to_owned()),
         }
         .map_err(RoochError::from)
     }
@@ -36,4 +37,5 @@ impl CommandAction<String> for Env {
 pub enum EnvCommand {
     Add(AddCommand),
     List(ListCommand),
+    Switch(SwitchCommand),
 }

--- a/crates/rooch/src/commands/env/mod.rs
+++ b/crates/rooch/src/commands/env/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use rooch_types::error::{RoochError, RoochResult};
 use std::path::PathBuf;
 
-use self::commands::add::AddCommand;
+use self::commands::{add::AddCommand, list::ListCommand};
 
 pub mod commands;
 
@@ -25,6 +25,7 @@ impl CommandAction<String> for Env {
     async fn execute(self) -> RoochResult<String> {
         match self.cmd {
             EnvCommand::Add(add) => add.execute().await.map(|_| "".to_owned()),
+            EnvCommand::List(list) => list.execute().await.map(|_| "".to_owned()),
         }
         .map_err(RoochError::from)
     }
@@ -34,4 +35,5 @@ impl CommandAction<String> for Env {
 #[clap(name = "env")]
 pub enum EnvCommand {
     Add(AddCommand),
+    List(ListCommand),
 }

--- a/crates/rooch/src/commands/env/mod.rs
+++ b/crates/rooch/src/commands/env/mod.rs
@@ -1,0 +1,37 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use async_trait::async_trait;
+use rooch_types::error::{RoochError, RoochResult};
+use std::path::PathBuf;
+
+use self::commands::add::AddCommand;
+
+pub mod commands;
+
+/// Interface for managing multiple environments
+#[derive(clap::Parser)]
+pub struct Env {
+    #[clap(subcommand)]
+    cmd: EnvCommand,
+    /// Sets the file storing the state of our user accounts (an empty one will be created if missing)
+    #[clap(long = "client.config")]
+    config: Option<PathBuf>,
+}
+
+#[async_trait]
+impl CommandAction<String> for Env {
+    async fn execute(self) -> RoochResult<String> {
+        match self.cmd {
+            EnvCommand::Add(add) => add.execute().await.map(|_| "".to_owned()),
+        }
+        .map_err(RoochError::from)
+    }
+}
+
+#[derive(Debug, clap::Subcommand)]
+#[clap(name = "env")]
+pub enum EnvCommand {
+    Add(AddCommand),
+}

--- a/crates/rooch/src/commands/mod.rs
+++ b/crates/rooch/src/commands/mod.rs
@@ -4,6 +4,7 @@
 pub mod abi;
 pub mod account;
 pub mod dashboard;
+pub mod env;
 pub mod event;
 pub mod init;
 pub mod move_cli;

--- a/crates/rooch/src/lib.rs
+++ b/crates/rooch/src/lib.rs
@@ -4,7 +4,7 @@
 use crate::commands::event::EventCommand;
 use cli_types::CommandAction;
 use commands::{
-    abi::ABI, account::Account, dashboard::Dashboard, init::Init, move_cli::MoveCli,
+    abi::ABI, account::Account, dashboard::Dashboard, env::Env, init::Init, move_cli::MoveCli,
     object::ObjectCommand, resource::ResourceCommand, server::Server, state::StateCommand,
     transaction::Transaction,
 };
@@ -37,6 +37,7 @@ pub enum Command {
     Event(EventCommand),
     Dashboard(Dashboard),
     ABI(ABI),
+    Env(Env),
 }
 
 pub async fn run_cli(opt: RoochCli) -> RoochResult<String> {
@@ -52,5 +53,6 @@ pub async fn run_cli(opt: RoochCli) -> RoochResult<String> {
         Command::Transaction(transation) => transation.execute().await,
         Command::Event(event) => event.execute().await,
         Command::ABI(abi) => abi.execute().await,
+        Command::Env(env) => env.execute().await,
     }
 }


### PR DESCRIPTION
This PR resolves #507 

It adds support for multiple environments in the Rooch CLI, the below features were implemented
- Add new env
- List all envs
- Switch active env
- Remove env