### PR TITLE
[MoveOS & Executor] Refactor validator to let caller got VMStatus

### DIFF
--- a/crates/rooch-executor/Cargo.toml
+++ b/crates/rooch-executor/Cargo.toml
@@ -31,6 +31,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 schemars = { workspace = true }
 serde_with = { workspace = true }
+log = { workspace = true }
 
 move-core-types = { workspace = true }
 move-resource-viewer = { workspace = true }

--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -11,13 +11,14 @@ use crate::actor::messages::{
     ListAnnotatedStatesMessage, ListStatesMessage,
 };
 use accumulator::inmemory::InMemoryAccumulator;
-use anyhow::bail;
 use anyhow::Result;
 use async_trait::async_trait;
 use coerce::actor::{context::ActorContext, message::Handler, Actor};
 use move_core_types::account_address::AccountAddress;
+use move_core_types::vm_status::VMStatus;
 use move_resource_viewer::MoveValueAnnotator;
 use moveos::moveos::MoveOS;
+use moveos::vm::vm_status_explainer::explain_vm_status;
 use moveos_store::transaction_store::TransactionStore;
 use moveos_store::MoveOSStore;
 use moveos_types::event::AnnotatedMoveOSEvent;
@@ -46,6 +47,9 @@ pub struct ExecutorActor {
     moveos: MoveOS,
     rooch_store: RoochStore,
 }
