### PR TITLE
[stdlib] remove the incorrect reference links from move docs

### DIFF
--- a/crates/rooch-framework/doc/account.md
+++ b/crates/rooch-framework/doc/account.md
@@ -24,13 +24,13 @@
 -  [Function `get_signer_capability_address`](#0x3_account_get_signer_capability_address)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">0x1::hash</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage">0x2::account_storage</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/bcs.md#0x2_bcs">0x2::bcs</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::hash</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::bcs</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account_authentication.md#0x3_account_authentication">0x3::account_authentication</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
 <b>use</b> <a href="gas_coin.md#0x3_gas_coin">0x3::gas_coin</a>;
@@ -148,7 +148,7 @@ Account already exists
 
 
 
-<pre><code><b>const</b> <a href="account.md#0x3_account_CONTRACT_ACCOUNT_AUTH_KEY_PLACEHOLDER">CONTRACT_ACCOUNT_AUTH_KEY_PLACEHOLDER</a>: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+<pre><code><b>const</b> <a href="account.md#0x3_account_CONTRACT_ACCOUNT_AUTH_KEY_PLACEHOLDER">CONTRACT_ACCOUNT_AUTH_KEY_PLACEHOLDER</a>: <a href="">vector</a>&lt;u8&gt; = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 </code></pre>
 
 
@@ -231,7 +231,7 @@ whose address matches an existing address of a MultiEd25519 wallet.
 
 
 
-<pre><code><b>const</b> <a href="account.md#0x3_account_ZERO_AUTH_KEY">ZERO_AUTH_KEY</a>: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+<pre><code><b>const</b> <a href="account.md#0x3_account_ZERO_AUTH_KEY">ZERO_AUTH_KEY</a>: <a href="">vector</a>&lt;u8&gt; = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 </code></pre>
 
 
@@ -243,7 +243,7 @@ whose address matches an existing address of a MultiEd25519 wallet.
 A entry function to create an account under <code>new_address</code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="account.md#0x3_account_create_account_entry">create_account_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, new_address: <b>address</b>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="account.md#0x3_account_create_account_entry">create_account_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, new_address: <b>address</b>)
 </code></pre>
 
 
@@ -274,7 +274,7 @@ is returned. This way, the caller of this function can publish additional resour
 <code>new_address</code>.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_create_account">create_account</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, new_address: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_create_account">create_account</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, new_address: <b>address</b>): <a href="">signer</a>
 </code></pre>
 
 
@@ -283,16 +283,16 @@ is returned. This way, the caller of this function can publish additional resour
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_create_account">create_account</a>(ctx: &<b>mut</b> StorageContext, new_address: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_create_account">create_account</a>(ctx: &<b>mut</b> StorageContext, new_address: <b>address</b>): <a href="">signer</a> {
    <b>assert</b>!(
       new_address != @vm_reserved && new_address != @rooch_framework,
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="account.md#0x3_account_ErrorAddressReseved">ErrorAddressReseved</a>)
+      <a href="_invalid_argument">error::invalid_argument</a>(<a href="account.md#0x3_account_ErrorAddressReseved">ErrorAddressReseved</a>)
    );
 
    // there cannot be an <a href="account.md#0x3_account_Account">Account</a> resource under new_addr already.
    <b>assert</b>!(
-      !<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, new_address),
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="account.md#0x3_account_ErrorAccountAlreadyExists">ErrorAccountAlreadyExists</a>)
+      !<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, new_address),
+      <a href="_already_exists">error::already_exists</a>(<a href="account.md#0x3_account_ErrorAccountAlreadyExists">ErrorAccountAlreadyExists</a>)
    );
 
    <b>let</b> new_account = <a href="account.md#0x3_account_create_account_unchecked">create_account_unchecked</a>(ctx, new_address);
@@ -313,7 +313,7 @@ is returned. This way, the caller of this function can publish additional resour
 create the account for system reserved addresses
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_create_framework_reserved_account">create_framework_reserved_account</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="account.md#0x3_account_SignerCapability">account::SignerCapability</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_create_framework_reserved_account">create_framework_reserved_account</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): (<a href="">signer</a>, <a href="account.md#0x3_account_SignerCapability">account::SignerCapability</a>)
 </code></pre>
 
 
@@ -322,7 +322,7 @@ create the account for system reserved addresses
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_create_framework_reserved_account">create_framework_reserved_account</a>(ctx: &<b>mut</b> StorageContext, addr: <b>address</b>): (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="account.md#0x3_account_SignerCapability">SignerCapability</a>) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_create_framework_reserved_account">create_framework_reserved_account</a>(ctx: &<b>mut</b> StorageContext, addr: <b>address</b>): (<a href="">signer</a>, <a href="account.md#0x3_account_SignerCapability">SignerCapability</a>) {
    <b>assert</b>!(
       addr == @0x1 ||
           addr == @0x2 ||
@@ -334,11 +334,11 @@ create the account for system reserved addresses
           addr == @0x8 ||
           addr == @0x9 ||
           addr == @0xa,
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="account.md#0x3_account_ErrorNoValidFrameworkReservedAddress">ErrorNoValidFrameworkReservedAddress</a>),
+      <a href="_permission_denied">error::permission_denied</a>(<a href="account.md#0x3_account_ErrorNoValidFrameworkReservedAddress">ErrorNoValidFrameworkReservedAddress</a>),
    );
-   <b>let</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a> = <a href="account.md#0x3_account_create_account_unchecked">create_account_unchecked</a>(ctx, addr);
+   <b>let</b> <a href="">signer</a> = <a href="account.md#0x3_account_create_account_unchecked">create_account_unchecked</a>(ctx, addr);
    <b>let</b> signer_cap = <a href="account.md#0x3_account_SignerCapability">SignerCapability</a> { addr };
-   (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, signer_cap)
+   (<a href="">signer</a>, signer_cap)
 }
 </code></pre>
 
@@ -353,7 +353,7 @@ create the account for system reserved addresses
 Return the current sequence number at <code>addr</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_sequence_number">sequence_number</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_sequence_number">sequence_number</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): u64
 </code></pre>
 
 
@@ -365,10 +365,10 @@ Return the current sequence number at <code>addr</code>
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_sequence_number">sequence_number</a>(ctx: &StorageContext, addr: <b>address</b>): u64 {
    // <b>if</b> <a href="account.md#0x3_account">account</a> does not exist, <b>return</b> 0 <b>as</b> sequence number
    // TODO: refactor this after we decide how <b>to</b> handle <a href="account.md#0x3_account">account</a> create.
-   <b>if</b> (!<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, addr)) {
+   <b>if</b> (!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, addr)) {
       <b>return</b> 0
    };
-   <b>let</b> <a href="account.md#0x3_account">account</a> = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, addr);
+   <b>let</b> <a href="account.md#0x3_account">account</a> = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, addr);
    <a href="account.md#0x3_account_sequence_number_for_account">sequence_number_for_account</a>(<a href="account.md#0x3_account">account</a>)
 }
 </code></pre>
@@ -383,7 +383,7 @@ Return the current sequence number at <code>addr</code>
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_sequence_number_for_sender">sequence_number_for_sender</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_sequence_number_for_sender">sequence_number_for_sender</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
 </code></pre>
 
 
@@ -393,7 +393,7 @@ Return the current sequence number at <code>addr</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_sequence_number_for_sender">sequence_number_for_sender</a>(ctx: &StorageContext): u64 {
-   <b>let</b> sender = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_sender">storage_context::sender</a>(ctx);
+   <b>let</b> sender = <a href="_sender">storage_context::sender</a>(ctx);
    <a href="account.md#0x3_account_sequence_number">sequence_number</a>(ctx, sender)
 }
 </code></pre>
@@ -408,7 +408,7 @@ Return the current sequence number at <code>addr</code>
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_increment_sequence_number">increment_sequence_number</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_increment_sequence_number">increment_sequence_number</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>)
 </code></pre>
 
 
@@ -418,13 +418,13 @@ Return the current sequence number at <code>addr</code>
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_increment_sequence_number">increment_sequence_number</a>(ctx: &<b>mut</b> StorageContext) {
-   <b>let</b> sender = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_sender">storage_context::sender</a>(ctx);
+   <b>let</b> sender = <a href="_sender">storage_context::sender</a>(ctx);
 
-   <b>let</b> sequence_number = &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, sender).sequence_number;
+   <b>let</b> sequence_number = &<b>mut</b> <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, sender).sequence_number;
 
    <b>assert</b>!(
       (*sequence_number <b>as</b> u128) &lt; <a href="account.md#0x3_account_MAX_U64">MAX_U64</a>,
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="account.md#0x3_account_ErrorSequenceNumberTooBig">ErrorSequenceNumberTooBig</a>)
+      <a href="_out_of_range">error::out_of_range</a>(<a href="account.md#0x3_account_ErrorSequenceNumberTooBig">ErrorSequenceNumberTooBig</a>)
    );
 
    *sequence_number = *sequence_number + 1;
@@ -465,7 +465,7 @@ Return the current sequence number at <code>addr</code>
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_is_resource_account">is_resource_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_is_resource_account">is_resource_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -477,8 +477,8 @@ Return the current sequence number at <code>addr</code>
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_is_resource_account">is_resource_account</a>(ctx: &StorageContext, addr: <b>address</b>): bool {
    // for resource <a href="account.md#0x3_account">account</a> , <a href="account.md#0x3_account">account</a> storage maybe not exist when create,
    // so need check <a href="account.md#0x3_account">account</a> storage eixst befor call <b>global</b> exist function
-   <b>if</b>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_exist_account_storage">account_storage::exist_account_storage</a>(ctx, addr)){
-      <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_ResourceAccount">ResourceAccount</a>&gt;(ctx, addr)
+   <b>if</b>(<a href="_exist_account_storage">account_storage::exist_account_storage</a>(ctx, addr)){
+      <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_ResourceAccount">ResourceAccount</a>&gt;(ctx, addr)
    } <b>else</b> {
       <b>false</b>
    }
@@ -495,7 +495,7 @@ Return the current sequence number at <code>addr</code>
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_exists_at">exists_at</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_exists_at">exists_at</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -505,8 +505,8 @@ Return the current sequence number at <code>addr</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_exists_at">exists_at</a>(ctx: &StorageContext, addr: <b>address</b>): bool {
-   <b>if</b>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_exist_account_storage">account_storage::exist_account_storage</a>(ctx, addr)){
-      <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, addr)
+   <b>if</b>(<a href="_exist_account_storage">account_storage::exist_account_storage</a>(ctx, addr)){
+      <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, addr)
    } <b>else</b> {
       <b>false</b>
    }
@@ -526,7 +526,7 @@ In Rooch a resource account is created based upon the sha3 256 of the source's a
 A resource account can only be created once
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_resource_account">create_resource_account</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, source: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>): (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="account.md#0x3_account_SignerCapability">account::SignerCapability</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_resource_account">create_resource_account</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, source: &<a href="">signer</a>): (<a href="">signer</a>, <a href="account.md#0x3_account_SignerCapability">account::SignerCapability</a>)
 </code></pre>
 
 
@@ -535,20 +535,20 @@ A resource account can only be created once
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_resource_account">create_resource_account</a>(ctx: &<b>mut</b> StorageContext, source: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>): (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="account.md#0x3_account_SignerCapability">SignerCapability</a>) {
-   <b>let</b> source_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(source);
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_resource_account">create_resource_account</a>(ctx: &<b>mut</b> StorageContext, source: &<a href="">signer</a>): (<a href="">signer</a>, <a href="account.md#0x3_account_SignerCapability">SignerCapability</a>) {
+   <b>let</b> source_addr = <a href="_address_of">signer::address_of</a>(source);
    <b>let</b> seed = <a href="account.md#0x3_account_generate_seed_bytes">generate_seed_bytes</a>(ctx, &source_addr);
    <b>let</b> resource_addr = <a href="account.md#0x3_account_create_resource_address">create_resource_address</a>(&source_addr, seed);
-   <b>assert</b>!(!<a href="account.md#0x3_account_is_resource_account">is_resource_account</a>(ctx, resource_addr), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="account.md#0x3_account_ErrorAccountIsAlreadyResourceAccount">ErrorAccountIsAlreadyResourceAccount</a>));
+   <b>assert</b>!(!<a href="account.md#0x3_account_is_resource_account">is_resource_account</a>(ctx, resource_addr), <a href="_invalid_state">error::invalid_state</a>(<a href="account.md#0x3_account_ErrorAccountIsAlreadyResourceAccount">ErrorAccountIsAlreadyResourceAccount</a>));
    <b>let</b> resource_signer = <b>if</b> (<a href="account.md#0x3_account_exists_at">exists_at</a>(ctx, resource_addr)) {
-      <b>let</b> <a href="account.md#0x3_account">account</a> = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, resource_addr);
-      <b>assert</b>!(<a href="account.md#0x3_account">account</a>.sequence_number == 0, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="account.md#0x3_account_ErrorResourceAccountAlreadyUsed">ErrorResourceAccountAlreadyUsed</a>));
+      <b>let</b> <a href="account.md#0x3_account">account</a> = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, resource_addr);
+      <b>assert</b>!(<a href="account.md#0x3_account">account</a>.sequence_number == 0, <a href="_invalid_state">error::invalid_state</a>(<a href="account.md#0x3_account_ErrorResourceAccountAlreadyUsed">ErrorResourceAccountAlreadyUsed</a>));
       <a href="account.md#0x3_account_create_signer">create_signer</a>(resource_addr)
    } <b>else</b> {
       <a href="account.md#0x3_account_create_account_unchecked">create_account_unchecked</a>(ctx, resource_addr)
    };
 
-   <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>&lt;<a href="account.md#0x3_account_ResourceAccount">ResourceAccount</a>&gt;(ctx,
+   <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="account.md#0x3_account_ResourceAccount">ResourceAccount</a>&gt;(ctx,
       &resource_signer,
       <a href="account.md#0x3_account_ResourceAccount">ResourceAccount</a> {}
    );
@@ -570,7 +570,7 @@ This is a helper function to compute resource addresses. Computation of the addr
 involves the use of a cryptographic hash operation and should be use thoughtfully.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_resource_address">create_resource_address</a>(source: &<b>address</b>, seed: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_resource_address">create_resource_address</a>(source: &<b>address</b>, seed: <a href="">vector</a>&lt;u8&gt;): <b>address</b>
 </code></pre>
 
 
@@ -579,11 +579,11 @@ involves the use of a cryptographic hash operation and should be use thoughtfull
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_resource_address">create_resource_address</a>(source: &<b>address</b>, seed: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b> {
-   <b>let</b> bytes = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(source);
-   <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> bytes, seed);
-   <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> bytes, <a href="account.md#0x3_account_SCHEME_DERIVE_RESOURCE_ACCOUNT">SCHEME_DERIVE_RESOURCE_ACCOUNT</a>);
-   bcs::to_address(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash_sha3_256">hash::sha3_256</a>(bytes))
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_resource_address">create_resource_address</a>(source: &<b>address</b>, seed: <a href="">vector</a>&lt;u8&gt;): <b>address</b> {
+   <b>let</b> bytes = <a href="_to_bytes">bcs::to_bytes</a>(source);
+   <a href="_append">vector::append</a>(&<b>mut</b> bytes, seed);
+   <a href="_push_back">vector::push_back</a>(&<b>mut</b> bytes, <a href="account.md#0x3_account_SCHEME_DERIVE_RESOURCE_ACCOUNT">SCHEME_DERIVE_RESOURCE_ACCOUNT</a>);
+   bcs::to_address(<a href="_sha3_256">hash::sha3_256</a>(bytes))
 }
 </code></pre>
 
@@ -597,7 +597,7 @@ involves the use of a cryptographic hash operation and should be use thoughtfull
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_signer_with_capability">create_signer_with_capability</a>(capability: &<a href="account.md#0x3_account_SignerCapability">account::SignerCapability</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_signer_with_capability">create_signer_with_capability</a>(capability: &<a href="account.md#0x3_account_SignerCapability">account::SignerCapability</a>): <a href="">signer</a>
 </code></pre>
 
 
@@ -606,7 +606,7 @@ involves the use of a cryptographic hash operation and should be use thoughtfull
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_signer_with_capability">create_signer_with_capability</a>(capability: &<a href="account.md#0x3_account_SignerCapability">SignerCapability</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x3_account_create_signer_with_capability">create_signer_with_capability</a>(capability: &<a href="account.md#0x3_account_SignerCapability">SignerCapability</a>): <a href="">signer</a> {
    <b>let</b> addr = &capability.addr;
    <a href="account.md#0x3_account_create_signer">create_signer</a>(*addr)
 }

--- a/crates/rooch-framework/doc/account_authentication.md
+++ b/crates/rooch-framework/doc/account_authentication.md
@@ -20,14 +20,14 @@ Migrate their from the account module for simplyfying the account module.
 -  [Function `install_auth_validator_entry`](#0x3_account_authentication_install_auth_validator_entry)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage">0x2::account_storage</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table">0x2::type_table</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
+<b>use</b> <a href="">0x2::tx_context</a>;
+<b>use</b> <a href="">0x2::type_table</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
 <b>use</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry">0x3::auth_validator_registry</a>;
 </code></pre>
@@ -53,7 +53,7 @@ ValidatorType is a phantom type parameter that is used to distinguish between di
 
 <dl>
 <dt>
-<code>authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+<code>authentication_key: <a href="">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
 
@@ -81,7 +81,7 @@ A resource that holds the authentication keys for this account.
 
 <dl>
 <dt>
-<code>authentication_keys: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a></code>
+<code>authentication_keys: <a href="_TypeTable">type_table::TypeTable</a></code>
 </dt>
 <dd>
 
@@ -109,7 +109,7 @@ A resource tha holds the auth validator ids for this account has installed.
 
 <dl>
 <dt>
-<code>validators: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+<code>validators: <a href="">vector</a>&lt;u64&gt;</code>
 </dt>
 <dd>
 
@@ -190,7 +190,7 @@ max authentication key length
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_init_authentication_keys">init_authentication_keys</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_init_authentication_keys">init_authentication_keys</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -199,11 +199,11 @@ max authentication key length
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_init_authentication_keys">init_authentication_keys</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_init_authentication_keys">init_authentication_keys</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
    <b>let</b> authentication_keys = <a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a> {
-      authentication_keys: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_new">type_table::new</a>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_context_mut">storage_context::tx_context_mut</a>(ctx)),
+      authentication_keys: <a href="_new">type_table::new</a>(<a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx)),
    };
-   <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, <a href="account.md#0x3_account">account</a>, authentication_keys);
+   <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, <a href="account.md#0x3_account">account</a>, authentication_keys);
 }
 </code></pre>
 
@@ -217,7 +217,7 @@ max authentication key length
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_get_authentication_key">get_authentication_key</a>&lt;ValidatorType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, account_addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_get_authentication_key">get_authentication_key</a>&lt;ValidatorType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, account_addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -226,15 +226,15 @@ max authentication key length
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_get_authentication_key">get_authentication_key</a>&lt;ValidatorType&gt;(ctx: &StorageContext, account_addr: <b>address</b>): Option&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; {
-   <b>if</b>(!<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr)){
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;()
+<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_get_authentication_key">get_authentication_key</a>&lt;ValidatorType&gt;(ctx: &StorageContext, account_addr: <b>address</b>): Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+   <b>if</b>(!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr)){
+      <a href="_none">option::none</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;()
    }<b>else</b>{
-      <b>let</b> authentication_keys = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr);
-      <b>if</b>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_contains">type_table::contains</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&authentication_keys.authentication_keys)){
-         <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_borrow">type_table::borrow</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&authentication_keys.authentication_keys).authentication_key)
+      <b>let</b> authentication_keys = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr);
+      <b>if</b>(<a href="_contains">type_table::contains</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&authentication_keys.authentication_keys)){
+         <a href="_some">option::some</a>(<a href="_borrow">type_table::borrow</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&authentication_keys.authentication_keys).authentication_key)
       }<b>else</b>{
-         <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;()
+         <a href="_none">option::none</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;()
       }
    }
 }
@@ -251,7 +251,7 @@ max authentication key length
 This function is used to rotate a resource account's authentication key, only the module which define the <code>ValidatorType</code> can call this function.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_rotate_authentication_key">rotate_authentication_key</a>&lt;ValidatorType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, account_addr: <b>address</b>, new_auth_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_rotate_authentication_key">rotate_authentication_key</a>&lt;ValidatorType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, account_addr: <b>address</b>, new_auth_key: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -260,22 +260,22 @@ This function is used to rotate a resource account's authentication key, only th
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_rotate_authentication_key">rotate_authentication_key</a>&lt;ValidatorType&gt;(ctx: &<b>mut</b> StorageContext, account_addr: <b>address</b>, new_auth_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_rotate_authentication_key">rotate_authentication_key</a>&lt;ValidatorType&gt;(ctx: &<b>mut</b> StorageContext, account_addr: <b>address</b>, new_auth_key: <a href="">vector</a>&lt;u8&gt;) {
 
    <b>assert</b>!(
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&new_auth_key) &lt;= <a href="account_authentication.md#0x3_account_authentication_MAX_AUTHENTICATION_KEY_LENGTH">MAX_AUTHENTICATION_KEY_LENGTH</a>,
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="account_authentication.md#0x3_account_authentication_ErrorMalformedAuthenticationKey">ErrorMalformedAuthenticationKey</a>)
+      <a href="_length">vector::length</a>(&new_auth_key) &lt;= <a href="account_authentication.md#0x3_account_authentication_MAX_AUTHENTICATION_KEY_LENGTH">MAX_AUTHENTICATION_KEY_LENGTH</a>,
+      <a href="_invalid_argument">error::invalid_argument</a>(<a href="account_authentication.md#0x3_account_authentication_ErrorMalformedAuthenticationKey">ErrorMalformedAuthenticationKey</a>)
    );
    //We need <b>to</b> ensure the <a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a> resource <b>exists</b> before we can rotate the authentication key.
-   <b>let</b> authentication_keys = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr);
-   <b>if</b>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_contains">type_table::contains</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&authentication_keys.authentication_keys)){
-      <b>let</b> authentication_key = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_borrow_mut">type_table::borrow_mut</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&<b>mut</b> authentication_keys.authentication_keys);
+   <b>let</b> authentication_keys = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr);
+   <b>if</b>(<a href="_contains">type_table::contains</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&authentication_keys.authentication_keys)){
+      <b>let</b> authentication_key = <a href="_borrow_mut">type_table::borrow_mut</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&<b>mut</b> authentication_keys.authentication_keys);
       authentication_key.authentication_key = new_auth_key;
    }<b>else</b>{
       <b>let</b> authentication_key = <a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt; {
          authentication_key: new_auth_key,
       };
-      <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_add">type_table::add</a>(&<b>mut</b> authentication_keys.authentication_keys, authentication_key);
+      <a href="_add">type_table::add</a>(&<b>mut</b> authentication_keys.authentication_keys, authentication_key);
    };
 }
 </code></pre>
