### PR TITLE
[RPC] Fix eth_chainId response

### DIFF
--- a/crates/rooch-rpc-server/src/server/eth_server.rs
+++ b/crates/rooch-rpc-server/src/server/eth_server.rs
@@ -52,7 +52,7 @@ impl EthAPIServer for EthServer {
     }
 
     async fn get_chain_id(&self) -> RpcResult<String> {
-        Ok(format!("0x{:X}", self.chain_id))
+        Ok(format!("0x{:x}", self.chain_id))
     }
 
     async fn get_block_number(&self) -> RpcResult<String> {
@@ -61,7 +61,7 @@ impl EthAPIServer for EthServer {
             .expect("Time went backwards");
 
         let block_number = now.as_secs();
-        Ok(format!("0x{:X}", block_number))
+        Ok(format!("0x{:x}", block_number))
     }
 
     async fn get_block_by_number(


### PR DESCRIPTION
## Summary

Change the `eth_chainId` API's `chainId` hex to lowercase.

- Closes #690 

cc @feliciss 