### PR TITLE
[VM] Refactor view_function result, return the VMStatus to caller

### DIFF
--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -8,7 +8,7 @@ use move_core_types::language_storage::StructTag;
 use moveos_types::access_path::AccessPath;
 use moveos_types::event::AnnotatedMoveOSEvent;
 use moveos_types::event_filter::EventFilter;
-use moveos_types::function_return_value::AnnotatedFunctionReturnValue;
+use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
 use moveos_types::state::{AnnotatedState, State};
 use moveos_types::transaction::FunctionCall;
@@ -51,7 +51,7 @@ pub struct ExecuteViewFunctionMessage {
 }
 
 impl Message for ExecuteViewFunctionMessage {
-    type Result = Result<Vec<AnnotatedFunctionReturnValue>, anyhow::Error>;
+    type Result = Result<AnnotatedFunctionResult, anyhow::Error>;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -16,14 +16,12 @@ use anyhow::Result;
 use coerce::actor::ActorRef;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::StructTag;
+use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
 use moveos_types::transaction::FunctionCall;
 use moveos_types::transaction::TransactionExecutionInfo;
 use moveos_types::transaction::TransactionOutput;
-use moveos_types::{
-    access_path::AccessPath, function_return_value::AnnotatedFunctionReturnValue,
-    transaction::VerifiedMoveOSTransaction,
-};
+use moveos_types::{access_path::AccessPath, transaction::VerifiedMoveOSTransaction};
 use moveos_types::{
     event::AnnotatedMoveOSEvent,
     event_filter::EventFilter,
@@ -64,7 +62,7 @@ impl ExecutorProxy {
     pub async fn execute_view_function(
         &self,
         call: FunctionCall,
-    ) -> Result<Vec<AnnotatedFunctionReturnValue>> {
+    ) -> Result<AnnotatedFunctionResult> {
         self.actor.send(ExecuteViewFunctionMessage { call }).await?
     }
 

--- a/crates/rooch-framework/sources/transaction_validator.move
+++ b/crates/rooch-framework/sources/transaction_validator.move
@@ -93,7 +93,7 @@ module rooch_framework::transaction_validator {
         if (!account::exists_at(ctx, sender)) {
             account::create_account(ctx, sender);
         };
-        // the transaction validator will put the multi chain address into the context
+        //the transaction validator will put the multi chain address into the context
         let multichain_address = storage_context::get<MultiChainAddress>(ctx);
         if (option::is_some(&multichain_address)) {
             let multichain_address = option::extract(&mut multichain_address);

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -48,13 +48,10 @@
         }
       ],
       "result": {
-        "name": "Vec<AnnotatedFunctionReturnValueView>",
+        "name": "AnnotatedFunctionResultView",
         "required": true,
         "schema": {
-          "type": "array",
-          "items": {
-            "$ref": "#/components/schemas/AnnotatedFunctionReturnValueView"
-          }
+          "$ref": "#/components/schemas/AnnotatedFunctionResultView"
         }
       }
     },
@@ -420,6 +417,26 @@
                 "type": "null"
               }
             ]
+          }
+        }
+      },
+      "AnnotatedFunctionResultView": {
+        "type": "object",
+        "required": [
+          "vm_status"
+        ],
+        "properties": {
+          "return_values": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AnnotatedFunctionReturnValueView"
+            }
+          },
+          "vm_status": {
+            "$ref": "#/components/schemas/VMStatusView"
           }
         }
       },
@@ -1432,6 +1449,88 @@
             "$ref": "#/components/schemas/TransactionTypeView"
           }
         }