@@ -291,7 +291,7 @@ This function is used to rotate a resource account's authentication key, only th
 This function is used to remove a resource account's authentication key, only the module which define the <code>ValidatorType</code> can call this function.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">remove_authentication_key</a>&lt;ValidatorType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, account_addr: <b>address</b>): <a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">account_authentication::AuthenticationKey</a>&lt;ValidatorType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">remove_authentication_key</a>&lt;ValidatorType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, account_addr: <b>address</b>): <a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">account_authentication::AuthenticationKey</a>&lt;ValidatorType&gt;
 </code></pre>
 
 
@@ -302,16 +302,16 @@ This function is used to remove a resource account's authentication key, only th
 
 <pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">remove_authentication_key</a>&lt;ValidatorType&gt;(ctx: &<b>mut</b> StorageContext, account_addr: <b>address</b>): <a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt; {
    <b>assert</b>!(
-      <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr),
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_authentication.md#0x3_account_authentication_ErrorAuthenticationKeysResourceNotFound">ErrorAuthenticationKeysResourceNotFound</a>)
+      <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr),
+      <a href="_not_found">error::not_found</a>(<a href="account_authentication.md#0x3_account_authentication_ErrorAuthenticationKeysResourceNotFound">ErrorAuthenticationKeysResourceNotFound</a>)
    );
-   <b>let</b> authentication_keys = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr);
+   <b>let</b> authentication_keys = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, account_addr);
    <b>assert</b>!(
-      <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_contains">type_table::contains</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&authentication_keys.authentication_keys),
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_authentication.md#0x3_account_authentication_ErrorAuthenticationKeyNotFound">ErrorAuthenticationKeyNotFound</a>)
+      <a href="_contains">type_table::contains</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&authentication_keys.authentication_keys),
+      <a href="_not_found">error::not_found</a>(<a href="account_authentication.md#0x3_account_authentication_ErrorAuthenticationKeyNotFound">ErrorAuthenticationKeyNotFound</a>)
    );
 
-   <b>let</b> removed_authentication_key = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_remove">type_table::remove</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&<b>mut</b> authentication_keys.authentication_keys);
+   <b>let</b> removed_authentication_key = <a href="_remove">type_table::remove</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKey">AuthenticationKey</a>&lt;ValidatorType&gt;&gt;(&<b>mut</b> authentication_keys.authentication_keys);
    removed_authentication_key
 }
 </code></pre>
@@ -327,7 +327,7 @@ This function is used to remove a resource account's authentication key, only th
 Return the authentication validator is installed for the account at <code>account_addr</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_is_auth_validator_installed">is_auth_validator_installed</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, account_addr: <b>address</b>, auth_validator_id: u64): bool
+<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_is_auth_validator_installed">is_auth_validator_installed</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, account_addr: <b>address</b>, auth_validator_id: u64): bool
 </code></pre>
 
 
@@ -337,9 +337,9 @@ Return the authentication validator is installed for the account at <code>accoun
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_is_auth_validator_installed">is_auth_validator_installed</a>(ctx: &StorageContext, account_addr: <b>address</b>, auth_validator_id: u64): bool {
-   <b>if</b>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_addr)){
-      <b>let</b> installed_auth_validator = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_addr);
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_contains">vector::contains</a>(&installed_auth_validator.validators, &auth_validator_id)
+   <b>if</b>(<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_addr)){
+      <b>let</b> installed_auth_validator = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_addr);
+      <a href="_contains">vector::contains</a>(&installed_auth_validator.validators, &auth_validator_id)
    }<b>else</b>{
       <b>false</b>
    }
@@ -356,7 +356,7 @@ Return the authentication validator is installed for the account at <code>accoun
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_install_auth_validator">install_auth_validator</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, account_signer: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_install_auth_validator">install_auth_validator</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, account_signer: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -365,24 +365,24 @@ Return the authentication validator is installed for the account at <code>accoun
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_install_auth_validator">install_auth_validator</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> StorageContext, account_signer: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_install_auth_validator">install_auth_validator</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> StorageContext, account_signer: &<a href="">signer</a>) {
    <b>let</b> validator = <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator_by_type">auth_validator_registry::borrow_validator_by_type</a>&lt;ValidatorType&gt;(ctx);
    <b>let</b> validator_id = <a href="auth_validator.md#0x3_auth_validator_validator_id">auth_validator::validator_id</a>(validator);
-   <b>let</b> account_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(account_signer);
+   <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(account_signer);
 
    <b>assert</b>!(
       !<a href="account_authentication.md#0x3_account_authentication_is_auth_validator_installed">is_auth_validator_installed</a>(ctx, account_addr, validator_id),
-      <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="account_authentication.md#0x3_account_authentication_ErrorAuthValidatorAlreadyInstalled">ErrorAuthValidatorAlreadyInstalled</a>));
+      <a href="_already_exists">error::already_exists</a>(<a href="account_authentication.md#0x3_account_authentication_ErrorAuthValidatorAlreadyInstalled">ErrorAuthValidatorAlreadyInstalled</a>));
 
 
-   <b>if</b>(!<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_addr)){
+   <b>if</b>(!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_addr)){
       <b>let</b> installed_auth_validator = <a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a> {
-         validators: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>(),
+         validators: <a href="_empty">vector::empty</a>(),
       };
-      <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_signer, installed_auth_validator);
+      <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_signer, installed_auth_validator);
    };
-   <b>let</b> installed_auth_validator = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_addr);
-   <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> installed_auth_validator.validators, validator_id);
+   <b>let</b> installed_auth_validator = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account_authentication.md#0x3_account_authentication_InstalledAuthValidator">InstalledAuthValidator</a>&gt;(ctx, account_addr);
+   <a href="_push_back">vector::push_back</a>(&<b>mut</b> installed_auth_validator.validators, validator_id);
 }
 </code></pre>
 
@@ -396,7 +396,7 @@ Return the authentication validator is installed for the account at <code>accoun
 
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_install_auth_validator_entry">install_auth_validator_entry</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, account_signer: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_install_auth_validator_entry">install_auth_validator_entry</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, account_signer: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -405,7 +405,7 @@ Return the authentication validator is installed for the account at <code>accoun
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_install_auth_validator_entry">install_auth_validator_entry</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> StorageContext, account_signer: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> entry <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_install_auth_validator_entry">install_auth_validator_entry</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> StorageContext, account_signer: &<a href="">signer</a>) {
    <a href="account_authentication.md#0x3_account_authentication_install_auth_validator">install_auth_validator</a>&lt;ValidatorType&gt;(ctx, account_signer);
 }
 </code></pre>

--- a/crates/rooch-framework/doc/address_mapping.md
+++ b/crates/rooch-framework/doc/address_mapping.md
@@ -16,14 +16,14 @@
 -  [Function `bind_no_check`](#0x3_address_mapping_bind_no_check)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage">0x2::account_storage</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/bcs.md#0x2_bcs">0x2::bcs</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x2_signer">0x2::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table">0x2::table</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::bcs</a>;
+<b>use</b> <a href="">0x2::signer</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
+<b>use</b> <a href="">0x2::table</a>;
+<b>use</b> <a href="">0x2::tx_context</a>;
 <b>use</b> <a href="core_addresses.md#0x3_core_addresses">0x3::core_addresses</a>;
 <b>use</b> <a href="hash.md#0x3_hash">0x3::hash</a>;
 </code></pre>
@@ -53,7 +53,7 @@
 
 </dd>
 <dt>
-<code>raw_address: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+<code>raw_address: <a href="">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
 
@@ -80,7 +80,7 @@
 
 <dl>
 <dt>
-<code>mapping: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_Table">table::Table</a>&lt;<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>, <b>address</b>&gt;</code>
+<code>mapping: <a href="_Table">table::Table</a>&lt;<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>, <b>address</b>&gt;</code>
 </dt>
 <dd>
 
@@ -162,7 +162,7 @@
 Resolve a multi-chain address to a rooch address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve">resolve</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve">resolve</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): <a href="_Option">option::Option</a>&lt;<b>address</b>&gt;
 </code></pre>
 
 
@@ -173,14 +173,14 @@ Resolve a multi-chain address to a rooch address
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve">resolve</a>(ctx: &StorageContext, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>): Option&lt;<b>address</b>&gt; {
     <b>if</b> (<a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(&maddress)) {
-        <b>return</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_some">option::some</a>(moveos_std::bcs::to_address(maddress.raw_address))
+        <b>return</b> <a href="_some">option::some</a>(moveos_std::bcs::to_address(maddress.raw_address))
     };
-    <b>let</b> am = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
-    <b>if</b>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_contains">table::contains</a>(&am.mapping, maddress)){
-        <b>let</b> addr = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_borrow">table::borrow</a>(&am.mapping, maddress);
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_some">option::some</a>(*addr)
+    <b>let</b> am = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
+    <b>if</b>(<a href="_contains">table::contains</a>(&am.mapping, maddress)){
+        <b>let</b> addr = <a href="_borrow">table::borrow</a>(&am.mapping, maddress);
+        <a href="_some">option::some</a>(*addr)
     }<b>else</b>{
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+        <a href="_none">option::none</a>()
     }
 }
 </code></pre>
@@ -196,7 +196,7 @@ Resolve a multi-chain address to a rooch address
 Resolve a multi-chain address to a rooch address, if not exists, generate a new rooch address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve_or_generate">resolve_or_generate</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve_or_generate">resolve_or_generate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): <b>address</b>
 </code></pre>
 
 
@@ -207,10 +207,10 @@ Resolve a multi-chain address to a rooch address, if not exists, generate a new 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve_or_generate">resolve_or_generate</a>(ctx: &StorageContext, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>): <b>address</b> {
     <b>let</b> addr = <a href="address_mapping.md#0x3_address_mapping_resolve">resolve</a>(ctx, maddress);
-    <b>if</b>(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&addr)){
+    <b>if</b>(<a href="_is_none">option::is_none</a>(&addr)){
         <a href="address_mapping.md#0x3_address_mapping_generate_rooch_address">generate_rooch_address</a>(maddress)
     }<b>else</b>{
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> addr)
+        <a href="_extract">option::extract</a>(&<b>mut</b> addr)
     }
 }
 </code></pre>
@@ -226,7 +226,7 @@ Resolve a multi-chain address to a rooch address, if not exists, generate a new 
 Check if a multi-chain address is bound to a rooch address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_exists_mapping">exists_mapping</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_exists_mapping">exists_mapping</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): bool
 </code></pre>
 
 
@@ -239,8 +239,8 @@ Check if a multi-chain address is bound to a rooch address
     <b>if</b> (<a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(&maddress)) {
         <b>return</b> <b>true</b>
     };
-    <b>let</b> am = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_contains">table::contains</a>(&am.mapping, maddress)
+    <b>let</b> am = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
+    <a href="_contains">table::contains</a>(&am.mapping, maddress)
 }
 </code></pre>
 
@@ -256,7 +256,7 @@ Bind a multi-chain address to the sender's rooch address
 The caller need to ensure the relationship between the multi-chain address and the rooch address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, sender: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, sender: &<a href="">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>)
 </code></pre>
 
 
@@ -265,8 +265,8 @@ The caller need to ensure the relationship between the multi-chain address and t
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) {
-    <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(sender), maddress);
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) {
+    <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx, <a href="_address_of">signer::address_of</a>(sender), maddress);
 }
 </code></pre>
 
@@ -281,7 +281,7 @@ The caller need to ensure the relationship between the multi-chain address and t
 Bind a rooch address to a multi-chain address
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, rooch_address: <b>address</b>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, rooch_address: <b>address</b>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>)
 </code></pre>
 
 
@@ -295,9 +295,9 @@ Bind a rooch address to a multi-chain address
         //Do nothing <b>if</b> the multi-chain <b>address</b> is a rooch <b>address</b>
         <b>return</b>
     };
-    <b>let</b> am = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_add">table::add</a>(&<b>mut</b> am.mapping, maddress, rooch_address);
-    //TODO matienance the reverse mapping rooch_address -&gt; <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>&gt;
+    <b>let</b> am = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
+    <a href="_add">table::add</a>(&<b>mut</b> am.mapping, maddress, rooch_address);
+    //TODO matienance the reverse mapping rooch_address -&gt; <a href="">vector</a>&lt;<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>&gt;
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/auth_validator.md
+++ b/crates/rooch-framework/doc/auth_validator.md
@@ -27,10 +27,10 @@ fun post_execute(ctx: &mut StorageContext)
 -  [Function `get_session_key_from_tx_ctx`](#0x3_auth_validator_get_session_key_from_tx_ctx)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii">0x1::ascii</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+<b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 </code></pre>
 
 
@@ -65,7 +65,7 @@ The Authentication Validator
 
 </dd>
 <dt>
-<code>module_name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a></code>
+<code>module_name: <a href="_String">ascii::String</a></code>
 </dt>
 <dd>
 
@@ -100,13 +100,13 @@ this result will be stored in the TxContext
  The auth validator's scheme that validate the transaction
 </dd>
 <dt>
-<code><a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;</code>
+<code><a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;</code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code><a href="session_key.md#0x3_session_key">session_key</a>: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
+<code><a href="session_key.md#0x3_session_key">session_key</a>: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;</code>
 </dt>
 <dd>
 
@@ -167,7 +167,7 @@ InvalidAuthenticator, include invalid signature
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_error_invalid_account_auth_key">error_invalid_account_auth_key</a>(): u64 {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="auth_validator.md#0x3_auth_validator_ErrorValidateInvalidAccountAuthKey">ErrorValidateInvalidAccountAuthKey</a>)
+    <a href="_invalid_argument">error::invalid_argument</a>(<a href="auth_validator.md#0x3_auth_validator_ErrorValidateInvalidAccountAuthKey">ErrorValidateInvalidAccountAuthKey</a>)
 }
 </code></pre>
 
@@ -191,7 +191,7 @@ InvalidAuthenticator, include invalid signature
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_error_invalid_authenticator">error_invalid_authenticator</a>(): u64 {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="auth_validator.md#0x3_auth_validator_ErrorValidateInvalidAuthenticator">ErrorValidateInvalidAuthenticator</a>)
+    <a href="_invalid_argument">error::invalid_argument</a>(<a href="auth_validator.md#0x3_auth_validator_ErrorValidateInvalidAuthenticator">ErrorValidateInvalidAuthenticator</a>)
 }
 </code></pre>
 
@@ -205,7 +205,7 @@ InvalidAuthenticator, include invalid signature
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_auth_validator">new_auth_validator</a>(id: u64, module_address: <b>address</b>, module_name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_auth_validator">new_auth_validator</a>(id: u64, module_address: <b>address</b>, module_name: <a href="_String">ascii::String</a>): <a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>
 </code></pre>
 
 
@@ -285,7 +285,7 @@ InvalidAuthenticator, include invalid signature
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_validator_module_name">validator_module_name</a>(validator: &<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_validator_module_name">validator_module_name</a>(validator: &<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>): <a href="_String">ascii::String</a>
 </code></pre>
 
 
@@ -309,7 +309,7 @@ InvalidAuthenticator, include invalid signature
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(scheme: u64, <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;, <a href="session_key.md#0x3_session_key">session_key</a>: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(scheme: u64, <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;, <a href="session_key.md#0x3_session_key">session_key</a>: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
 </code></pre>
 
 
@@ -321,7 +321,7 @@ InvalidAuthenticator, include invalid signature
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(
     scheme: u64,
     <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: Option&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">AuthValidator</a>&gt;,
-    <a href="session_key.md#0x3_session_key">session_key</a>: Option&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+    <a href="session_key.md#0x3_session_key">session_key</a>: Option&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 ): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a> {
     <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a> {
         scheme: scheme,
@@ -342,7 +342,7 @@ InvalidAuthenticator, include invalid signature
 Get the TxValidateResult from the TxContext, Only can be called after the transaction is validated
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validate_result_from_tx_ctx">get_validate_result_from_tx_ctx</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validate_result_from_tx_ctx">get_validate_result_from_tx_ctx</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
 </code></pre>
 
 
@@ -352,9 +352,9 @@ Get the TxValidateResult from the TxContext, Only can be called after the transa
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validate_result_from_tx_ctx">get_validate_result_from_tx_ctx</a>(ctx: &StorageContext): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a> {
-    <b>let</b> validate_result_opt = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_get">storage_context::get</a>&lt;<a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a>&gt;(ctx);
-    <b>assert</b>!(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&validate_result_opt), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="auth_validator.md#0x3_auth_validator_ErrorMustExecuteAfterValidate">ErrorMustExecuteAfterValidate</a>));
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validate_result_opt)
+    <b>let</b> validate_result_opt = <a href="_get">storage_context::get</a>&lt;<a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a>&gt;(ctx);
+    <b>assert</b>!(<a href="_is_some">option::is_some</a>(&validate_result_opt), <a href="_invalid_state">error::invalid_state</a>(<a href="auth_validator.md#0x3_auth_validator_ErrorMustExecuteAfterValidate">ErrorMustExecuteAfterValidate</a>));
+    <a href="_extract">option::extract</a>(&<b>mut</b> validate_result_opt)
 }
 </code></pre>
 
@@ -369,7 +369,7 @@ Get the TxValidateResult from the TxContext, Only can be called after the transa
 Get the auth validator's scheme from the TxValidateResult in the TxContext
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_scheme_from_tx_ctx">get_validator_scheme_from_tx_ctx</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_scheme_from_tx_ctx">get_validator_scheme_from_tx_ctx</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
 </code></pre>
 
 
@@ -396,7 +396,7 @@ Get the session key from the TxValidateResult in the TxContext
 If the TxValidateResult is None or SessionKey is None, return None
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx_option">get_session_key_from_tx_ctx_option</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx_option">get_session_key_from_tx_ctx_option</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -405,13 +405,13 @@ If the TxValidateResult is None or SessionKey is None, return None
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx_option">get_session_key_from_tx_ctx_option</a>(ctx: &StorageContext): Option&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; {
-    <b>let</b> validate_result_opt = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_get">storage_context::get</a>&lt;<a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a>&gt;(ctx);
-    <b>if</b> (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&validate_result_opt)) {
-        <b>let</b> validate_result = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validate_result_opt);
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx_option">get_session_key_from_tx_ctx_option</a>(ctx: &StorageContext): Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    <b>let</b> validate_result_opt = <a href="_get">storage_context::get</a>&lt;<a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a>&gt;(ctx);
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&validate_result_opt)) {
+        <b>let</b> validate_result = <a href="_extract">option::extract</a>(&<b>mut</b> validate_result_opt);
         validate_result.<a href="session_key.md#0x3_session_key">session_key</a>
     }<b>else</b> {
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;()
+        <a href="_none">option::none</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;()
     }
 }
 </code></pre>
@@ -427,7 +427,7 @@ If the TxValidateResult is None or SessionKey is None, return None
 The current tx is validate via the session key or not
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_is_validate_via_session_key">is_validate_via_session_key</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_is_validate_via_session_key">is_validate_via_session_key</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): bool
 </code></pre>
 
 
@@ -437,7 +437,7 @@ The current tx is validate via the session key or not
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_is_validate_via_session_key">is_validate_via_session_key</a>(ctx: &StorageContext): bool {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&<a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx_option">get_session_key_from_tx_ctx_option</a>(ctx))
+    <a href="_is_some">option::is_some</a>(&<a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx_option">get_session_key_from_tx_ctx_option</a>(ctx))
 }
 </code></pre>
 
@@ -453,7 +453,7 @@ Get the session key from the TxValidateResult in the TxContext
 Only can be called after the transaction is validated
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx">get_session_key_from_tx_ctx</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx">get_session_key_from_tx_ctx</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -462,9 +462,9 @@ Only can be called after the transaction is validated
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx">get_session_key_from_tx_ctx</a>(ctx: &StorageContext): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>assert</b>!(<a href="auth_validator.md#0x3_auth_validator_is_validate_via_session_key">is_validate_via_session_key</a>(ctx), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="auth_validator.md#0x3_auth_validator_ErrorMustExecuteAfterValidate">ErrorMustExecuteAfterValidate</a>));
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx_option">get_session_key_from_tx_ctx_option</a>(ctx))
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx">get_session_key_from_tx_ctx</a>(ctx: &StorageContext): <a href="">vector</a>&lt;u8&gt; {
+    <b>assert</b>!(<a href="auth_validator.md#0x3_auth_validator_is_validate_via_session_key">is_validate_via_session_key</a>(ctx), <a href="_invalid_state">error::invalid_state</a>(<a href="auth_validator.md#0x3_auth_validator_ErrorMustExecuteAfterValidate">ErrorMustExecuteAfterValidate</a>));
+    <a href="_extract">option::extract</a>(&<b>mut</b> <a href="auth_validator.md#0x3_auth_validator_get_session_key_from_tx_ctx_option">get_session_key_from_tx_ctx_option</a>(ctx))
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/auth_validator_registry.md
+++ b/crates/rooch-framework/doc/auth_validator_registry.md
@@ -15,14 +15,14 @@
 -  [Function `borrow_validator_by_type`](#0x3_auth_validator_registry_borrow_validator_by_type)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii">0x1::ascii</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage">0x2::account_storage</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table">0x2::table</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info">0x2::type_info</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table">0x2::type_table</a>;
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+<b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
+<b>use</b> <a href="">0x2::table</a>;
+<b>use</b> <a href="">0x2::tx_context</a>;
+<b>use</b> <a href="">0x2::type_info</a>;
+<b>use</b> <a href="">0x2::type_table</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
 </code></pre>
 
@@ -78,13 +78,13 @@
 How many validators are registered
 </dd>
 <dt>
-<code>validators: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_Table">table::Table</a>&lt;u64, <a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;</code>
+<code>validators: <a href="_Table">table::Table</a>&lt;u64, <a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;</code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code>validators_with_type: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a></code>
+<code>validators_with_type: <a href="_TypeTable">type_table::TypeTable</a></code>
 </dt>
 <dd>
 
@@ -124,7 +124,7 @@ How many validators are registered
 Init function called by genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, sender: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, sender: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -133,13 +133,13 @@ Init function called by genesis.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>){
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="">signer</a>){
     <b>let</b> registry = <a href="auth_validator_registry.md#0x3_auth_validator_registry_ValidatorRegistry">ValidatorRegistry</a> {
         validator_num: 0,
-        validators: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_new">table::new</a>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_context_mut">storage_context::tx_context_mut</a>(ctx)),
-        validators_with_type: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_new">type_table::new</a>(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_context_mut">storage_context::tx_context_mut</a>(ctx)),
+        validators: <a href="_new">table::new</a>(<a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx)),
+        validators_with_type: <a href="_new">type_table::new</a>(<a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx)),
     };
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>(ctx, sender, registry);
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, sender, registry);
 }
 </code></pre>
 
