### PR TITLE
[gh-714] fix build directory.

### DIFF
--- a/crates/rooch-genesis/build.rs
+++ b/crates/rooch-genesis/build.rs
@@ -36,7 +36,7 @@ fn main() {
         println!(
             "cargo:rerun-if-changed={}",
             root_dir
-                .join("moveos/moveos-stdlib/os-stdlib")
+                .join("moveos/moveos-stdlib/moveos-stdlib")
                 .join("sources")
                 .display()
         );

--- a/docs/website/pages/docs/reference/rpc.en-US.mdx
+++ b/docs/website/pages/docs/reference/rpc.en-US.mdx
@@ -7,4 +7,4 @@
 
 ## Reference
 
-- [Rooch RPC spec](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/rooch-network/rooch/main/crates/rooch-open-rpc/spec/openrpc.json)
+- [Rooch RPC spec](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/rooch-network/rooch/main/crates/rooch-open-rpc-spec/schemas/openrpc.json)

--- a/docs/website/pages/docs/reference/rpc.zh-CN.mdx
+++ b/docs/website/pages/docs/reference/rpc.zh-CN.mdx
@@ -7,4 +7,4 @@
 
 ## 引用
 
-- [Rooch RPC spec](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/rooch-network/rooch/main/crates/rooch-open-rpc/spec/openrpc.json)
+- [Rooch RPC spec](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/rooch-network/rooch/main/crates/rooch-open-rpc-spec/schemas/openrpc.json)


### PR DESCRIPTION
## Summary

1. Fix moveos-stdlib genesis build directory.
2. Fix RPC links.

- Closes #714 again