+      },
+      "VMStatusView": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "Executed"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "MoveAbort"
+            ],
+            "properties": {
+              "MoveAbort": {
+                "type": "object",
+                "required": [
+                  "abort_code",
+                  "location"
+                ],
+                "properties": {
+                  "abort_code": {
+                    "$ref": "#/components/schemas/u64"
+                  },
+                  "location": {
+                    "$ref": "#/components/schemas/move_core_types::vm_status::AbortLocation"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "ExecutionFailure"
+            ],
+            "properties": {
+              "ExecutionFailure": {
+                "type": "object",
+                "required": [
+                  "code_offset",
+                  "function",
+                  "location",
+                  "status_code"
+                ],
+                "properties": {
+                  "code_offset": {
+                    "type": "integer",
+                    "format": "uint16",
+                    "minimum": 0.0
+                  },
+                  "function": {
+                    "type": "integer",
+                    "format": "uint16",
+                    "minimum": 0.0
+                  },
+                  "location": {
+                    "$ref": "#/components/schemas/move_core_types::vm_status::AbortLocation"
+                  },
+                  "status_code": {
+                    "$ref": "#/components/schemas/u64"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Error"
+            ],
+            "properties": {
+              "Error": {
+                "$ref": "#/components/schemas/u64"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "alloc::vec::Vec<u8>": {
         "type": "string"

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::{
-    AccessPathView, AnnotatedEventView, AnnotatedFunctionReturnValueView, AnnotatedStateView,
+    AccessPathView, AnnotatedEventView, AnnotatedFunctionResultView, AnnotatedStateView,
     EventFilterView, EventPageView, ExecuteTransactionResponseView, FunctionCallView, H256View,
     ListAnnotatedStatesPageView, ListStatesPageView, StateView, StrView, StructTagView,
     TransactionExecutionInfoView, TransactionInfoPageView, TransactionView,
@@ -33,7 +33,7 @@ pub trait RoochAPI {
     async fn execute_view_function(
         &self,
         function_call: FunctionCallView,
-    ) -> RpcResult<Vec<AnnotatedFunctionReturnValueView>>;
+    ) -> RpcResult<AnnotatedFunctionResultView>;
 
     /// Get the states by access_path
     #[method(name = "getStates")]

--- a/crates/rooch-rpc-api/src/jsonrpc_types/function_return_value_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/function_return_value_view.rs
@@ -1,13 +1,119 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use super::AbortLocationView;
 use crate::jsonrpc_types::{
     move_types::{AnnotatedMoveValueView, TypeTagView},
     StrView,
 };
-use moveos_types::function_return_value::{AnnotatedFunctionReturnValue, FunctionReturnValue};
+use move_core_types::vm_status::{StatusCode, VMStatus};
+use moveos_types::function_return_value::{
+    AnnotatedFunctionResult, AnnotatedFunctionReturnValue, FunctionResult, FunctionReturnValue,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub enum VMStatusView {
+    Executed,
+    MoveAbort {
+        location: AbortLocationView,
+        abort_code: StrView<u64>,
+    },
+    ExecutionFailure {
+        location: AbortLocationView,
+        function: u16,
+        code_offset: u16,
+        status_code: StrView<u64>,
+    },
+    Error(StrView<u64>),
+}
+
+impl From<VMStatus> for VMStatusView {
+    fn from(vm_status: VMStatus) -> Self {
+        match vm_status {
+            VMStatus::Executed => Self::Executed,
+            VMStatus::MoveAbort(location, abort_code) => Self::MoveAbort {
+                location: location.into(),
+                abort_code: StrView(abort_code),
+            },
+            VMStatus::ExecutionFailure {
+                location,
+                function,
+                code_offset,
+                status_code,
+            } => Self::ExecutionFailure {
+                location: location.into(),
+                function,
+                code_offset,
+                status_code: StrView(status_code as u64),
+            },
+            VMStatus::Error(status_code) => Self::Error(StrView(status_code as u64)),
+        }
+    }
+}
+
+impl TryFrom<VMStatusView> for VMStatus {
+    type Error = anyhow::Error;
+
+    fn try_from(value: VMStatusView) -> Result<Self, anyhow::Error> {
+        match value {
+            VMStatusView::Executed => Ok(VMStatus::Executed),
+            VMStatusView::MoveAbort {
+                location,
+                abort_code,
+            } => Ok(VMStatus::MoveAbort(location.0, abort_code.0)),
+            VMStatusView::ExecutionFailure {
+                location,
+                function,
+                code_offset,
+                status_code,
+            } => Ok(VMStatus::ExecutionFailure {
+                location: location.0,
+                function,
+                code_offset,
+                status_code: StatusCode::try_from(status_code.0)
+                    .map_err(|e| anyhow::anyhow!("StatusCode convert error:{}", e))?,
+            }),
+            VMStatusView::Error(status_code) => Ok(VMStatus::Error(
+                StatusCode::try_from(status_code.0)
+                    .map_err(|e| anyhow::anyhow!("StatusCode convert error:{}", e))?,
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AnnotatedFunctionResultView {
+    pub vm_status: VMStatusView,
+    pub return_values: Option<Vec<AnnotatedFunctionReturnValueView>>,
+}
+
+impl From<AnnotatedFunctionResult> for AnnotatedFunctionResultView {
+    fn from(value: AnnotatedFunctionResult) -> Self {
+        Self {
+            vm_status: value.vm_status.into(),
+            return_values: value
+                .return_values
+                .map(|v| v.into_iter().map(|v| v.into()).collect()),
+        }
+    }
+}
+
+impl TryFrom<AnnotatedFunctionResultView> for FunctionResult {
+    type Error = anyhow::Error;
+
+    fn try_from(value: AnnotatedFunctionResultView) -> Result<Self, Self::Error> {
+        Ok(Self {
+            vm_status: value.vm_status.try_into()?,
+            return_values: value.return_values.map(|v| {
+                v.into_iter()
+                    .map(|v| v.value.into())
+                    .collect::<Vec<FunctionReturnValue>>()
+            }),
+        })
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FunctionReturnValueView {

--- a/crates/rooch-rpc-client/src/lib.rs
+++ b/crates/rooch-rpc-client/src/lib.rs
@@ -5,18 +5,17 @@ use anyhow::Result;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use moveos_types::{
     access_path::AccessPath,
-    function_return_value::FunctionReturnValue,
+    function_return_value::FunctionResult,
     module_binding::MoveFunctionCaller,
     state::{MoveStructType, State},
     transaction::FunctionCall,
     tx_context::TxContext,
 };
-use rooch_rpc_api::jsonrpc_types::{EventPageView, StructTagView};
+use rooch_rpc_api::jsonrpc_types::{AnnotatedFunctionResultView, EventPageView, StructTagView};
 use rooch_rpc_api::{
     api::rooch_api::RoochAPIClient,
     jsonrpc_types::{
-        AnnotatedFunctionReturnValueView, AnnotatedStateView, ExecuteTransactionResponseView,
-        StateView, TransactionView,
+        AnnotatedStateView, ExecuteTransactionResponseView, StateView, TransactionView,
     },
 };
 use rooch_types::{
@@ -105,7 +104,7 @@ impl Client {
     pub async fn execute_view_function(
         &self,
         function_call: FunctionCall,
-    ) -> Result<Vec<AnnotatedFunctionReturnValueView>> {
+    ) -> Result<AnnotatedFunctionResultView> {
         self.rpc
             .http
             .execute_view_function(function_call.into())
@@ -175,11 +174,9 @@ impl MoveFunctionCaller for Client {
         &self,
         _ctx: &TxContext,
         function_call: FunctionCall,
-    ) -> Result<Vec<FunctionReturnValue>> {
-        futures::executor::block_on(self.execute_view_function(function_call)).map(|v| {
-            v.into_iter()
-                .map(|v| FunctionReturnValue::from(v.value))
-                .collect()
-        })
+    ) -> Result<FunctionResult> {
+        let function_result =
+            futures::executor::block_on(self.execute_view_function(function_call))?;
+        function_result.try_into()
     }
 }

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -7,14 +7,17 @@ use jsonrpsee::{
     RpcModule,
 };
 use moveos_types::h256::H256;
-use rooch_rpc_api::api::{RoochRpcModule, MAX_RESULT_LIMIT_USIZE};
 use rooch_rpc_api::jsonrpc_types::{
-    AccessPathView, AnnotatedEventView, AnnotatedFunctionReturnValueView, AnnotatedStateView,
-    EventFilterView, EventPageView, ExecuteTransactionResponseView, FunctionCallView, H256View,
-    ListAnnotatedStatesPageView, ListStatesPageView, StateView, StrView, StructTagView,
-    TransactionExecutionInfoView, TransactionInfoPageView, TransactionView,
+    AccessPathView, AnnotatedEventView, AnnotatedStateView, EventFilterView, EventPageView,
+    ExecuteTransactionResponseView, FunctionCallView, H256View, ListAnnotatedStatesPageView,
+    ListStatesPageView, StateView, StrView, StructTagView, TransactionExecutionInfoView,
+    TransactionInfoPageView, TransactionView,
 };
 use rooch_rpc_api::{api::rooch_api::RoochAPIServer, api::MAX_RESULT_LIMIT};
+use rooch_rpc_api::{
+    api::{RoochRpcModule, MAX_RESULT_LIMIT_USIZE},
+    jsonrpc_types::AnnotatedFunctionResultView,
+};
 use rooch_types::transaction::rooch::RoochTransaction;
 use rooch_types::transaction::{AbstractTransaction, TypedTransaction};
 use std::cmp::min;
@@ -55,14 +58,12 @@ impl RoochAPIServer for RoochServer {
     async fn execute_view_function(
         &self,
         function_call: FunctionCallView,
-    ) -> RpcResult<Vec<AnnotatedFunctionReturnValueView>> {
+    ) -> RpcResult<AnnotatedFunctionResultView> {
         Ok(self
             .rpc_service
             .execute_view_function(function_call.into())
             .await?
-            .into_iter()
-            .map(AnnotatedFunctionReturnValueView::from)
-            .collect())
+            .into())
     }
 
     async fn get_states(&self, access_path: AccessPathView) -> RpcResult<Vec<Option<StateView>>> {

--- a/crates/rooch-rpc-server/src/service/mod.rs
+++ b/crates/rooch-rpc-server/src/service/mod.rs
@@ -7,7 +7,7 @@ use move_core_types::language_storage::StructTag;
 use moveos_types::access_path::AccessPath;
 use moveos_types::event::AnnotatedMoveOSEvent;
 use moveos_types::event_filter::EventFilter;
-use moveos_types::function_return_value::AnnotatedFunctionReturnValue;
+use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::state::{AnnotatedState, State};
 use moveos_types::transaction::{FunctionCall, TransactionExecutionInfo};
 use rooch_executor::proxy::ExecutorProxy;
@@ -69,7 +69,7 @@ impl RpcService {
     pub async fn execute_view_function(
         &self,
         function_call: FunctionCall,
-    ) -> Result<Vec<AnnotatedFunctionReturnValue>> {
+    ) -> Result<AnnotatedFunctionResult> {
         let resp = self.executor.execute_view_function(function_call).await?;
         Ok(resp)
     }

--- a/crates/rooch-types/Cargo.toml
+++ b/crates/rooch-types/Cargo.toml
@@ -42,6 +42,7 @@ clap = { workspace = true }
 move-core-types = { workspace = true }
 move-stdlib = { workspace = true }
 move-command-line-common = { workspace = true }
+move-binary-format = { workspace = true }
 
 moveos-types = { workspace = true }
 moveos-stdlib = { workspace = true }

--- a/crates/rooch-types/src/framework/account_authentication.rs
+++ b/crates/rooch-types/src/framework/account_authentication.rs
@@ -74,12 +74,17 @@ impl<'a> AuthenticationKeyModule<'a> {
                 .expect("address should serialize")],
         );
         let ctx = TxContext::new_readonly_ctx(address);
-        self.caller.call_function(&ctx, call).map(|values| {
-            let value = values.get(0).expect("Expected return value");
-            let result =
-                MoveOption::<Vec<u8>>::from_bytes(&value.value).expect("Expected Option<address>");
-            result.into()
-        })
+        let auth_key = self
+            .caller
+            .call_function(&ctx, call)?
+            .into_result()
+            .map(|values| {
+                let value = values.get(0).expect("Expected return value");
+                let result = MoveOption::<Vec<u8>>::from_bytes(&value.value)
+                    .expect("Expected Option<address>");
+                result.into()
+            })?;
+        Ok(auth_key)
     }
 }
 

--- a/crates/rooch-types/src/framework/auth_validator.rs
+++ b/crates/rooch-types/src/framework/auth_validator.rs
@@ -128,7 +128,8 @@ impl<'a> AuthValidatorCaller<'a> {
             vec![MoveValue::vector_u8(payload).simple_serialize().unwrap()],
         );
         self.caller
-            .call_function(ctx, auth_validator_call)
+            .call_function(ctx, auth_validator_call)?
+            .into_result()
             .map(|values| {
                 debug_assert!(values.is_empty(), "should not have return values");
             })?;

--- a/crates/rooch-types/src/framework/bitcoin_validator.rs
+++ b/crates/rooch-types/src/framework/bitcoin_validator.rs
@@ -46,7 +46,8 @@ impl<'a> BitcoinValidatorModule<'a> {
             vec![MoveValue::vector_u8(payload).simple_serialize().unwrap()],
         );
         self.caller
-            .call_function(ctx, auth_validator_call)
+            .call_function(ctx, auth_validator_call)?
+            .into_result()
             .map(|values| {
                 debug_assert!(values.is_empty(), "should not have return values");
             })?;

--- a/crates/rooch-types/src/framework/empty.rs
+++ b/crates/rooch-types/src/framework/empty.rs
@@ -23,9 +23,12 @@ impl<'a> Empty<'a> {
         let empty_call =
             FunctionCall::new(Self::function_id(Self::EMPTY_FUNCTION_NAME), vec![], vec![]);
 
-        self.caller.call_function(ctx, empty_call).map(|values| {
-            debug_assert!(values.is_empty(), "should not have return values");
-        })?;
+        self.caller
+            .call_function(ctx, empty_call)?
+            .into_result()
+            .map(|values| {
+                debug_assert!(values.is_empty(), "should not have return values");
+            })?;
         Ok(())
     }
 

--- a/crates/rooch-types/src/framework/ethereum_validator.rs
+++ b/crates/rooch-types/src/framework/ethereum_validator.rs
@@ -46,7 +46,8 @@ impl<'a> EthereumValidatorModule<'a> {
             vec![MoveValue::vector_u8(payload).simple_serialize().unwrap()],
         );
         self.caller
-            .call_function(ctx, auth_validator_call)
+            .call_function(ctx, auth_validator_call)?
+            .into_result()
             .map(|values| {
                 debug_assert!(values.is_empty(), "should not have return values");
             })?;

--- a/crates/rooch-types/src/framework/native_validator.rs
+++ b/crates/rooch-types/src/framework/native_validator.rs
@@ -46,7 +46,8 @@ impl<'a> NativeValidatorModule<'a> {
             vec![MoveValue::vector_u8(payload).simple_serialize().unwrap()],
         );
         self.caller
-            .call_function(ctx, auth_validator_call)
+            .call_function(ctx, auth_validator_call)?
+            .into_result()
             .map(|values| {
                 debug_assert!(values.is_empty(), "should not have return values");
             })?;

--- a/crates/rooch-types/src/framework/nostr_validator.rs
+++ b/crates/rooch-types/src/framework/nostr_validator.rs
@@ -46,7 +46,8 @@ impl<'a> NostrValidatorModule<'a> {
             vec![MoveValue::vector_u8(payload).simple_serialize().unwrap()],
         );
         self.caller
-            .call_function(ctx, auth_validator_call)
+            .call_function(ctx, auth_validator_call)?
+            .into_result()
             .map(|values| {
                 debug_assert!(values.is_empty(), "should not have return values");
             })?;

--- a/crates/rooch-types/src/framework/session_key.rs
+++ b/crates/rooch-types/src/framework/session_key.rs
@@ -150,12 +150,16 @@ impl<'a> SessionKeyModule<'a> {
             ],
         );
         let ctx = TxContext::new_readonly_ctx(account_address);
-        let session_key = self.caller.call_function(&ctx, call).map(|mut values| {
-            let value = values.pop().expect("should have one return value");
-            bcs::from_bytes::<MoveOption<SessionKey>>(&value.value)
-                .expect("should be a valid MoveOption<SessionKey>")
-                .into()
-        })?;
+        let session_key =
+            self.caller
+                .call_function(&ctx, call)?
+                .into_result()
+                .map(|mut values| {
+                    let value = values.pop().expect("should have one return value");
+                    bcs::from_bytes::<MoveOption<SessionKey>>(&value.value)
+                        .expect("should be a valid MoveOption<SessionKey>")
+                        .into()
+                })?;
         Ok(session_key)
     }
 

--- a/crates/rooch-types/src/framework/transaction_validator.rs
+++ b/crates/rooch-types/src/framework/transaction_validator.rs
@@ -41,14 +41,15 @@ impl<'a> TransactionValidator<'a> {
                     .unwrap(),
             ],
         );
-        let auth_validator =
-            self.caller
-                .call_function(ctx, tx_validator_call)
-                .map(|mut values| {
-                    let value = values.pop().expect("should have one return value");
-                    bcs::from_bytes::<TxValidateResult>(&value.value)
-                        .expect("should be a valid TxValidateResult")
-                })?;
+        let auth_validator = self
+            .caller
+            .call_function(ctx, tx_validator_call)?
+            .into_result()
+            .map(|mut values| {
+                let value = values.pop().expect("should have one return value");
+                bcs::from_bytes::<TxValidateResult>(&value.value)
+                    .expect("should be a valid TxValidateResult")
+            })?;
         Ok(auth_validator)
     }
 

--- a/crates/rooch/src/commands/move_cli/commands/run_view_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_view_function.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use move_core_types::value::MoveValue;
 use moveos_types::{move_types::FunctionId, transaction::FunctionCall};
 use rooch_rpc_api::jsonrpc_types::{
-    AnnotatedFunctionReturnValueView, TransactionArgumentView, TypeTagView,
+    AnnotatedFunctionResultView, TransactionArgumentView, TypeTagView,
 };
 use rooch_types::error::{RoochError, RoochResult};
 
@@ -49,8 +49,8 @@ pub struct RunViewFunction {
 }
 
 #[async_trait]
-impl CommandAction<Vec<AnnotatedFunctionReturnValueView>> for RunViewFunction {
-    async fn execute(self) -> RoochResult<Vec<AnnotatedFunctionReturnValueView>> {
+impl CommandAction<AnnotatedFunctionResultView> for RunViewFunction {
+    async fn execute(self) -> RoochResult<AnnotatedFunctionResultView> {
         let args = self
             .args
             .iter()

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -83,10 +83,10 @@ Feature: Rooch CLI integration tests
       # The counter example
       Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default} --by-move"
       Then cmd: "move view --function {default}::counter::value"
-      Then assert: "{{$.move[-1][0].move_value}} == 0"
+      Then assert: "{{$.move[-1].return_values[0].move_value}} == 0"
       Then cmd: "move run --function {default}::counter::increase --sender-account {default}"
       Then cmd: "move view --function {default}::counter::value"
-      Then assert: "{{$.move[-1][0].move_value}} == 1"
+      Then assert: "{{$.move[-1].return_values[0].move_value}} == 1"
       Then cmd: "resource --address {default} --resource {default}::counter::Counter"
       Then assert: "{{$.resource[-1].move_value.value.value}} == 1"
 

--- a/moveos/moveos-types/Cargo.toml
+++ b/moveos/moveos-types/Cargo.toml
@@ -20,7 +20,6 @@ hex = { workspace = true }
 once_cell = { workspace = true }
 thiserror = { workspace = true }
 rand = { workspace = true }
-
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
@@ -28,16 +27,18 @@ serde_with = { workspace = true }
 schemars = { workspace = true }
 primitive-types = { workspace = true }
 tiny-keccak = { workspace = true, features = ["keccak", "sha3"] }
+fastcrypto = { workspace = true }
+proptest = { default-features = false, optional = true, workspace = true }
+proptest-derive = { default-features = false, optional = true, workspace = true }
 
 move-core-types = { workspace = true }
 move-resource-viewer = { workspace = true }
 move-bytecode-utils = { workspace = true }
-fastcrypto = { workspace = true }
+move-binary-format = { workspace = true }
 
 smt = { workspace = true }
 
-proptest = { default-features = false, optional = true, workspace = true }
-proptest-derive = { default-features = false, optional = true, workspace = true }
+
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/moveos/moveos-types/src/function_return_value.rs
+++ b/moveos/moveos-types/src/function_return_value.rs
@@ -1,9 +1,64 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::language_storage::TypeTag;
+use move_binary_format::errors::{VMError, VMResult};
+use move_core_types::{language_storage::TypeTag, vm_status::VMStatus};
 use move_resource_viewer::AnnotatedMoveValue;
 use serde::{Deserialize, Serialize};
+
+/// The result of a readonly function call in MoveOS
+/// If the vm_status is not Executed, the return_values will be None
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionResult {
+    pub vm_status: VMStatus,
+    pub return_values: Option<Vec<FunctionReturnValue>>,
+}
+
+impl FunctionResult {
+    pub fn ok(return_values: Vec<FunctionReturnValue>) -> Self {
+        Self {
+            vm_status: VMStatus::Executed,
+            return_values: Some(return_values),
+        }
+    }
+
+    pub fn err(vm_error: VMError) -> Self {
+        Self {
+            vm_status: vm_error.into_vm_status(),
+            return_values: None,
+        }
+    }
+
+    pub fn into_result(self) -> Result<Vec<FunctionReturnValue>, anyhow::Error> {
+        match self.vm_status {
+            VMStatus::Executed => Ok(self
+                .return_values
+                .expect("return_values must be Some, if vm_status is Executed")),
+            _ => Err(anyhow::anyhow!(
+                "Function call failed with VMStatus: {:?}",
+                self.vm_status
+            )),
+        }
+    }
+}
+
+impl From<VMResult<Vec<FunctionReturnValue>>> for FunctionResult {
+    fn from(result: VMResult<Vec<FunctionReturnValue>>) -> Self {
+        match result {
+            Ok(return_values) => Self::ok(return_values),
+            Err(vm_error) => Self {
+                vm_status: vm_error.into_vm_status(),
+                return_values: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AnnotatedFunctionResult {
+    pub vm_status: VMStatus,
+    pub return_values: Option<Vec<AnnotatedFunctionReturnValue>>,
+}
 
 /// The function return value in MoveOS
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/moveos/moveos-types/src/module_binding.rs
+++ b/moveos/moveos-types/src/module_binding.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    function_return_value::FunctionReturnValue,
+    function_return_value::FunctionResult,
     move_types::FunctionId,
     transaction::{FunctionCall, MoveAction},
     tx_context::TxContext,
@@ -16,11 +16,7 @@ use move_core_types::{
 };
 
 pub trait MoveFunctionCaller {
-    fn call_function(
-        &self,
-        ctx: &TxContext,
-        call: FunctionCall,
-    ) -> Result<Vec<FunctionReturnValue>>;
+    fn call_function(&self, ctx: &TxContext, call: FunctionCall) -> Result<FunctionResult>;
 
     fn as_module_binding<'a, M: ModuleBinding<'a>>(&'a self) -> M
     where
@@ -34,11 +30,7 @@ impl<C> MoveFunctionCaller for &C
 where
     C: MoveFunctionCaller,
 {
-    fn call_function(
-        &self,
-        ctx: &TxContext,
-        call: FunctionCall,
-    ) -> Result<Vec<FunctionReturnValue>> {
+    fn call_function(&self, ctx: &TxContext, call: FunctionCall) -> Result<FunctionResult> {
         (*self).call_function(ctx, call)
     }
 }

--- a/moveos/moveos/src/vm/moveos_vm.rs
+++ b/moveos/moveos/src/vm/moveos_vm.rs
@@ -5,10 +5,9 @@ use super::{
     data_cache::{into_change_set, MoveosDataCache},
     tx_argument_resolver::TxArgumentResolver,
 };
-use anyhow::ensure;
 use move_binary_format::{
     compatibility::Compatibility,
-    errors::{Location, VMError, VMResult},
+    errors::{Location, PartialVMError, VMError, VMResult},
     file_format::AbilitySet,
     CompiledModule,
 };
@@ -18,7 +17,7 @@ use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
     value::MoveTypeLayout,
-    vm_status::{KeptVMStatus, VMStatus},
+    vm_status::{KeptVMStatus, StatusCode, VMStatus},
 };
 use move_vm_runtime::{
     config::VMConfig,
@@ -431,7 +430,7 @@ where
     pub fn finish_with_extensions(
         self,
         vm_status: VMStatus,
-    ) -> Result<(TxContext, TransactionOutput), anyhow::Error> {
+    ) -> VMResult<(TxContext, TransactionOutput)> {
         let (finalized_session, status) = match vm_status.keep_or_discard() {
             Ok(status) => self.post_execute(status),
             Err(discard_status) => {
@@ -459,22 +458,29 @@ where
             into_change_set(table_data).map_err(|e| e.finish(Location::Undefined))?;
 
         if read_only {
-            ensure!(
-                changeset.accounts().is_empty(),
-                "ChangeSet should be empty as never used."
-            );
-            ensure!(
-                raw_events.is_empty(),
-                "Events should be empty when execute readonly function"
-            );
-            ensure!(
-                state_changeset.changes.is_empty(),
-                "Table change set should be empty when execute readonly function"
-            );
-            ensure!(
-                ctx.tx_context.ids_created == 0,
-                "ids_created should be zero when execute readonly function"
-            );
+            if !changeset.accounts().is_empty() {
+                return Err(PartialVMError::new(StatusCode::UNKNOWN_VALIDATION_STATUS)
+                    .with_message("ChangeSet should be empty as never used.".to_owned())
+                    .finish(Location::Undefined));
+            }
+
+            if !raw_events.is_empty() {
+                return Err(PartialVMError::new(StatusCode::UNKNOWN_VALIDATION_STATUS)
+                    .with_message("Events should be empty as never used.".to_owned())
+                    .finish(Location::Undefined));
+            }
+
+            if !state_changeset.changes.is_empty() {
+                return Err(PartialVMError::new(StatusCode::UNKNOWN_VALIDATION_STATUS)
+                    .with_message("Table change set should be empty as never used.".to_owned())
+                    .finish(Location::Undefined));
+            }
+
+            if ctx.tx_context.ids_created > 0 {
+                return Err(PartialVMError::new(StatusCode::UNKNOWN_VALIDATION_STATUS)
+                    .with_message("TxContext::ids_created should be zero as never used.".to_owned())
+                    .finish(Location::Undefined));
+            }
         }
 
         let events = raw_events
@@ -505,11 +511,18 @@ where
         // this ensure via the check in new_session
         let mut pre_execute_session = self;
         for function_call in pre_execute_session.pre_execute_functions.clone() {
-            //TODO handle pre_execute function error
-            //Because if we allow user to write pre_execute function, we need to handle the error
-            pre_execute_session
-                .execute_function_bypass_visibility(function_call)
-                .expect("pre_execute function should always success");
+            let pre_execute_function_id = function_call.function_id.clone();
+            let result = pre_execute_session.execute_function_bypass_visibility(function_call);
+            if let Err(e) = result {
+                //TODO handle pre_execute function error
+                //Because if we allow user to write pre_execute function, we need to handle the error
+                log::error!(
+                    "pre_execute function {} error: {:?}",
+                    pre_execute_function_id,
+                    e
+                );
+                panic!("pre_execute function should success")
+            }
         }
         pre_execute_session
     }

--- a/sdk/typescript/src/client/rooch-client.ts
+++ b/sdk/typescript/src/client/rooch-client.ts
@@ -5,7 +5,7 @@ import { HTTPTransport, RequestManager } from '@open-rpc/client-js'
 import { JsonRpcClient } from '../generated/client'
 import {
   // AnnotatedEventView,
-  AnnotatedFunctionReturnValueView,
+  AnnotatedFunctionResultView,
   // AnnotatedStateView,
   // EventFilterView,
   // FunctionCallView,
@@ -50,7 +50,7 @@ export class RoochClient {
     funcId: FunctionId,
     args?: Uint8Array[],
     tyArgs?: string[],
-  ): Promise<AnnotatedFunctionReturnValueView[]> {
+  ): Promise<AnnotatedFunctionResultView> {
     // let _args = args.map((v) => {
     //   let se = new BcsSerializer()
     //   typeTagToSCS(v).serialize(se)


### PR DESCRIPTION
Prepare for #644 


1. Define `FunctionResult`, and return the `VMStatus` and `Vec<FunctionReturnValue>` to the caller.
2. The RPC `execute_view_function` response changed from `Vec<AnnotatedFunctionReturnValue>` to `AnnotatedFunctionResultView`. This change will break the RPC, and some documents need to be updated. @geometryolife 

```bash
rooch move view --function 0x2763f0616014847fc57b78fe267d0999f4277770ddf521507005059839ac0946::counter::value
```
```json
{
  "vm_status": "Executed",
  "return_values": [
    {
      "value": {
        "type_tag": "u64",
        "value": "0x0000000000000000"
      },
      "move_value": "0"
    }
  ]
}
```

Now, the caller can handle the function abort code.