@@ -153,7 +153,7 @@ Init function called by genesis.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_register">register</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_register">register</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>): u64
 </code></pre>
 
 
@@ -177,7 +177,7 @@ Init function called by genesis.
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">register_internal</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">register_internal</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>): u64
 </code></pre>
 
 
@@ -187,27 +187,27 @@ Init function called by genesis.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">register_internal</a>&lt;ValidatorType: store&gt;(ctx: &<b>mut</b> StorageContext) : u64{
-    <b>let</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info">type_info</a> = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_type_of">type_info::type_of</a>&lt;ValidatorType&gt;();
-    <b>let</b> module_address = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_account_address">type_info::account_address</a>(&<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info">type_info</a>);
-    //TODO consider change <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_module_name">type_info::module_name</a> <b>to</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a>.
-    <b>let</b> module_name = std::ascii::string(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_module_name">type_info::module_name</a>(&<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info">type_info</a>));
+    <b>let</b> <a href="">type_info</a> = <a href="_type_of">type_info::type_of</a>&lt;ValidatorType&gt;();
+    <b>let</b> module_address = <a href="_account_address">type_info::account_address</a>(&<a href="">type_info</a>);
+    //TODO consider change <a href="_module_name">type_info::module_name</a> <b>to</b> <a href="_String">ascii::String</a>.
+    <b>let</b> module_name = std::ascii::string(<a href="_module_name">type_info::module_name</a>(&<a href="">type_info</a>));
 
-    <b>let</b> registry = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_ValidatorRegistry">ValidatorRegistry</a>&gt;(ctx, @rooch_framework);
+    <b>let</b> registry = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_ValidatorRegistry">ValidatorRegistry</a>&gt;(ctx, @rooch_framework);
     <b>let</b> id = registry.validator_num;
 
-    <b>assert</b>!(!<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_contains">type_table::contains</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_AuthValidatorWithType">AuthValidatorWithType</a>&lt;ValidatorType&gt;&gt;(&registry.validators_with_type), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="auth_validator_registry.md#0x3_auth_validator_registry_ErrorValidatorAlreadyRegistered">ErrorValidatorAlreadyRegistered</a>));
+    <b>assert</b>!(!<a href="_contains">type_table::contains</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_AuthValidatorWithType">AuthValidatorWithType</a>&lt;ValidatorType&gt;&gt;(&registry.validators_with_type), <a href="_already_exists">error::already_exists</a>(<a href="auth_validator_registry.md#0x3_auth_validator_registry_ErrorValidatorAlreadyRegistered">ErrorValidatorAlreadyRegistered</a>));
 
     <b>let</b> validator_with_type = <a href="auth_validator_registry.md#0x3_auth_validator_registry_AuthValidatorWithType">AuthValidatorWithType</a>&lt;ValidatorType&gt;{
         id,
     };
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_add">type_table::add</a>(&<b>mut</b> registry.validators_with_type, validator_with_type);
+    <a href="_add">type_table::add</a>(&<b>mut</b> registry.validators_with_type, validator_with_type);
 
     <b>let</b> validator = <a href="auth_validator.md#0x3_auth_validator_new_auth_validator">auth_validator::new_auth_validator</a>(
         id,
         module_address,
         module_name,
     );
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_add">table::add</a>(&<b>mut</b> registry.validators, id, validator);
+    <a href="_add">table::add</a>(&<b>mut</b> registry.validators, id, validator);
 
     registry.validator_num = registry.validator_num + 1;
     id
@@ -224,7 +224,7 @@ Init function called by genesis.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">borrow_validator</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, id: u64): &<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">borrow_validator</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, id: u64): &<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>
 </code></pre>
 
 
@@ -234,8 +234,8 @@ Init function called by genesis.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">borrow_validator</a>(ctx: &StorageContext, id: u64): &AuthValidator {
-    <b>let</b> registry = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_ValidatorRegistry">ValidatorRegistry</a>&gt;(ctx, @rooch_framework);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_borrow">table::borrow</a>(&registry.validators, id)
+    <b>let</b> registry = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_ValidatorRegistry">ValidatorRegistry</a>&gt;(ctx, @rooch_framework);
+    <a href="_borrow">table::borrow</a>(&registry.validators, id)
 }
 </code></pre>
 
@@ -249,7 +249,7 @@ Init function called by genesis.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator_by_type">borrow_validator_by_type</a>&lt;ValidatorType: store&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator_by_type">borrow_validator_by_type</a>&lt;ValidatorType: store&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): &<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>
 </code></pre>
 
 
@@ -259,11 +259,11 @@ Init function called by genesis.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator_by_type">borrow_validator_by_type</a>&lt;ValidatorType: store&gt;(ctx: &StorageContext): &AuthValidator {
-    <b>let</b> registry = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_ValidatorRegistry">ValidatorRegistry</a>&gt;(ctx, @rooch_framework);
-    <b>assert</b>!(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_contains">type_table::contains</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_AuthValidatorWithType">AuthValidatorWithType</a>&lt;ValidatorType&gt;&gt;(&registry.validators_with_type), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="auth_validator_registry.md#0x3_auth_validator_registry_ErrorValidatorUnregistered">ErrorValidatorUnregistered</a>));
-    <b>let</b> validator_with_type = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_borrow">type_table::borrow</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_AuthValidatorWithType">AuthValidatorWithType</a>&lt;ValidatorType&gt;&gt;(&registry.validators_with_type);
-    <b>assert</b>!(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_contains">table::contains</a>(&registry.validators, validator_with_type.id), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="auth_validator_registry.md#0x3_auth_validator_registry_ErrorValidatorUnregistered">ErrorValidatorUnregistered</a>));
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_borrow">table::borrow</a>(&registry.validators, validator_with_type.id)
+    <b>let</b> registry = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_ValidatorRegistry">ValidatorRegistry</a>&gt;(ctx, @rooch_framework);
+    <b>assert</b>!(<a href="_contains">type_table::contains</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_AuthValidatorWithType">AuthValidatorWithType</a>&lt;ValidatorType&gt;&gt;(&registry.validators_with_type), <a href="_not_found">error::not_found</a>(<a href="auth_validator_registry.md#0x3_auth_validator_registry_ErrorValidatorUnregistered">ErrorValidatorUnregistered</a>));
+    <b>let</b> validator_with_type = <a href="_borrow">type_table::borrow</a>&lt;<a href="auth_validator_registry.md#0x3_auth_validator_registry_AuthValidatorWithType">AuthValidatorWithType</a>&lt;ValidatorType&gt;&gt;(&registry.validators_with_type);
+    <b>assert</b>!(<a href="_contains">table::contains</a>(&registry.validators, validator_with_type.id), <a href="_not_found">error::not_found</a>(<a href="auth_validator_registry.md#0x3_auth_validator_registry_ErrorValidatorUnregistered">ErrorValidatorUnregistered</a>));
+    <a href="_borrow">table::borrow</a>(&registry.validators, validator_with_type.id)
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/bitcoin_address.md
+++ b/crates/rooch-framework/doc/bitcoin_address.md
@@ -16,7 +16,7 @@
 -  [Function `create_bech32_address`](#0x3_bitcoin_address_create_bech32_address)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1">0x3::ecdsa_k1</a>;
 <b>use</b> <a href="encoding.md#0x3_encoding">0x3::encoding</a>;
 </code></pre>
@@ -40,7 +40,7 @@
 
 <dl>
 <dt>
-<code>bytes: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+<code>bytes: <a href="">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
 
@@ -161,7 +161,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_new_legacy">new_legacy</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimal_prefix: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_new_legacy">new_legacy</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;, decimal_prefix: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
 </code></pre>
 
 
@@ -170,17 +170,17 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_new_legacy">new_legacy</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimal_prefix: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_new_legacy">new_legacy</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;, decimal_prefix: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
     // Check the decimal_prefix, i.e. <b>address</b> type
     <b>assert</b>!(
         decimal_prefix == <a href="bitcoin_address.md#0x3_bitcoin_address_P2PKH_ADDR_DECIMAL_PREFIX">P2PKH_ADDR_DECIMAL_PREFIX</a>
         || decimal_prefix == <a href="bitcoin_address.md#0x3_bitcoin_address_P2SH_ADDR_DECIMAL_PREFIX">P2SH_ADDR_DECIMAL_PREFIX</a>,
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidDecimalPrefix">ErrorInvalidDecimalPrefix</a>)
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidDecimalPrefix">ErrorInvalidDecimalPrefix</a>)
     );
     // Check the <b>public</b> key length
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(pub_key) == <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">ecdsa_k1::public_key_length</a>(),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidCompressedPublicKeyLength">ErrorInvalidCompressedPublicKeyLength</a>)
+        <a href="_length">vector::length</a>(pub_key) == <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">ecdsa_k1::public_key_length</a>(),
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidCompressedPublicKeyLength">ErrorInvalidCompressedPublicKeyLength</a>)
     );
     // Perform <b>address</b> creation
     <b>let</b> <a href="bitcoin_address.md#0x3_bitcoin_address">bitcoin_address</a> = <b>if</b> (decimal_prefix == <a href="bitcoin_address.md#0x3_bitcoin_address_P2PKH_ADDR_DECIMAL_PREFIX">P2PKH_ADDR_DECIMAL_PREFIX</a>) { // P2PKH <b>address</b>
@@ -189,7 +189,7 @@ error code
         <a href="bitcoin_address.md#0x3_bitcoin_address_create_p2sh_address">create_p2sh_address</a>(pub_key)
     } <b>else</b> {
         <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
-            bytes: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;()
+            bytes: <a href="_empty">vector::empty</a>&lt;u8&gt;()
         }
     };
 
@@ -207,7 +207,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_new_bech32">new_bech32</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_new_bech32">new_bech32</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;, version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
 </code></pre>
 
 
@@ -216,23 +216,23 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_new_bech32">new_bech32</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_new_bech32">new_bech32</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;, version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
     // Check the <b>script</b> version
     <b>assert</b>!(
         version &lt;= 16,
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidScriptVersion">ErrorInvalidScriptVersion</a>)
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidScriptVersion">ErrorInvalidScriptVersion</a>)
     );
     // Check the <b>script</b> version and the <b>public</b> key relationship
     <b>if</b> (version == 0) {
         <b>assert</b>!(
-            <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(pub_key) == 20 || <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(pub_key) == 32,
-            <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidHashedPublicKeyLength">ErrorInvalidHashedPublicKeyLength</a>)
+            <a href="_length">vector::length</a>(pub_key) == 20 || <a href="_length">vector::length</a>(pub_key) == 32,
+            <a href="_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidHashedPublicKeyLength">ErrorInvalidHashedPublicKeyLength</a>)
         );
     };
     <b>if</b> (version == 1) {
         <b>assert</b>!(
-            <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(pub_key) == 32,
-            <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidSchnorrPublicKeyLength">ErrorInvalidSchnorrPublicKeyLength</a>)
+            <a href="_length">vector::length</a>(pub_key) == 32,
+            <a href="_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidSchnorrPublicKeyLength">ErrorInvalidSchnorrPublicKeyLength</a>)
         );
     };
     // This will create Segwit Bech32 or Taproot Bech32m addresses depending on the <b>public</b> key length and the <b>script</b> version
@@ -252,7 +252,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_as_bytes">as_bytes</a>(addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>): &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_as_bytes">as_bytes</a>(addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>): &<a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -261,7 +261,7 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_as_bytes">as_bytes</a>(addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a>): &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_as_bytes">as_bytes</a>(addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a>): &<a href="">vector</a>&lt;u8&gt; {
     &addr.bytes
 }
 </code></pre>
@@ -276,7 +276,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_into_bytes">into_bytes</a>(addr: <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_into_bytes">into_bytes</a>(addr: <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -285,7 +285,7 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_into_bytes">into_bytes</a>(addr: <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_into_bytes">into_bytes</a>(addr: <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a>): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> { bytes } = addr;
     bytes
 }
@@ -301,7 +301,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_p2pkh_address">create_p2pkh_address</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_p2pkh_address">create_p2pkh_address</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
 </code></pre>
 
 
@@ -310,7 +310,7 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_p2pkh_address">create_p2pkh_address</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_p2pkh_address">create_p2pkh_address</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
     <b>let</b> address_bytes = <a href="encoding.md#0x3_encoding_p2pkh">encoding::p2pkh</a>(pub_key);
 
     <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
@@ -329,7 +329,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_p2sh_address">create_p2sh_address</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_p2sh_address">create_p2sh_address</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
 </code></pre>
 
 
@@ -338,7 +338,7 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_p2sh_address">create_p2sh_address</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_p2sh_address">create_p2sh_address</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
     <b>let</b> address_bytes = <a href="encoding.md#0x3_encoding_p2sh">encoding::p2sh</a>(pub_key);
 
     <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
@@ -357,7 +357,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_bech32_address">create_bech32_address</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_bech32_address">create_bech32_address</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;, version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
 </code></pre>
 
 
@@ -366,7 +366,7 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_bech32_address">create_bech32_address</a>(pub_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_create_bech32_address">create_bech32_address</a>(pub_key: &<a href="">vector</a>&lt;u8&gt;, version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
     <b>let</b> address_bytes = <a href="encoding.md#0x3_encoding_bech32">encoding::bech32</a>(pub_key, version);
 
     <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {

--- a/crates/rooch-framework/doc/bitcoin_validator.md
+++ b/crates/rooch-framework/doc/bitcoin_validator.md
@@ -21,11 +21,11 @@ This module implements bitcoin validator with the ECDSA signature over Secp256k1
 -  [Function `validate`](#0x3_bitcoin_validator_validate)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/debug.md#0x1_debug">0x1::debug</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::debug</a>;
+<b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account_authentication.md#0x3_account_authentication">0x3::account_authentication</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
 <b>use</b> <a href="bitcoin_address.md#0x3_bitcoin_address">0x3::bitcoin_address</a>;
@@ -118,7 +118,7 @@ there defines scheme for each blockchain
 becuase ecdsa k1 scheme only supports key generation of 33-bytes compressed public key at this time.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8)
+<pre><code><b>public</b> entry <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, public_key: <a href="">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8)
 </code></pre>
 
 
@@ -129,21 +129,21 @@ becuase ecdsa k1 scheme only supports key generation of 33-bytes compressed publ
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
+    public_key: <a href="">vector</a>&lt;u8&gt;,
     decimal_prefix_or_version: u8,
 ) {
     // compare newly passed <b>public</b> key <b>with</b> Bitcoin <b>public</b> key length <b>to</b> ensure it's compatible
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&public_key) == <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">ecdsa_k1::public_key_length</a>()
-        || <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&public_key) == 20 // TODO support key generation of 20-bytes <b>public</b> key for Bitcoin bech32 addresses
-        || <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&public_key) == 32, // TODO support key generation of 32-bytes <b>public</b> key for Bitcoin bech32 addresses
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_validator.md#0x3_bitcoin_validator_ErrorInvalidPublicKeyLength">ErrorInvalidPublicKeyLength</a>)
+        <a href="_length">vector::length</a>(&public_key) == <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">ecdsa_k1::public_key_length</a>()
+        || <a href="_length">vector::length</a>(&public_key) == 20 // TODO support key generation of 20-bytes <b>public</b> key for Bitcoin bech32 addresses
+        || <a href="_length">vector::length</a>(&public_key) == 32, // TODO support key generation of 32-bytes <b>public</b> key for Bitcoin bech32 addresses
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="bitcoin_validator.md#0x3_bitcoin_validator_ErrorInvalidPublicKeyLength">ErrorInvalidPublicKeyLength</a>)
     );
 
     // User can rotate the authentication key arbitrarily, so we do not need <b>to</b> check the new <b>public</b> key <b>with</b> the <a href="account.md#0x3_account">account</a> <b>address</b>.
     <b>let</b> authentication_key = <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key, decimal_prefix_or_version);
-    <b>let</b> account_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <a href="bitcoin_validator.md#0x3_bitcoin_validator_rotate_authentication_key">rotate_authentication_key</a>(ctx, account_addr, authentication_key);
 }
 </code></pre>
@@ -158,7 +158,7 @@ becuase ecdsa k1 scheme only supports key generation of 33-bytes compressed publ
 
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -167,8 +167,8 @@ becuase ecdsa k1 scheme only supports key generation of 33-bytes compressed publ
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">account_authentication::remove_authentication_key</a>&lt;<a href="bitcoin_validator.md#0x3_bitcoin_validator_BitcoinValidator">BitcoinValidator</a>&gt;(ctx, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
+<pre><code><b>public</b> entry <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+    <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">account_authentication::remove_authentication_key</a>&lt;<a href="bitcoin_validator.md#0x3_bitcoin_validator_BitcoinValidator">BitcoinValidator</a>&gt;(ctx, <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
 }
 </code></pre>
 
@@ -183,7 +183,7 @@ becuase ecdsa k1 scheme only supports key generation of 33-bytes compressed publ
 Get the authentication key of the given authenticator from authenticator_payload.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -192,7 +192,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> public_key = <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_public_key_from_authenticator_payload">ecdsa_k1::get_public_key_from_authenticator_payload</a>(authenticator_payload);
     <b>let</b> addr = <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_address">public_key_to_address</a>(public_key, decimal_prefix_or_version);
     <a href="bitcoin_address.md#0x3_bitcoin_address_into_bytes">bitcoin_address::into_bytes</a>(addr)
@@ -209,7 +209,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
 </code></pre>
 
 
@@ -218,9 +218,9 @@ Get the authentication key of the given authenticator from authenticator_payload
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): BTCAddress {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): BTCAddress {
     // Determine the <b>public</b> key length, 33-bytes for a legacy <b>address</b> and 32- and 20-bytes for a bech32 <b>address</b>.
-    <b>if</b> (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&public_key) == <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">ecdsa_k1::public_key_length</a>()) {
+    <b>if</b> (<a href="_length">vector::length</a>(&public_key) == <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">ecdsa_k1::public_key_length</a>()) {
         <b>let</b> decimal_prefix = decimal_prefix_or_version;
         <a href="bitcoin_address.md#0x3_bitcoin_address_new_legacy">bitcoin_address::new_legacy</a>(&public_key, decimal_prefix)
     } <b>else</b> {
@@ -241,7 +241,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 Get the authentication key of the given public key.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -250,7 +250,7 @@ Get the authentication key of the given public key.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;, decimal_prefix_or_version: u8): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> addr = <a href="bitcoin_validator.md#0x3_bitcoin_validator_public_key_to_address">public_key_to_address</a>(public_key, decimal_prefix_or_version);
     <a href="bitcoin_address.md#0x3_bitcoin_address_into_bytes">bitcoin_address::into_bytes</a>(addr)
 }
@@ -267,7 +267,7 @@ Get the authentication key of the given public key.
 Get the authentication key option of the given account.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -276,7 +276,7 @@ Get the authentication key option of the given account.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): Option&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
     <a href="account_authentication.md#0x3_account_authentication_get_authentication_key">account_authentication::get_authentication_key</a>&lt;<a href="bitcoin_validator.md#0x3_bitcoin_validator_BitcoinValidator">BitcoinValidator</a>&gt;(ctx, addr)
 }
 </code></pre>
@@ -292,7 +292,7 @@ Get the authentication key option of the given account.
 The authentication key exists in account or not.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_is_authentication_key_in_account">is_authentication_key_in_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_is_authentication_key_in_account">is_authentication_key_in_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -302,7 +302,7 @@ The authentication key exists in account or not.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_is_authentication_key_in_account">is_authentication_key_in_account</a>(ctx: &StorageContext, addr: <b>address</b>): bool {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&<a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
+    <a href="_is_some">option::is_some</a>(&<a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
 }
 </code></pre>
 
@@ -317,7 +317,7 @@ The authentication key exists in account or not.
 Extract the authentication key of the authentication key option.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -326,8 +326,8 @@ Extract the authentication key of the authentication key option.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt; {
+    <a href="_extract">option::extract</a>(&<b>mut</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
 }
 </code></pre>
 
@@ -342,7 +342,7 @@ Extract the authentication key of the authentication key option.
 Only validate the authenticator's signature.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, tx_hash: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -351,7 +351,7 @@ Only validate the authenticator's signature.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, tx_hash: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
         <a href="ecdsa_k1.md#0x3_ecdsa_k1_verify">ecdsa_k1::verify</a>(
             &<a href="ecdsa_k1.md#0x3_ecdsa_k1_get_signature_from_authenticator_payload">ecdsa_k1::get_signature_from_authenticator_payload</a>(authenticator_payload),
@@ -374,7 +374,7 @@ Only validate the authenticator's signature.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_validate">validate</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, authenticator_payload: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -383,8 +383,8 @@ Only validate the authenticator's signature.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_validate">validate</a>(ctx: &StorageContext, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>let</b> tx_hash = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_hash">storage_context::tx_hash</a>(ctx);
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator_validate">validate</a>(ctx: &StorageContext, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) {
+    <b>let</b> tx_hash = <a href="_tx_hash">storage_context::tx_hash</a>(ctx);
     <a href="bitcoin_validator.md#0x3_bitcoin_validator_validate_signature">validate_signature</a>(&authenticator_payload, &tx_hash);
 
     // TODO compare the auth_key from the payload <b>with</b> the auth_key from the <a href="account.md#0x3_account">account</a>

--- a/crates/rooch-framework/doc/builtin_validators.md
+++ b/crates/rooch-framework/doc/builtin_validators.md
@@ -10,8 +10,8 @@
 -  [Function `is_builtin_scheme`](#0x3_builtin_validators_is_builtin_scheme)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry">0x3::auth_validator_registry</a>;
 <b>use</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator">0x3::bitcoin_validator</a>;
 <b>use</b> <a href="ethereum_validator.md#0x3_ethereum_validator">0x3::ethereum_validator</a>;
@@ -42,7 +42,7 @@
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, _genesis_account: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, _genesis_account: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -51,7 +51,7 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, _genesis_account: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>){
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, _genesis_account: &<a href="">signer</a>){
     // SCHEME_NATIVE: u64 = 0;
     <b>let</b> id = <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">auth_validator_registry::register_internal</a>&lt;<a href="native_validator.md#0x3_native_validator_NativeValidator">native_validator::NativeValidator</a>&gt;(ctx);
     <b>assert</b>!(id == <a href="native_validator.md#0x3_native_validator_scheme">native_validator::scheme</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));

--- a/crates/rooch-framework/doc/chain_id.md
+++ b/crates/rooch-framework/doc/chain_id.md
@@ -10,8 +10,8 @@
 -  [Function `chain_id`](#0x3_chain_id_chain_id)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage">0x2::account_storage</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 </code></pre>
 
 
@@ -50,7 +50,7 @@ The ChainID in the global storage
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="chain_id.md#0x3_chain_id_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, genesis_account: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="chain_id.md#0x3_chain_id_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, genesis_account: &<a href="">signer</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64)
 </code></pre>
 
 
@@ -59,11 +59,11 @@ The ChainID in the global storage
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="chain_id.md#0x3_chain_id_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, genesis_account: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64){
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="chain_id.md#0x3_chain_id_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, genesis_account: &<a href="">signer</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64){
     <b>let</b> <a href="chain_id.md#0x3_chain_id">chain_id</a> = <a href="chain_id.md#0x3_chain_id_ChainID">ChainID</a>{
         id: <a href="chain_id.md#0x3_chain_id">chain_id</a>
     };
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, <a href="chain_id.md#0x3_chain_id">chain_id</a>);
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, <a href="chain_id.md#0x3_chain_id">chain_id</a>);
 }
 </code></pre>
 