+
+type ValidateAuthenticatorResult =
+    Result<(TxValidateResult, Vec<FunctionCall>, Vec<FunctionCall>), VMStatus>;
 
 impl ExecutorActor {
     pub fn new(moveos_store: MoveOSStore, rooch_store: RoochStore) -> Result<Self> {
@@ -76,14 +80,14 @@ impl ExecutorActor {
     pub fn validate<T: AbstractTransaction>(&self, tx: T) -> Result<VerifiedMoveOSTransaction> {
         let multi_chain_address_sender = tx.sender();
 
-        let resolved_sender = self.resolve_or_generate(multi_chain_address_sender.clone());
+        let resolved_sender = self.resolve_or_generate(multi_chain_address_sender.clone())?;
         let authenticator = tx.authenticator_info();
 
-        let mut moveos_tx = tx.construct_moveos_transaction(resolved_sender?)?;
+        let mut moveos_tx = tx.construct_moveos_transaction(resolved_sender)?;
 
-        let result = self.validate_authenticator(&moveos_tx.ctx, authenticator);
+        let vm_result = self.validate_authenticator(&moveos_tx.ctx, authenticator)?;
 
-        match result {
+        match vm_result {
             Ok((tx_validate_result, pre_execute_functions, post_execute_functions)) => {
                 // Add the original multichain address to the context
                 moveos_tx
@@ -101,12 +105,14 @@ impl ExecutorActor {
                 Ok(self.moveos.verify(moveos_tx)?)
             }
             Err(e) => {
-                //TODO handle the abort error code
-                //let status = explain_vm_status(self.db.get_state_store(), e.into_vm_status())?;
-                println!("validate failed: {:?}", e);
-                // If the error code is EUnsupportedScheme, then we can try to call the sender's validate function
-                // This is the Account Abstraction.
-                bail!("validate failed: {:?}", e)
+                let status_view = explain_vm_status(self.moveos.moveos_resolver(), e.clone())?;
+                log::warn!(
+                    "transaction validate vm error, tx_hash: {}, error:{:?}",
+                    moveos_tx.ctx.tx_hash(),
+                    status_view,
+                );
+                //TODO how to return the vm status to rpc client.
+                Err(e.into())
             }
         }
     }
@@ -115,41 +121,58 @@ impl ExecutorActor {
         &self,
         ctx: &TxContext,
         authenticator: AuthenticatorInfo,
-    ) -> Result<(TxValidateResult, Vec<FunctionCall>, Vec<FunctionCall>)> {
+    ) -> Result<ValidateAuthenticatorResult> {
         let tx_validator = self.moveos.as_module_binding::<TransactionValidator>();
-        let tx_validate_result = tx_validator.validate(ctx, authenticator.clone())?;
-        let auth_validator_option = tx_validate_result.auth_validator();
-        match auth_validator_option {
-            Some(auth_validator) => {
-                let auth_validator_caller = AuthValidatorCaller::new(&self.moveos, auth_validator);
-                auth_validator_caller.validate(ctx, authenticator.authenticator.payload)?;
-                // pre_execute_function: TransactionValidator first, then AuthValidator
-                let pre_execute_functions = vec![
-                    TransactionValidator::pre_execute_function_call(),
-                    auth_validator_caller.pre_execute_function_call(),
-                ];
-                // post_execute_function: AuthValidator first, then TransactionValidator
-                let post_execute_functions = vec![
-                    auth_validator_caller.post_execute_function_call(),
-                    TransactionValidator::post_execute_function_call(),
-                ];
-                Ok((
-                    tx_validate_result,
-                    pre_execute_functions,
-                    post_execute_functions,
-                ))
+        let tx_validate_function_result = tx_validator
+            .validate(ctx, authenticator.clone())?
+            .into_result();
+        let vm_result = match tx_validate_function_result {
+            Ok(tx_validate_result) => {
+                let auth_validator_option = tx_validate_result.auth_validator();
+                match auth_validator_option {
+                    Some(auth_validator) => {
+                        let auth_validator_caller =
+                            AuthValidatorCaller::new(&self.moveos, auth_validator);
+                        let auth_validator_function_result = auth_validator_caller
+                            .validate(ctx, authenticator.authenticator.payload)?
+                            .into_result();
+                        match auth_validator_function_result {
+                            Ok(_) => {
+                                // pre_execute_function: TransactionValidator first, then AuthValidator
+                                let pre_execute_functions = vec![
+                                    TransactionValidator::pre_execute_function_call(),
+                                    auth_validator_caller.pre_execute_function_call(),
+                                ];
+                                // post_execute_function: AuthValidator first, then TransactionValidator
+                                let post_execute_functions = vec![
+                                    auth_validator_caller.post_execute_function_call(),
+                                    TransactionValidator::post_execute_function_call(),
+                                ];
+                                Ok((
+                                    tx_validate_result,
+                                    pre_execute_functions,
+                                    post_execute_functions,
+                                ))
+                            }
+                            Err(vm_status) => Err(vm_status),
+                        }
+                    }
+                    None => {
+                        let pre_execute_functions =
+                            vec![TransactionValidator::pre_execute_function_call()];
+                        let post_execute_functions =
+                            vec![TransactionValidator::post_execute_function_call()];
+                        Ok((
+                            tx_validate_result,
+                            pre_execute_functions,
+                            post_execute_functions,
+                        ))
+                    }
+                }
             }
-            None => {
-                let pre_execute_functions = vec![TransactionValidator::pre_execute_function_call()];
-                let post_execute_functions =
-                    vec![TransactionValidator::post_execute_function_call()];
-                Ok((
-                    tx_validate_result,
-                    pre_execute_functions,
-                    post_execute_functions,
-                ))
-            }
-        }
+            Err(vm_status) => Err(vm_status),
+        };
+        Ok(vm_result)
     }
 
     pub fn get_rooch_store(&self) -> RoochStore {

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -36,6 +36,7 @@ pub struct ExecuteTransactionMessage {
     pub tx: VerifiedMoveOSTransaction,
 }
 
+#[derive(Debug)]
 pub struct ExecuteTransactionResult {
     pub output: TransactionOutput,
     pub transaction_info: TransactionExecutionInfo,

--- a/crates/rooch-types/src/framework/auth_validator.rs
+++ b/crates/rooch-types/src/framework/auth_validator.rs
@@ -3,11 +3,12 @@
 
 use super::transaction_validator::TransactionValidator;
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use move_core_types::value::MoveValue;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::ModuleId,
 };
+use moveos_types::function_return_value::DecodedFunctionResult;
 use moveos_types::move_option::MoveOption;
 use moveos_types::{
     module_binding::MoveFunctionCaller,
@@ -121,7 +122,7 @@ impl<'a> AuthValidatorCaller<'a> {
         }
     }
 
-    pub fn validate(&self, ctx: &TxContext, payload: Vec<u8>) -> Result<()> {
+    pub fn validate(&self, ctx: &TxContext, payload: Vec<u8>) -> Result<DecodedFunctionResult<()>> {
         let auth_validator_call = FunctionCall::new(
             self.auth_validator.validator_function_id(),
             vec![],
@@ -129,11 +130,10 @@ impl<'a> AuthValidatorCaller<'a> {
         );
         self.caller
             .call_function(ctx, auth_validator_call)?
-            .into_result()
-            .map(|values| {
-                debug_assert!(values.is_empty(), "should not have return values");
-            })?;
-        Ok(())
+            .decode(|values| {
+                ensure!(values.is_empty(), "should not have return values");
+                Ok(())
+            })
     }
 
     pub fn pre_execute_function_id(&self) -> FunctionId {

--- a/crates/rooch-types/src/framework/transaction_validator.rs
+++ b/crates/rooch-types/src/framework/transaction_validator.rs
@@ -9,6 +9,7 @@ use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
 };
 use moveos_types::{
+    function_return_value::DecodedFunctionResult,
     module_binding::{ModuleBinding, MoveFunctionCaller},
     move_types::FunctionId,
     transaction::FunctionCall,
@@ -25,7 +26,11 @@ impl<'a> TransactionValidator<'a> {
     pub const PRE_EXECUTE_FUNCTION_NAME: &IdentStr = ident_str!("pre_execute");
     pub const POST_EXECUTE_FUNCTION_NAME: &IdentStr = ident_str!("post_execute");
 
-    pub fn validate(&self, ctx: &TxContext, auth: AuthenticatorInfo) -> Result<TxValidateResult> {
+    pub fn validate(
+        &self,
+        ctx: &TxContext,
+        auth: AuthenticatorInfo,
+    ) -> Result<DecodedFunctionResult<TxValidateResult>> {
         let tx_validator_call = FunctionCall::new(
             Self::function_id(Self::VALIDATE_FUNCTION_NAME),
             vec![],
@@ -41,15 +46,14 @@ impl<'a> TransactionValidator<'a> {
                     .unwrap(),
             ],
         );
-        let auth_validator = self
-            .caller
-            .call_function(ctx, tx_validator_call)?
-            .into_result()
-            .map(|mut values| {
-                let value = values.pop().expect("should have one return value");
-                bcs::from_bytes::<TxValidateResult>(&value.value)
-                    .expect("should be a valid TxValidateResult")
-            })?;
+        let auth_validator =
+            self.caller
+                .call_function(ctx, tx_validator_call)?
+                .decode(|mut values| {
+                    let value = values.pop().expect("should have one return value");
+                    let result = bcs::from_bytes::<TxValidateResult>(&value.value)?;
+                    Ok(result)
+                })?;
         Ok(auth_validator)
     }
 

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -3,7 +3,7 @@
 
 use crate::vm::moveos_vm::MoveOSVM;
 use anyhow::{bail, ensure, Result};
-use move_binary_format::errors::{vm_status_of_result, Location, PartialVMError};
+use move_binary_format::errors::{vm_status_of_result, Location, PartialVMError, VMResult};
 use move_core_types::vm_status::{KeptVMStatus, VMStatus};
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
@@ -124,7 +124,7 @@ impl MoveOS {
         self.db.0.get_transaction_store()
     }
 
-    pub fn verify(&self, tx: MoveOSTransaction) -> Result<VerifiedMoveOSTransaction> {
+    pub fn verify(&self, tx: MoveOSTransaction) -> VMResult<VerifiedMoveOSTransaction> {
         let MoveOSTransaction {
             ctx,
             action,


### PR DESCRIPTION
follow #646 

resolve #644 

1. Return VMStatus from VM execute_view_function to validate function. We need to define some embed Result struct, eg: `Result<Result<T>, VMStatus>`.
2. Improve the session key test, to check the move abort code.

cc @feliciss 