@@ -77,7 +77,7 @@ The ChainID in the global storage
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id">chain_id</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id">chain_id</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
 </code></pre>
 
 
@@ -87,7 +87,7 @@ The ChainID in the global storage
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id">chain_id</a>(ctx: &StorageContext) : u64 {
-    <b>let</b> <a href="chain_id.md#0x3_chain_id">chain_id</a> = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="chain_id.md#0x3_chain_id_ChainID">ChainID</a>&gt;(ctx, @rooch_framework);
+    <b>let</b> <a href="chain_id.md#0x3_chain_id">chain_id</a> = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="chain_id.md#0x3_chain_id_ChainID">ChainID</a>&gt;(ctx, @rooch_framework);
     <a href="chain_id.md#0x3_chain_id">chain_id</a>.id
 }
 </code></pre>

--- a/crates/rooch-framework/doc/coin.md
+++ b/crates/rooch-framework/doc/coin.md
@@ -65,17 +65,17 @@ This module provides the foundation for typesafe Coins.
 -  [Function `unfreeze_coin_store_entry`](#0x3_coin_unfreeze_coin_store_entry)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage">0x2::account_storage</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/event.md#0x2_event">0x2::event</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x2_signer">0x2::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table">0x2::table</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info">0x2::type_info</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table">0x2::type_table</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::event</a>;
+<b>use</b> <a href="">0x2::signer</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
+<b>use</b> <a href="">0x2::table</a>;
+<b>use</b> <a href="">0x2::tx_context</a>;
+<b>use</b> <a href="">0x2::type_info</a>;
+<b>use</b> <a href="">0x2::type_table</a>;
 </code></pre>
 
 
@@ -161,13 +161,13 @@ Information about a specific coin type. Stored on the creator of the coin's acco
 
 <dl>
 <dt>
-<code>name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
+<code>name: <a href="_String">string::String</a></code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code>symbol: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
+<code>symbol: <a href="_String">string::String</a></code>
 </dt>
 <dd>
  Symbol of the coin, usually a shorter version of the name.
@@ -210,7 +210,7 @@ A resource that holds the CoinInfo for all accounts.
 
 <dl>
 <dt>
-<code>coin_infos: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a></code>
+<code>coin_infos: <a href="_TypeTable">type_table::TypeTable</a></code>
 </dt>
 <dd>
 
@@ -239,7 +239,7 @@ The main scenario is that the user can actively turn off the AutoAcceptCoin sett
 
 <dl>
 <dt>
-<code>auto_accept_coins: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_Table">table::Table</a>&lt;<b>address</b>, bool&gt;</code>
+<code>auto_accept_coins: <a href="_Table">table::Table</a>&lt;<b>address</b>, bool&gt;</code>
 </dt>
 <dd>
 
@@ -268,7 +268,7 @@ Default Deposit Coin no longer depends on accept coin
 
 <dl>
 <dt>
-<code>coin_stores: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a></code>
+<code>coin_stores: <a href="_TypeTable">type_table::TypeTable</a></code>
 </dt>
 <dd>
 
@@ -296,7 +296,7 @@ Event emitted when some amount of a coin is deposited into an account.
 
 <dl>
 <dt>
-<code>coin_type_info: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_TypeInfo">type_info::TypeInfo</a></code>
+<code>coin_type_info: <a href="_TypeInfo">type_info::TypeInfo</a></code>
 </dt>
 <dd>
  The type info for the coin that was sent
@@ -330,7 +330,7 @@ Event emitted when some amount of a coin is withdrawn from an account.
 
 <dl>
 <dt>
-<code>coin_type_info: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_TypeInfo">type_info::TypeInfo</a></code>
+<code>coin_type_info: <a href="_TypeInfo">type_info::TypeInfo</a></code>
 </dt>
 <dd>
  The type info for the coin that was sent
@@ -392,7 +392,7 @@ Event emitted when coin minted.
 
 <dl>
 <dt>
-<code>coin_type_info: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_TypeInfo">type_info::TypeInfo</a></code>
+<code>coin_type_info: <a href="_TypeInfo">type_info::TypeInfo</a></code>
 </dt>
 <dd>
  full info of coin
@@ -426,7 +426,7 @@ Event emitted when coin burned.
 
 <dl>
 <dt>
-<code>coin_type_info: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_TypeInfo">type_info::TypeInfo</a></code>
+<code>coin_type_info: <a href="_TypeInfo">type_info::TypeInfo</a></code>
 </dt>
 <dd>
  full info of coin
@@ -725,7 +725,7 @@ Coin amount cannot be zero
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="coin.md#0x3_coin_init_account_coin_store">init_account_coin_store</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="coin.md#0x3_coin_init_account_coin_store">init_account_coin_store</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -734,10 +734,10 @@ Coin amount cannot be zero
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="coin.md#0x3_coin_init_account_coin_store">init_account_coin_store</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>){
-    <b>let</b> tx_ctx = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>(ctx, <a href="account.md#0x3_account">account</a>, <a href="coin.md#0x3_coin_CoinStores">CoinStores</a>{
-        coin_stores: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_new">type_table::new</a>(tx_ctx),
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="coin.md#0x3_coin_init_account_coin_store">init_account_coin_store</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>){
+    <b>let</b> tx_ctx = <a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, <a href="account.md#0x3_account">account</a>, <a href="coin.md#0x3_coin_CoinStores">CoinStores</a>{
+        coin_stores: <a href="_new">type_table::new</a>(tx_ctx),
     });
 }
 </code></pre>
@@ -753,7 +753,7 @@ Coin amount cannot be zero
 Returns the balance of <code>addr</code> for provided <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_balance">balance</a>&lt;CoinType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): u256
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_balance">balance</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): u256
 </code></pre>
 
 
@@ -782,7 +782,7 @@ Returns the balance of <code>addr</code> for provided <code>CoinType</code>.
 Returns <code><b>true</b></code> if the type <code>CoinType</code> is an initialized coin.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): bool
 </code></pre>
 
 
@@ -792,9 +792,9 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is an initial
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;(ctx: &StorageContext): bool {
-    <b>if</b> (<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework)) {
-        <b>let</b> coin_infos = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
-        <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(&coin_infos.coin_infos)
+    <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework)) {
+        <b>let</b> coin_infos = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
+        <a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(&coin_infos.coin_infos)
     } <b>else</b> {
         <b>false</b>
     }
@@ -812,7 +812,7 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is an initial
 Returns the name of the coin.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_name">name</a>&lt;CoinType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_name">name</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): <a href="_String">string::String</a>
 </code></pre>
 
 
@@ -821,7 +821,7 @@ Returns the name of the coin.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_name">name</a>&lt;CoinType&gt;(ctx: &StorageContext): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_name">name</a>&lt;CoinType&gt;(ctx: &StorageContext): <a href="_String">string::String</a> {
     <a href="coin.md#0x3_coin_borrow_coin_info">borrow_coin_info</a>&lt;CoinType&gt;(ctx).name
 }
 </code></pre>
@@ -837,7 +837,7 @@ Returns the name of the coin.
 Returns the symbol of the coin, usually a shorter version of the name.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_symbol">symbol</a>&lt;CoinType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_symbol">symbol</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): <a href="_String">string::String</a>
 </code></pre>
 
 
@@ -846,7 +846,7 @@ Returns the symbol of the coin, usually a shorter version of the name.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_symbol">symbol</a>&lt;CoinType&gt;(ctx: &StorageContext): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_symbol">symbol</a>&lt;CoinType&gt;(ctx: &StorageContext): <a href="_String">string::String</a> {
     <a href="coin.md#0x3_coin_borrow_coin_info">borrow_coin_info</a>&lt;CoinType&gt;(ctx).symbol
 }
 </code></pre>
@@ -864,7 +864,7 @@ For example, if <code>decimals</code> equals <code>2</code>, a balance of <code>
 be displayed to a user as <code>5.05</code> (<code>505 / 10 ** 2</code>).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_decimals">decimals</a>&lt;CoinType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): u8
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_decimals">decimals</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u8
 </code></pre>
 
 
@@ -889,7 +889,7 @@ be displayed to a user as <code>5.05</code> (<code>505 / 10 ** 2</code>).
 Returns the amount of coin in existence.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_supply">supply</a>&lt;CoinType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): u256
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_supply">supply</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u256
 </code></pre>
 
 
@@ -939,7 +939,7 @@ Return true if the type <code>CoinType1</code> is same with <code>CoinType2</cod
 Return whether the account at <code>addr</code> accept <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> type coins
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_account_accept_coin">is_account_accept_coin</a>&lt;CoinType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_account_accept_coin">is_account_accept_coin</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -969,7 +969,7 @@ Check whether the address can auto accept coin.
 Default is true if absent
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_can_auto_accept_coin">can_auto_accept_coin</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_can_auto_accept_coin">can_auto_accept_coin</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -979,10 +979,10 @@ Default is true if absent
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_can_auto_accept_coin">can_auto_accept_coin</a>(ctx: &StorageContext, addr: <b>address</b>): bool {
-    <b>if</b> (<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_AutoAcceptCoins">AutoAcceptCoins</a>&gt;(ctx, @rooch_framework)) {
-        <b>let</b> auto_accept_coins = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_AutoAcceptCoins">AutoAcceptCoins</a>&gt;(ctx, @rooch_framework);
-        <b>if</b> (<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_contains">table::contains</a>&lt;<b>address</b>, bool&gt;(&auto_accept_coins.auto_accept_coins, addr)) {
-            <b>return</b> *<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_borrow">table::borrow</a>&lt;<b>address</b>, bool&gt;(&auto_accept_coins.auto_accept_coins, addr)
+    <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_AutoAcceptCoins">AutoAcceptCoins</a>&gt;(ctx, @rooch_framework)) {
+        <b>let</b> auto_accept_coins = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_AutoAcceptCoins">AutoAcceptCoins</a>&gt;(ctx, @rooch_framework);
+        <b>if</b> (<a href="_contains">table::contains</a>&lt;<b>address</b>, bool&gt;(&auto_accept_coins.auto_accept_coins, addr)) {
+            <b>return</b> *<a href="_borrow">table::borrow</a>&lt;<b>address</b>, bool&gt;(&auto_accept_coins.auto_accept_coins, addr)
         }
     };
     <b>true</b>
@@ -1001,7 +1001,7 @@ Add a balance of <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> type to t
 If user turns off AutoAcceptCoin, call this method to receive the corresponding Coin
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -1010,8 +1010,8 @@ If user turns off AutoAcceptCoin, call this method to receive the corresponding 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType&gt;(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <b>let</b> addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType&gt;(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+    <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <a href="coin.md#0x3_coin_ensure_coin_store_pass_auto_accept_flag">ensure_coin_store_pass_auto_accept_flag</a>&lt;CoinType&gt;(ctx, addr);
 }
 </code></pre>
@@ -1027,7 +1027,7 @@ If user turns off AutoAcceptCoin, call this method to receive the corresponding 
 Configure whether auto-accept coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_set_auto_accept_coin">set_auto_accept_coin</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, enable: bool)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_set_auto_accept_coin">set_auto_accept_coin</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, enable: bool)
 </code></pre>
 
 
@@ -1036,12 +1036,12 @@ Configure whether auto-accept coins.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_set_auto_accept_coin">set_auto_accept_coin</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, enable: bool)  {
-    <b>let</b> addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
-    <b>let</b> auto_accept_coins = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="coin.md#0x3_coin_AutoAcceptCoins">AutoAcceptCoins</a>&gt;(ctx, @rooch_framework);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_upsert">table::upsert</a>&lt;<b>address</b>, bool&gt;(&<b>mut</b> auto_accept_coins.auto_accept_coins, addr, enable);
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_set_auto_accept_coin">set_auto_accept_coin</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, enable: bool)  {
+    <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> auto_accept_coins = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="coin.md#0x3_coin_AutoAcceptCoins">AutoAcceptCoins</a>&gt;(ctx, @rooch_framework);
+    <a href="_upsert">table::upsert</a>&lt;<b>address</b>, bool&gt;(&<b>mut</b> auto_accept_coins.auto_accept_coins, addr, enable);
 
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/event.md#0x2_event_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_AcceptCoinEvent">AcceptCoinEvent</a>&gt;(ctx,
+    <a href="_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_AcceptCoinEvent">AcceptCoinEvent</a>&gt;(ctx,
         <a href="coin.md#0x3_coin_AcceptCoinEvent">AcceptCoinEvent</a> {
             enable,
         },
@@ -1060,7 +1060,7 @@ Configure whether auto-accept coins.
 Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from the signing account.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1071,23 +1071,23 @@ Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from the sig
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
     amount: u256,
 ): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
-    <b>let</b> addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <b>assert</b>!(
         <a href="coin.md#0x3_coin_is_account_accept_coin">is_account_accept_coin</a>&lt;CoinType&gt;(ctx, addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorAccountNotAcceptCoin">ErrorAccountNotAcceptCoin</a>),
+        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorAccountNotAcceptCoin">ErrorAccountNotAcceptCoin</a>),
     );
 
     <b>assert</b>!(
         !<a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="coin.md#0x3_coin_ErrorAccountWithCoinFrozen">ErrorAccountWithCoinFrozen</a>),
+        <a href="_permission_denied">error::permission_denied</a>(<a href="coin.md#0x3_coin_ErrorAccountWithCoinFrozen">ErrorAccountWithCoinFrozen</a>),
     );
 
     <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    <b>let</b> coin_type_info = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_type_of">type_info::type_of</a>&lt;CoinType&gt;();
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/event.md#0x2_event_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_WithdrawEvent">WithdrawEvent</a>&gt;(ctx, <a href="coin.md#0x3_coin_WithdrawEvent">WithdrawEvent</a> {
+    <b>let</b> coin_type_info = <a href="_type_of">type_info::type_of</a>&lt;CoinType&gt;();
+    <a href="_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_WithdrawEvent">WithdrawEvent</a>&gt;(ctx, <a href="coin.md#0x3_coin_WithdrawEvent">WithdrawEvent</a> {
         coin_type_info,
         amount,
     });
@@ -1107,7 +1107,7 @@ Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from the sig
 Deposit the coin balance into the recipient's account and emit an event.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit">deposit</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit">deposit</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1119,17 +1119,17 @@ Deposit the coin balance into the recipient's account and emit an event.
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit">deposit</a>&lt;CoinType&gt;(ctx: &<b>mut</b> StorageContext, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
     <b>assert</b>!(
         <a href="coin.md#0x3_coin_is_account_accept_coin">is_account_accept_coin</a>&lt;CoinType&gt;(ctx, addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorAccountNotAcceptCoin">ErrorAccountNotAcceptCoin</a>),
+        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorAccountNotAcceptCoin">ErrorAccountNotAcceptCoin</a>),
     );
 
     <b>assert</b>!(
         !<a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="coin.md#0x3_coin_ErrorAccountWithCoinFrozen">ErrorAccountWithCoinFrozen</a>),
+        <a href="_permission_denied">error::permission_denied</a>(<a href="coin.md#0x3_coin_ErrorAccountWithCoinFrozen">ErrorAccountWithCoinFrozen</a>),
     );
 
     <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    <b>let</b> coin_type_info = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_type_of">type_info::type_of</a>&lt;CoinType&gt;();
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/event.md#0x2_event_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_DepositEvent">DepositEvent</a>&gt;(ctx, <a href="coin.md#0x3_coin_DepositEvent">DepositEvent</a> {
+    <b>let</b> coin_type_info = <a href="_type_of">type_info::type_of</a>&lt;CoinType&gt;();
+    <a href="_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_DepositEvent">DepositEvent</a>&gt;(ctx, <a href="coin.md#0x3_coin_DepositEvent">DepositEvent</a> {
         coin_type_info,
         amount: <a href="coin.md#0x3_coin_value">value</a>(&<a href="coin.md#0x3_coin">coin</a>),
     });
@@ -1149,7 +1149,7 @@ Deposit the coin balance into the recipient's account and emit an event.
 Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</code> to <code><b>to</b></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_transfer">transfer</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, from: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u256)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_transfer">transfer</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, from: &<a href="">signer</a>, <b>to</b>: <b>address</b>, amount: u256)
 </code></pre>
 
 
@@ -1160,7 +1160,7 @@ Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</cod
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_transfer">transfer</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    from: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    from: &<a href="">signer</a>,
     <b>to</b>: <b>address</b>,
     amount: u256,
 ) {
@@ -1181,7 +1181,7 @@ Burn <code><a href="coin.md#0x3_coin">coin</a></code> with capability.
 The capability <code>_cap</code> should be passed as a reference to <code><a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn">burn</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;, _cap: &<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn">burn</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;, _cap: &<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1197,10 +1197,10 @@ The capability <code>_cap</code> should be passed as a reference to <code><a hre
 ) {
     <b>let</b> <a href="coin.md#0x3_coin_Coin">Coin</a> { value: amount } = <a href="coin.md#0x3_coin">coin</a>;
 
-    <b>let</b> coin_type_info = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_type_of">type_info::type_of</a>&lt;CoinType&gt;();
+    <b>let</b> coin_type_info = <a href="_type_of">type_info::type_of</a>&lt;CoinType&gt;();
     <b>let</b> coin_info = <a href="coin.md#0x3_coin_borrow_mut_coin_info">borrow_mut_coin_info</a>&lt;CoinType&gt;(ctx);
     coin_info.supply = coin_info.supply - amount;
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/event.md#0x2_event_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_BurnEvent">BurnEvent</a>&gt;(ctx, <a href="coin.md#0x3_coin_BurnEvent">BurnEvent</a> {
+    <a href="_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_BurnEvent">BurnEvent</a>&gt;(ctx, <a href="coin.md#0x3_coin_BurnEvent">BurnEvent</a> {
         coin_type_info,
         amount,
     });
@@ -1220,7 +1220,7 @@ The capability <code>burn_cap</code> should be passed as a reference to <code><a
 This function shouldn't fail as it's called as part of transaction fee burning.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn_from">burn_from</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, amount: u256, burn_cap: &<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn_from">burn_from</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, amount: u256, burn_cap: &<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1265,7 +1265,7 @@ a <code><a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a></code> for 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_zero">destroy_zero</a>&lt;CoinType&gt;(zero_coin: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
     <b>let</b> <a href="coin.md#0x3_coin_Coin">Coin</a> { value } = zero_coin;
-    <b>assert</b>!(value == 0, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorDestroyOfNonZeroCoin">ErrorDestroyOfNonZeroCoin</a>))
+    <b>assert</b>!(value == 0, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorDestroyOfNonZeroCoin">ErrorDestroyOfNonZeroCoin</a>))
 }
 </code></pre>
 
@@ -1290,7 +1290,7 @@ Extracts <code>amount</code> from the passed-in <code><a href="coin.md#0x3_coin"
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract">extract</a>&lt;CoinType&gt;(<a href="coin.md#0x3_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;, amount: u256): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
-    <b>assert</b>!(<a href="coin.md#0x3_coin">coin</a>.value &gt;= amount, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorInSufficientBalance">ErrorInSufficientBalance</a>));
+    <b>assert</b>!(<a href="coin.md#0x3_coin">coin</a>.value &gt;= amount, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorInSufficientBalance">ErrorInSufficientBalance</a>));
     <a href="coin.md#0x3_coin">coin</a>.value = <a href="coin.md#0x3_coin">coin</a>.value - amount;
     <a href="coin.md#0x3_coin_Coin">Coin</a> { value: amount }
 }
@@ -1334,7 +1334,7 @@ Extracts the entire amount from the passed-in <code><a href="coin.md#0x3_coin">c
 Freeze a CoinStore to prevent transfers
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store">freeze_coin_store</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, _freeze_cap: &<a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store">freeze_coin_store</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, _freeze_cap: &<a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1365,7 +1365,7 @@ Freeze a CoinStore to prevent transfers
 Unfreeze a CoinStore to allow transfers
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store">unfreeze_coin_store</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, _freeze_cap: &<a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store">unfreeze_coin_store</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, _freeze_cap: &<a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1398,7 +1398,7 @@ The given signer also becomes the account hosting the information about the coin
 (name, supply, etc.).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_initialize">initialize</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a>, symbol: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a>, decimals: u8): (<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_initialize">initialize</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, name: <a href="_String">string::String</a>, symbol: <a href="_String">string::String</a>, decimals: u8): (<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1409,25 +1409,25 @@ The given signer also becomes the account hosting the information about the coin
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_initialize">initialize</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
     // addr: <b>address</b>,
-    name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a>,
-    symbol: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_String">string::String</a>,
+    name: <a href="_String">string::String</a>,
+    symbol: <a href="_String">string::String</a>,
     decimals: u8,
 ): (<a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_MintCapability">MintCapability</a>&lt;CoinType&gt;) {
-    <b>let</b> addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <b>assert</b>!(
         <a href="coin.md#0x3_coin_coin_address">coin_address</a>&lt;CoinType&gt;() == addr,
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinInfoAddressMismatch">ErrorCoinInfoAddressMismatch</a>),
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinInfoAddressMismatch">ErrorCoinInfoAddressMismatch</a>),
     );
 
     <b>assert</b>!(
-        !<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(ctx, addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="coin.md#0x3_coin_ErrorCoinInfoAlreadyPublished">ErrorCoinInfoAlreadyPublished</a>),
+        !<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(ctx, addr),
+        <a href="_already_exists">error::already_exists</a>(<a href="coin.md#0x3_coin_ErrorCoinInfoAlreadyPublished">ErrorCoinInfoAlreadyPublished</a>),
     );
 
-    <b>assert</b>!(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt;= <a href="coin.md#0x3_coin_MAX_COIN_NAME_LENGTH">MAX_COIN_NAME_LENGTH</a>, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinNameTooLong">ErrorCoinNameTooLong</a>));
-    <b>assert</b>!(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&symbol) &lt;= <a href="coin.md#0x3_coin_MAX_COIN_SYMBOL_LENGTH">MAX_COIN_SYMBOL_LENGTH</a>, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinSymbolTooLong">ErrorCoinSymbolTooLong</a>));
+    <b>assert</b>!(<a href="_length">string::length</a>(&name) &lt;= <a href="coin.md#0x3_coin_MAX_COIN_NAME_LENGTH">MAX_COIN_NAME_LENGTH</a>, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinNameTooLong">ErrorCoinNameTooLong</a>));
+    <b>assert</b>!(<a href="_length">string::length</a>(&symbol) &lt;= <a href="coin.md#0x3_coin_MAX_COIN_SYMBOL_LENGTH">MAX_COIN_SYMBOL_LENGTH</a>, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinSymbolTooLong">ErrorCoinSymbolTooLong</a>));
 
     <b>let</b> coin_info = <a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt; {
         name,
@@ -1435,8 +1435,8 @@ The given signer also becomes the account hosting the information about the coin
         decimals,
         supply: 0u256,
     };
-    <b>let</b> coin_infos = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_add">type_table::add</a>(&<b>mut</b> coin_infos.coin_infos, coin_info);
+    <b>let</b> coin_infos = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
+    <a href="_add">type_table::add</a>(&<b>mut</b> coin_infos.coin_infos, coin_info);
 
     (<a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt; {}, <a href="coin.md#0x3_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt; {}, <a href="coin.md#0x3_coin_MintCapability">MintCapability</a>&lt;CoinType&gt; {})
 }
@@ -1482,7 +1482,7 @@ The capability <code>_cap</code> should be passed as reference to <code><a href=
 Returns minted <code><a href="coin.md#0x3_coin_Coin">Coin</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_mint">mint</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, amount: u256, _cap: &<a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;CoinType&gt;): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_mint">mint</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, amount: u256, _cap: &<a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;CoinType&gt;): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1498,8 +1498,8 @@ Returns minted <code><a href="coin.md#0x3_coin_Coin">Coin</a></code>.
 ): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
    <b>let</b> coin_info = <a href="coin.md#0x3_coin_borrow_mut_coin_info">borrow_mut_coin_info</a>&lt;CoinType&gt;(ctx);
     coin_info.supply = coin_info.supply + amount;
-    <b>let</b> coin_type_info = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_info.md#0x2_type_info_type_of">type_info::type_of</a>&lt;CoinType&gt;();
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/event.md#0x2_event_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_MintEvent">MintEvent</a>&gt;(ctx, <a href="coin.md#0x3_coin_MintEvent">MintEvent</a> {
+    <b>let</b> coin_type_info = <a href="_type_of">type_info::type_of</a>&lt;CoinType&gt;();
+    <a href="_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_MintEvent">MintEvent</a>&gt;(ctx, <a href="coin.md#0x3_coin_MintEvent">MintEvent</a> {
         coin_type_info,
         amount,
     });
@@ -1569,7 +1569,7 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -1579,9 +1579,9 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx: &StorageContext, addr: <b>address</b>): bool {
-    <b>if</b> (<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr)) {
-        <b>let</b> coin_stores = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr);
-        <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md#0x2_type_table_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(&coin_stores.coin_stores)
+    <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr)) {
+        <b>let</b> coin_stores = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr);
+        <a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(&coin_stores.coin_stores)
     } <b>else</b> {
         <b>false</b>
     }
@@ -1598,7 +1598,7 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -1704,7 +1704,7 @@ Mint and Burn Capabilities will be stored under <code><a href="account.md#0x3_ac
 A developer can create his own coin and care less about mint and burn capabilities
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_initialize_entry">initialize_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, symbol: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, decimals: u8)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_initialize_entry">initialize_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, name: <a href="">vector</a>&lt;u8&gt;, symbol: <a href="">vector</a>&lt;u8&gt;, decimals: u8)
 </code></pre>
 
 
@@ -1715,21 +1715,21 @@ A developer can create his own coin and care less about mint and burn capabiliti
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_initialize_entry">initialize_entry</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    symbol: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
+    name: <a href="">vector</a>&lt;u8&gt;,
+    symbol: <a href="">vector</a>&lt;u8&gt;,
     decimals: u8,
 ) {
-    // <b>let</b> addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    // <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <b>let</b> (burn_cap, freeze_cap, mint_cap) = <a href="coin.md#0x3_coin_initialize">initialize</a>&lt;CoinType&gt;(
         ctx,
         <a href="account.md#0x3_account">account</a>,
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(name),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(symbol),
+        <a href="_utf8">string::utf8</a>(name),
+        <a href="_utf8">string::utf8</a>(symbol),
         decimals,
     );
 
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>(ctx, <a href="account.md#0x3_account">account</a>, <a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt; {
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, <a href="account.md#0x3_account">account</a>, <a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt; {
         burn_cap,
         freeze_cap,
         mint_cap
@@ -1748,7 +1748,7 @@ A developer can create his own coin and care less about mint and burn capabiliti
 Create new coins <code>CoinType</code> and deposit them into dst_addr's account.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_mint_entry">mint_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, dst_addr: <b>address</b>, amount: u256)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_mint_entry">mint_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, dst_addr: <b>address</b>, amount: u256)
 </code></pre>
 
 
@@ -1759,22 +1759,22 @@ Create new coins <code>CoinType</code> and deposit them into dst_addr's account.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_mint_entry">mint_entry</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
     dst_addr: <b>address</b>,
     amount: u256,
 ) {
-    <b>let</b> account_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
 
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
+        <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
+        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
     );
 
-    <b>let</b> cap = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    // <b>let</b> cap = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
+    <b>let</b> cap = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
+    // <b>let</b> cap = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
     <b>let</b> coins_minted = <a href="coin.md#0x3_coin_mint">mint</a>(ctx, amount, &cap.mint_cap);
     <a href="coin.md#0x3_coin_deposit">deposit</a>(ctx, dst_addr, coins_minted);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap)
+    <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap)
 }
 </code></pre>
 
@@ -1789,7 +1789,7 @@ Create new coins <code>CoinType</code> and deposit them into dst_addr's account.
 Withdraw an <code>amount</code> of coin <code>CoinType</code> from <code><a href="account.md#0x3_account">account</a></code> and burn it.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_burn_entry">burn_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, amount: u256)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_burn_entry">burn_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, amount: u256)
 </code></pre>
 
 
@@ -1800,21 +1800,21 @@ Withdraw an <code>amount</code> of coin <code>CoinType</code> from <code><a href
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_burn_entry">burn_entry</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
     amount: u256,
 ) {
-    <b>let</b> account_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
 
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
+        <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
+        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
     );
 
-    // <b>let</b> cap = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    <b>let</b> cap = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
+    // <b>let</b> cap = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
+    <b>let</b> cap = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
     <b>let</b> to_burn = <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType&gt;(ctx, <a href="account.md#0x3_account">account</a>, amount);
     <a href="coin.md#0x3_coin_burn">burn</a>&lt;CoinType&gt;(ctx, to_burn, &cap.burn_cap);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap);
+    <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap);
 }
 </code></pre>
 
@@ -1830,7 +1830,7 @@ Creating a resource that stores balance of <code>CoinType</code> on user's accou
 Required if user wants to start accepting deposits of <code>CoinType</code> in his account.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_accept_coin_entry">accept_coin_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_accept_coin_entry">accept_coin_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -1839,7 +1839,7 @@ Required if user wants to start accepting deposits of <code>CoinType</code> in h
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_accept_coin_entry">accept_coin_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_accept_coin_entry">accept_coin_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
     <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType&gt;(ctx, <a href="account.md#0x3_account">account</a>)
 }
 </code></pre>
@@ -1856,7 +1856,7 @@ Enable account's auto-accept-coin feature.
 The script function is reenterable.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_enable_auto_accept_coin_entry">enable_auto_accept_coin_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_enable_auto_accept_coin_entry">enable_auto_accept_coin_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -1865,7 +1865,7 @@ The script function is reenterable.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_enable_auto_accept_coin_entry">enable_auto_accept_coin_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_enable_auto_accept_coin_entry">enable_auto_accept_coin_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
     <a href="coin.md#0x3_coin_set_auto_accept_coin">set_auto_accept_coin</a>(ctx, <a href="account.md#0x3_account">account</a>, <b>true</b>)
 }
 </code></pre>
@@ -1882,7 +1882,7 @@ Disable account's auto-accept-coin feature.
 The script function is reenterable.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_disable_auto_accept_coin_entry">disable_auto_accept_coin_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_disable_auto_accept_coin_entry">disable_auto_accept_coin_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -1891,7 +1891,7 @@ The script function is reenterable.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_disable_auto_accept_coin_entry">disable_auto_accept_coin_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_disable_auto_accept_coin_entry">disable_auto_accept_coin_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
     <a href="coin.md#0x3_coin_set_auto_accept_coin">set_auto_accept_coin</a>(ctx, <a href="account.md#0x3_account">account</a>, <b>false</b>);
 }
 </code></pre>
@@ -1907,7 +1907,7 @@ The script function is reenterable.
 Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</code> to <code><b>to</b></code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_transfer_entry">transfer_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, from: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u256)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_transfer_entry">transfer_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, from: &<a href="">signer</a>, <b>to</b>: <b>address</b>, amount: u256)
 </code></pre>
 
 
@@ -1918,7 +1918,7 @@ Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</cod
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_transfer_entry">transfer_entry</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    from: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    from: &<a href="">signer</a>,
     <b>to</b>: <b>address</b>,
     amount: u256,
 ) {
@@ -1937,7 +1937,7 @@ Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</cod
 Freeze a CoinStore to prevent transfers
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_entry">freeze_coin_store_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_entry">freeze_coin_store_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -1948,17 +1948,17 @@ Freeze a CoinStore to prevent transfers
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_entry">freeze_coin_store_entry</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>
 ) {
-    <b>let</b> account_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
+        <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
+        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
     );
-    // <b>let</b> cap = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    <b>let</b> cap = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
+    // <b>let</b> cap = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
+    <b>let</b> cap = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
     <a href="coin.md#0x3_coin_freeze_coin_store">freeze_coin_store</a>(ctx, account_addr, &cap.freeze_cap);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap)
+    <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap)
 }
 </code></pre>
 
@@ -1973,7 +1973,7 @@ Freeze a CoinStore to prevent transfers
 Unfreeze a CoinStore to allow transfers
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_entry">unfreeze_coin_store_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_entry">unfreeze_coin_store_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -1984,17 +1984,17 @@ Unfreeze a CoinStore to allow transfers
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_entry">unfreeze_coin_store_entry</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>
 ) {
-    <b>let</b> account_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
+        <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
+        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
     );
-    <b>let</b> cap = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    // <b>let</b> cap = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
+    <b>let</b> cap = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
+    // <b>let</b> cap = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
     <a href="coin.md#0x3_coin_unfreeze_coin_store">unfreeze_coin_store</a>(ctx, account_addr, &cap.freeze_cap);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap)
+    <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap)
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/core_addresses.md
+++ b/crates/rooch-framework/doc/core_addresses.md
@@ -24,8 +24,8 @@
 -  [Function `genesis_address`](#0x3_core_addresses_genesis_address)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::signer</a>;
 </code></pre>
 
 
@@ -91,7 +91,7 @@ The operation can only be performed by the VM
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_genesis">assert_rooch_genesis</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_genesis">assert_rooch_genesis</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -100,8 +100,8 @@ The operation can only be performed by the VM
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_genesis">assert_rooch_genesis</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="core_addresses.md#0x3_core_addresses_assert_rooch_genesis_address">assert_rooch_genesis_address</a>(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>))
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_genesis">assert_rooch_genesis</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+    <a href="core_addresses.md#0x3_core_addresses_assert_rooch_genesis_address">assert_rooch_genesis_address</a>(<a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>))
 }
 </code></pre>
 
@@ -125,7 +125,7 @@ The operation can only be performed by the VM
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_genesis_address">assert_rooch_genesis_address</a>(addr: <b>address</b>) {
-    <b>assert</b>!(<a href="core_addresses.md#0x3_core_addresses_is_rooch_genesis_address">is_rooch_genesis_address</a>(addr), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorNotGenesisAddress">ErrorNotGenesisAddress</a>))
+    <b>assert</b>!(<a href="core_addresses.md#0x3_core_addresses_is_rooch_genesis_address">is_rooch_genesis_address</a>(addr), <a href="_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorNotGenesisAddress">ErrorNotGenesisAddress</a>))
 }
 </code></pre>
 
@@ -163,7 +163,7 @@ The operation can only be performed by the VM
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_association">assert_rooch_association</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_association">assert_rooch_association</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -172,8 +172,8 @@ The operation can only be performed by the VM
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_association">assert_rooch_association</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="core_addresses.md#0x3_core_addresses_assert_rooch_association_address">assert_rooch_association_address</a>(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>))
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_association">assert_rooch_association</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+    <a href="core_addresses.md#0x3_core_addresses_assert_rooch_association_address">assert_rooch_association_address</a>(<a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>))
 }
 </code></pre>
 
@@ -197,7 +197,7 @@ The operation can only be performed by the VM
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_association_address">assert_rooch_association_address</a>(addr: <b>address</b>) {
-    <b>assert</b>!(<a href="core_addresses.md#0x3_core_addresses_is_rooch_association_address">is_rooch_association_address</a>(addr), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorNotAssociationAddress">ErrorNotAssociationAddress</a>))
+    <b>assert</b>!(<a href="core_addresses.md#0x3_core_addresses_is_rooch_association_address">is_rooch_association_address</a>(addr), <a href="_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorNotAssociationAddress">ErrorNotAssociationAddress</a>))
 }
 </code></pre>
 
@@ -235,7 +235,7 @@ The operation can only be performed by the VM
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_framework">assert_rooch_framework</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_framework">assert_rooch_framework</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -244,10 +244,10 @@ The operation can only be performed by the VM
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_framework">assert_rooch_framework</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_rooch_framework">assert_rooch_framework</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
     <b>assert</b>!(
-        <a href="core_addresses.md#0x3_core_addresses_is_rooch_framework_address">is_rooch_framework_address</a>(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>)),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorNotRoochFrameworkAddress">ErrorNotRoochFrameworkAddress</a>),
+        <a href="core_addresses.md#0x3_core_addresses_is_rooch_framework_address">is_rooch_framework_address</a>(<a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>)),
+        <a href="_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorNotRoochFrameworkAddress">ErrorNotRoochFrameworkAddress</a>),
     )
 }
 </code></pre>
@@ -262,7 +262,7 @@ The operation can only be performed by the VM
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_framework_reserved_address">assert_framework_reserved_address</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_framework_reserved_address">assert_framework_reserved_address</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -271,8 +271,8 @@ The operation can only be performed by the VM
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_framework_reserved_address">assert_framework_reserved_address</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="core_addresses.md#0x3_core_addresses_assert_framework_reserved">assert_framework_reserved</a>(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_framework_reserved_address">assert_framework_reserved_address</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+    <a href="core_addresses.md#0x3_core_addresses_assert_framework_reserved">assert_framework_reserved</a>(<a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
 }
 </code></pre>
 
@@ -298,7 +298,7 @@ The operation can only be performed by the VM
 <pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_framework_reserved">assert_framework_reserved</a>(addr: <b>address</b>) {
     <b>assert</b>!(
         <a href="core_addresses.md#0x3_core_addresses_is_framework_reserved_address">is_framework_reserved_address</a>(addr),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorNotFrameworkReservedAddress">ErrorNotFrameworkReservedAddress</a>),
+        <a href="_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorNotFrameworkReservedAddress">ErrorNotFrameworkReservedAddress</a>),
     )
 }
 </code></pre>
@@ -373,7 +373,7 @@ Return true if <code>addr</code> is 0x3.
 Assert that the signer has the VM reserved address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_vm">assert_vm</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_vm">assert_vm</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -382,8 +382,8 @@ Assert that the signer has the VM reserved address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_vm">assert_vm</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <b>assert</b>!(<a href="core_addresses.md#0x3_core_addresses_is_vm">is_vm</a>(<a href="account.md#0x3_account">account</a>), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorVm">ErrorVm</a>))
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_assert_vm">assert_vm</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+    <b>assert</b>!(<a href="core_addresses.md#0x3_core_addresses_is_vm">is_vm</a>(<a href="account.md#0x3_account">account</a>), <a href="_permission_denied">error::permission_denied</a>(<a href="core_addresses.md#0x3_core_addresses_ErrorVm">ErrorVm</a>))
 }
 </code></pre>
 
@@ -398,7 +398,7 @@ Assert that the signer has the VM reserved address.
 Return true if <code>addr</code> is a reserved address for the VM to call system modules.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_is_vm">is_vm</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_is_vm">is_vm</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>): bool
 </code></pre>
 
 
@@ -407,8 +407,8 @@ Return true if <code>addr</code> is a reserved address for the VM to call system
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_is_vm">is_vm</a>(<a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>): bool {
-    <a href="core_addresses.md#0x3_core_addresses_is_vm_address">is_vm_address</a>(<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>))
+<pre><code><b>public</b> <b>fun</b> <a href="core_addresses.md#0x3_core_addresses_is_vm">is_vm</a>(<a href="account.md#0x3_account">account</a>: &<a href="">signer</a>): bool {
+    <a href="core_addresses.md#0x3_core_addresses_is_vm_address">is_vm_address</a>(<a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>))
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/decoding.md
+++ b/crates/rooch-framework/doc/decoding.md
@@ -22,7 +22,7 @@ Module which defines decoding functions.
 Decode the Bitcoin address bytes with Base58 algorithm and returns a raw address bytes
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="decoding.md#0x3_decoding_base58">base58</a>(encoded_address_bytes: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="decoding.md#0x3_decoding_base58">base58</a>(encoded_address_bytes: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -31,7 +31,7 @@ Decode the Bitcoin address bytes with Base58 algorithm and returns a raw address
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="decoding.md#0x3_decoding_base58">base58</a>(encoded_address_bytes: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="decoding.md#0x3_decoding_base58">base58</a>(encoded_address_bytes: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -47,7 +47,7 @@ Decode the Bitcoin address bytes with Base58 algorithm and returns a raw address
 Decode the Bitcoin address bytes with Base58Check algorithm and returns a raw address bytes without checksum
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="decoding.md#0x3_decoding_base58check">base58check</a>(encoded_address_bytes: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version_byte: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="decoding.md#0x3_decoding_base58check">base58check</a>(encoded_address_bytes: &<a href="">vector</a>&lt;u8&gt;, version_byte: u8): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -56,7 +56,7 @@ Decode the Bitcoin address bytes with Base58Check algorithm and returns a raw ad
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="decoding.md#0x3_decoding_base58check">base58check</a>(encoded_address_bytes: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version_byte: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="decoding.md#0x3_decoding_base58check">base58check</a>(encoded_address_bytes: &<a href="">vector</a>&lt;u8&gt;, version_byte: u8): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 

--- a/crates/rooch-framework/doc/ecdsa_k1.md
+++ b/crates/rooch-framework/doc/ecdsa_k1.md
@@ -253,7 +253,7 @@ built-in functions
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -262,13 +262,13 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = <a href="ecdsa_k1.md#0x3_ecdsa_k1_scheme_length">scheme_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>();
     <b>let</b> public_key_position = <a href="ecdsa_k1.md#0x3_ecdsa_k1_scheme_length">scheme_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">public_key_length</a>();
     <b>while</b> (i &lt; public_key_position) {
-        <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
         i = i + 1;
     };
     public_key
@@ -285,7 +285,7 @@ built-in functions
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -294,13 +294,13 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> sign = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = <a href="ecdsa_k1.md#0x3_ecdsa_k1_scheme_length">scheme_length</a>();
     <b>let</b> signature_position = <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>() + 1;
     <b>while</b> (i &lt; signature_position) {
-        <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
         i = i + 1;
     };
     sign
@@ -324,7 +324,7 @@ Ecdsa. This is an non-recoverable signature without recovery id.
 If the signature is valid to the pubkey and hashed message, return true. Else false.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_verify">verify</a>(signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">hash</a>: u8): bool
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_verify">verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;, <a href="">hash</a>: u8): bool
 </code></pre>
 
 
@@ -334,10 +334,10 @@ If the signature is valid to the pubkey and hashed message, return true. Else fa
 
 
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_verify">verify</a>(
-    signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">hash</a>: u8
+    signature: &<a href="">vector</a>&lt;u8&gt;,
+    public_key: &<a href="">vector</a>&lt;u8&gt;,
+    msg: &<a href="">vector</a>&lt;u8&gt;,
+    <a href="">hash</a>: u8
 ): bool;
 </code></pre>
 

--- a/crates/rooch-framework/doc/ecdsa_k1_recoverable.md
+++ b/crates/rooch-framework/doc/ecdsa_k1_recoverable.md
@@ -266,7 +266,7 @@ built-in functions
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -275,13 +275,13 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_scheme_length">scheme_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>();
     <b>let</b> public_key_position = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_scheme_length">scheme_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">public_key_length</a>();
     <b>while</b> (i &lt; public_key_position) {
-            <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(authenticator_payload, i);
-            <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
+            <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+            <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
             i = i + 1;
     };
     public_key
@@ -298,7 +298,7 @@ built-in functions
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -307,13 +307,13 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> sign = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_scheme_length">scheme_length</a>();
     <b>let</b> signature_position = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>() + 1;
     <b>while</b> (i &lt; signature_position) {
-            <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(authenticator_payload, i);
-            <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
+            <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+            <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
             i = i + 1;
     };
     sign
@@ -338,7 +338,7 @@ key, otherwise throw error. This is similar to ecrecover in Ethereum, can only b
 applied to Ecdsa signatures.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ecrecover">ecrecover</a>(signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">hash</a>: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ecrecover">ecrecover</a>(signature: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;, <a href="">hash</a>: u8): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -347,7 +347,7 @@ applied to Ecdsa signatures.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ecrecover">ecrecover</a>(signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">hash</a>: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ecrecover">ecrecover</a>(signature: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;, <a href="">hash</a>: u8): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -364,7 +364,7 @@ If the compressed public key is valid, return the 65-bytes uncompressed public k
 otherwise throw error.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_decompress_pubkey">decompress_pubkey</a>(pubkey: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_decompress_pubkey">decompress_pubkey</a>(pubkey: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -373,7 +373,7 @@ otherwise throw error.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_decompress_pubkey">decompress_pubkey</a>(pubkey: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_decompress_pubkey">decompress_pubkey</a>(pubkey: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -392,7 +392,7 @@ Ecdsa. This is a recoverable signature with a recovery id.
 If the signature is valid to the pubkey and hashed message, return true. Else false.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_verify">verify</a>(signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">hash</a>: u8): bool
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_verify">verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;, <a href="">hash</a>: u8): bool
 </code></pre>
 
 
@@ -402,9 +402,9 @@ If the signature is valid to the pubkey and hashed message, return true. Else fa
 
 
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_verify">verify</a>(
-    signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">hash</a>: u8
+    signature: &<a href="">vector</a>&lt;u8&gt;,
+    msg: &<a href="">vector</a>&lt;u8&gt;,
+    <a href="">hash</a>: u8
 ): bool;
 </code></pre>
 

--- a/crates/rooch-framework/doc/ed25519.md
+++ b/crates/rooch-framework/doc/ed25519.md
@@ -130,7 +130,7 @@ built-in functions
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -139,13 +139,13 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = <a href="ed25519.md#0x3_ed25519_scheme_length">scheme_length</a>() + <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>();
     <b>let</b> public_key_position = <a href="ed25519.md#0x3_ed25519_scheme_length">scheme_length</a>() + <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>() + <a href="ed25519.md#0x3_ed25519_public_key_length">public_key_length</a>();
     <b>while</b> (i &lt; public_key_position) {
-        <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
         i = i + 1;
     };
     public_key
@@ -162,7 +162,7 @@ built-in functions
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -171,13 +171,13 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> sign = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = <a href="ed25519.md#0x3_ed25519_scheme_length">scheme_length</a>();
     <b>let</b> signature_position = <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>() + 1;
     <b>while</b> (i &lt; signature_position) {
-        <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
         i = i + 1;
     };
     sign
@@ -200,7 +200,7 @@ If the signature is a valid Ed25519 signature of the message and public key, ret
 Otherwise, return false.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_verify">verify</a>(signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_verify">verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): bool
 </code></pre>
 
 
@@ -209,7 +209,7 @@ Otherwise, return false.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_verify">verify</a>(signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_verify">verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;): bool;
 </code></pre>
 
 

--- a/crates/rooch-framework/doc/encoding.md
+++ b/crates/rooch-framework/doc/encoding.md
@@ -25,7 +25,7 @@ Module which defines encoding functions.
 Encode the address bytes with Base58 algorithm and returns an encoded Bitcoin address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_base58">base58</a>(address_bytes: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_base58">base58</a>(address_bytes: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -34,7 +34,7 @@ Encode the address bytes with Base58 algorithm and returns an encoded Bitcoin ad
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_base58">base58</a>(address_bytes: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_base58">base58</a>(address_bytes: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -50,7 +50,7 @@ Encode the address bytes with Base58 algorithm and returns an encoded Bitcoin ad
 Encode the address bytes with Base58Check algorithm and returns an encoded Bitcoin address with checksum
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_base58check">base58check</a>(address_bytes: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version_byte: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_base58check">base58check</a>(address_bytes: &<a href="">vector</a>&lt;u8&gt;, version_byte: u8): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -59,7 +59,7 @@ Encode the address bytes with Base58Check algorithm and returns an encoded Bitco
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_base58check">base58check</a>(address_bytes: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version_byte: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_base58check">base58check</a>(address_bytes: &<a href="">vector</a>&lt;u8&gt;, version_byte: u8): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -75,7 +75,7 @@ Encode the address bytes with Base58Check algorithm and returns an encoded Bitco
 Encode the public key with Bech32 or Bech32m encoding algorithm and returns 42 or 62 length Bitcoin Bech32 address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_bech32">bech32</a>(public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_bech32">bech32</a>(public_key: &<a href="">vector</a>&lt;u8&gt;, version: u8): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -84,7 +84,7 @@ Encode the public key with Bech32 or Bech32m encoding algorithm and returns 42 o
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_bech32">bech32</a>(public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, version: u8): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_bech32">bech32</a>(public_key: &<a href="">vector</a>&lt;u8&gt;, version: u8): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -99,7 +99,7 @@ Encode the public key with Bech32 or Bech32m encoding algorithm and returns 42 o
 Creates a pay to script hash P2SH address from a script converted from a compressed public key.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_p2sh">p2sh</a>(public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_p2sh">p2sh</a>(public_key: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -108,7 +108,7 @@ Creates a pay to script hash P2SH address from a script converted from a compres
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_p2sh">p2sh</a>(public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_p2sh">p2sh</a>(public_key: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -123,7 +123,7 @@ Creates a pay to script hash P2SH address from a script converted from a compres
 Creates a pay to (compressed) public key hash address from a public key.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_p2pkh">p2pkh</a>(public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_p2pkh">p2pkh</a>(public_key: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -132,7 +132,7 @@ Creates a pay to (compressed) public key hash address from a public key.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_p2pkh">p2pkh</a>(public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="encoding.md#0x3_encoding_p2pkh">p2pkh</a>(public_key: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 

--- a/crates/rooch-framework/doc/ethereum_address.md
+++ b/crates/rooch-framework/doc/ethereum_address.md
@@ -12,7 +12,7 @@
 -  [Function `into_bytes`](#0x3_ethereum_address_into_bytes)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable">0x3::ecdsa_k1_recoverable</a>;
 <b>use</b> <a href="hash.md#0x3_hash">0x3::hash</a>;
 </code></pre>
@@ -36,7 +36,7 @@
 
 <dl>
 <dt>
-<code>bytes: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+<code>bytes: <a href="">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
 
@@ -85,7 +85,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_new">new</a>(pub_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_new">new</a>(pub_key: <a href="">vector</a>&lt;u8&gt;): <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>
 </code></pre>
 
 
@@ -94,33 +94,33 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_new">new</a>(pub_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_new">new</a>(pub_key: <a href="">vector</a>&lt;u8&gt;): <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a> {
     // A pubkey is a 33-bytes compressed <b>public</b> key
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&pub_key) == <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">ecdsa_k1_recoverable::public_key_length</a>(),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="ethereum_address.md#0x3_ethereum_address_ErrorMalformedPublicKey">ErrorMalformedPublicKey</a>)
+        <a href="_length">vector::length</a>(&pub_key) == <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">ecdsa_k1_recoverable::public_key_length</a>(),
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="ethereum_address.md#0x3_ethereum_address_ErrorMalformedPublicKey">ErrorMalformedPublicKey</a>)
     );
     // Decompressing the pubkey <b>to</b> a 65-bytes <b>public</b> key.
     <b>let</b> uncompressed = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_decompress_pubkey">ecdsa_k1_recoverable::decompress_pubkey</a>(&pub_key);
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&uncompressed) == <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_uncompressed_public_key_length">ecdsa_k1_recoverable::uncompressed_public_key_length</a>(),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_internal">error::internal</a>(<a href="ethereum_address.md#0x3_ethereum_address_ErrorDecompressPublicKey">ErrorDecompressPublicKey</a>)
+        <a href="_length">vector::length</a>(&uncompressed) == <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_uncompressed_public_key_length">ecdsa_k1_recoverable::uncompressed_public_key_length</a>(),
+        <a href="_internal">error::internal</a>(<a href="ethereum_address.md#0x3_ethereum_address_ErrorDecompressPublicKey">ErrorDecompressPublicKey</a>)
     );
     // Ignore the first byte and take the last 64-bytes of the uncompressed pubkey.
-    <b>let</b> uncompressed_64 = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+    <b>let</b> uncompressed_64 = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = 1;
     <b>while</b> (i &lt; 65) {
-        <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&uncompressed, i);
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> uncompressed_64, *value);
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(&uncompressed, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> uncompressed_64, *value);
         i = i + 1;
     };
-    // Take the last 20 bytes of the <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">hash</a> of the 64-bytes uncompressed pubkey.
+    // Take the last 20 bytes of the <a href="">hash</a> of the 64-bytes uncompressed pubkey.
     <b>let</b> hashed = hash::keccak256(&uncompressed_64);
-    <b>let</b> address_bytes = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+    <b>let</b> address_bytes = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = 12;
     <b>while</b> (i &lt; 32) {
-        <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&hashed, i);
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> address_bytes, *value);
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(&hashed, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> address_bytes, *value);
         i = i + 1;
     };
     // Return the 20 bytes <b>address</b> <b>as</b> the Ethereum <b>address</b>
@@ -140,7 +140,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_as_bytes">as_bytes</a>(addr: &<a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>): &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_as_bytes">as_bytes</a>(addr: &<a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>): &<a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -149,7 +149,7 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_as_bytes">as_bytes</a>(addr: &<a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a>): &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_as_bytes">as_bytes</a>(addr: &<a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a>): &<a href="">vector</a>&lt;u8&gt; {
     &addr.bytes
 }
 </code></pre>
@@ -164,7 +164,7 @@ error code
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_into_bytes">into_bytes</a>(addr: <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_into_bytes">into_bytes</a>(addr: <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -173,7 +173,7 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_into_bytes">into_bytes</a>(addr: <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_into_bytes">into_bytes</a>(addr: <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a>): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a> { bytes } = addr;
     bytes
 }

--- a/crates/rooch-framework/doc/ethereum_validator.md
+++ b/crates/rooch-framework/doc/ethereum_validator.md
@@ -21,11 +21,11 @@ This module implements Ethereum validator with the ECDSA recoverable signature o
 -  [Function `validate`](#0x3_ethereum_validator_validate)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/debug.md#0x1_debug">0x1::debug</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::debug</a>;
+<b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account_authentication.md#0x3_account_authentication">0x3::account_authentication</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
 <b>use</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable">0x3::ecdsa_k1_recoverable</a>;
@@ -116,7 +116,7 @@ there defines scheme for each blockchain
 
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, public_key: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -127,18 +127,18 @@ there defines scheme for each blockchain
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
+    public_key: <a href="">vector</a>&lt;u8&gt;
 ) {
     // compare newly passed <b>public</b> key <b>with</b> Ethereum <b>public</b> key length <b>to</b> ensure it's compatible
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&public_key) == <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">ecdsa_k1_recoverable::public_key_length</a>(),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="ethereum_validator.md#0x3_ethereum_validator_ErrorInvalidPublicKeyLength">ErrorInvalidPublicKeyLength</a>)
+        <a href="_length">vector::length</a>(&public_key) == <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">ecdsa_k1_recoverable::public_key_length</a>(),
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="ethereum_validator.md#0x3_ethereum_validator_ErrorInvalidPublicKeyLength">ErrorInvalidPublicKeyLength</a>)
     );
 
     // User can rotate the authentication key arbitrarily, so we do not need <b>to</b> check the new <b>public</b> key <b>with</b> the <a href="account.md#0x3_account">account</a> <b>address</b>.
     <b>let</b> authentication_key = <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key);
-    <b>let</b> account_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <a href="ethereum_validator.md#0x3_ethereum_validator_rotate_authentication_key">rotate_authentication_key</a>(ctx, account_addr, authentication_key);
 }
 </code></pre>
@@ -153,7 +153,7 @@ there defines scheme for each blockchain
 
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -162,8 +162,8 @@ there defines scheme for each blockchain
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">account_authentication::remove_authentication_key</a>&lt;<a href="ethereum_validator.md#0x3_ethereum_validator_EthereumValidator">EthereumValidator</a>&gt;(ctx, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
+<pre><code><b>public</b> entry <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+    <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">account_authentication::remove_authentication_key</a>&lt;<a href="ethereum_validator.md#0x3_ethereum_validator_EthereumValidator">EthereumValidator</a>&gt;(ctx, <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
 }
 </code></pre>
 
@@ -178,7 +178,7 @@ there defines scheme for each blockchain
 Get the authentication key of the given authenticator from authenticator_payload.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -187,7 +187,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> public_key = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload">ecdsa_k1_recoverable::get_public_key_from_authenticator_payload</a>(authenticator_payload);
     <b>let</b> addr = <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_address">public_key_to_address</a>(public_key);
     <a href="ethereum_address.md#0x3_ethereum_address_into_bytes">ethereum_address::into_bytes</a>(addr)
@@ -204,7 +204,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>
 </code></pre>
 
 
@@ -213,7 +213,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): ETHAddress {
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="">vector</a>&lt;u8&gt;): ETHAddress {
     <a href="ethereum_address.md#0x3_ethereum_address_new">ethereum_address::new</a>(public_key)
 }
 </code></pre>
@@ -229,7 +229,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 Get the authentication key of the given public key.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -238,7 +238,7 @@ Get the authentication key of the given public key.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> addr = <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_address">public_key_to_address</a>(public_key);
     <a href="ethereum_address.md#0x3_ethereum_address_into_bytes">ethereum_address::into_bytes</a>(addr)
 }
@@ -255,7 +255,7 @@ Get the authentication key of the given public key.
 Get the authentication key option of the given account.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -264,7 +264,7 @@ Get the authentication key option of the given account.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): Option&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
     <a href="account_authentication.md#0x3_account_authentication_get_authentication_key">account_authentication::get_authentication_key</a>&lt;<a href="ethereum_validator.md#0x3_ethereum_validator_EthereumValidator">EthereumValidator</a>&gt;(ctx, addr)
 }
 </code></pre>
@@ -280,7 +280,7 @@ Get the authentication key option of the given account.
 The authentication key exists in account or not.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_is_authentication_key_in_account">is_authentication_key_in_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_is_authentication_key_in_account">is_authentication_key_in_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -290,7 +290,7 @@ The authentication key exists in account or not.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_is_authentication_key_in_account">is_authentication_key_in_account</a>(ctx: &StorageContext, addr: <b>address</b>): bool {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&<a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
+    <a href="_is_some">option::is_some</a>(&<a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
 }
 </code></pre>
 
@@ -305,7 +305,7 @@ The authentication key exists in account or not.
 Extract the authentication key of the authentication key option.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -314,8 +314,8 @@ Extract the authentication key of the authentication key option.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt; {
+    <a href="_extract">option::extract</a>(&<b>mut</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
 }
 </code></pre>
 
@@ -330,7 +330,7 @@ Extract the authentication key of the authentication key option.
 Only validate the authenticator's signature.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, tx_hash: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -339,7 +339,7 @@ Only validate the authenticator's signature.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, tx_hash: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
         <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_verify">ecdsa_k1_recoverable::verify</a>(
             &<a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload">ecdsa_k1_recoverable::get_signature_from_authenticator_payload</a>(authenticator_payload),
@@ -361,7 +361,7 @@ Only validate the authenticator's signature.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_validate">validate</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, authenticator_payload: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -370,8 +370,8 @@ Only validate the authenticator's signature.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_validate">validate</a>(ctx: &StorageContext, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>let</b> tx_hash = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_hash">storage_context::tx_hash</a>(ctx);
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_validate">validate</a>(ctx: &StorageContext, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) {
+    <b>let</b> tx_hash = <a href="_tx_hash">storage_context::tx_hash</a>(ctx);
     <a href="ethereum_validator.md#0x3_ethereum_validator_validate_signature">validate_signature</a>(&authenticator_payload, &tx_hash);
 
     // TODO compare the auth_key from the payload <b>with</b> the auth_key from the <a href="account.md#0x3_account">account</a>

--- a/crates/rooch-framework/doc/gas_coin.md
+++ b/crates/rooch-framework/doc/gas_coin.md
@@ -16,10 +16,10 @@ This module defines Rooch Gas Coin.
 -  [Function `destroy_mint_cap`](#0x3_gas_coin_destroy_mint_cap)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage">0x2::account_storage</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
 <b>use</b> <a href="core_addresses.md#0x3_core_addresses">0x3::core_addresses</a>;
 </code></pre>
@@ -126,7 +126,7 @@ The container stores the current pending delegations.
 
 <dl>
 <dt>
-<code>inner: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="gas_coin.md#0x3_gas_coin_DelegatedMintCapability">gas_coin::DelegatedMintCapability</a>&gt;</code>
+<code>inner: <a href="">vector</a>&lt;<a href="gas_coin.md#0x3_gas_coin_DelegatedMintCapability">gas_coin::DelegatedMintCapability</a>&gt;</code>
 </dt>
 <dd>
 
@@ -158,7 +158,7 @@ Account does not have mint capability
 Can only called during genesis to initialize the Rooch coin.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_initialize">initialize</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, rooch_framework: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>): (<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">gas_coin::GasCoin</a>&gt;, <a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">gas_coin::GasCoin</a>&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_initialize">initialize</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, rooch_framework: &<a href="">signer</a>): (<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">gas_coin::GasCoin</a>&gt;, <a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">gas_coin::GasCoin</a>&gt;)
 </code></pre>
 
 
@@ -167,20 +167,20 @@ Can only called during genesis to initialize the Rooch coin.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_initialize">initialize</a>(ctx: &<b>mut</b> StorageContext, rooch_framework: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>): (BurnCapability&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a>&gt;, MintCapability&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a>&gt;) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_initialize">initialize</a>(ctx: &<b>mut</b> StorageContext, rooch_framework: &<a href="">signer</a>): (BurnCapability&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a>&gt;, MintCapability&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a>&gt;) {
     <a href="core_addresses.md#0x3_core_addresses_assert_rooch_framework">core_addresses::assert_rooch_framework</a>(rooch_framework);
 
     <b>let</b> (burn_cap, freeze_cap, mint_cap) = <a href="coin.md#0x3_coin_initialize">coin::initialize</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a>&gt;(
         ctx,
         rooch_framework,
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"Rooch Gas Coin"),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"RGC"),
+        <a href="_utf8">string::utf8</a>(b"Rooch Gas Coin"),
+        <a href="_utf8">string::utf8</a>(b"RGC"),
         9, // decimals
     );
 
     // Rooch framework needs mint cap <b>to</b> mint coins <b>to</b> initial validators. This will be revoked once the validators
     // have been initialized.
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>(ctx, rooch_framework, <a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a> { mint_cap });
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, rooch_framework, <a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a> { mint_cap });
 
     <a href="coin.md#0x3_coin_destroy_freeze_cap">coin::destroy_freeze_cap</a>(freeze_cap);
     (burn_cap, mint_cap)
@@ -197,7 +197,7 @@ Can only called during genesis to initialize the Rooch coin.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_has_mint_capability">has_mint_capability</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_has_mint_capability">has_mint_capability</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>): bool
 </code></pre>
 
 
@@ -206,8 +206,8 @@ Can only called during genesis to initialize the Rooch coin.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_has_mint_capability">has_mint_capability</a>(ctx: &StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>): bool {
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a>&gt;(ctx, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>))
+<pre><code><b>public</b> <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_has_mint_capability">has_mint_capability</a>(ctx: &StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>): bool {
+    <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a>&gt;(ctx, <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>))
 }
 </code></pre>
 
@@ -223,7 +223,7 @@ Only called during genesis to destroy the rooch framework account's mint capabil
 and accounts have been initialized during genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_destroy_mint_cap">destroy_mint_cap</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, rooch_framework: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_destroy_mint_cap">destroy_mint_cap</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, rooch_framework: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -232,9 +232,9 @@ and accounts have been initialized during genesis.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_destroy_mint_cap">destroy_mint_cap</a>(ctx: &<b>mut</b> StorageContext, rooch_framework: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_destroy_mint_cap">destroy_mint_cap</a>(ctx: &<b>mut</b> StorageContext, rooch_framework: &<a href="">signer</a>) {
     <a href="core_addresses.md#0x3_core_addresses_assert_rooch_framework">core_addresses::assert_rooch_framework</a>(rooch_framework);
-    <b>let</b> <a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a> { mint_cap } = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_from">account_storage::global_move_from</a>&lt;<a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a>&gt;(ctx,@rooch_framework);
+    <b>let</b> <a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a> { mint_cap } = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a>&gt;(ctx,@rooch_framework);
     <a href="coin.md#0x3_coin_destroy_mint_cap">coin::destroy_mint_cap</a>(mint_cap);
 }
 </code></pre>

--- a/crates/rooch-framework/doc/genesis.md
+++ b/crates/rooch-framework/doc/genesis.md
@@ -9,10 +9,10 @@
 -  [Constants](#@Constants_0)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x2_signer">0x2::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x2::signer</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry">0x3::auth_validator_registry</a>;
 <b>use</b> <a href="builtin_validators.md#0x3_builtin_validators">0x3::builtin_validators</a>;
 <b>use</b> <a href="chain_id.md#0x3_chain_id">0x3::chain_id</a>;

--- a/crates/rooch-framework/doc/hash.md
+++ b/crates/rooch-framework/doc/hash.md
@@ -14,7 +14,7 @@ Move standard library and wrap the functions at here.
 -  [Function `ripemd160`](#0x3_hash_ripemd160)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">0x1::hash</a>;
+<pre><code><b>use</b> <a href="">0x1::hash</a>;
 </code></pre>
 
 
@@ -25,7 +25,7 @@ Move standard library and wrap the functions at here.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_sha2_256">sha2_256</a>(data: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_sha2_256">sha2_256</a>(data: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -34,7 +34,7 @@ Move standard library and wrap the functions at here.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_sha2_256">sha2_256</a>(data: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_sha2_256">sha2_256</a>(data: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
    std::hash::sha2_256(data)
 }
 </code></pre>
@@ -49,7 +49,7 @@ Move standard library and wrap the functions at here.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_sha3_256">sha3_256</a>(data: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_sha3_256">sha3_256</a>(data: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -58,7 +58,7 @@ Move standard library and wrap the functions at here.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_sha3_256">sha3_256</a>(data: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_sha3_256">sha3_256</a>(data: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
    std::hash::sha3_256(data)
 }
 </code></pre>
@@ -75,7 +75,7 @@ Move standard library and wrap the functions at here.
 Hash the input bytes using Blake2b-256 and returns 32 bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_blake2b256">blake2b256</a>(data: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_blake2b256">blake2b256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -84,7 +84,7 @@ Hash the input bytes using Blake2b-256 and returns 32 bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_blake2b256">blake2b256</a>(data: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_blake2b256">blake2b256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -99,7 +99,7 @@ Hash the input bytes using Blake2b-256 and returns 32 bytes.
 Hash the input bytes using keccak256 and returns 32 bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_keccak256">keccak256</a>(data: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_keccak256">keccak256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -108,7 +108,7 @@ Hash the input bytes using keccak256 and returns 32 bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_keccak256">keccak256</a>(data: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_keccak256">keccak256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -123,7 +123,7 @@ Hash the input bytes using keccak256 and returns 32 bytes.
 Hash the input bytes using ripemd160 and returns 20 bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_ripemd160">ripemd160</a>(data: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_ripemd160">ripemd160</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -132,7 +132,7 @@ Hash the input bytes using ripemd160 and returns 20 bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_ripemd160">ripemd160</a>(data: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x3_hash_ripemd160">ripemd160</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 

--- a/crates/rooch-framework/doc/multi_ed25519_validator.md
+++ b/crates/rooch-framework/doc/multi_ed25519_validator.md
@@ -12,8 +12,8 @@ This module implements the multi-ed25519 validator scheme.
 -  [Function `validate`](#0x3_multi_ed25519_validator_validate)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 </code></pre>
 
 
@@ -89,7 +89,7 @@ This module implements the multi-ed25519 validator scheme.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="multi_ed25519_validator.md#0x3_multi_ed25519_validator_validate">validate</a>(_ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, _payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="multi_ed25519_validator.md#0x3_multi_ed25519_validator_validate">validate</a>(_ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, _payload: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -98,7 +98,7 @@ This module implements the multi-ed25519 validator scheme.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="multi_ed25519_validator.md#0x3_multi_ed25519_validator_validate">validate</a>(_ctx: &StorageContext, _payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;){
+<pre><code><b>public</b> <b>fun</b> <a href="multi_ed25519_validator.md#0x3_multi_ed25519_validator_validate">validate</a>(_ctx: &StorageContext, _payload: <a href="">vector</a>&lt;u8&gt;){
    //TODO
    <b>abort</b> std::error::not_implemented(1)
 }

--- a/crates/rooch-framework/doc/native_validator.md
+++ b/crates/rooch-framework/doc/native_validator.md
@@ -20,12 +20,12 @@ This module implements the native validator scheme.
 -  [Function `validate`](#0x3_native_validator_validate)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/bcs.md#0x2_bcs">0x2::bcs</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="">0x2::bcs</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account_authentication.md#0x3_account_authentication">0x3::account_authentication</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
 <b>use</b> <a href="ed25519.md#0x3_ed25519">0x3::ed25519</a>;
@@ -116,7 +116,7 @@ there defines scheme for each blockchain
 
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_validator.md#0x3_native_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_validator.md#0x3_native_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, public_key: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -127,18 +127,18 @@ there defines scheme for each blockchain
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="native_validator.md#0x3_native_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
+    public_key: <a href="">vector</a>&lt;u8&gt;
 ) {
     // compare newly passed <b>public</b> key <b>with</b> Rooch <b>public</b> key length <b>to</b> ensure it's compatible
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&public_key) == <a href="ed25519.md#0x3_ed25519_public_key_length">ed25519::public_key_length</a>(),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="native_validator.md#0x3_native_validator_ErrorInvalidPublicKeyLength">ErrorInvalidPublicKeyLength</a>)
+        <a href="_length">vector::length</a>(&public_key) == <a href="ed25519.md#0x3_ed25519_public_key_length">ed25519::public_key_length</a>(),
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="native_validator.md#0x3_native_validator_ErrorInvalidPublicKeyLength">ErrorInvalidPublicKeyLength</a>)
     );
 
     // User can rotate the authentication key arbitrarily, so we do not need <b>to</b> check the new <b>public</b> key <b>with</b> the <a href="account.md#0x3_account">account</a> <b>address</b>.
     <b>let</b> authentication_key = <a href="native_validator.md#0x3_native_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key);
-    <b>let</b> account_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <a href="native_validator.md#0x3_native_validator_rotate_authentication_key">rotate_authentication_key</a>(ctx, account_addr, authentication_key);
 }
 </code></pre>
@@ -153,7 +153,7 @@ there defines scheme for each blockchain
 
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_validator.md#0x3_native_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_validator.md#0x3_native_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -162,8 +162,8 @@ there defines scheme for each blockchain
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_validator.md#0x3_native_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">account_authentication::remove_authentication_key</a>&lt;<a href="native_validator.md#0x3_native_validator_NativeValidator">NativeValidator</a>&gt;(ctx, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_validator.md#0x3_native_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+    <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">account_authentication::remove_authentication_key</a>&lt;<a href="native_validator.md#0x3_native_validator_NativeValidator">NativeValidator</a>&gt;(ctx, <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
 }
 </code></pre>
 
@@ -178,7 +178,7 @@ there defines scheme for each blockchain
 Get the authentication key of the given authenticator from authenticator_payload.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -187,7 +187,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> public_key = <a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">ed25519::get_public_key_from_authenticator_payload</a>(authenticator_payload);
     <b>let</b> addr = <a href="native_validator.md#0x3_native_validator_public_key_to_address">public_key_to_address</a>(public_key);
     moveos_std::bcs::to_bytes(&addr)
@@ -204,7 +204,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <b>address</b>
 </code></pre>
 
 
@@ -213,7 +213,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b> {
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <b>address</b> {
     moveos_std::bcs::to_address(<a href="native_validator.md#0x3_native_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key))
 }
 </code></pre>
@@ -229,7 +229,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 Get the authentication key of the given public key.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -238,9 +238,9 @@ Get the authentication key of the given public key.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> bytes = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_singleton">vector::singleton</a>((<a href="native_validator.md#0x3_native_validator_scheme">scheme</a>() <b>as</b> u8));
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> bytes, public_key);
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> bytes = <a href="_singleton">vector::singleton</a>((<a href="native_validator.md#0x3_native_validator_scheme">scheme</a>() <b>as</b> u8));
+    <a href="_append">vector::append</a>(&<b>mut</b> bytes, public_key);
     hash::blake2b256(&bytes)
 }
 </code></pre>
@@ -256,7 +256,7 @@ Get the authentication key of the given public key.
 Get the authentication key of the given account, if it not exist, return the account address as authentication key.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_authentication_key_with_default">get_authentication_key_with_default</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_authentication_key_with_default">get_authentication_key_with_default</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -265,10 +265,10 @@ Get the authentication key of the given account, if it not exist, return the acc
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_authentication_key_with_default">get_authentication_key_with_default</a>(ctx: &StorageContext, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_authentication_key_with_default">get_authentication_key_with_default</a>(ctx: &StorageContext, addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> auth_key_option = <a href="account_authentication.md#0x3_account_authentication_get_authentication_key">account_authentication::get_authentication_key</a>&lt;<a href="native_validator.md#0x3_native_validator_NativeValidator">NativeValidator</a>&gt;(ctx, addr);
-    <b>if</b> (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&auth_key_option)) {
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> auth_key_option)
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&auth_key_option)) {
+        <a href="_extract">option::extract</a>(&<b>mut</b> auth_key_option)
     }<b>else</b> {
         <a href="native_validator.md#0x3_native_validator_default_authentication_key">default_authentication_key</a>(addr)
     }
@@ -285,7 +285,7 @@ Get the authentication key of the given account, if it not exist, return the acc
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_default_authentication_key">default_authentication_key</a>(addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_default_authentication_key">default_authentication_key</a>(addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -294,7 +294,7 @@ Get the authentication key of the given account, if it not exist, return the acc
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_default_authentication_key">default_authentication_key</a>(addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_default_authentication_key">default_authentication_key</a>(addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt; {
     moveos_std::bcs::to_bytes(&addr)
 }
 </code></pre>
@@ -310,7 +310,7 @@ Get the authentication key of the given account, if it not exist, return the acc
 Only validate the authenticator's signature.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, tx_hash: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -319,7 +319,7 @@ Only validate the authenticator's signature.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, tx_hash: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
         <a href="ed25519.md#0x3_ed25519_verify">ed25519::verify</a>(
             &<a href="ed25519.md#0x3_ed25519_get_signature_from_authenticator_payload">ed25519::get_signature_from_authenticator_payload</a>(authenticator_payload),
@@ -341,7 +341,7 @@ Only validate the authenticator's signature.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_validate">validate</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, authenticator_payload: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -350,12 +350,12 @@ Only validate the authenticator's signature.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_validate">validate</a>(ctx: &StorageContext, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>let</b> tx_hash = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_hash">storage_context::tx_hash</a>(ctx);
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_validate">validate</a>(ctx: &StorageContext, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) {
+    <b>let</b> tx_hash = <a href="_tx_hash">storage_context::tx_hash</a>(ctx);
     <a href="native_validator.md#0x3_native_validator_validate_signature">validate_signature</a>(&authenticator_payload, &tx_hash);
 
     <b>let</b> auth_key_from_authenticator_payload = <a href="native_validator.md#0x3_native_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(&authenticator_payload);
-    <b>let</b> auth_key_in_account = <a href="native_validator.md#0x3_native_validator_get_authentication_key_with_default">get_authentication_key_with_default</a>(ctx, <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_sender">storage_context::sender</a>(ctx));
+    <b>let</b> auth_key_in_account = <a href="native_validator.md#0x3_native_validator_get_authentication_key_with_default">get_authentication_key_with_default</a>(ctx, <a href="_sender">storage_context::sender</a>(ctx));
     <b>assert</b>!(
         auth_key_in_account == auth_key_from_authenticator_payload,
         <a href="auth_validator.md#0x3_auth_validator_error_invalid_account_auth_key">auth_validator::error_invalid_account_auth_key</a>()

--- a/crates/rooch-framework/doc/nostr_validator.md
+++ b/crates/rooch-framework/doc/nostr_validator.md
@@ -21,13 +21,13 @@ This module implements Nostr validator with the Schnorr crypto scheme.
 -  [Function `validate`](#0x3_nostr_validator_validate)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/debug.md#0x1_debug">0x1::debug</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/bcs.md#0x2_bcs">0x2::bcs</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
+<pre><code><b>use</b> <a href="">0x1::debug</a>;
+<b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="">0x2::bcs</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account_authentication.md#0x3_account_authentication">0x3::account_authentication</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
 <b>use</b> <a href="hash.md#0x3_hash">0x3::hash</a>;
@@ -118,7 +118,7 @@ there defines scheme for each blockchain
 
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, public_key: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -129,18 +129,18 @@ there defines scheme for each blockchain
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_rotate_authentication_key_entry">rotate_authentication_key_entry</a>(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
+    public_key: <a href="">vector</a>&lt;u8&gt;
 ) {
     // compare newly passed <b>public</b> key <b>with</b> Nostr <b>public</b> key length <b>to</b> ensure it's compatible
     <b>assert</b>!(
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&public_key) == <a href="schnorr.md#0x3_schnorr_public_key_length">schnorr::public_key_length</a>(),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="nostr_validator.md#0x3_nostr_validator_ErrorInvalidPublicKeyLength">ErrorInvalidPublicKeyLength</a>)
+        <a href="_length">vector::length</a>(&public_key) == <a href="schnorr.md#0x3_schnorr_public_key_length">schnorr::public_key_length</a>(),
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="nostr_validator.md#0x3_nostr_validator_ErrorInvalidPublicKeyLength">ErrorInvalidPublicKeyLength</a>)
     );
 
     // User can rotate the authentication key arbitrarily, so we do not need <b>to</b> check the new <b>public</b> key <b>with</b> the <a href="account.md#0x3_account">account</a> <b>address</b>.
     <b>let</b> authentication_key = <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key);
-    <b>let</b> account_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <a href="nostr_validator.md#0x3_nostr_validator_rotate_authentication_key">rotate_authentication_key</a>(ctx, account_addr, authentication_key);
 }
 </code></pre>
@@ -155,7 +155,7 @@ there defines scheme for each blockchain
 
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -164,8 +164,8 @@ there defines scheme for each blockchain
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">account_authentication::remove_authentication_key</a>&lt;<a href="nostr_validator.md#0x3_nostr_validator_NostrValidator">NostrValidator</a>&gt;(ctx, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
+<pre><code><b>public</b> entry <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_remove_authentication_key_entry">remove_authentication_key_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+    <a href="account_authentication.md#0x3_account_authentication_remove_authentication_key">account_authentication::remove_authentication_key</a>&lt;<a href="nostr_validator.md#0x3_nostr_validator_NostrValidator">NostrValidator</a>&gt;(ctx, <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>));
 }
 </code></pre>
 
@@ -180,7 +180,7 @@ there defines scheme for each blockchain
 Get the authentication key of the given authenticator from authenticator_payload.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -189,7 +189,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> public_key = <a href="schnorr.md#0x3_schnorr_get_public_key_from_authenticator_payload">schnorr::get_public_key_from_authenticator_payload</a>(authenticator_payload);
     <b>let</b> addr = <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_address">public_key_to_address</a>(public_key);
     moveos_std::bcs::to_bytes(&addr)
@@ -207,7 +207,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 TODO: https://github.com/rooch-network/rooch/issues/615
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <b>address</b>
 </code></pre>
 
 
@@ -216,7 +216,7 @@ TODO: https://github.com/rooch-network/rooch/issues/615
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b> {
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_address">public_key_to_address</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <b>address</b> {
     moveos_std::bcs::to_address(<a href="nostr_validator.md#0x3_nostr_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key))
 }
 </code></pre>
@@ -232,7 +232,7 @@ TODO: https://github.com/rooch-network/rooch/issues/615
 Get the authentication key of the given public key.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -241,9 +241,9 @@ Get the authentication key of the given public key.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> bytes = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_singleton">vector::singleton</a>((<a href="nostr_validator.md#0x3_nostr_validator_scheme">scheme</a>() <b>as</b> u8));
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> bytes, public_key);
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> bytes = <a href="_singleton">vector::singleton</a>((<a href="nostr_validator.md#0x3_nostr_validator_scheme">scheme</a>() <b>as</b> u8));
+    <a href="_append">vector::append</a>(&<b>mut</b> bytes, public_key);
     hash::blake2b256(&bytes)
 }
 </code></pre>
@@ -259,7 +259,7 @@ Get the authentication key of the given public key.
 Get the authentication key option of the given account.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -268,7 +268,7 @@ Get the authentication key option of the given account.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): Option&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
     <a href="account_authentication.md#0x3_account_authentication_get_authentication_key">account_authentication::get_authentication_key</a>&lt;<a href="nostr_validator.md#0x3_nostr_validator_NostrValidator">NostrValidator</a>&gt;(ctx, addr)
 }
 </code></pre>
@@ -284,7 +284,7 @@ Get the authentication key option of the given account.
 The authentication key exists in account or not.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_is_authentication_key_in_account">is_authentication_key_in_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_is_authentication_key_in_account">is_authentication_key_in_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -294,7 +294,7 @@ The authentication key exists in account or not.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_is_authentication_key_in_account">is_authentication_key_in_account</a>(ctx: &StorageContext, addr: <b>address</b>): bool {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&<a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
+    <a href="_is_some">option::is_some</a>(&<a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
 }
 </code></pre>
 
@@ -309,7 +309,7 @@ The authentication key exists in account or not.
 Extract the authentication key of the authentication key option.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -318,8 +318,8 @@ Extract the authentication key of the authentication key option.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_from_account">get_authentication_key_from_account</a>(ctx: &StorageContext, addr: <b>address</b>): <a href="">vector</a>&lt;u8&gt; {
+    <a href="_extract">option::extract</a>(&<b>mut</b> <a href="nostr_validator.md#0x3_nostr_validator_get_authentication_key_option_from_account">get_authentication_key_option_from_account</a>(ctx, addr))
 }
 </code></pre>
 
@@ -334,7 +334,7 @@ Extract the authentication key of the authentication key option.
 Only validate the authenticator's signature.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, tx_hash: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -343,7 +343,7 @@ Only validate the authenticator's signature.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, tx_hash: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
         <a href="schnorr.md#0x3_schnorr_verify">schnorr::verify</a>(
             &<a href="schnorr.md#0x3_schnorr_get_signature_from_authenticator_payload">schnorr::get_signature_from_authenticator_payload</a>(authenticator_payload),
@@ -366,7 +366,7 @@ Only validate the authenticator's signature.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_validate">validate</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, authenticator_payload: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -375,8 +375,8 @@ Only validate the authenticator's signature.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_validate">validate</a>(ctx: &StorageContext, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>let</b> tx_hash = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_hash">storage_context::tx_hash</a>(ctx);
+<pre><code><b>public</b> <b>fun</b> <a href="nostr_validator.md#0x3_nostr_validator_validate">validate</a>(ctx: &StorageContext, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) {
+    <b>let</b> tx_hash = <a href="_tx_hash">storage_context::tx_hash</a>(ctx);
     <a href="nostr_validator.md#0x3_nostr_validator_validate_signature">validate_signature</a>(&authenticator_payload, &tx_hash);
 
     // TODO compare the auth_key from the payload <b>with</b> the auth_key from the <a href="account.md#0x3_account">account</a>

--- a/crates/rooch-framework/doc/schnorr.md
+++ b/crates/rooch-framework/doc/schnorr.md
@@ -194,7 +194,7 @@ built-in functions
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -203,13 +203,13 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = <a href="schnorr.md#0x3_schnorr_scheme_length">scheme_length</a>() + <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>();
     <b>let</b> public_key_position = <a href="schnorr.md#0x3_schnorr_scheme_length">scheme_length</a>() + <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>() + <a href="schnorr.md#0x3_schnorr_public_key_length">public_key_length</a>();
     <b>while</b> (i &lt; public_key_position) {
-        <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
         i = i + 1;
     };
     public_key
@@ -226,7 +226,7 @@ built-in functions
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -235,13 +235,13 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> sign = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
     <b>let</b> i = <a href="schnorr.md#0x3_schnorr_scheme_length">scheme_length</a>();
     <b>let</b> signature_position = <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>() + 1;
     <b>while</b> (i &lt; signature_position) {
-        <b>let</b> value = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
         i = i + 1;
     };
     sign
@@ -264,7 +264,7 @@ built-in functions
 If the signature is valid to the pubkey and hashed message, return true. Else false.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_verify">verify</a>(signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">hash</a>: u8): bool
+<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_verify">verify</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: &<a href="">vector</a>&lt;u8&gt;, <a href="">hash</a>: u8): bool
 </code></pre>
 
 
@@ -274,10 +274,10 @@ If the signature is valid to the pubkey and hashed message, return true. Else fa
 
 
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_verify">verify</a>(
-    signature: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    public_key: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    msg: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/hash.md#0x1_hash">hash</a>: u8
+    signature: &<a href="">vector</a>&lt;u8&gt;,
+    public_key: &<a href="">vector</a>&lt;u8&gt;,
+    msg: &<a href="">vector</a>&lt;u8&gt;,
+    <a href="">hash</a>: u8
 ): bool;
 </code></pre>
 

--- a/crates/rooch-framework/doc/session_key.md
+++ b/crates/rooch-framework/doc/session_key.md
@@ -18,16 +18,16 @@
 -  [Function `active_session_key`](#0x3_session_key_active_session_key)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii">0x1::ascii</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage">0x2::account_storage</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table">0x2::table</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/tx_meta.md#0x2_tx_meta">0x2::tx_meta</a>;
+<pre><code><b>use</b> <a href="">0x1::ascii</a>;
+<b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
+<b>use</b> <a href="">0x2::table</a>;
+<b>use</b> <a href="">0x2::tx_context</a>;
+<b>use</b> <a href="">0x2::tx_meta</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
 <b>use</b> <a href="native_validator.md#0x3_native_validator">0x3::native_validator</a>;
 </code></pre>
@@ -58,13 +58,13 @@ The session's scope
 
 </dd>
 <dt>
-<code>module_name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a></code>
+<code>module_name: <a href="_String">ascii::String</a></code>
 </dt>
 <dd>
  The scope module name, <code>*</code> means all modules in the module address
 </dd>
 <dt>
-<code>function_name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a></code>
+<code>function_name: <a href="_String">ascii::String</a></code>
 </dt>
 <dd>
  The scope function name, <code>*</code> means all functions in the module
@@ -91,13 +91,13 @@ The session's scope
 
 <dl>
 <dt>
-<code>authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+<code>authentication_key: <a href="">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code>scopes: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="session_key.md#0x3_session_key_SessionScope">session_key::SessionScope</a>&gt;</code>
+<code>scopes: <a href="">vector</a>&lt;<a href="session_key.md#0x3_session_key_SessionScope">session_key::SessionScope</a>&gt;</code>
 </dt>
 <dd>
 
@@ -142,7 +142,7 @@ The session's scope
 
 <dl>
 <dt>
-<code>keys: <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_Table">table::Table</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="session_key.md#0x3_session_key_SessionKey">session_key::SessionKey</a>&gt;</code>
+<code>keys: <a href="_Table">table::Table</a>&lt;<a href="">vector</a>&lt;u8&gt;, <a href="session_key.md#0x3_session_key_SessionKey">session_key::SessionKey</a>&gt;</code>
 </dt>
 <dd>
 
@@ -213,7 +213,7 @@ The session key is invalid
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_new_session_scope">new_session_scope</a>(module_address: <b>address</b>, module_name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a>, function_name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="session_key.md#0x3_session_key_SessionScope">session_key::SessionScope</a>
+<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_new_session_scope">new_session_scope</a>(module_address: <b>address</b>, module_name: <a href="_String">ascii::String</a>, function_name: <a href="_String">ascii::String</a>): <a href="session_key.md#0x3_session_key_SessionScope">session_key::SessionScope</a>
 </code></pre>
 
 
@@ -241,7 +241,7 @@ The session key is invalid
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_exists_session_key">exists_session_key</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, account_address: <b>address</b>, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_exists_session_key">exists_session_key</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, account_address: <b>address</b>, authentication_key: <a href="">vector</a>&lt;u8&gt;): bool
 </code></pre>
 
 
@@ -250,8 +250,8 @@ The session key is invalid
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_exists_session_key">exists_session_key</a>(ctx: &StorageContext, account_address: <b>address</b>, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) : bool {
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&<a href="session_key.md#0x3_session_key_get_session_key">get_session_key</a>(ctx, account_address, authentication_key))
+<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_exists_session_key">exists_session_key</a>(ctx: &StorageContext, account_address: <b>address</b>, authentication_key: <a href="">vector</a>&lt;u8&gt;) : bool {
+    <a href="_is_some">option::is_some</a>(&<a href="session_key.md#0x3_session_key_get_session_key">get_session_key</a>(ctx, account_address, authentication_key))
 }
 </code></pre>
 
@@ -266,7 +266,7 @@ The session key is invalid
 Get the session key of the account_address by the authentication key
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_get_session_key">get_session_key</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, account_address: <b>address</b>, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="session_key.md#0x3_session_key_SessionKey">session_key::SessionKey</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_get_session_key">get_session_key</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, account_address: <b>address</b>, authentication_key: <a href="">vector</a>&lt;u8&gt;): <a href="_Option">option::Option</a>&lt;<a href="session_key.md#0x3_session_key_SessionKey">session_key::SessionKey</a>&gt;
 </code></pre>
 
 
@@ -275,15 +275,15 @@ Get the session key of the account_address by the authentication key
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_get_session_key">get_session_key</a>(ctx: &StorageContext, account_address: <b>address</b>, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) : Option&lt;<a href="session_key.md#0x3_session_key_SessionKey">SessionKey</a>&gt; {
-    <b>if</b> (!<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, account_address)){
-        <b>return</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_get_session_key">get_session_key</a>(ctx: &StorageContext, account_address: <b>address</b>, authentication_key: <a href="">vector</a>&lt;u8&gt;) : Option&lt;<a href="session_key.md#0x3_session_key_SessionKey">SessionKey</a>&gt; {
+    <b>if</b> (!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, account_address)){
+        <b>return</b> <a href="_none">option::none</a>()
     };
-    <b>let</b> session_keys = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow">account_storage::global_borrow</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, account_address);
-    <b>if</b> (!<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_contains">table::contains</a>(&session_keys.keys, authentication_key)){
-        <b>return</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+    <b>let</b> session_keys = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, account_address);
+    <b>if</b> (!<a href="_contains">table::contains</a>(&session_keys.keys, authentication_key)){
+        <b>return</b> <a href="_none">option::none</a>()
     }<b>else</b>{
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_some">option::some</a>(*<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_borrow">table::borrow</a>(&session_keys.keys, authentication_key))
+        <a href="_some">option::some</a>(*<a href="_borrow">table::borrow</a>(&session_keys.keys, authentication_key))
     }
 }
 </code></pre>
@@ -298,7 +298,7 @@ Get the session key of the account_address by the authentication key
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_create_session_key">create_session_key</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, sender: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, scopes: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="session_key.md#0x3_session_key_SessionScope">session_key::SessionScope</a>&gt;, expiration_time: u64, max_inactive_interval: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_create_session_key">create_session_key</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, sender: &<a href="">signer</a>, authentication_key: <a href="">vector</a>&lt;u8&gt;, scopes: <a href="">vector</a>&lt;<a href="session_key.md#0x3_session_key_SessionScope">session_key::SessionScope</a>&gt;, expiration_time: u64, max_inactive_interval: u64)
 </code></pre>
 
 
@@ -307,11 +307,11 @@ Get the session key of the account_address by the authentication key
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_create_session_key">create_session_key</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, scopes: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="session_key.md#0x3_session_key_SessionScope">SessionScope</a>&gt;, expiration_time: u64, max_inactive_interval: u64) {
+<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_create_session_key">create_session_key</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="">signer</a>, authentication_key: <a href="">vector</a>&lt;u8&gt;, scopes: <a href="">vector</a>&lt;<a href="session_key.md#0x3_session_key_SessionScope">SessionScope</a>&gt;, expiration_time: u64, max_inactive_interval: u64) {
     //Can not create new session key by the other session key
-    <b>assert</b>!(!<a href="auth_validator.md#0x3_auth_validator_is_validate_via_session_key">auth_validator::is_validate_via_session_key</a>(ctx), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="session_key.md#0x3_session_key_ErrorSessionKeyCreatePermissionDenied">ErrorSessionKeyCreatePermissionDenied</a>));
-    <b>let</b> sender_addr = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(sender);
-    <b>assert</b>!(!<a href="session_key.md#0x3_session_key_exists_session_key">exists_session_key</a>(ctx, sender_addr, authentication_key), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="session_key.md#0x3_session_key_ErrorSessionKeyAlreadyExists">ErrorSessionKeyAlreadyExists</a>));
+    <b>assert</b>!(!<a href="auth_validator.md#0x3_auth_validator_is_validate_via_session_key">auth_validator::is_validate_via_session_key</a>(ctx), <a href="_permission_denied">error::permission_denied</a>(<a href="session_key.md#0x3_session_key_ErrorSessionKeyCreatePermissionDenied">ErrorSessionKeyCreatePermissionDenied</a>));
+    <b>let</b> sender_addr = <a href="_address_of">signer::address_of</a>(sender);
+    <b>assert</b>!(!<a href="session_key.md#0x3_session_key_exists_session_key">exists_session_key</a>(ctx, sender_addr, authentication_key), <a href="_already_exists">error::already_exists</a>(<a href="session_key.md#0x3_session_key_ErrorSessionKeyAlreadyExists">ErrorSessionKeyAlreadyExists</a>));
 
     <b>let</b> <a href="session_key.md#0x3_session_key">session_key</a> = <a href="session_key.md#0x3_session_key_SessionKey">SessionKey</a> {
         authentication_key: authentication_key,
@@ -321,13 +321,13 @@ Get the session key of the account_address by the authentication key
         last_active_time: 0,
         max_inactive_interval: max_inactive_interval,
     };
-    <b>if</b> (!<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr)){
-        <b>let</b> keys = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_new">table::new</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="session_key.md#0x3_session_key_SessionKey">SessionKey</a>&gt;(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_context_mut">storage_context::tx_context_mut</a>(ctx));
-        <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_move_to">account_storage::global_move_to</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender, <a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>{keys});
+    <b>if</b> (!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr)){
+        <b>let</b> keys = <a href="_new">table::new</a>&lt;<a href="">vector</a>&lt;u8&gt;, <a href="session_key.md#0x3_session_key_SessionKey">SessionKey</a>&gt;(<a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx));
+        <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender, <a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>{keys});
     };
 
-    <b>let</b> session_keys = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr);
-    <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_add">table::add</a>(&<b>mut</b> session_keys.keys, authentication_key, <a href="session_key.md#0x3_session_key">session_key</a>);
+    <b>let</b> session_keys = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr);
+    <a href="_add">table::add</a>(&<b>mut</b> session_keys.keys, authentication_key, <a href="session_key.md#0x3_session_key">session_key</a>);
 }
 </code></pre>
 
@@ -341,7 +341,7 @@ Get the session key of the account_address by the authentication key
 
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="session_key.md#0x3_session_key_create_session_key_entry">create_session_key_entry</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, sender: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, scope_module_address: <b>address</b>, scope_module_name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a>, scope_function_name: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/ascii.md#0x1_ascii_String">ascii::String</a>, expiration_time: u64, max_inactive_interval: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="session_key.md#0x3_session_key_create_session_key_entry">create_session_key_entry</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, sender: &<a href="">signer</a>, authentication_key: <a href="">vector</a>&lt;u8&gt;, scope_module_address: <b>address</b>, scope_module_name: <a href="_String">ascii::String</a>, scope_function_name: <a href="_String">ascii::String</a>, expiration_time: u64, max_inactive_interval: u64)
 </code></pre>
 
 
@@ -350,8 +350,8 @@ Get the session key of the account_address by the authentication key
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="session_key.md#0x3_session_key_create_session_key_entry">create_session_key_entry</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="../../moveos/moveos-stdlib/move-stdlib/doc/signer.md#0x1_signer">signer</a>, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, scope_module_address: <b>address</b>, scope_module_name: std::ascii::String, scope_function_name: std::ascii::String,expiration_time: u64, max_inactive_interval: u64) {
-    <a href="session_key.md#0x3_session_key_create_session_key">create_session_key</a>(ctx, sender, authentication_key, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector_singleton">vector::singleton</a>(<a href="session_key.md#0x3_session_key_SessionScope">SessionScope</a>{
+<pre><code><b>public</b> entry <b>fun</b> <a href="session_key.md#0x3_session_key_create_session_key_entry">create_session_key_entry</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="">signer</a>, authentication_key: <a href="">vector</a>&lt;u8&gt;, scope_module_address: <b>address</b>, scope_module_name: std::ascii::String, scope_function_name: std::ascii::String,expiration_time: u64, max_inactive_interval: u64) {
+    <a href="session_key.md#0x3_session_key_create_session_key">create_session_key</a>(ctx, sender, authentication_key, <a href="_singleton">vector::singleton</a>(<a href="session_key.md#0x3_session_key_SessionScope">SessionScope</a>{
         module_address: scope_module_address,
         module_name: scope_module_name,
         function_name: scope_function_name,
@@ -372,7 +372,7 @@ If the authentication key is not a session key, return option::none
 If the session key is expired or invalid, abort the tx, otherwise return option::some(authentication key)
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, scheme: u64, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -381,29 +381,29 @@ If the session key is expired or invalid, abort the tx, otherwise return option:
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &StorageContext, scheme: u64, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) : Option&lt;<a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; {
-    <b>let</b> sender_addr = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_sender">storage_context::sender</a>(ctx);
-    <b>if</b> (!<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr)){
-        <b>return</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &StorageContext, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) : Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+    <b>let</b> sender_addr = <a href="_sender">storage_context::sender</a>(ctx);
+    <b>if</b> (!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr)){
+        <b>return</b> <a href="_none">option::none</a>()
     };
     // We only support <b>native</b> validator for <a href="session_key.md#0x3_session_key_SessionKey">SessionKey</a> now
     <b>if</b>(scheme != validator::scheme()){
-        <b>return</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+        <b>return</b> <a href="_none">option::none</a>()
     };
 
     <b>let</b> auth_key = validator::get_authentication_key_from_authenticator_payload(&authenticator_payload);
 
     <b>let</b> session_key_option = <a href="session_key.md#0x3_session_key_get_session_key">get_session_key</a>(ctx, sender_addr, auth_key);
-    <b>if</b> (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&session_key_option)){
-        <b>return</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+    <b>if</b> (<a href="_is_none">option::is_none</a>(&session_key_option)){
+        <b>return</b> <a href="_none">option::none</a>()
     };
-    <b>let</b> <a href="session_key.md#0x3_session_key">session_key</a> = <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> session_key_option);
-    <b>assert</b>!(!<a href="session_key.md#0x3_session_key_is_expired">is_expired</a>(ctx, &<a href="session_key.md#0x3_session_key">session_key</a>), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="session_key.md#0x3_session_key_ErrorSessionIsExpired">ErrorSessionIsExpired</a>));
+    <b>let</b> <a href="session_key.md#0x3_session_key">session_key</a> = <a href="_extract">option::extract</a>(&<b>mut</b> session_key_option);
+    <b>assert</b>!(!<a href="session_key.md#0x3_session_key_is_expired">is_expired</a>(ctx, &<a href="session_key.md#0x3_session_key">session_key</a>), <a href="_permission_denied">error::permission_denied</a>(<a href="session_key.md#0x3_session_key_ErrorSessionIsExpired">ErrorSessionIsExpired</a>));
 
-    <b>assert</b>!(<a href="session_key.md#0x3_session_key_in_session_scope">in_session_scope</a>(ctx, &<a href="session_key.md#0x3_session_key">session_key</a>), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="session_key.md#0x3_session_key_ErrorFunctionCallBeyondSessionScope">ErrorFunctionCallBeyondSessionScope</a>));
+    <b>assert</b>!(<a href="session_key.md#0x3_session_key_in_session_scope">in_session_scope</a>(ctx, &<a href="session_key.md#0x3_session_key">session_key</a>), <a href="_permission_denied">error::permission_denied</a>(<a href="session_key.md#0x3_session_key_ErrorFunctionCallBeyondSessionScope">ErrorFunctionCallBeyondSessionScope</a>));
 
-    validator::validate_signature(&authenticator_payload, &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_tx_hash">storage_context::tx_hash</a>(ctx));
-    <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_some">option::some</a>(auth_key)
+    validator::validate_signature(&authenticator_payload, &<a href="_tx_hash">storage_context::tx_hash</a>(ctx));
+    <a href="_some">option::some</a>(auth_key)
 }
 </code></pre>
 
@@ -417,7 +417,7 @@ If the session key is expired or invalid, abort the tx, otherwise return option:
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_active_session_key">active_session_key</a>(ctx: &<b>mut</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_active_session_key">active_session_key</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, authentication_key: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -426,12 +426,12 @@ If the session key is expired or invalid, abort the tx, otherwise return option:
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_active_session_key">active_session_key</a>(ctx: &<b>mut</b> StorageContext, authentication_key: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>let</b> sender_addr = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_sender">storage_context::sender</a>(ctx);
-    <b>assert</b>!(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="session_key.md#0x3_session_key_ErrorSessionKeyIsInvalid">ErrorSessionKeyIsInvalid</a>));
-    <b>let</b> session_keys = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md#0x2_account_storage_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr);
-    <b>assert</b>!(<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_contains">table::contains</a>(&session_keys.keys, authentication_key), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="session_key.md#0x3_session_key_ErrorSessionKeyIsInvalid">ErrorSessionKeyIsInvalid</a>));
-    <b>let</b> <a href="session_key.md#0x3_session_key">session_key</a> = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> session_keys.keys, authentication_key);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_active_session_key">active_session_key</a>(ctx: &<b>mut</b> StorageContext, authentication_key: <a href="">vector</a>&lt;u8&gt;) {
+    <b>let</b> sender_addr = <a href="_sender">storage_context::sender</a>(ctx);
+    <b>assert</b>!(<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr), <a href="_not_found">error::not_found</a>(<a href="session_key.md#0x3_session_key_ErrorSessionKeyIsInvalid">ErrorSessionKeyIsInvalid</a>));
+    <b>let</b> session_keys = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr);
+    <b>assert</b>!(<a href="_contains">table::contains</a>(&session_keys.keys, authentication_key), <a href="_not_found">error::not_found</a>(<a href="session_key.md#0x3_session_key_ErrorSessionKeyIsInvalid">ErrorSessionKeyIsInvalid</a>));
+    <b>let</b> <a href="session_key.md#0x3_session_key">session_key</a> = <a href="_borrow_mut">table::borrow_mut</a>(&<b>mut</b> session_keys.keys, authentication_key);
     //TODO set the last active time <b>to</b> now when the timestamp is supported
     <a href="session_key.md#0x3_session_key">session_key</a>.last_active_time = <a href="session_key.md#0x3_session_key">session_key</a>.last_active_time + 1;
 }

--- a/crates/rooch-framework/doc/transaction_validator.md
+++ b/crates/rooch-framework/doc/transaction_validator.md
@@ -9,10 +9,10 @@
 -  [Function `validate`](#0x3_transaction_validator_validate)
 
 
-<pre><code><b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context">0x2::storage_context</a>;
-<b>use</b> <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/tx_result.md#0x2_tx_result">0x2::tx_result</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
+<b>use</b> <a href="">0x2::tx_result</a>;
 <b>use</b> <a href="account.md#0x3_account">0x3::account</a>;
 <b>use</b> <a href="account_authentication.md#0x3_account_authentication">0x3::account_authentication</a>;
 <b>use</b> <a href="address_mapping.md#0x3_address_mapping">0x3::address_mapping</a>;
@@ -134,7 +134,7 @@ This function is for Rooch to validate the transaction sender's authenticator.
 If the authenticator is invaid, abort this function.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(ctx: &<a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64, scheme: u64, authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
 </code></pre>
 
 
@@ -147,37 +147,37 @@ If the authenticator is invaid, abort this function.
     ctx: &StorageContext,
     <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64,
     scheme: u64,
-    authenticator_payload: <a href="../../moveos/moveos-stdlib/move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+    authenticator_payload: <a href="">vector</a>&lt;u8&gt;
 ): TxValidateResult {
 
     // === validate the chain id ===
     <b>assert</b>!(
         <a href="chain_id.md#0x3_chain_id">chain_id</a> == <a href="chain_id.md#0x3_chain_id_chain_id">chain_id::chain_id</a>(ctx),
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateBadChainId">ErrorValidateBadChainId</a>)
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateBadChainId">ErrorValidateBadChainId</a>)
     );
 
     // === validate the sequence number ===
-    <b>let</b> tx_sequence_number = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_sequence_number">storage_context::sequence_number</a>(ctx);
+    <b>let</b> tx_sequence_number = <a href="_sequence_number">storage_context::sequence_number</a>(ctx);
     <b>assert</b>!(
         (tx_sequence_number <b>as</b> u128) &lt; <a href="transaction_validator.md#0x3_transaction_validator_MAX_U64">MAX_U64</a>,
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateSequenceNumberTooBig">ErrorValidateSequenceNumberTooBig</a>)
+        <a href="_out_of_range">error::out_of_range</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateSequenceNumberTooBig">ErrorValidateSequenceNumberTooBig</a>)
     );
 
     <b>let</b> account_sequence_number = <a href="account.md#0x3_account_sequence_number_for_sender">account::sequence_number_for_sender</a>(ctx);
     <b>assert</b>!(
         tx_sequence_number &gt;= account_sequence_number,
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateSequenceNuberTooOld">ErrorValidateSequenceNuberTooOld</a>)
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateSequenceNuberTooOld">ErrorValidateSequenceNuberTooOld</a>)
     );
 
     // [PCA12]: Check that the transaction's sequence number matches the
     // current sequence number. Otherwise sequence number is too new by [PCA11].
     <b>assert</b>!(
         tx_sequence_number == account_sequence_number,
-        <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateSequenceNumberTooNew">ErrorValidateSequenceNumberTooNew</a>)
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateSequenceNumberTooNew">ErrorValidateSequenceNumberTooNew</a>)
     );
 
     // === validate gas ===
-    <b>let</b> _max_gas_amount = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_max_gas_amount">storage_context::max_gas_amount</a>(ctx);
+    <b>let</b> _max_gas_amount = <a href="_max_gas_amount">storage_context::max_gas_amount</a>(ctx);
     //TODO check the <a href="account.md#0x3_account">account</a> can pay the gas fee
 
     // === validate the authenticator ===
@@ -185,20 +185,20 @@ If the authenticator is invaid, abort this function.
     // <b>if</b> the authenticator authenticator_payload is session key, validate the session key
     // otherwise <b>return</b> the authentication validator via the scheme
     <b>let</b> session_key_option = <a href="session_key.md#0x3_session_key_validate">session_key::validate</a>(ctx, scheme, authenticator_payload);
-    <b>if</b> (<a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&session_key_option)) {
-        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>(), session_key_option)
+    <b>if</b> (<a href="_is_some">option::is_some</a>(&session_key_option)) {
+        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="_none">option::none</a>(), session_key_option)
     }<b>else</b> {
-        <b>let</b> sender = <a href="../../moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md#0x2_storage_context_sender">storage_context::sender</a>(ctx);
+        <b>let</b> sender = <a href="_sender">storage_context::sender</a>(ctx);
         <b>let</b> <a href="auth_validator.md#0x3_auth_validator">auth_validator</a> = <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">auth_validator_registry::borrow_validator</a>(ctx, scheme);
         <b>let</b> validator_id = <a href="auth_validator.md#0x3_auth_validator_validator_id">auth_validator::validator_id</a>(<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>);
         // builtin scheme do not need <b>to</b> install
         <b>if</b> (!rooch_framework::builtin_validators::is_builtin_scheme(scheme)) {
             <b>assert</b>!(
                 <a href="account_authentication.md#0x3_account_authentication_is_auth_validator_installed">account_authentication::is_auth_validator_installed</a>(ctx, sender, validator_id),
-                <a href="../../moveos/moveos-stdlib/move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator">ErrorValidateNotInstalledAuthValidator</a>)
+                <a href="_invalid_state">error::invalid_state</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator">ErrorValidateNotInstalledAuthValidator</a>)
             );
         };
-        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_some">option::some</a>(*<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>), <a href="../../moveos/moveos-stdlib/move-stdlib/doc/option.md#0x1_option_none">option::none</a>())
+        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="_some">option::some</a>(*<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>), <a href="_none">option::none</a>())
     }
 }
 </code></pre>

--- a/moveos/moveos-stdlib-builder/src/lib.rs
+++ b/moveos/moveos-stdlib-builder/src/lib.rs
@@ -74,7 +74,7 @@ pub struct StdlibBuildConfig {
 }
 
 impl StdlibBuildConfig {
-    pub fn build(self, deps: &[StdlibBuildConfig]) -> Result<StdlibPackage> {
+    pub fn build(self, _deps: &[StdlibBuildConfig]) -> Result<StdlibPackage> {
         println!("Build stdlib at {:?}", self.path);
         let original_current_dir = current_dir()?;
         let project_path = self.path.clone();

--- a/moveos/moveos-stdlib-builder/src/lib.rs
+++ b/moveos/moveos-stdlib-builder/src/lib.rs
@@ -13,9 +13,10 @@ use moveos_verifier::build::run_verifier;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
+    env::current_dir,
     fs::{self, File},
     io::{stderr, Write},
-    path::{Path, PathBuf}, env::current_dir,
+    path::{Path, PathBuf},
 };
 
 pub mod dependency_order;
@@ -84,7 +85,11 @@ impl StdlibBuildConfig {
             .clone()
             .compile_package_no_exit(&self.path, &mut stderr())?;
 
-        run_verifier(&project_path, self.build_config.clone(), &mut compiled_package)?;
+        run_verifier(
+            &project_path,
+            self.build_config.clone(),
+            &mut compiled_package,
+        )?;
         let module_map = compiled_package.root_modules_map();
         let mut modules = module_map.iter_modules().into_iter();
 

--- a/moveos/moveos-stdlib-builder/src/lib.rs
+++ b/moveos/moveos-stdlib-builder/src/lib.rs
@@ -157,7 +157,7 @@ impl StdlibBuildConfig {
             include_impl: true,
             include_private_fun: false,
             output_directory: self.document_output_directory.to_string_lossy().to_string(),
-            compile_relative_to_output_dir: qfalse,
+            compile_relative_to_output_dir: false,
             doc_path: deps_doc_paths,
             ..Default::default()
         };


### PR DESCRIPTION
## Summary

The document reference link is incorrect, and I removed it temporarily, We should fix it in the future #737 .

The path from `crates/rooch-framework/doc/address_mapping.md` to `moveos/moveos-stdlib/move-stdlib/doc/option.md` is `../../../moveos/moveos-stdlib/move-stdlib/doc/option.md`, not `../../moveos/moveos-stdlib/move-stdlib/doc/option.md`


- Closes #issue