### PR TITLE
[Framework]Refactor coin module 

### DIFF
--- a/crates/rooch-framework/doc/coin.md
+++ b/crates/rooch-framework/doc/coin.md
@@ -32,22 +32,24 @@ This module provides the foundation for typesafe Coins.
 -  [Function `do_accept_coin`](#0x3_coin_do_accept_coin)
 -  [Function `set_auto_accept_coin`](#0x3_coin_set_auto_accept_coin)
 -  [Function `withdraw`](#0x3_coin_withdraw)
--  [Function `withdraw_extend`](#0x3_coin_withdraw_extend)
 -  [Function `deposit`](#0x3_coin_deposit)
 -  [Function `transfer`](#0x3_coin_transfer)
--  [Function `burn_extend`](#0x3_coin_burn_extend)
 -  [Function `destroy_zero`](#0x3_coin_destroy_zero)
 -  [Function `extract`](#0x3_coin_extract)
 -  [Function `extract_all`](#0x3_coin_extract_all)
--  [Function `freeze_coin_store_extend`](#0x3_coin_freeze_coin_store_extend)
--  [Function `unfreeze_coin_store_extend`](#0x3_coin_unfreeze_coin_store_extend)
--  [Function `register_extend`](#0x3_coin_register_extend)
 -  [Function `merge`](#0x3_coin_merge)
--  [Function `mint_extend`](#0x3_coin_mint_extend)
 -  [Function `value`](#0x3_coin_value)
 -  [Function `zero`](#0x3_coin_zero)
 -  [Function `exist_coin_store`](#0x3_coin_exist_coin_store)
 -  [Function `is_coin_store_frozen`](#0x3_coin_is_coin_store_frozen)
+-  [Function `register_extend`](#0x3_coin_register_extend)
+-  [Function `mint_extend`](#0x3_coin_mint_extend)
+-  [Function `withdraw_extend`](#0x3_coin_withdraw_extend)
+-  [Function `deposit_extend`](#0x3_coin_deposit_extend)
+-  [Function `transfer_extend`](#0x3_coin_transfer_extend)
+-  [Function `burn_extend`](#0x3_coin_burn_extend)
+-  [Function `freeze_coin_store_extend`](#0x3_coin_freeze_coin_store_extend)
+-  [Function `unfreeze_coin_store_extend`](#0x3_coin_unfreeze_coin_store_extend)
 -  [Function `accept_coin_entry`](#0x3_coin_accept_coin_entry)
 -  [Function `enable_auto_accept_coin_entry`](#0x3_coin_enable_auto_accept_coin_entry)
 -  [Function `disable_auto_accept_coin_entry`](#0x3_coin_disable_auto_accept_coin_entry)
@@ -76,7 +78,7 @@ Core data structures
 Main structure representing a coin/coin in an account's custody.
 
 
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; <b>has</b> store
+<pre><code><b>struct</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType: key&gt; <b>has</b> store
 </code></pre>
 
 
@@ -104,7 +106,7 @@ Main structure representing a coin/coin in an account's custody.
 
 
 
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&lt;CoinType&gt; <b>has</b> key
+<pre><code><b>struct</b> <a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&lt;CoinType: key&gt; <b>has</b> key
 </code></pre>
 
 
@@ -138,7 +140,7 @@ Main structure representing a coin/coin in an account's custody.
 Information about a specific coin type. Stored on the creator of the coin's account.
 
 
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt; <b>has</b> key
+<pre><code><b>struct</b> <a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType: key&gt; <b>has</b> key
 </code></pre>
 
 
@@ -627,7 +629,7 @@ Coin amount cannot be zero
 Returns the balance of <code>addr</code> for provided <code>CoinType</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_balance">balance</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): u256
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_balance">balance</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): u256
 </code></pre>
 
 
@@ -636,7 +638,7 @@ Returns the balance of <code>addr</code> for provided <code>CoinType</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_balance">balance</a>&lt;CoinType&gt;(ctx: &StorageContext, addr: <b>address</b>): u256 {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_balance">balance</a>&lt;CoinType: key&gt;(ctx: &StorageContext, addr: <b>address</b>): u256 {
     <b>if</b> (<a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx, addr)) {
         <a href="coin.md#0x3_coin_borrow_coin_store">borrow_coin_store</a>&lt;CoinType&gt;(ctx, addr).<a href="coin.md#0x3_coin">coin</a>.value
     } <b>else</b> {
@@ -656,7 +658,7 @@ Returns the balance of <code>addr</code> for provided <code>CoinType</code>.
 Returns <code><b>true</b></code> if the type <code>CoinType</code> is an registered coin.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_registered">is_coin_registered</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_registered">is_coin_registered</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): bool
 </code></pre>
 
 
@@ -665,7 +667,7 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is an registe
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_registered">is_coin_registered</a>&lt;CoinType&gt;(ctx: &StorageContext): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_registered">is_coin_registered</a>&lt;CoinType: key&gt;(ctx: &StorageContext): bool {
     <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework)) {
         <b>let</b> coin_infos = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
         <a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(&coin_infos.coin_infos)
@@ -686,7 +688,7 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is an registe
 Returns the name of the coin.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_name">name</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): <a href="_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_name">name</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): <a href="_String">string::String</a>
 </code></pre>
 
 
@@ -695,7 +697,7 @@ Returns the name of the coin.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_name">name</a>&lt;CoinType&gt;(ctx: &StorageContext): <a href="_String">string::String</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_name">name</a>&lt;CoinType: key&gt;(ctx: &StorageContext): <a href="_String">string::String</a> {
     <a href="coin.md#0x3_coin_borrow_coin_info">borrow_coin_info</a>&lt;CoinType&gt;(ctx).name
 }
 </code></pre>
@@ -711,7 +713,7 @@ Returns the name of the coin.
 Returns the symbol of the coin, usually a shorter version of the name.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_symbol">symbol</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): <a href="_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_symbol">symbol</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): <a href="_String">string::String</a>
 </code></pre>
 
 
@@ -720,7 +722,7 @@ Returns the symbol of the coin, usually a shorter version of the name.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_symbol">symbol</a>&lt;CoinType&gt;(ctx: &StorageContext): <a href="_String">string::String</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_symbol">symbol</a>&lt;CoinType: key&gt;(ctx: &StorageContext): <a href="_String">string::String</a> {
     <a href="coin.md#0x3_coin_borrow_coin_info">borrow_coin_info</a>&lt;CoinType&gt;(ctx).symbol
 }
 </code></pre>
@@ -738,7 +740,7 @@ For example, if <code>decimals</code> equals <code>2</code>, a balance of <code>
 be displayed to a user as <code>5.05</code> (<code>505 / 10 ** 2</code>).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_decimals">decimals</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u8
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_decimals">decimals</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u8
 </code></pre>
 
 
@@ -747,7 +749,7 @@ be displayed to a user as <code>5.05</code> (<code>505 / 10 ** 2</code>).
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_decimals">decimals</a>&lt;CoinType&gt;(ctx: &StorageContext): u8 {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_decimals">decimals</a>&lt;CoinType: key&gt;(ctx: &StorageContext): u8 {
     <a href="coin.md#0x3_coin_borrow_coin_info">borrow_coin_info</a>&lt;CoinType&gt;(ctx).decimals
 }
 </code></pre>
@@ -763,7 +765,7 @@ be displayed to a user as <code>5.05</code> (<code>505 / 10 ** 2</code>).
 Returns the amount of coin in existence.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_supply">supply</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u256
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_supply">supply</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u256
 </code></pre>
 
 
@@ -772,7 +774,7 @@ Returns the amount of coin in existence.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_supply">supply</a>&lt;CoinType&gt;(ctx: &StorageContext): u256 {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_supply">supply</a>&lt;CoinType: key&gt;(ctx: &StorageContext): u256 {
     <a href="coin.md#0x3_coin_borrow_coin_info">borrow_coin_info</a>&lt;CoinType&gt;(ctx).supply
 }
 </code></pre>
@@ -813,7 +815,7 @@ Return true if the type <code>CoinType1</code> is same with <code>CoinType2</cod
 Return whether the account at <code>addr</code> accept <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> type coins
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_account_accept_coin">is_account_accept_coin</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_account_accept_coin">is_account_accept_coin</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -822,7 +824,7 @@ Return whether the account at <code>addr</code> accept <code><a href="coin.md#0x
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_account_accept_coin">is_account_accept_coin</a>&lt;CoinType&gt;(ctx: &StorageContext, addr: <b>address</b>): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_account_accept_coin">is_account_accept_coin</a>&lt;CoinType: key&gt;(ctx: &StorageContext, addr: <b>address</b>): bool {
     <b>if</b> (<a href="coin.md#0x3_coin_can_auto_accept_coin">can_auto_accept_coin</a>(ctx, addr)) {
         <b>true</b>
     } <b>else</b> {
@@ -875,7 +877,7 @@ Add a balance of <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> type to t
 If user turns off AutoAcceptCoin, call this method to receive the corresponding Coin
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -884,7 +886,7 @@ If user turns off AutoAcceptCoin, call this method to receive the corresponding 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType&gt;(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
     <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <a href="coin.md#0x3_coin_ensure_coin_store_pass_auto_accept_flag">ensure_coin_store_pass_auto_accept_flag</a>&lt;CoinType&gt;(ctx, addr);
 }
@@ -932,9 +934,10 @@ Configure whether auto-accept coins.
 ## Function `withdraw`
 
 Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from the signing account.
+This public entry function requires the <code>CoinType</code> to have <code>key</code> and <code>store</code> abilities.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType: store, key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -943,48 +946,15 @@ Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from the sig
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType: key + store&gt;(
     ctx: &<b>mut</b> StorageContext,
     <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
     amount: u256,
 ): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
     <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     // the <a href="coin.md#0x3_coin">coin</a> `frozen` only affect user withdraw, does not affect `withdraw_extend`.
-    <b>assert</b>!(
-        !<a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr),
-        <a href="_permission_denied">error::permission_denied</a>(<a href="coin.md#0x3_coin_ErrorAccountWithCoinFrozen">ErrorAccountWithCoinFrozen</a>),
-    );
-    <a href="coin.md#0x3_coin_withdraw_interal">withdraw_interal</a>&lt;CoinType&gt;(ctx, addr, amount)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_withdraw_extend"></a>
-
-## Function `withdraw_extend`
-
-Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from any addr, this function does not check the Coin <code>frozen</code> attribute
-This function is only called by the <code>CoinType</code> module, for the developer to extend custom withdraw logic
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw_extend">withdraw_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw_extend">withdraw_extend</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    addr: <b>address</b>,
-    amount: u256,
-): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
-    <a href="coin.md#0x3_coin_withdraw_interal">withdraw_interal</a>&lt;CoinType&gt;(ctx, addr, amount)
+    <a href="coin.md#0x3_coin_check_coin_store_frozen">check_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr);
+    <a href="coin.md#0x3_coin_withdraw_internal">withdraw_internal</a>&lt;CoinType&gt;(ctx, addr, amount)
 }
 </code></pre>
 
@@ -996,10 +966,11 @@ This function is only called by the <code>CoinType</code> module, for the develo
 
 ## Function `deposit`
 
-Deposit the coin balance into the recipient's account and emit an event.
+Deposit the coin into the recipient's account and emit an event.
+This public entry function requires the <code>CoinType</code> to have <code>key</code> and <code>store</code> abilities.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit">deposit</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit">deposit</a>&lt;CoinType: store, key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1008,25 +979,9 @@ Deposit the coin balance into the recipient's account and emit an event.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit">deposit</a>&lt;CoinType&gt;(ctx: &<b>mut</b> StorageContext, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
-    <b>assert</b>!(
-        <a href="coin.md#0x3_coin_is_account_accept_coin">is_account_accept_coin</a>&lt;CoinType&gt;(ctx, addr),
-        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorAccountNotAcceptCoin">ErrorAccountNotAcceptCoin</a>),
-    );
-
-    <b>assert</b>!(
-        !<a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr),
-        <a href="_permission_denied">error::permission_denied</a>(<a href="coin.md#0x3_coin_ErrorAccountWithCoinFrozen">ErrorAccountWithCoinFrozen</a>),
-    );
-
-    <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    <b>let</b> coin_type_info = <a href="_type_of">type_info::type_of</a>&lt;CoinType&gt;();
-    <a href="_emit">event::emit</a>&lt;<a href="coin.md#0x3_coin_DepositEvent">DepositEvent</a>&gt;(ctx, <a href="coin.md#0x3_coin_DepositEvent">DepositEvent</a> {
-        coin_type_info,
-        amount: <a href="coin.md#0x3_coin_value">value</a>(&<a href="coin.md#0x3_coin">coin</a>),
-    });
-
-    <a href="coin.md#0x3_coin_merge_coin">merge_coin</a>(ctx, addr, <a href="coin.md#0x3_coin">coin</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit">deposit</a>&lt;CoinType: key + store&gt;(ctx: &<b>mut</b> StorageContext, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
+    <a href="coin.md#0x3_coin_check_coin_store_frozen">check_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr);
+    <a href="coin.md#0x3_coin_deposit_internal">deposit_internal</a>(ctx, addr, <a href="coin.md#0x3_coin">coin</a>);
 }
 </code></pre>
 
@@ -1039,9 +994,10 @@ Deposit the coin balance into the recipient's account and emit an event.
 ## Function `transfer`
 
 Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</code> to <code><b>to</b></code>.
+Any account and module can call this function to transfer coins, the <code>CoinType</code> must have <code>key</code> and <code>store</code> abilities.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_transfer">transfer</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, from: &<a href="">signer</a>, <b>to</b>: <b>address</b>, amount: u256)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_transfer">transfer</a>&lt;CoinType: store, key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, from: &<a href="">signer</a>, <b>to</b>: <b>address</b>, amount: u256)
 </code></pre>
 
 
@@ -1050,43 +1006,16 @@ Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_transfer">transfer</a>&lt;CoinType&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_transfer">transfer</a>&lt;CoinType: key + store&gt;(
     ctx: &<b>mut</b> StorageContext,
     from: &<a href="">signer</a>,
     <b>to</b>: <b>address</b>,
     amount: u256,
 ) {
-    <b>let</b> <a href="coin.md#0x3_coin">coin</a> = <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType&gt;(ctx, from, amount);
-    <a href="coin.md#0x3_coin_deposit">deposit</a>(ctx, <b>to</b>, <a href="coin.md#0x3_coin">coin</a>);
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_burn_extend"></a>
-
-## Function `burn_extend`
-
-Burn <code><a href="coin.md#0x3_coin">coin</a></code>
-This function is only called by the <code>CoinType</code> module, for the developer to extend custom burn logic
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn_extend">burn_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn_extend">burn_extend</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;,
-) {
-    <a href="coin.md#0x3_coin_burn_internal">burn_internal</a>(ctx, <a href="coin.md#0x3_coin">coin</a>)
+    <b>let</b> from_addr = <a href="_address_of">signer::address_of</a>(from);
+    <a href="coin.md#0x3_coin_check_coin_store_frozen">check_coin_store_frozen</a>&lt;CoinType&gt;(ctx, from_addr);
+    <a href="coin.md#0x3_coin_check_coin_store_frozen">check_coin_store_frozen</a>&lt;CoinType&gt;(ctx, <b>to</b>);
+    <a href="coin.md#0x3_coin_transfer_internal">transfer_internal</a>&lt;CoinType&gt;(ctx, from_addr, <b>to</b>, amount);
 }
 </code></pre>
 
@@ -1102,7 +1031,7 @@ Destroys a zero-value coin. Calls will fail if the <code>value</code> in the pas
 so it is impossible to "burn" any non-zero amount of <code><a href="coin.md#0x3_coin_Coin">Coin</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_zero">destroy_zero</a>&lt;CoinType&gt;(zero_coin: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_zero">destroy_zero</a>&lt;CoinType: key&gt;(zero_coin: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1111,7 +1040,7 @@ so it is impossible to "burn" any non-zero amount of <code><a href="coin.md#0x3_
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_zero">destroy_zero</a>&lt;CoinType&gt;(zero_coin: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_zero">destroy_zero</a>&lt;CoinType: key&gt;(zero_coin: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
     <b>let</b> <a href="coin.md#0x3_coin_Coin">Coin</a> { value } = zero_coin;
     <b>assert</b>!(value == 0, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorDestroyOfNonZeroCoin">ErrorDestroyOfNonZeroCoin</a>))
 }
@@ -1128,7 +1057,7 @@ so it is impossible to "burn" any non-zero amount of <code><a href="coin.md#0x3_
 Extracts <code>amount</code> from the passed-in <code><a href="coin.md#0x3_coin">coin</a></code>, where the original coin is modified in place.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract">extract</a>&lt;CoinType&gt;(<a href="coin.md#0x3_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract">extract</a>&lt;CoinType: key&gt;(<a href="coin.md#0x3_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1137,7 +1066,7 @@ Extracts <code>amount</code> from the passed-in <code><a href="coin.md#0x3_coin"
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract">extract</a>&lt;CoinType&gt;(<a href="coin.md#0x3_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;, amount: u256): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract">extract</a>&lt;CoinType: key&gt;(<a href="coin.md#0x3_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;, amount: u256): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
     <b>assert</b>!(<a href="coin.md#0x3_coin">coin</a>.value &gt;= amount, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorInSufficientBalance">ErrorInSufficientBalance</a>));
     <a href="coin.md#0x3_coin">coin</a>.value = <a href="coin.md#0x3_coin">coin</a>.value - amount;
     <a href="coin.md#0x3_coin_Coin">Coin</a> { value: amount }
@@ -1155,7 +1084,7 @@ Extracts <code>amount</code> from the passed-in <code><a href="coin.md#0x3_coin"
 Extracts the entire amount from the passed-in <code><a href="coin.md#0x3_coin">coin</a></code>, where the original coin is modified in place.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract_all">extract_all</a>&lt;CoinType&gt;(<a href="coin.md#0x3_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract_all">extract_all</a>&lt;CoinType: key&gt;(<a href="coin.md#0x3_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1164,7 +1093,7 @@ Extracts the entire amount from the passed-in <code><a href="coin.md#0x3_coin">c
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract_all">extract_all</a>&lt;CoinType&gt;(<a href="coin.md#0x3_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract_all">extract_all</a>&lt;CoinType: key&gt;(<a href="coin.md#0x3_coin">coin</a>: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
     <b>let</b> total_value = <a href="coin.md#0x3_coin">coin</a>.value;
     <a href="coin.md#0x3_coin">coin</a>.value = 0;
     <a href="coin.md#0x3_coin_Coin">Coin</a> { value: total_value }
@@ -1175,14 +1104,15 @@ Extracts the entire amount from the passed-in <code><a href="coin.md#0x3_coin">c
 
 </details>
 
-<a name="0x3_coin_freeze_coin_store_extend"></a>
+<a name="0x3_coin_merge"></a>
 
-## Function `freeze_coin_store_extend`
+## Function `merge`
 
-Freeze a CoinStore to prevent transfers
+"Merges" the two given coins.  The coin passed in as <code>dst_coin</code> will have a value equal
+to the sum of the two coins (<code>dst_coin</code> and <code>source_coin</code>).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_extend">freeze_coin_store_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_merge">merge</a>&lt;CoinType: key&gt;(dst_coin: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;, source_coin: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1191,13 +1121,9 @@ Freeze a CoinStore to prevent transfers
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_extend">freeze_coin_store_extend</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    addr: <b>address</b>,
-) {
-    <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_coin_store">borrow_mut_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    coin_store.frozen = <b>true</b>;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_merge">merge</a>&lt;CoinType: key&gt;(dst_coin: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;, source_coin: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
+    <b>let</b> <a href="coin.md#0x3_coin_Coin">Coin</a> { value } = source_coin;
+    dst_coin.value = dst_coin.value + value;
 }
 </code></pre>
 
@@ -1205,14 +1131,14 @@ Freeze a CoinStore to prevent transfers
 
 </details>
 
-<a name="0x3_coin_unfreeze_coin_store_extend"></a>
+<a name="0x3_coin_value"></a>
 
-## Function `unfreeze_coin_store_extend`
+## Function `value`
 
-Unfreeze a CoinStore to allow transfers
+Returns the <code>value</code> passed in <code><a href="coin.md#0x3_coin">coin</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_extend">unfreeze_coin_store_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_value">value</a>&lt;CoinType: key&gt;(<a href="coin.md#0x3_coin">coin</a>: &<a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;): u256
 </code></pre>
 
 
@@ -1221,13 +1147,92 @@ Unfreeze a CoinStore to allow transfers
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_extend">unfreeze_coin_store_extend</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    addr: <b>address</b>,
-) {
-    <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_coin_store">borrow_mut_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    coin_store.frozen = <b>false</b>;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_value">value</a>&lt;CoinType: key&gt;(<a href="coin.md#0x3_coin">coin</a>: &<a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;): u256 {
+    <a href="coin.md#0x3_coin">coin</a>.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_zero"></a>
+
+## Function `zero`
+
+Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</code> with a value of <code>0</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_zero">zero</a>&lt;CoinType: key&gt;(): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_zero">zero</a>&lt;CoinType: key&gt;(): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
+    <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
+        value: 0
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_exist_coin_store"></a>
+
+## Function `exist_coin_store`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType: key&gt;(ctx: &StorageContext, addr: <b>address</b>): bool {
+    <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr)) {
+        <b>let</b> coin_stores = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr);
+        <a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(&coin_stores.coin_stores)
+    } <b>else</b> {
+        <b>false</b>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_is_coin_store_frozen"></a>
+
+## Function `is_coin_store_frozen`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType: key&gt;(ctx: &StorageContext, addr: <b>address</b>): bool {
+    <b>if</b> (<a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx, addr)) {
+        <a href="coin.md#0x3_coin_borrow_coin_store">borrow_coin_store</a>&lt;CoinType&gt;(ctx, addr).frozen
+    } <b>else</b> {
+        <b>false</b>
+    }
 }
 </code></pre>
 
@@ -1245,7 +1250,7 @@ The given signer also becomes the account hosting the information about the coin
 This function is protected by <code>private_generics</code>, so it can only be called by the <code>CoinType</code> module.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_register_extend">register_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, name: <a href="_String">string::String</a>, symbol: <a href="_String">string::String</a>, decimals: u8)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_register_extend">register_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, name: <a href="_String">string::String</a>, symbol: <a href="_String">string::String</a>, decimals: u8)
 </code></pre>
 
 
@@ -1254,7 +1259,7 @@ This function is protected by <code>private_generics</code>, so it can only be c
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_register_extend">register_extend</a>&lt;CoinType&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_register_extend">register_extend</a>&lt;CoinType: key&gt;(
     ctx: &<b>mut</b> StorageContext,
     name: <a href="_String">string::String</a>,
     symbol: <a href="_String">string::String</a>,
@@ -1285,33 +1290,6 @@ This function is protected by <code>private_generics</code>, so it can only be c
 
 </details>
 
-<a name="0x3_coin_merge"></a>
-
-## Function `merge`
-
-"Merges" the two given coins.  The coin passed in as <code>dst_coin</code> will have a value equal
-to the sum of the two coins (<code>dst_coin</code> and <code>source_coin</code>).
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_merge">merge</a>&lt;CoinType&gt;(dst_coin: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;, source_coin: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_merge">merge</a>&lt;CoinType&gt;(dst_coin: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;, source_coin: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
-    <b>let</b> <a href="coin.md#0x3_coin_Coin">Coin</a> { value } = source_coin;
-    dst_coin.value = dst_coin.value + value;
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x3_coin_mint_extend"></a>
 
 ## Function `mint_extend`
@@ -1319,7 +1297,7 @@ to the sum of the two coins (<code>dst_coin</code> and <code>source_coin</code>)
 Mint new <code><a href="coin.md#0x3_coin_Coin">Coin</a></code>, this function is only called by the <code>CoinType</code> module, for the developer to extend custom mint logic
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_mint_extend">mint_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_mint_extend">mint_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1328,7 +1306,7 @@ Mint new <code><a href="coin.md#0x3_coin_Coin">Coin</a></code>, this function is
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_mint_extend">mint_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> StorageContext,amount: u256) : <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_mint_extend">mint_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> StorageContext,amount: u256) : <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
     <a href="coin.md#0x3_coin_mint_internal">mint_internal</a>&lt;CoinType&gt;(ctx, amount)
 }
 </code></pre>
@@ -1337,14 +1315,15 @@ Mint new <code><a href="coin.md#0x3_coin_Coin">Coin</a></code>, this function is
 
 </details>
 
-<a name="0x3_coin_value"></a>
+<a name="0x3_coin_withdraw_extend"></a>
 
-## Function `value`
+## Function `withdraw_extend`
 
-Returns the <code>value</code> passed in <code><a href="coin.md#0x3_coin">coin</a></code>.
+Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from any addr, this function does not check the Coin <code>frozen</code> attribute
+This function is only called by the <code>CoinType</code> module, for the developer to extend custom withdraw logic
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_value">value</a>&lt;CoinType&gt;(<a href="coin.md#0x3_coin">coin</a>: &<a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;): u256
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw_extend">withdraw_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
 </code></pre>
 
 
@@ -1353,8 +1332,12 @@ Returns the <code>value</code> passed in <code><a href="coin.md#0x3_coin">coin</
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_value">value</a>&lt;CoinType&gt;(<a href="coin.md#0x3_coin">coin</a>: &<a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;): u256 {
-    <a href="coin.md#0x3_coin">coin</a>.value
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_withdraw_extend">withdraw_extend</a>&lt;CoinType: key&gt;(
+    ctx: &<b>mut</b> StorageContext,
+    addr: <b>address</b>,
+    amount: u256,
+): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
+    <a href="coin.md#0x3_coin_withdraw_internal">withdraw_internal</a>&lt;CoinType&gt;(ctx, addr, amount)
 }
 </code></pre>
 
@@ -1362,14 +1345,15 @@ Returns the <code>value</code> passed in <code><a href="coin.md#0x3_coin">coin</
 
 </details>
 
-<a name="0x3_coin_zero"></a>
+<a name="0x3_coin_deposit_extend"></a>
 
-## Function `zero`
+## Function `deposit_extend`
 
-Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</code> with a value of <code>0</code>.
+Deposit the coin into the recipient's account and emit an event.
+This function is only called by the <code>CoinType</code> module, for the developer to extend custom deposit logic
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_zero">zero</a>&lt;CoinType&gt;(): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit_extend">deposit_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1378,10 +1362,8 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_zero">zero</a>&lt;CoinType&gt;(): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
-    <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
-        value: 0
-    }
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit_extend">deposit_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> StorageContext, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
+    <a href="coin.md#0x3_coin_deposit_internal">deposit_internal</a>(ctx, addr, <a href="coin.md#0x3_coin">coin</a>);
 }
 </code></pre>
 
@@ -1389,13 +1371,15 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 
 </details>
 
-<a name="0x3_coin_exist_coin_store"></a>
+<a name="0x3_coin_transfer_extend"></a>
 
-## Function `exist_coin_store`
+## Function `transfer_extend`
+
+Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</code> to <code><b>to</b></code>.
+This function is only called by the <code>CoinType</code> module, for the developer to extend custom transfer logic
 
 
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_transfer_extend">transfer_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, from: <b>address</b>, <b>to</b>: <b>address</b>, amount: u256)
 </code></pre>
 
 
@@ -1404,13 +1388,13 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx: &StorageContext, addr: <b>address</b>): bool {
-    <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr)) {
-        <b>let</b> coin_stores = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr);
-        <a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(&coin_stores.coin_stores)
-    } <b>else</b> {
-        <b>false</b>
-    }
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_transfer_extend">transfer_extend</a>&lt;CoinType: key&gt;(
+    ctx: &<b>mut</b> StorageContext,
+    from: <b>address</b>,
+    <b>to</b>: <b>address</b>,
+    amount: u256,
+) {
+    <a href="coin.md#0x3_coin_transfer_internal">transfer_internal</a>&lt;CoinType&gt;(ctx, from, <b>to</b>, amount);
 }
 </code></pre>
 
@@ -1418,13 +1402,15 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 
 </details>
 
-<a name="0x3_coin_is_coin_store_frozen"></a>
+<a name="0x3_coin_burn_extend"></a>
 
-## Function `is_coin_store_frozen`
+## Function `burn_extend`
+
+Burn <code><a href="coin.md#0x3_coin">coin</a></code>
+This function is only called by the <code>CoinType</code> module, for the developer to extend custom burn logic
 
 
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn_extend">burn_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
 </code></pre>
 
 
@@ -1433,12 +1419,71 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(ctx: &StorageContext, addr: <b>address</b>): bool {
-    <b>if</b> (<a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx, addr)) {
-        <a href="coin.md#0x3_coin_borrow_coin_store">borrow_coin_store</a>&lt;CoinType&gt;(ctx, addr).frozen
-    } <b>else</b> {
-        <b>false</b>
-    }
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn_extend">burn_extend</a>&lt;CoinType: key&gt;(
+    ctx: &<b>mut</b> StorageContext,
+    <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;,
+) {
+    <a href="coin.md#0x3_coin_burn_internal">burn_internal</a>(ctx, <a href="coin.md#0x3_coin">coin</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_freeze_coin_store_extend"></a>
+
+## Function `freeze_coin_store_extend`
+
+Freeze a CoinStore to prevent transfers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_extend">freeze_coin_store_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_extend">freeze_coin_store_extend</a>&lt;CoinType: key&gt;(
+    ctx: &<b>mut</b> StorageContext,
+    addr: <b>address</b>,
+) {
+    <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
+    <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_coin_store">borrow_mut_coin_store</a>&lt;CoinType&gt;(ctx, addr);
+    coin_store.frozen = <b>true</b>;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_unfreeze_coin_store_extend"></a>
+
+## Function `unfreeze_coin_store_extend`
+
+Unfreeze a CoinStore to allow transfers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_extend">unfreeze_coin_store_extend</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_extend">unfreeze_coin_store_extend</a>&lt;CoinType: key&gt;(
+    ctx: &<b>mut</b> StorageContext,
+    addr: <b>address</b>,
+) {
+    <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
+    <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_coin_store">borrow_mut_coin_store</a>&lt;CoinType&gt;(ctx, addr);
+    coin_store.frozen = <b>false</b>;
 }
 </code></pre>
 
@@ -1454,7 +1499,7 @@ Creating a resource that stores balance of <code>CoinType</code> on user's accou
 Required if user wants to start accepting deposits of <code>CoinType</code> in his account.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_accept_coin_entry">accept_coin_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_accept_coin_entry">accept_coin_entry</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -1463,7 +1508,7 @@ Required if user wants to start accepting deposits of <code>CoinType</code> in h
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_accept_coin_entry">accept_coin_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_accept_coin_entry">accept_coin_entry</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
     <a href="coin.md#0x3_coin_do_accept_coin">do_accept_coin</a>&lt;CoinType&gt;(ctx, <a href="account.md#0x3_account">account</a>)
 }
 </code></pre>
@@ -1529,9 +1574,10 @@ The script function is reenterable.
 ## Function `transfer_entry`
 
 Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</code> to <code><b>to</b></code>.
+This public entry function requires the <code>CoinType</code> to have <code>key</code> and <code>store</code> abilities.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_transfer_entry">transfer_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, from: &<a href="">signer</a>, <b>to</b>: <b>address</b>, amount: u256)
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_transfer_entry">transfer_entry</a>&lt;CoinType: store, key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, from: &<a href="">signer</a>, <b>to</b>: <b>address</b>, amount: u256)
 </code></pre>
 
 
@@ -1540,13 +1586,14 @@ Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_transfer_entry">transfer_entry</a>&lt;CoinType&gt;(
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_transfer_entry">transfer_entry</a>&lt;CoinType: key + store&gt;(
     ctx: &<b>mut</b> StorageContext,
     from: &<a href="">signer</a>,
     <b>to</b>: <b>address</b>,
     amount: u256,
 ) {
-    <a href="coin.md#0x3_coin_transfer">transfer</a>&lt;CoinType&gt;(ctx, from, <b>to</b>, amount)
+    <b>let</b> from_addr = <a href="_address_of">signer::address_of</a>(from);
+    <a href="coin.md#0x3_coin_transfer_internal">transfer_internal</a>&lt;CoinType&gt;(ctx, from_addr, <b>to</b>, amount)
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/coin.md
+++ b/crates/rooch-framework/doc/coin.md
@@ -17,15 +17,11 @@ This module provides the foundation for typesafe Coins.
 -  [Struct `AcceptCoinEvent`](#0x3_coin_AcceptCoinEvent)
 -  [Struct `MintEvent`](#0x3_coin_MintEvent)
 -  [Struct `BurnEvent`](#0x3_coin_BurnEvent)
--  [Resource `MintCapability`](#0x3_coin_MintCapability)
--  [Resource `FreezeCapability`](#0x3_coin_FreezeCapability)
--  [Resource `BurnCapability`](#0x3_coin_BurnCapability)
--  [Resource `Capabilities`](#0x3_coin_Capabilities)
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x3_coin_genesis_init)
 -  [Function `init_account_coin_store`](#0x3_coin_init_account_coin_store)
 -  [Function `balance`](#0x3_coin_balance)
--  [Function `is_coin_initialized`](#0x3_coin_is_coin_initialized)
+-  [Function `is_coin_registered`](#0x3_coin_is_coin_registered)
 -  [Function `name`](#0x3_coin_name)
 -  [Function `symbol`](#0x3_coin_symbol)
 -  [Function `decimals`](#0x3_coin_decimals)
@@ -39,34 +35,23 @@ This module provides the foundation for typesafe Coins.
 -  [Function `withdraw_extend`](#0x3_coin_withdraw_extend)
 -  [Function `deposit`](#0x3_coin_deposit)
 -  [Function `transfer`](#0x3_coin_transfer)
--  [Function `burn`](#0x3_coin_burn)
 -  [Function `burn_extend`](#0x3_coin_burn_extend)
--  [Function `burn_from`](#0x3_coin_burn_from)
 -  [Function `destroy_zero`](#0x3_coin_destroy_zero)
 -  [Function `extract`](#0x3_coin_extract)
 -  [Function `extract_all`](#0x3_coin_extract_all)
--  [Function `freeze_coin_store`](#0x3_coin_freeze_coin_store)
--  [Function `unfreeze_coin_store`](#0x3_coin_unfreeze_coin_store)
--  [Function `initialize`](#0x3_coin_initialize)
+-  [Function `freeze_coin_store_extend`](#0x3_coin_freeze_coin_store_extend)
+-  [Function `unfreeze_coin_store_extend`](#0x3_coin_unfreeze_coin_store_extend)
+-  [Function `register_extend`](#0x3_coin_register_extend)
 -  [Function `merge`](#0x3_coin_merge)
--  [Function `mint`](#0x3_coin_mint)
 -  [Function `mint_extend`](#0x3_coin_mint_extend)
 -  [Function `value`](#0x3_coin_value)
 -  [Function `zero`](#0x3_coin_zero)
 -  [Function `exist_coin_store`](#0x3_coin_exist_coin_store)
 -  [Function `is_coin_store_frozen`](#0x3_coin_is_coin_store_frozen)
--  [Function `destroy_freeze_cap`](#0x3_coin_destroy_freeze_cap)
--  [Function `destroy_mint_cap`](#0x3_coin_destroy_mint_cap)
--  [Function `destroy_burn_cap`](#0x3_coin_destroy_burn_cap)
--  [Function `initialize_entry`](#0x3_coin_initialize_entry)
--  [Function `mint_entry`](#0x3_coin_mint_entry)
--  [Function `burn_entry`](#0x3_coin_burn_entry)
 -  [Function `accept_coin_entry`](#0x3_coin_accept_coin_entry)
 -  [Function `enable_auto_accept_coin_entry`](#0x3_coin_enable_auto_accept_coin_entry)
 -  [Function `disable_auto_accept_coin_entry`](#0x3_coin_disable_auto_accept_coin_entry)
 -  [Function `transfer_entry`](#0x3_coin_transfer_entry)
--  [Function `freeze_coin_store_entry`](#0x3_coin_freeze_coin_store_entry)
--  [Function `unfreeze_coin_store_entry`](#0x3_coin_unfreeze_coin_store_entry)
 
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
@@ -445,131 +430,6 @@ Event emitted when coin burned.
 
 </details>
 
-<a name="0x3_coin_MintCapability"></a>
-
-## Resource `MintCapability`
-
-Capability required to mint coins.
-
-
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_MintCapability">MintCapability</a>&lt;CoinType&gt; <b>has</b> <b>copy</b>, store, key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>dummy_field: bool</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x3_coin_FreezeCapability"></a>
-
-## Resource `FreezeCapability`
-
-Capability required to freeze a coin store.
-
-
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt; <b>has</b> <b>copy</b>, store, key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>dummy_field: bool</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x3_coin_BurnCapability"></a>
-
-## Resource `BurnCapability`
-
-Capability required to burn coins.
-
-
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt; <b>has</b> <b>copy</b>, store, key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>dummy_field: bool</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x3_coin_Capabilities"></a>
-
-## Resource `Capabilities`
-
-Capabilities resource storing mint and burn capabilities.
-The resource is stored on the account that initialized coin <code>CoinType</code>.
-
-
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt; <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>burn_cap: <a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>freeze_cap: <a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>mint_cap: <a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;CoinType&gt;</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
 <a name="@Constants_0"></a>
 
 ## Constants
@@ -609,7 +469,7 @@ Maximum possible coin supply.
 Account hasn't accept <code>CoinType</code>
 
 
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorAccountNotAcceptCoin">ErrorAccountNotAcceptCoin</a>: u64 = 9;
+<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorAccountNotAcceptCoin">ErrorAccountNotAcceptCoin</a>: u64 = 8;
 </code></pre>
 
 
@@ -619,27 +479,17 @@ Account hasn't accept <code>CoinType</code>
 CoinStore is frozen. Coins cannot be deposited or withdrawn
 
 
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorAccountWithCoinFrozen">ErrorAccountWithCoinFrozen</a>: u64 = 8;
-</code></pre>
-
-
-
-<a name="0x3_coin_ErrorCoinInfoAddressMismatch"></a>
-
-Address of account which is used to initialize a coin <code>CoinType</code> doesn't match the deployer of module
-
-
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorCoinInfoAddressMismatch">ErrorCoinInfoAddressMismatch</a>: u64 = 1;
+<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorAccountWithCoinFrozen">ErrorAccountWithCoinFrozen</a>: u64 = 7;
 </code></pre>
 
 
 
 <a name="0x3_coin_ErrorCoinInfoAlreadyPublished"></a>
 
-<code>CoinType</code> is already initialized as a coin
+<code>CoinType</code> is already registered as a coin
 
 
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorCoinInfoAlreadyPublished">ErrorCoinInfoAlreadyPublished</a>: u64 = 2;
+<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorCoinInfoAlreadyPublished">ErrorCoinInfoAlreadyPublished</a>: u64 = 1;
 </code></pre>
 
 
@@ -649,7 +499,7 @@ Address of account which is used to initialize a coin <code>CoinType</code> does
 Name of the coin is too long
 
 
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorCoinNameTooLong">ErrorCoinNameTooLong</a>: u64 = 6;
+<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorCoinNameTooLong">ErrorCoinNameTooLong</a>: u64 = 5;
 </code></pre>
 
 
@@ -659,7 +509,7 @@ Name of the coin is too long
 Symbol of the coin is too long
 
 
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorCoinSymbolTooLong">ErrorCoinSymbolTooLong</a>: u64 = 7;
+<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorCoinSymbolTooLong">ErrorCoinSymbolTooLong</a>: u64 = 6;
 </code></pre>
 
 
@@ -669,7 +519,7 @@ Symbol of the coin is too long
 Cannot destroy non-zero coins
 
 
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorDestroyOfNonZeroCoin">ErrorDestroyOfNonZeroCoin</a>: u64 = 4;
+<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorDestroyOfNonZeroCoin">ErrorDestroyOfNonZeroCoin</a>: u64 = 3;
 </code></pre>
 
 
@@ -679,17 +529,7 @@ Cannot destroy non-zero coins
 Not enough coins to complete transaction
 
 
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorInSufficientBalance">ErrorInSufficientBalance</a>: u64 = 3;
-</code></pre>
-
-
-
-<a name="0x3_coin_ErrorNoCapabilities"></a>
-
-account has no capabilities (burn/mint).
-
-
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>: u64 = 12;
+<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorInSufficientBalance">ErrorInSufficientBalance</a>: u64 = 2;
 </code></pre>
 
 
@@ -699,7 +539,7 @@ account has no capabilities (burn/mint).
 Coin amount cannot be zero
 
 
-<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorZeroCoinAmount">ErrorZeroCoinAmount</a>: u64 = 5;
+<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorZeroCoinAmount">ErrorZeroCoinAmount</a>: u64 = 4;
 </code></pre>
 
 
@@ -809,14 +649,14 @@ Returns the balance of <code>addr</code> for provided <code>CoinType</code>.
 
 </details>
 
-<a name="0x3_coin_is_coin_initialized"></a>
+<a name="0x3_coin_is_coin_registered"></a>
 
-## Function `is_coin_initialized`
+## Function `is_coin_registered`
 
-Returns <code><b>true</b></code> if the type <code>CoinType</code> is an initialized coin.
+Returns <code><b>true</b></code> if the type <code>CoinType</code> is an registered coin.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_registered">is_coin_registered</a>&lt;CoinType&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): bool
 </code></pre>
 
 
@@ -825,7 +665,7 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is an initial
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;(ctx: &StorageContext): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_registered">is_coin_registered</a>&lt;CoinType&gt;(ctx: &StorageContext): bool {
     <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework)) {
         <b>let</b> coin_infos = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
         <a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(&coin_infos.coin_infos)
@@ -1109,6 +949,11 @@ Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from the sig
     amount: u256,
 ): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
     <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
+    // the <a href="coin.md#0x3_coin">coin</a> `frozen` only affect user withdraw, does not affect `withdraw_extend`.
+    <b>assert</b>!(
+        !<a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr),
+        <a href="_permission_denied">error::permission_denied</a>(<a href="coin.md#0x3_coin_ErrorAccountWithCoinFrozen">ErrorAccountWithCoinFrozen</a>),
+    );
     <a href="coin.md#0x3_coin_withdraw_interal">withdraw_interal</a>&lt;CoinType&gt;(ctx, addr, amount)
 }
 </code></pre>
@@ -1121,7 +966,7 @@ Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from the sig
 
 ## Function `withdraw_extend`
 
-Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from any addr
+Withdraw specifed <code>amount</code> of coin <code>CoinType</code> from any addr, this function does not check the Coin <code>frozen</code> attribute
 This function is only called by the <code>CoinType</code> module, for the developer to extend custom withdraw logic
 
 
@@ -1220,36 +1065,6 @@ Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</cod
 
 </details>
 
-<a name="0x3_coin_burn"></a>
-
-## Function `burn`
-
-Burn <code><a href="coin.md#0x3_coin">coin</a></code> with capability.
-The capability <code>_cap</code> should be passed as a reference to <code><a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code>.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn">burn</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;, _cap: &<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn">burn</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;,
-    _cap: &<a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;,
-) {
-    <a href="coin.md#0x3_coin_burn_internal">burn_internal</a>(ctx, <a href="coin.md#0x3_coin">coin</a>)
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x3_coin_burn_extend"></a>
 
 ## Function `burn_extend`
@@ -1279,47 +1094,12 @@ This function is only called by the <code>CoinType</code> module, for the develo
 
 </details>
 
-<a name="0x3_coin_burn_from"></a>
-
-## Function `burn_from`
-
-Burn <code><a href="coin.md#0x3_coin">coin</a></code> from the specified <code><a href="account.md#0x3_account">account</a></code> with capability.
-The capability <code>burn_cap</code> should be passed as a reference to <code><a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;</code>.
-This function shouldn't fail as it's called as part of transaction fee burning.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn_from">burn_from</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, amount: u256, burn_cap: &<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_burn_from">burn_from</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    addr: <b>address</b>,
-    amount: u256,
-    burn_cap: &<a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;,
-) {
-    <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_coin_store">borrow_mut_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    <b>let</b> coin_to_burn = <a href="coin.md#0x3_coin_extract">extract</a>(&<b>mut</b> coin_store.<a href="coin.md#0x3_coin">coin</a>, amount);
-    <a href="coin.md#0x3_coin_burn">burn</a>(ctx, coin_to_burn, burn_cap);
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x3_coin_destroy_zero"></a>
 
 ## Function `destroy_zero`
 
 Destroys a zero-value coin. Calls will fail if the <code>value</code> in the passed-in <code><a href="coin.md#0x3_coin">coin</a></code> is non-zero
-so it is impossible to "burn" any non-zero amount of <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> without having
-a <code><a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a></code> for the specific <code>CoinType</code>.
+so it is impossible to "burn" any non-zero amount of <code><a href="coin.md#0x3_coin_Coin">Coin</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_zero">destroy_zero</a>&lt;CoinType&gt;(zero_coin: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
@@ -1395,14 +1175,14 @@ Extracts the entire amount from the passed-in <code><a href="coin.md#0x3_coin">c
 
 </details>
 
-<a name="0x3_coin_freeze_coin_store"></a>
+<a name="0x3_coin_freeze_coin_store_extend"></a>
 
-## Function `freeze_coin_store`
+## Function `freeze_coin_store_extend`
 
 Freeze a CoinStore to prevent transfers
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store">freeze_coin_store</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, _freeze_cap: &<a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_extend">freeze_coin_store_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>)
 </code></pre>
 
 
@@ -1411,10 +1191,9 @@ Freeze a CoinStore to prevent transfers
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store">freeze_coin_store</a>&lt;CoinType&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_extend">freeze_coin_store_extend</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
     addr: <b>address</b>,
-    _freeze_cap: &<a href="coin.md#0x3_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt;,
 ) {
     <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
     <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_coin_store">borrow_mut_coin_store</a>&lt;CoinType&gt;(ctx, addr);
@@ -1426,14 +1205,14 @@ Freeze a CoinStore to prevent transfers
 
 </details>
 
-<a name="0x3_coin_unfreeze_coin_store"></a>
+<a name="0x3_coin_unfreeze_coin_store_extend"></a>
 
-## Function `unfreeze_coin_store`
+## Function `unfreeze_coin_store_extend`
 
 Unfreeze a CoinStore to allow transfers
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store">unfreeze_coin_store</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>, _freeze_cap: &<a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_extend">unfreeze_coin_store_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>)
 </code></pre>
 
 
@@ -1442,10 +1221,9 @@ Unfreeze a CoinStore to allow transfers
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store">unfreeze_coin_store</a>&lt;CoinType&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_extend">unfreeze_coin_store_extend</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
     addr: <b>address</b>,
-    _freeze_cap: &<a href="coin.md#0x3_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt;,
 ) {
     <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
     <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_coin_store">borrow_mut_coin_store</a>&lt;CoinType&gt;(ctx, addr);
@@ -1457,16 +1235,17 @@ Unfreeze a CoinStore to allow transfers
 
 </details>
 
-<a name="0x3_coin_initialize"></a>
+<a name="0x3_coin_register_extend"></a>
 
-## Function `initialize`
+## Function `register_extend`
 
-Creates a new Coin with given <code>CoinType</code> and returns minting/freezing/burning capabilities.
+Creates a new Coin with given <code>CoinType</code>
 The given signer also becomes the account hosting the information about the coin
 (name, supply, etc.).
+This function is protected by <code>private_generics</code>, so it can only be called by the <code>CoinType</code> module.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_initialize">initialize</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, name: <a href="_String">string::String</a>, symbol: <a href="_String">string::String</a>, decimals: u8): (<a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;CoinType&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_register_extend">register_extend</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, name: <a href="_String">string::String</a>, symbol: <a href="_String">string::String</a>, decimals: u8)
 </code></pre>
 
 
@@ -1475,22 +1254,17 @@ The given signer also becomes the account hosting the information about the coin
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_initialize">initialize</a>&lt;CoinType&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_register_extend">register_extend</a>&lt;CoinType&gt;(
     ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
-    // addr: <b>address</b>,
     name: <a href="_String">string::String</a>,
     symbol: <a href="_String">string::String</a>,
     decimals: u8,
-): (<a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x3_coin_MintCapability">MintCapability</a>&lt;CoinType&gt;) {
-    <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
-    <b>assert</b>!(
-        <a href="coin.md#0x3_coin_coin_address">coin_address</a>&lt;CoinType&gt;() == addr,
-        <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinInfoAddressMismatch">ErrorCoinInfoAddressMismatch</a>),
-    );
+){
+
+    <b>let</b> coin_infos = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
 
     <b>assert</b>!(
-        !<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(ctx, addr),
+        !<a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(&coin_infos.coin_infos),
         <a href="_already_exists">error::already_exists</a>(<a href="coin.md#0x3_coin_ErrorCoinInfoAlreadyPublished">ErrorCoinInfoAlreadyPublished</a>),
     );
 
@@ -1503,10 +1277,7 @@ The given signer also becomes the account hosting the information about the coin
         decimals,
         supply: 0u256,
     };
-    <b>let</b> coin_infos = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
     <a href="_add">type_table::add</a>(&<b>mut</b> coin_infos.coin_infos, coin_info);
-
-    (<a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt; {}, <a href="coin.md#0x3_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt; {}, <a href="coin.md#0x3_coin_MintCapability">MintCapability</a>&lt;CoinType&gt; {})
 }
 </code></pre>
 
@@ -1534,37 +1305,6 @@ to the sum of the two coins (<code>dst_coin</code> and <code>source_coin</code>)
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_merge">merge</a>&lt;CoinType&gt;(dst_coin: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;, source_coin: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
     <b>let</b> <a href="coin.md#0x3_coin_Coin">Coin</a> { value } = source_coin;
     dst_coin.value = dst_coin.value + value;
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_mint"></a>
-
-## Function `mint`
-
-Mint new <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> with capability.
-The capability <code>_cap</code> should be passed as reference to <code><a href="coin.md#0x3_coin_MintCapability">MintCapability</a>&lt;CoinType&gt;</code>.
-Returns minted <code><a href="coin.md#0x3_coin_Coin">Coin</a></code>.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_mint">mint</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, amount: u256, _cap: &<a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;CoinType&gt;): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_mint">mint</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    amount: u256,
-    _cap: &<a href="coin.md#0x3_coin_MintCapability">MintCapability</a>&lt;CoinType&gt;,
-): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
-    <a href="coin.md#0x3_coin_mint_internal">mint_internal</a>&lt;CoinType&gt;(ctx, amount)
 }
 </code></pre>
 
@@ -1706,208 +1446,6 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 
 </details>
 
-<a name="0x3_coin_destroy_freeze_cap"></a>
-
-## Function `destroy_freeze_cap`
-
-Destroy a freeze capability. Freeze capability is dangerous and therefore should be destroyed if not used.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_freeze_cap">destroy_freeze_cap</a>&lt;CoinType&gt;(freeze_cap: <a href="coin.md#0x3_coin_FreezeCapability">coin::FreezeCapability</a>&lt;CoinType&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_freeze_cap">destroy_freeze_cap</a>&lt;CoinType&gt;(freeze_cap: <a href="coin.md#0x3_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt;) {
-    <b>let</b> <a href="coin.md#0x3_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt; {} = freeze_cap;
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_destroy_mint_cap"></a>
-
-## Function `destroy_mint_cap`
-
-Destroy a mint capability.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_mint_cap">destroy_mint_cap</a>&lt;CoinType&gt;(mint_cap: <a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;CoinType&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_mint_cap">destroy_mint_cap</a>&lt;CoinType&gt;(mint_cap: <a href="coin.md#0x3_coin_MintCapability">MintCapability</a>&lt;CoinType&gt;) {
-    <b>let</b> <a href="coin.md#0x3_coin_MintCapability">MintCapability</a>&lt;CoinType&gt; {} = mint_cap;
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_destroy_burn_cap"></a>
-
-## Function `destroy_burn_cap`
-
-Destroy a burn capability.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_burn_cap">destroy_burn_cap</a>&lt;CoinType&gt;(burn_cap: <a href="coin.md#0x3_coin_BurnCapability">coin::BurnCapability</a>&lt;CoinType&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_destroy_burn_cap">destroy_burn_cap</a>&lt;CoinType&gt;(burn_cap: <a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;) {
-    <b>let</b> <a href="coin.md#0x3_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt; {} = burn_cap;
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_initialize_entry"></a>
-
-## Function `initialize_entry`
-
-Initialize new coin <code>CoinType</code> in Rooch Blockchain.
-Mint and Burn Capabilities will be stored under <code><a href="account.md#0x3_account">account</a></code> in <code><a href="coin.md#0x3_coin_Capabilities">Capabilities</a></code> resource.
-A developer can create his own coin and care less about mint and burn capabilities
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_initialize_entry">initialize_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, name: <a href="">vector</a>&lt;u8&gt;, symbol: <a href="">vector</a>&lt;u8&gt;, decimals: u8)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_initialize_entry">initialize_entry</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
-    name: <a href="">vector</a>&lt;u8&gt;,
-    symbol: <a href="">vector</a>&lt;u8&gt;,
-    decimals: u8,
-) {
-    // <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
-    <b>let</b> (burn_cap, freeze_cap, mint_cap) = <a href="coin.md#0x3_coin_initialize">initialize</a>&lt;CoinType&gt;(
-        ctx,
-        <a href="account.md#0x3_account">account</a>,
-        <a href="_utf8">string::utf8</a>(name),
-        <a href="_utf8">string::utf8</a>(symbol),
-        decimals,
-    );
-
-    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, <a href="account.md#0x3_account">account</a>, <a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt; {
-        burn_cap,
-        freeze_cap,
-        mint_cap
-    });
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_mint_entry"></a>
-
-## Function `mint_entry`
-
-Create new coins <code>CoinType</code> and deposit them into dst_addr's account.
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_mint_entry">mint_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, dst_addr: <b>address</b>, amount: u256)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_mint_entry">mint_entry</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
-    dst_addr: <b>address</b>,
-    amount: u256,
-) {
-    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
-
-    <b>assert</b>!(
-        <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
-        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
-    );
-
-    <b>let</b> cap = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    // <b>let</b> cap = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    <b>let</b> coins_minted = <a href="coin.md#0x3_coin_mint">mint</a>(ctx, amount, &cap.mint_cap);
-    <a href="coin.md#0x3_coin_deposit">deposit</a>(ctx, dst_addr, coins_minted);
-    <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_burn_entry"></a>
-
-## Function `burn_entry`
-
-Withdraw an <code>amount</code> of coin <code>CoinType</code> from <code><a href="account.md#0x3_account">account</a></code> and burn it.
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_burn_entry">burn_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>, amount: u256)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_burn_entry">burn_entry</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>,
-    amount: u256,
-) {
-    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
-
-    <b>assert</b>!(
-        <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
-        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
-    );
-
-    // <b>let</b> cap = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    <b>let</b> cap = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    <b>let</b> to_burn = <a href="coin.md#0x3_coin_withdraw">withdraw</a>&lt;CoinType&gt;(ctx, <a href="account.md#0x3_account">account</a>, amount);
-    <a href="coin.md#0x3_coin_burn">burn</a>&lt;CoinType&gt;(ctx, to_burn, &cap.burn_cap);
-    <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap);
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x3_coin_accept_coin_entry"></a>
 
 ## Function `accept_coin_entry`
@@ -2009,78 +1547,6 @@ Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</cod
     amount: u256,
 ) {
     <a href="coin.md#0x3_coin_transfer">transfer</a>&lt;CoinType&gt;(ctx, from, <b>to</b>, amount)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_freeze_coin_store_entry"></a>
-
-## Function `freeze_coin_store_entry`
-
-Freeze a CoinStore to prevent transfers
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_entry">freeze_coin_store_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_freeze_coin_store_entry">freeze_coin_store_entry</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>
-) {
-    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
-    <b>assert</b>!(
-        <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
-        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
-    );
-    // <b>let</b> cap = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    <b>let</b> cap = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    <a href="coin.md#0x3_coin_freeze_coin_store">freeze_coin_store</a>(ctx, account_addr, &cap.freeze_cap);
-    <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_coin_unfreeze_coin_store_entry"></a>
-
-## Function `unfreeze_coin_store_entry`
-
-Unfreeze a CoinStore to allow transfers
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_entry">unfreeze_coin_store_entry</a>&lt;CoinType&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x3_coin_unfreeze_coin_store_entry">unfreeze_coin_store_entry</a>&lt;CoinType&gt;(
-    ctx: &<b>mut</b> StorageContext,
-    <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>
-) {
-    <b>let</b> account_addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
-    <b>assert</b>!(
-        <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr),
-        <a href="_not_found">error::not_found</a>(<a href="coin.md#0x3_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>),
-    );
-    <b>let</b> cap = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    // <b>let</b> cap = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, account_addr);
-    <a href="coin.md#0x3_coin_unfreeze_coin_store">unfreeze_coin_store</a>(ctx, account_addr, &cap.freeze_cap);
-    <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="coin.md#0x3_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(ctx, <a href="account.md#0x3_account">account</a>, cap)
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/gas_coin.md
+++ b/crates/rooch-framework/doc/gas_coin.md
@@ -141,7 +141,7 @@ Mint gas coin to the given account.
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_faucet">faucet</a>(ctx: &<b>mut</b> StorageContext, addr: <b>address</b>, amount: u256) {
     <b>let</b> <a href="coin.md#0x3_coin">coin</a> = <a href="gas_coin.md#0x3_gas_coin_mint">mint</a>(ctx, amount);
-    <a href="coin.md#0x3_coin_deposit">coin::deposit</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a>&gt;(ctx, addr, <a href="coin.md#0x3_coin">coin</a>);
+    <a href="coin.md#0x3_coin_deposit_extend">coin::deposit_extend</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a>&gt;(ctx, addr, <a href="coin.md#0x3_coin">coin</a>);
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/gas_coin.md
+++ b/crates/rooch-framework/doc/gas_coin.md
@@ -7,26 +7,18 @@ This module defines Rooch Gas Coin.
 
 
 -  [Resource `GasCoin`](#0x3_gas_coin_GasCoin)
--  [Resource `MintCapStore`](#0x3_gas_coin_MintCapStore)
--  [Struct `DelegatedMintCapability`](#0x3_gas_coin_DelegatedMintCapability)
--  [Resource `Delegations`](#0x3_gas_coin_Delegations)
--  [Constants](#@Constants_0)
 -  [Function `balance`](#0x3_gas_coin_balance)
 -  [Function `burn`](#0x3_gas_coin_burn)
 -  [Function `deduct_gas`](#0x3_gas_coin_deduct_gas)
 -  [Function `faucet`](#0x3_gas_coin_faucet)
 -  [Function `faucet_entry`](#0x3_gas_coin_faucet_entry)
 -  [Function `genesis_init`](#0x3_gas_coin_genesis_init)
--  [Function `has_mint_capability`](#0x3_gas_coin_has_mint_capability)
--  [Function `destroy_mint_cap`](#0x3_gas_coin_destroy_mint_cap)
 
 
 <pre><code><b>use</b> <a href="">0x1::signer</a>;
 <b>use</b> <a href="">0x1::string</a>;
-<b>use</b> <a href="">0x2::account_storage</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
-<b>use</b> <a href="core_addresses.md#0x3_core_addresses">0x3::core_addresses</a>;
 </code></pre>
 
 
@@ -57,104 +49,6 @@ This module defines Rooch Gas Coin.
 
 
 </details>
-
-<a name="0x3_gas_coin_MintCapStore"></a>
-
-## Resource `MintCapStore`
-
-
-
-<pre><code><b>struct</b> <a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>mint_cap: <a href="coin.md#0x3_coin_MintCapability">coin::MintCapability</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">gas_coin::GasCoin</a>&gt;</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x3_gas_coin_DelegatedMintCapability"></a>
-
-## Struct `DelegatedMintCapability`
-
-Delegation coin created by delegator and can be claimed by the delegatee as MintCapability.
-
-
-<pre><code><b>struct</b> <a href="gas_coin.md#0x3_gas_coin_DelegatedMintCapability">DelegatedMintCapability</a> <b>has</b> store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code><b>to</b>: <b>address</b></code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x3_gas_coin_Delegations"></a>
-
-## Resource `Delegations`
-
-The container stores the current pending delegations.
-
-
-<pre><code><b>struct</b> <a href="gas_coin.md#0x3_gas_coin_Delegations">Delegations</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>inner: <a href="">vector</a>&lt;<a href="gas_coin.md#0x3_gas_coin_DelegatedMintCapability">gas_coin::DelegatedMintCapability</a>&gt;</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="@Constants_0"></a>
-
-## Constants
-
-
-<a name="0x3_gas_coin_ErrorNoCapabilities"></a>
-
-Account does not have mint capability
-
-
-<pre><code><b>const</b> <a href="gas_coin.md#0x3_gas_coin_ErrorNoCapabilities">ErrorNoCapabilities</a>: u64 = 1;
-</code></pre>
-
-
 
 <a name="0x3_gas_coin_balance"></a>
 
@@ -289,7 +183,7 @@ TODO find a way to protect this function from DOS attack.
 Can only called during genesis to initialize the Rooch coin.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, genesis_account: &<a href="">signer</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, _genesis_account: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -298,75 +192,13 @@ Can only called during genesis to initialize the Rooch coin.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, genesis_account: &<a href="">signer</a>){
-    <b>let</b> (burn_cap, freeze_cap, mint_cap) = <a href="coin.md#0x3_coin_initialize">coin::initialize</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a>&gt;(
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, _genesis_account: &<a href="">signer</a>){
+    <a href="coin.md#0x3_coin_register_extend">coin::register_extend</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a>&gt;(
         ctx,
-        genesis_account,
         <a href="_utf8">string::utf8</a>(b"Rooch Gas Coin"),
         <a href="_utf8">string::utf8</a>(b"RGC"),
         9, // decimals
     );
-
-    // Rooch framework needs mint cap <b>to</b> mint coins <b>to</b> initial validators. This will be revoked once the validators
-    // have been initialized.
-    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, <a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a> { mint_cap });
-
-    //TODO do we need the cap?
-    <a href="coin.md#0x3_coin_destroy_freeze_cap">coin::destroy_freeze_cap</a>(freeze_cap);
-    <a href="coin.md#0x3_coin_destroy_mint_cap">coin::destroy_mint_cap</a>(mint_cap);
-    <a href="coin.md#0x3_coin_destroy_burn_cap">coin::destroy_burn_cap</a>(burn_cap);
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_gas_coin_has_mint_capability"></a>
-
-## Function `has_mint_capability`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_has_mint_capability">has_mint_capability</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>): bool
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_has_mint_capability">has_mint_capability</a>(ctx: &StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>): bool {
-    <a href="_global_exists">account_storage::global_exists</a>&lt;<a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a>&gt;(ctx, <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>))
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_gas_coin_destroy_mint_cap"></a>
-
-## Function `destroy_mint_cap`
-
-Only called during genesis to destroy the rooch framework account's mint capability once all initial validators
-and accounts have been initialized during genesis.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_destroy_mint_cap">destroy_mint_cap</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, rooch_framework: &<a href="">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_destroy_mint_cap">destroy_mint_cap</a>(ctx: &<b>mut</b> StorageContext, rooch_framework: &<a href="">signer</a>) {
-    <a href="core_addresses.md#0x3_core_addresses_assert_rooch_framework">core_addresses::assert_rooch_framework</a>(rooch_framework);
-    <b>let</b> <a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a> { mint_cap } = <a href="_global_move_from">account_storage::global_move_from</a>&lt;<a href="gas_coin.md#0x3_gas_coin_MintCapStore">MintCapStore</a>&gt;(ctx,@rooch_framework);
-    <a href="coin.md#0x3_coin_destroy_mint_cap">coin::destroy_mint_cap</a>(mint_cap);
 }
 </code></pre>
 

--- a/crates/rooch-framework/sources/coin.move
+++ b/crates/rooch-framework/sources/coin.move
@@ -55,7 +55,7 @@ module rooch_framework::coin {
     /// Core data structures
 
     /// Main structure representing a coin/coin in an account's custody.
-    struct Coin<phantom CoinType> has store {
+    struct Coin<phantom CoinType : key> has store {
         /// Amount of coin this address has.
         /// Following the ERC20 standard, both asset balance and supply are expressed in u256
         value: u256,
@@ -66,7 +66,7 @@ module rooch_framework::coin {
 
     // /// A holder of a specific coin types.
     // /// These are kept in a single resource to ensure locality of data.
-    struct CoinStore<phantom CoinType> has key {
+    struct CoinStore<phantom CoinType : key> has key {
         coin: Coin<CoinType>,
         frozen: bool,
     }
@@ -77,7 +77,7 @@ module rooch_framework::coin {
     const MAX_U256: u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
     /// Information about a specific coin type. Stored on the creator of the coin's account.
-    struct CoinInfo<phantom CoinType> has key {
+    struct CoinInfo<phantom CoinType : key> has key {
         name: string::String,
         /// Symbol of the coin, usually a shorter version of the name.
         /// For example, Singapore Dollar is SGD.
@@ -166,14 +166,14 @@ module rooch_framework::coin {
     //
 
     /// A helper function that returns the address of CoinType.
-    fun coin_address<CoinType>(): address {
+    fun coin_address<CoinType: key>(): address {
         let type_info = type_info::type_of<CoinType>();
         type_info::account_address(&type_info)
     }
 
 
     /// Returns the balance of `addr` for provided `CoinType`.
-    public fun balance<CoinType>(ctx: &StorageContext, addr: address): u256 {
+    public fun balance<CoinType: key>(ctx: &StorageContext, addr: address): u256 {
         if (exist_coin_store<CoinType>(ctx, addr)) {
             borrow_coin_store<CoinType>(ctx, addr).coin.value
         } else {
@@ -182,7 +182,7 @@ module rooch_framework::coin {
     }
 
     /// Returns `true` if the type `CoinType` is an registered coin.
-    public fun is_coin_registered<CoinType>(ctx: &StorageContext): bool {
+    public fun is_coin_registered<CoinType: key>(ctx: &StorageContext): bool {
         if (account_storage::global_exists<CoinInfos>(ctx, @rooch_framework)) {
             let coin_infos = account_storage::global_borrow<CoinInfos>(ctx, @rooch_framework);
             type_table::contains<CoinInfo<CoinType>>(&coin_infos.coin_infos)
@@ -192,25 +192,25 @@ module rooch_framework::coin {
     }
 
     /// Returns the name of the coin.
-    public fun name<CoinType>(ctx: &StorageContext): string::String {
+    public fun name<CoinType: key>(ctx: &StorageContext): string::String {
         borrow_coin_info<CoinType>(ctx).name
     }
 
     /// Returns the symbol of the coin, usually a shorter version of the name.
-    public fun symbol<CoinType>(ctx: &StorageContext): string::String {
+    public fun symbol<CoinType: key>(ctx: &StorageContext): string::String {
         borrow_coin_info<CoinType>(ctx).symbol
     }
 
     /// Returns the number of decimals used to get its user representation.
     /// For example, if `decimals` equals `2`, a balance of `505` coins should
     /// be displayed to a user as `5.05` (`505 / 10 ** 2`).
-    public fun decimals<CoinType>(ctx: &StorageContext): u8 {
+    public fun decimals<CoinType: key>(ctx: &StorageContext): u8 {
         borrow_coin_info<CoinType>(ctx).decimals
     }
 
 
     /// Returns the amount of coin in existence.
-    public fun supply<CoinType>(ctx: &StorageContext): u256 {
+    public fun supply<CoinType: key>(ctx: &StorageContext): u256 {
         borrow_coin_info<CoinType>(ctx).supply
     }
 
@@ -223,12 +223,12 @@ module rooch_framework::coin {
     // Helper functions
     //
 
-    fun borrow_coin_info<CoinType>(ctx: &StorageContext): &CoinInfo<CoinType> {
+    fun borrow_coin_info<CoinType: key>(ctx: &StorageContext): &CoinInfo<CoinType> {
         let coin_infos = account_storage::global_borrow<CoinInfos>(ctx, @rooch_framework);
         type_table::borrow<CoinInfo<CoinType>>(&coin_infos.coin_infos)
     }
 
-    fun borrow_mut_coin_info<CoinType>(ctx: &mut StorageContext): &mut CoinInfo<CoinType> {
+    fun borrow_mut_coin_info<CoinType: key>(ctx: &mut StorageContext): &mut CoinInfo<CoinType> {
         let coin_infos = account_storage::global_borrow_mut<CoinInfos>(ctx, @rooch_framework);
         type_table::borrow_mut<CoinInfo<CoinType>>(&mut coin_infos.coin_infos)
     }
@@ -238,29 +238,29 @@ module rooch_framework::coin {
         table::contains<address, bool>(&auto_accept_coins.auto_accept_coins, addr)
     }
 
-    fun borrow_coin_store<CoinType>(ctx: &StorageContext, addr: address): &CoinStore<CoinType> {
+    fun borrow_coin_store<CoinType: key>(ctx: &StorageContext, addr: address): &CoinStore<CoinType> {
         let coin_stores = account_storage::global_borrow<CoinStores>(ctx, addr);
         type_table::borrow<CoinStore<CoinType>>(&coin_stores.coin_stores)
     }
 
-    fun borrow_mut_coin_store<CoinType>(ctx: &mut StorageContext, addr: address): &mut CoinStore<CoinType> {
+    fun borrow_mut_coin_store<CoinType: key>(ctx: &mut StorageContext, addr: address): &mut CoinStore<CoinType> {
         let coin_stores = account_storage::global_borrow_mut<CoinStores>(ctx, addr);
         type_table::borrow_mut<CoinStore<CoinType>>(&mut coin_stores.coin_stores)
     }
 
-    fun ensure_coin_store<CoinType>(ctx: &mut StorageContext, addr: address) {
+    fun ensure_coin_store<CoinType: key>(ctx: &mut StorageContext, addr: address) {
         if (!exist_coin_store<CoinType>(ctx, addr) && can_auto_accept_coin(ctx, addr)) {
             inner_new_coin_store<CoinType>(ctx, addr)
         }
     }
 
-    fun ensure_coin_store_pass_auto_accept_flag<CoinType>(ctx: &mut StorageContext, addr: address) {
+    fun ensure_coin_store_pass_auto_accept_flag<CoinType: key>(ctx: &mut StorageContext, addr: address) {
         if (!exist_coin_store<CoinType>(ctx, addr)) {
             inner_new_coin_store<CoinType>(ctx, addr)
         }
     }
 
-    fun inner_new_coin_store<CoinType>(ctx: &mut StorageContext, addr: address) {
+    fun inner_new_coin_store<CoinType: key>(ctx: &mut StorageContext, addr: address) {
         let coin_stores = account_storage::global_borrow_mut<CoinStores>(ctx, addr);
         type_table::add<CoinStore<CoinType>>(&mut coin_stores.coin_stores, CoinStore<CoinType> {
             coin: Coin { value: 0 },
@@ -268,12 +268,108 @@ module rooch_framework::coin {
         })
     }
 
+    fun extract_coin<CoinType: key>(ctx: &mut StorageContext, addr: address, amount: u256): Coin<CoinType> {
+        let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
+        extract<CoinType>(&mut coin_store.coin, amount)
+    }
+
+    fun merge_coin<CoinType: key>(ctx: &mut StorageContext, addr: address, coin: Coin<CoinType>) {
+        let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
+        merge<CoinType>(&mut coin_store.coin, coin)
+    }
+
+    fun check_coin_store_frozen<CoinType: key>(ctx: &StorageContext, addr: address) {
+        assert!(
+            !is_coin_store_frozen<CoinType>(ctx, addr),
+            error::permission_denied(ErrorAccountWithCoinFrozen),
+        );
+    }
+
+    //
+    // Internal functions
+    //
+
+    fun mint_internal<CoinType: key>(ctx: &mut StorageContext,
+        amount: u256): Coin<CoinType>{
+        let coin_info = borrow_mut_coin_info<CoinType>(ctx);
+        coin_info.supply = coin_info.supply + amount;
+        let coin_type_info = type_info::type_of<CoinType>();
+        event::emit<MintEvent>(ctx, MintEvent {
+            coin_type_info,
+            amount,
+        });
+        Coin<CoinType> { value: amount }
+    }
+
+    fun withdraw_internal<CoinType: key>(
+        ctx: &mut StorageContext,
+        addr: address,
+        amount: u256,
+    ): Coin<CoinType> {
+        assert!(
+            is_account_accept_coin<CoinType>(ctx, addr),
+            error::not_found(ErrorAccountNotAcceptCoin),
+        );
+
+        
+        ensure_coin_store<CoinType>(ctx, addr);
+        let coin_type_info = type_info::type_of<CoinType>();
+        event::emit<WithdrawEvent>(ctx, WithdrawEvent {
+            coin_type_info,
+            amount,
+        });
+
+        extract_coin(ctx, addr, amount)
+    }
+
+    fun deposit_internal<CoinType: key>(ctx: &mut StorageContext, addr: address, coin: Coin<CoinType>) {
+        assert!(
+            is_account_accept_coin<CoinType>(ctx, addr),
+            error::not_found(ErrorAccountNotAcceptCoin),
+        );
+
+        ensure_coin_store<CoinType>(ctx, addr);
+        let coin_type_info = type_info::type_of<CoinType>();
+        event::emit<DepositEvent>(ctx, DepositEvent {
+            coin_type_info,
+            amount: value(&coin),
+        });
+
+        merge_coin(ctx, addr, coin);
+    }
+
+    fun transfer_internal<CoinType: key>(
+        ctx: &mut StorageContext,
+        from: address,
+        to: address,
+        amount: u256,
+    ) {
+        let coin = withdraw_internal<CoinType>(ctx, from, amount);
+        deposit_internal(ctx, to, coin);
+    }
+
+    fun burn_internal<CoinType: key>(
+        ctx: &mut StorageContext,
+        coin: Coin<CoinType>,
+    ) {
+        let Coin { value: amount } = coin;
+
+        let coin_type_info = type_info::type_of<CoinType>();
+        let coin_info = borrow_mut_coin_info<CoinType>(ctx);
+        coin_info.supply = coin_info.supply - amount;
+        event::emit<BurnEvent>(ctx, BurnEvent {
+            coin_type_info,
+            amount,
+        });
+    }
+
+
     //
     // Public functions
     //
 
     /// Return whether the account at `addr` accept `Coin` type coins
-    public fun is_account_accept_coin<CoinType>(ctx: &StorageContext, addr: address): bool {
+    public fun is_account_accept_coin<CoinType: key>(ctx: &StorageContext, addr: address): bool {
         if (can_auto_accept_coin(ctx, addr)) {
             true
         } else {
@@ -295,7 +391,7 @@ module rooch_framework::coin {
 
     /// Add a balance of `Coin` type to the sending account.
     /// If user turns off AutoAcceptCoin, call this method to receive the corresponding Coin
-    public fun do_accept_coin<CoinType>(ctx: &mut StorageContext, account: &signer) {
+    public fun do_accept_coin<CoinType: key>(ctx: &mut StorageContext, account: &signer) {
         let addr = signer::address_of(account);
         ensure_coin_store_pass_auto_accept_flag<CoinType>(ctx, addr);
     }
@@ -314,159 +410,106 @@ module rooch_framework::coin {
     }
 
     /// Withdraw specifed `amount` of coin `CoinType` from the signing account.
-    public fun withdraw<CoinType>(
+    /// This public entry function requires the `CoinType` to have `key` and `store` abilities.
+    public fun withdraw<CoinType: key + store>(
         ctx: &mut StorageContext,
         account: &signer,
         amount: u256,
     ): Coin<CoinType> {
         let addr = signer::address_of(account);
         // the coin `frozen` only affect user withdraw, does not affect `withdraw_extend`. 
-        assert!(
-            !is_coin_store_frozen<CoinType>(ctx, addr),
-            error::permission_denied(ErrorAccountWithCoinFrozen),
-        );
-        withdraw_interal<CoinType>(ctx, addr, amount) 
+        check_coin_store_frozen<CoinType>(ctx, addr);
+        withdraw_internal<CoinType>(ctx, addr, amount) 
     }
 
-    #[private_generics(CoinType)]
-    /// Withdraw specifed `amount` of coin `CoinType` from any addr, this function does not check the Coin `frozen` attribute
-    /// This function is only called by the `CoinType` module, for the developer to extend custom withdraw logic
-    public fun withdraw_extend<CoinType>(
-        ctx: &mut StorageContext,
-        addr: address,
-        amount: u256,
-    ): Coin<CoinType> {
-        withdraw_interal<CoinType>(ctx, addr, amount) 
-    }
-
-    fun withdraw_interal<CoinType>(
-        ctx: &mut StorageContext,
-        addr: address,
-        amount: u256,
-    ): Coin<CoinType> {
-        assert!(
-            is_account_accept_coin<CoinType>(ctx, addr),
-            error::not_found(ErrorAccountNotAcceptCoin),
-        );
-
-        
-        ensure_coin_store<CoinType>(ctx, addr);
-        let coin_type_info = type_info::type_of<CoinType>();
-        event::emit<WithdrawEvent>(ctx, WithdrawEvent {
-            coin_type_info,
-            amount,
-        });
-
-        extract_coin(ctx, addr, amount)
-    }
-
-    /// Deposit the coin balance into the recipient's account and emit an event.
-    public fun deposit<CoinType>(ctx: &mut StorageContext, addr: address, coin: Coin<CoinType>) {
-        assert!(
-            is_account_accept_coin<CoinType>(ctx, addr),
-            error::not_found(ErrorAccountNotAcceptCoin),
-        );
-
-        assert!(
-            !is_coin_store_frozen<CoinType>(ctx, addr),
-            error::permission_denied(ErrorAccountWithCoinFrozen),
-        );
-
-        ensure_coin_store<CoinType>(ctx, addr);
-        let coin_type_info = type_info::type_of<CoinType>();
-        event::emit<DepositEvent>(ctx, DepositEvent {
-            coin_type_info,
-            amount: value(&coin),
-        });
-
-        merge_coin(ctx, addr, coin);
+    /// Deposit the coin into the recipient's account and emit an event.
+    /// This public entry function requires the `CoinType` to have `key` and `store` abilities.
+    public fun deposit<CoinType: key + store>(ctx: &mut StorageContext, addr: address, coin: Coin<CoinType>) {
+        check_coin_store_frozen<CoinType>(ctx, addr);
+        deposit_internal(ctx, addr, coin);
     }
 
     /// Transfer `amount` of coins `CoinType` from `from` to `to`.
-    public fun transfer<CoinType>(
+    /// Any account and module can call this function to transfer coins, the `CoinType` must have `key` and `store` abilities.
+    public fun transfer<CoinType: key + store>(
         ctx: &mut StorageContext,
         from: &signer,
         to: address,
         amount: u256,
     ) {
-        let coin = withdraw<CoinType>(ctx, from, amount);
-        deposit(ctx, to, coin);
-    }
-
-    #[private_generics(CoinType)]
-    /// Burn `coin`
-    /// This function is only called by the `CoinType` module, for the developer to extend custom burn logic
-    public fun burn_extend<CoinType>(
-        ctx: &mut StorageContext,
-        coin: Coin<CoinType>,
-    ) {
-        burn_internal(ctx, coin) 
-    }
-
-    fun burn_internal<CoinType>(
-        ctx: &mut StorageContext,
-        coin: Coin<CoinType>,
-    ) {
-        let Coin { value: amount } = coin;
-
-        let coin_type_info = type_info::type_of<CoinType>();
-        let coin_info = borrow_mut_coin_info<CoinType>(ctx);
-        coin_info.supply = coin_info.supply - amount;
-        event::emit<BurnEvent>(ctx, BurnEvent {
-            coin_type_info,
-            amount,
-        });
+        let from_addr = signer::address_of(from);
+        check_coin_store_frozen<CoinType>(ctx, from_addr);
+        check_coin_store_frozen<CoinType>(ctx, to);
+        transfer_internal<CoinType>(ctx, from_addr, to, amount);
     }
 
     /// Destroys a zero-value coin. Calls will fail if the `value` in the passed-in `coin` is non-zero
     /// so it is impossible to "burn" any non-zero amount of `Coin`. 
-    public fun destroy_zero<CoinType>(zero_coin: Coin<CoinType>) {
+    public fun destroy_zero<CoinType: key>(zero_coin: Coin<CoinType>) {
         let Coin { value } = zero_coin;
         assert!(value == 0, error::invalid_argument(ErrorDestroyOfNonZeroCoin))
     }
 
     /// Extracts `amount` from the passed-in `coin`, where the original coin is modified in place.
-    public fun extract<CoinType>(coin: &mut Coin<CoinType>, amount: u256): Coin<CoinType> {
+    public fun extract<CoinType: key>(coin: &mut Coin<CoinType>, amount: u256): Coin<CoinType> {
         assert!(coin.value >= amount, error::invalid_argument(ErrorInSufficientBalance));
         coin.value = coin.value - amount;
         Coin { value: amount }
     }
 
     /// Extracts the entire amount from the passed-in `coin`, where the original coin is modified in place.
-    public fun extract_all<CoinType>(coin: &mut Coin<CoinType>): Coin<CoinType> {
+    public fun extract_all<CoinType: key>(coin: &mut Coin<CoinType>): Coin<CoinType> {
         let total_value = coin.value;
         coin.value = 0;
         Coin { value: total_value }
     }
 
-    #[private_generics(CoinType)]
-    /// Freeze a CoinStore to prevent transfers
-    public fun freeze_coin_store_extend<CoinType>(
-        ctx: &mut StorageContext,
-        addr: address,
-    ) {
-        ensure_coin_store<CoinType>(ctx, addr);
-        let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
-        coin_store.frozen = true;
+    /// "Merges" the two given coins.  The coin passed in as `dst_coin` will have a value equal
+    /// to the sum of the two coins (`dst_coin` and `source_coin`).
+    public fun merge<CoinType: key>(dst_coin: &mut Coin<CoinType>, source_coin: Coin<CoinType>) {
+        let Coin { value } = source_coin;
+        dst_coin.value = dst_coin.value + value;
     }
 
-    #[private_generics(CoinType)]
-    /// Unfreeze a CoinStore to allow transfers
-    public fun unfreeze_coin_store_extend<CoinType>(
-        ctx: &mut StorageContext,
-        addr: address,
-    ) {
-        ensure_coin_store<CoinType>(ctx, addr);
-        let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
-        coin_store.frozen = false;
+    /// Returns the `value` passed in `coin`.
+    public fun value<CoinType: key>(coin: &Coin<CoinType>): u256 {
+        coin.value
     }
+
+    /// Create a new `Coin<CoinType>` with a value of `0`.
+    public fun zero<CoinType: key>(): Coin<CoinType> {
+        Coin<CoinType> {
+            value: 0
+        }
+    }
+
+    public fun exist_coin_store<CoinType: key>(ctx: &StorageContext, addr: address): bool {
+        if (account_storage::global_exists<CoinStores>(ctx, addr)) {
+            let coin_stores = account_storage::global_borrow<CoinStores>(ctx, addr);
+            type_table::contains<CoinStore<CoinType>>(&coin_stores.coin_stores)
+        } else {
+            false
+        }
+    }
+
+    public fun is_coin_store_frozen<CoinType: key>(ctx: &StorageContext, addr: address): bool {
+        if (exist_coin_store<CoinType>(ctx, addr)) {
+            borrow_coin_store<CoinType>(ctx, addr).frozen
+        } else {
+            false
+        }
+    }
+
+    //
+    // Extend functions
+    //
 
     #[private_generics(CoinType)]
     /// Creates a new Coin with given `CoinType`
     /// The given signer also becomes the account hosting the information about the coin
     /// (name, supply, etc.).
     /// This function is protected by `private_generics`, so it can only be called by the `CoinType` module.
-    public fun register_extend<CoinType>(
+    public fun register_extend<CoinType: key>(
         ctx: &mut StorageContext,
         name: string::String,
         symbol: string::String,
@@ -492,73 +535,81 @@ module rooch_framework::coin {
         type_table::add(&mut coin_infos.coin_infos, coin_info);
     }
 
-    /// "Merges" the two given coins.  The coin passed in as `dst_coin` will have a value equal
-    /// to the sum of the two coins (`dst_coin` and `source_coin`).
-    public fun merge<CoinType>(dst_coin: &mut Coin<CoinType>, source_coin: Coin<CoinType>) {
-        let Coin { value } = source_coin;
-        dst_coin.value = dst_coin.value + value;
-    }
-
     #[private_generics(CoinType)]
     /// Mint new `Coin`, this function is only called by the `CoinType` module, for the developer to extend custom mint logic
-    public fun mint_extend<CoinType>(ctx: &mut StorageContext,amount: u256) : Coin<CoinType> {
+    public fun mint_extend<CoinType: key>(ctx: &mut StorageContext,amount: u256) : Coin<CoinType> {
         mint_internal<CoinType>(ctx, amount)
     }
 
-    fun mint_internal<CoinType>(ctx: &mut StorageContext,
-        amount: u256): Coin<CoinType>{
-        let coin_info = borrow_mut_coin_info<CoinType>(ctx);
-        coin_info.supply = coin_info.supply + amount;
-        let coin_type_info = type_info::type_of<CoinType>();
-        event::emit<MintEvent>(ctx, MintEvent {
-            coin_type_info,
-            amount,
-        });
-        Coin<CoinType> { value: amount }
+    #[private_generics(CoinType)]
+    /// Withdraw specifed `amount` of coin `CoinType` from any addr, this function does not check the Coin `frozen` attribute
+    /// This function is only called by the `CoinType` module, for the developer to extend custom withdraw logic
+    public fun withdraw_extend<CoinType: key>(
+        ctx: &mut StorageContext,
+        addr: address,
+        amount: u256,
+    ): Coin<CoinType> {
+        withdraw_internal<CoinType>(ctx, addr, amount) 
     }
 
-    /// Returns the `value` passed in `coin`.
-    public fun value<CoinType>(coin: &Coin<CoinType>): u256 {
-        coin.value
+    #[private_generics(CoinType)]
+    /// Deposit the coin into the recipient's account and emit an event.
+    /// This function is only called by the `CoinType` module, for the developer to extend custom deposit logic
+    public fun deposit_extend<CoinType: key>(ctx: &mut StorageContext, addr: address, coin: Coin<CoinType>) {
+        deposit_internal(ctx, addr, coin);
     }
 
-    /// Create a new `Coin<CoinType>` with a value of `0`.
-    public fun zero<CoinType>(): Coin<CoinType> {
-        Coin<CoinType> {
-            value: 0
-        }
+    #[private_generics(CoinType)]
+    /// Transfer `amount` of coins `CoinType` from `from` to `to`.
+    /// This function is only called by the `CoinType` module, for the developer to extend custom transfer logic
+    public fun transfer_extend<CoinType: key>(
+        ctx: &mut StorageContext,
+        from: address,
+        to: address,
+        amount: u256,
+    ) {
+        transfer_internal<CoinType>(ctx, from, to, amount);
     }
 
-    public fun exist_coin_store<CoinType>(ctx: &StorageContext, addr: address): bool {
-        if (account_storage::global_exists<CoinStores>(ctx, addr)) {
-            let coin_stores = account_storage::global_borrow<CoinStores>(ctx, addr);
-            type_table::contains<CoinStore<CoinType>>(&coin_stores.coin_stores)
-        } else {
-            false
-        }
+    #[private_generics(CoinType)]
+    /// Burn `coin`
+    /// This function is only called by the `CoinType` module, for the developer to extend custom burn logic
+    public fun burn_extend<CoinType: key>(
+        ctx: &mut StorageContext,
+        coin: Coin<CoinType>,
+    ) {
+        burn_internal(ctx, coin) 
     }
 
-    public fun is_coin_store_frozen<CoinType>(ctx: &StorageContext, addr: address): bool {
-        if (exist_coin_store<CoinType>(ctx, addr)) {
-            borrow_coin_store<CoinType>(ctx, addr).frozen
-        } else {
-            false
-        }
-    }
-
-    fun extract_coin<CoinType>(ctx: &mut StorageContext, addr: address, amount: u256): Coin<CoinType> {
+    #[private_generics(CoinType)]
+    /// Freeze a CoinStore to prevent transfers
+    public fun freeze_coin_store_extend<CoinType: key>(
+        ctx: &mut StorageContext,
+        addr: address,
+    ) {
+        ensure_coin_store<CoinType>(ctx, addr);
         let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
-        extract<CoinType>(&mut coin_store.coin, amount)
+        coin_store.frozen = true;
     }
 
-    fun merge_coin<CoinType>(ctx: &mut StorageContext, addr: address, coin: Coin<CoinType>) {
+    #[private_generics(CoinType)]
+    /// Unfreeze a CoinStore to allow transfers
+    public fun unfreeze_coin_store_extend<CoinType: key>(
+        ctx: &mut StorageContext,
+        addr: address,
+    ) {
+        ensure_coin_store<CoinType>(ctx, addr);
         let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
-        merge<CoinType>(&mut coin_store.coin, coin)
+        coin_store.frozen = false;
     }
+
+    //
+    // Entry functions
+    //
 
     /// Creating a resource that stores balance of `CoinType` on user's account.
     /// Required if user wants to start accepting deposits of `CoinType` in his account.
-    public entry fun accept_coin_entry<CoinType>(ctx: &mut StorageContext, account: &signer) {
+    public entry fun accept_coin_entry<CoinType: key>(ctx: &mut StorageContext, account: &signer) {
         do_accept_coin<CoinType>(ctx, account)
     }
 
@@ -574,15 +625,16 @@ module rooch_framework::coin {
         set_auto_accept_coin(ctx, account, false);
     }
 
-
     /// Transfer `amount` of coins `CoinType` from `from` to `to`.
-    public entry fun transfer_entry<CoinType>(
+    /// This public entry function requires the `CoinType` to have `key` and `store` abilities.
+    public entry fun transfer_entry<CoinType: key + store>(
         ctx: &mut StorageContext,
         from: &signer,
         to: address,
         amount: u256,
     ) {
-        transfer<CoinType>(ctx, from, to, amount)
+        let from_addr = signer::address_of(from);
+        transfer_internal<CoinType>(ctx, from_addr, to, amount)
     }
 
 }

--- a/crates/rooch-framework/sources/gas_coin.move
+++ b/crates/rooch-framework/sources/gas_coin.move
@@ -35,7 +35,7 @@ module rooch_framework::gas_coin {
     /// Mint gas coin to the given account.
     public(friend) fun faucet(ctx: &mut StorageContext, addr: address, amount: u256) {
         let coin = mint(ctx, amount);
-        coin::deposit<GasCoin>(ctx, addr, coin);
+        coin::deposit_extend<GasCoin>(ctx, addr, coin);
     }
 
     #[test_only]

--- a/crates/rooch-framework/sources/gas_coin.move
+++ b/crates/rooch-framework/sources/gas_coin.move
@@ -2,32 +2,13 @@
 module rooch_framework::gas_coin {
     use std::string;
     use std::signer;
-    use moveos_std::account_storage;
     use moveos_std::storage_context::StorageContext;
-    use rooch_framework::coin::{Self, Coin, MintCapability};
-    use rooch_framework::core_addresses;
+    use rooch_framework::coin::{Self, Coin};
 
     friend rooch_framework::genesis;
     friend rooch_framework::transaction_validator;
 
-    /// Account does not have mint capability
-    const ErrorNoCapabilities: u64 = 1;
-
     struct GasCoin has key {}
-
-    struct MintCapStore has key {
-        mint_cap: MintCapability<GasCoin>,
-    }
-
-    /// Delegation coin created by delegator and can be claimed by the delegatee as MintCapability.
-    struct DelegatedMintCapability has store {
-        to: address
-    }
-
-    /// The container stores the current pending delegations.
-    struct Delegations has key {
-        inner: vector<DelegatedMintCapability>,
-    }
 
     public fun balance(ctx: &StorageContext, addr: address): u256 {
         coin::balance<GasCoin>(ctx, addr)
@@ -70,35 +51,14 @@ module rooch_framework::gas_coin {
     }
 
     /// Can only called during genesis to initialize the Rooch coin.
-    public(friend) fun genesis_init(ctx: &mut StorageContext, genesis_account: &signer){
-        let (burn_cap, freeze_cap, mint_cap) = coin::initialize<GasCoin>(
+    public(friend) fun genesis_init(ctx: &mut StorageContext, _genesis_account: &signer){
+        coin::register_extend<GasCoin>(
             ctx,
-            genesis_account,
             string::utf8(b"Rooch Gas Coin"),
             string::utf8(b"RGC"),
             9, // decimals
         );
-
-        // Rooch framework needs mint cap to mint coins to initial validators. This will be revoked once the validators
-        // have been initialized.
-        account_storage::global_move_to(ctx, genesis_account, MintCapStore { mint_cap });
-
-        //TODO do we need the cap?
-        coin::destroy_freeze_cap(freeze_cap);
-        coin::destroy_mint_cap(mint_cap);
-        coin::destroy_burn_cap(burn_cap);
     }
 
-    public fun has_mint_capability(ctx: &StorageContext, account: &signer): bool {
-        account_storage::global_exists<MintCapStore>(ctx, signer::address_of(account))
-    }
-
-    /// Only called during genesis to destroy the rooch framework account's mint capability once all initial validators
-    /// and accounts have been initialized during genesis.
-    public(friend) fun destroy_mint_cap(ctx: &mut StorageContext, rooch_framework: &signer) {
-        core_addresses::assert_rooch_framework(rooch_framework);
-        let MintCapStore { mint_cap } = account_storage::global_move_from<MintCapStore>(ctx,@rooch_framework);
-        coin::destroy_mint_cap(mint_cap);
-    }
 
 }

--- a/crates/rooch-framework/sources/tests/coin_test.move
+++ b/crates/rooch-framework/sources/tests/coin_test.move
@@ -3,13 +3,12 @@
 module rooch_framework::coin_test{
     use std::signer;
     use std::string;
-    use moveos_std::account_storage;
     use moveos_std::storage_context::{Self, StorageContext};
     use rooch_framework::account;
     use rooch_framework::coin;
-    use rooch_framework::coin::{BurnCapability, FreezeCapability, MintCapability, mint, initialize,
-        supply, name, symbol, decimals, balance, value, burn, freeze_coin_store, unfreeze_coin_store,
-        is_coin_store_frozen, burn_from, zero, destroy_zero, is_coin_initialized, deposit, extract, transfer, withdraw,
+    use rooch_framework::coin::{register_extend,
+        supply, name, symbol, decimals, balance, value, mint_extend, burn_extend, freeze_coin_store_extend, unfreeze_coin_store_extend,
+        is_coin_store_frozen, zero, destroy_zero, is_coin_registered, deposit, extract, transfer, withdraw, withdraw_extend,
         is_account_accept_coin, do_accept_coin, set_auto_accept_coin
     };
 
@@ -17,62 +16,18 @@ module rooch_framework::coin_test{
     struct FakeCoin {}
 
     #[test_only]
-    struct FakeCoinCapabilities has key {
-        burn_cap: BurnCapability<FakeCoin>,
-        freeze_cap: FreezeCapability<FakeCoin>,
-        mint_cap: MintCapability<FakeCoin>,
-    }
-
-    #[test_only]
-    fun initialize_fake_coin(
+    fun register_fake_coin(
         ctx: &mut StorageContext,
-        account: &signer,
         decimals: u8,
-    ): (BurnCapability<FakeCoin>, FreezeCapability<FakeCoin>, MintCapability<FakeCoin>) {
-        coin::initialize<FakeCoin>(
+    ) {
+        coin::register_extend<FakeCoin>(
             ctx,
-            account,
             string::utf8(b"Fake coin"),
             string::utf8(b"FCD"),
             decimals,
-        )
-    }
-
-    #[test_only]
-    fun initialize_and_init_coin_store(
-        ctx: &mut StorageContext,
-        account: &signer,
-        decimals: u8,
-    ): (BurnCapability<FakeCoin>, FreezeCapability<FakeCoin>, MintCapability<FakeCoin>) {
-        let (burn_cap, freeze_cap, mint_cap) = initialize_fake_coin(
-            ctx,
-            account,
-            decimals,
         );
-        (burn_cap, freeze_cap, mint_cap)
     }
-
-    #[test_only]
-    fun create_fake_coin(
-        source: &signer,
-        destination: &signer,
-        amount: u256
-    ) {
-        let source_ctx = storage_context::new_test_context(signer::address_of(source));
-        let destination_ctx = storage_context::new_test_context_random(signer::address_of(destination), b"test_tx1");
-
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut source_ctx, source, 9);
-
-        let coins_minted = mint<FakeCoin>(&mut source_ctx, amount, &mint_cap);
-        deposit(&mut source_ctx, signer::address_of(source), coins_minted);
-        account_storage::global_move_to(&mut source_ctx, source, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
-        moveos_std::storage_context::drop_test_context(source_ctx);
-        moveos_std::storage_context::drop_test_context(destination_ctx);
-    }
+   
 
     #[test(source = @rooch_framework, destination = @0x55)]
     fun test_end_to_end(
@@ -88,9 +43,8 @@ module rooch_framework::coin_test{
         let symbol = string::utf8(b"FCD");
         let decimals = 9u8;
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize<FakeCoin>(
+        register_extend<FakeCoin>(
             &mut source_ctx,
-            &source,
             name,
             symbol,
             decimals,
@@ -103,7 +57,7 @@ module rooch_framework::coin_test{
         assert!(symbol<FakeCoin>(&source_ctx) == symbol, 2);
         assert!(decimals<FakeCoin>(&source_ctx) == decimals, 3);
 
-        let coins_minted = mint<FakeCoin>(&mut source_ctx, 100, &mint_cap);
+        let coins_minted = mint_extend<FakeCoin>(&mut source_ctx, 100);
         deposit(&mut source_ctx, source_addr, coins_minted);
         transfer<FakeCoin>(&mut source_ctx, &source, destination_addr, 50);
 
@@ -113,13 +67,8 @@ module rooch_framework::coin_test{
 
         let coin = withdraw<FakeCoin>(&mut source_ctx, &source, 10);
         assert!(value(&coin) == 10, 7);
-        burn(&mut source_ctx, coin, &burn_cap);
+        burn_extend(&mut source_ctx, coin);
         assert!(supply<FakeCoin>(&source_ctx, ) == 90, 8);
-        account_storage::global_move_to(&mut source_ctx, &source, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(source_ctx);
         moveos_std::storage_context::drop_test_context(destination_ctx);
     }
@@ -134,12 +83,12 @@ module rooch_framework::coin_test{
         let destination_addr = signer::address_of(&destination);
         let destination_ctx = storage_context::new_test_context_random(signer::address_of(&destination), b"test_tx1");
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut source_ctx, &source, 9);
+        register_fake_coin(&mut source_ctx, 9);
 
         account::create_account_for_test(&mut destination_ctx, signer::address_of(&destination));
         assert!(supply<FakeCoin>(&source_ctx) == 0, 0);
 
-        let coins_minted = mint<FakeCoin>(&mut source_ctx, 100, &mint_cap);
+        let coins_minted = mint_extend<FakeCoin>(&mut source_ctx, 100);
         deposit<FakeCoin>(&mut source_ctx, source_addr, coins_minted);
         transfer<FakeCoin>(&mut source_ctx, &source, destination_addr, 50);
 
@@ -148,40 +97,33 @@ module rooch_framework::coin_test{
         assert!(supply<FakeCoin>(&source_ctx) > 0, 3);
 
         let coin = withdraw<FakeCoin>(&mut source_ctx, &source, 10);
-        burn(&mut source_ctx, coin, &burn_cap);
+        burn_extend(&mut source_ctx, coin);
         assert!(supply<FakeCoin>(&source_ctx) > 0, 4);
 
-        account_storage::global_move_to(&mut source_ctx, &source, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(source_ctx);
         moveos_std::storage_context::drop_test_context(destination_ctx);
     }
 
-    #[test(source = @0x55, framework = @rooch_framework)]
-    #[expected_failure(abort_code = 65537, location = rooch_framework::coin)]
-    public fun fail_initialize(source: signer, framework: signer) {
+    #[test]
+    #[expected_failure(abort_code = 524289, location = rooch_framework::coin)]
+    public fun fail_register() {
         let source_ctx = rooch_framework::genesis::init_for_test();
-        let framework_ctx = storage_context::new_test_context_random(signer::address_of(&framework), b"test_tx1");
 
-        // coin::init_for_test(&mut source_ctx, &source);
-        let (burn_cap, freeze_cap, mint_cap) = initialize<FakeCoin>(
+        register_extend<FakeCoin>(
             &mut source_ctx,
-            &source,
             string::utf8(b"Fake coin"),
             string::utf8(b"FCD"),
             9,
         );
 
-        account_storage::global_move_to(&mut source_ctx, &source, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        register_extend<FakeCoin>(
+            &mut source_ctx,
+            string::utf8(b"Fake coin"),
+            string::utf8(b"FCD"),
+            9,
+        );
+
         moveos_std::storage_context::drop_test_context(source_ctx);
-        moveos_std::storage_context::drop_test_context(framework_ctx);
     }
 
     #[test(source = @rooch_framework, destination = @0x55)]
@@ -195,64 +137,49 @@ module rooch_framework::coin_test{
         let destination_addr = signer::address_of(&destination);
         let destination_ctx = storage_context::new_test_context_random(signer::address_of(&destination), b"test_tx1");
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut source_ctx, &source, 9);
+        register_fake_coin(&mut source_ctx, 9);
         assert!(supply<FakeCoin>(&source_ctx) == 0, 0);
 
-        let coins_minted = mint<FakeCoin>(&mut source_ctx, 100, &mint_cap);
+        let coins_minted = mint_extend<FakeCoin>(&mut source_ctx, 100);
         deposit(&mut source_ctx, source_addr, coins_minted);
         transfer<FakeCoin>(&mut source_ctx, &source, destination_addr, 50);
 
-        account_storage::global_move_to(&mut source_ctx, &source, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(source_ctx);
         moveos_std::storage_context::drop_test_context(destination_ctx);
     }
 
     #[test(source = @rooch_framework)]
-    fun test_burn_from_with_capability(
+    fun test_withdraw_from(
         source: signer,
     ) {
         let source_ctx = rooch_framework::genesis::init_for_test();
         let source_addr = signer::address_of(&source);
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut source_ctx, &source, 9);
+        register_fake_coin(&mut source_ctx, 9);
 
-        let coins_minted = mint<FakeCoin>(&mut source_ctx, 100, &mint_cap);
+        let coins_minted = mint_extend<FakeCoin>(&mut source_ctx, 100);
         deposit(&mut source_ctx, source_addr, coins_minted);
         assert!(balance<FakeCoin>(&source_ctx, source_addr) == 100, 0);
         assert!(supply<FakeCoin>(&source_ctx) == 100, 1);
 
-        burn_from<FakeCoin>(&mut source_ctx, source_addr, 10, &burn_cap);
+        let coin = withdraw_extend<FakeCoin>(&mut source_ctx, source_addr, 10);
+        burn_extend<FakeCoin>(&mut source_ctx, coin);
         assert!(balance<FakeCoin>(&source_ctx, source_addr) == 90, 2);
         assert!(supply<FakeCoin>(&source_ctx) == 90, 3);
 
-        account_storage::global_move_to(&mut source_ctx, &source, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(source_ctx);
     }
 
-    #[test(source = @rooch_framework)]
-    #[expected_failure(abort_code = 65540, location = rooch_framework::coin)]
+    #[test]
+    #[expected_failure(abort_code = 65539, location = rooch_framework::coin)]
     public fun test_destroy_non_zero(
-        source: signer,
     ) {
         let source_ctx = rooch_framework::genesis::init_for_test();
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut source_ctx, &source, 9);
-        let coins_minted = mint<FakeCoin>(&mut source_ctx, 100, &mint_cap);
+        register_fake_coin(&mut source_ctx, 9);
+        let coins_minted = mint_extend<FakeCoin>(&mut source_ctx, 100);
         destroy_zero(coins_minted);
 
-        account_storage::global_move_to(&mut source_ctx, &source, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(source_ctx);
     }
 
@@ -263,8 +190,8 @@ module rooch_framework::coin_test{
     ) {
         let source_ctx = rooch_framework::genesis::init_for_test();
         let source_addr = signer::address_of(&source);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut source_ctx, &source, 9);
-        let coins_minted = mint<FakeCoin>(&mut source_ctx, 100, &mint_cap);
+        register_fake_coin(&mut source_ctx, 9);
+        let coins_minted = mint_extend<FakeCoin>(&mut source_ctx, 100);
 
         let extracted = extract(&mut coins_minted, 25);
         assert!(value(&coins_minted) == 75, 0);
@@ -275,28 +202,17 @@ module rooch_framework::coin_test{
 
         assert!(balance<FakeCoin>(&source_ctx, source_addr) == 100, 2);
 
-        account_storage::global_move_to(&mut source_ctx, &source, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(source_ctx);
     }
 
 
-    #[test(source = @rooch_framework)]
-    public fun test_is_coin_initialized(source: signer) {
+    #[test]
+    public fun test_is_coin_registered() {
         let ctx = rooch_framework::genesis::init_for_test();
-        assert!(!is_coin_initialized<FakeCoin>(&ctx), 0);
+        assert!(!is_coin_registered<FakeCoin>(&ctx), 0);
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize_fake_coin(&mut ctx, &source, 9);
-        assert!(is_coin_initialized<FakeCoin>(&ctx), 1);
-
-        account_storage::global_move_to(&mut ctx, &source, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        register_fake_coin(&mut ctx, 9);
+        assert!(is_coin_registered<FakeCoin>(&ctx), 1);
         moveos_std::storage_context::drop_test_context(ctx);
     }
 
@@ -307,22 +223,17 @@ module rooch_framework::coin_test{
         // An non do_accept_coined account is has a frozen coin store by default
         assert!(!is_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut ctx, &account, 9);
+        register_fake_coin(&mut ctx, 9);
 
         assert!(!is_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
         // freeze account
-        freeze_coin_store(&mut ctx, addr, &freeze_cap);
+        freeze_coin_store_extend<FakeCoin>(&mut ctx, addr);
         assert!(is_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
 
         // unfreeze account
-        unfreeze_coin_store(&mut ctx, addr, &freeze_cap);
+        unfreeze_coin_store_extend<FakeCoin>(&mut ctx, addr);
         assert!(!is_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
 
-        account_storage::global_move_to(&mut ctx, &account, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(ctx);
     }
 
@@ -337,57 +248,43 @@ module rooch_framework::coin_test{
     fun test_burn_frozen(account: signer) {
         let ctx = rooch_framework::genesis::init_for_test();
         let account_addr = signer::address_of(&account);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut ctx, &account, 9);
+        register_fake_coin(&mut ctx, 9);
 
-        let coins_minted = mint<FakeCoin>(&mut ctx, 100, &mint_cap);
+        let coins_minted = mint_extend<FakeCoin>(&mut ctx, 100);
         deposit(&mut ctx, account_addr, coins_minted);
 
-        freeze_coin_store(&mut ctx, account_addr, &freeze_cap);
-        burn_from(&mut ctx, account_addr, 100, &burn_cap);
+        freeze_coin_store_extend<FakeCoin>(&mut ctx, account_addr);
+        let coin = withdraw_extend<FakeCoin>(&mut ctx, account_addr, 100);
+        burn_extend(&mut ctx, coin);
 
-        account_storage::global_move_to(&mut ctx, &account, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(ctx);
     }
 
     #[test(account = @rooch_framework)]
-    #[expected_failure(abort_code = 327688, location = rooch_framework::coin)]
+    #[expected_failure(abort_code = 327687, location = rooch_framework::coin)]
     fun test_withdraw_frozen(account: signer) {
         let ctx = rooch_framework::genesis::init_for_test();
         let account_addr = signer::address_of(&account);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut ctx, &account, 9);
+        register_fake_coin(&mut ctx, 9);
 
-        freeze_coin_store(&mut ctx, account_addr, &freeze_cap);
+        freeze_coin_store_extend<FakeCoin>(&mut ctx, account_addr);
         let coin = withdraw<FakeCoin>(&mut ctx, &account, 10);
-        burn(&mut ctx, coin, &burn_cap);
+        burn_extend(&mut ctx, coin);
 
-        account_storage::global_move_to(&mut ctx, &account, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(ctx);
     }
 
     #[test(account = @rooch_framework)]
-    #[expected_failure(abort_code = 327688, location = rooch_framework::coin)]
+    #[expected_failure(abort_code = 327687, location = rooch_framework::coin)]
     fun test_deposit_frozen(account: signer) {
         let ctx = rooch_framework::genesis::init_for_test();
         let account_addr = signer::address_of(&account);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut ctx, &account, 9);
+        register_fake_coin(&mut ctx, 9);
 
-        let coins_minted = mint<FakeCoin>(&mut ctx, 100, &mint_cap);
-        freeze_coin_store(&mut ctx, account_addr, &freeze_cap);
+        let coins_minted = mint_extend<FakeCoin>(&mut ctx, 100);
+        freeze_coin_store_extend<FakeCoin>(&mut ctx, account_addr);
         deposit(&mut ctx, account_addr, coins_minted);
 
-        account_storage::global_move_to(&mut ctx, &account, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(ctx);
     }
 
@@ -395,23 +292,18 @@ module rooch_framework::coin_test{
     fun test_deposit_widthdraw_unfrozen(account: signer) {
         let ctx = rooch_framework::genesis::init_for_test();
         let account_addr = signer::address_of(&account);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut ctx, &account, 9);
+        register_fake_coin(&mut ctx, 9);
 
-        let coins_minted = mint<FakeCoin>(&mut ctx, 100, &mint_cap);
-        freeze_coin_store(&mut ctx, account_addr, &freeze_cap);
-        unfreeze_coin_store(&mut ctx, account_addr, &freeze_cap);
+        let coins_minted = mint_extend<FakeCoin>(&mut ctx, 100);
+        freeze_coin_store_extend<FakeCoin>(&mut ctx, account_addr);
+        unfreeze_coin_store_extend<FakeCoin>(&mut ctx, account_addr);
         deposit(&mut ctx, account_addr, coins_minted);
 
-        freeze_coin_store(&mut ctx, account_addr, &freeze_cap);
-        unfreeze_coin_store(&mut ctx, account_addr, &freeze_cap);
+        freeze_coin_store_extend<FakeCoin>(&mut ctx, account_addr);
+        unfreeze_coin_store_extend<FakeCoin>(&mut ctx, account_addr);
         let coin = withdraw<FakeCoin>(&mut ctx, &account, 10);
-        burn(&mut ctx, coin, &burn_cap);
+        burn_extend(&mut ctx, coin);
 
-        account_storage::global_move_to(&mut ctx, &account, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(ctx);
     }
 
@@ -419,34 +311,29 @@ module rooch_framework::coin_test{
     #[test(framework = @rooch_framework)]
     fun test_accept_twice_should_not_fail(framework: signer) {
         let ctx = rooch_framework::genesis::init_for_test();
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut ctx, &framework, 9);
+        register_fake_coin(&mut ctx, 9);
 
         // Registering twice should not fail.
         do_accept_coin<FakeCoin>(&mut ctx, &framework);
         do_accept_coin<FakeCoin>(&mut ctx, &framework);
         assert!(is_account_accept_coin<FakeCoin>(&ctx, @rooch_framework), 1);
 
-        account_storage::global_move_to(&mut ctx, &framework, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(ctx);
     }
 
-    #[test(framework = @rooch_framework, source1 = @0x33, source2 = @0x66)]
-    #[expected_failure(abort_code = 393225, location = rooch_framework::coin)]
-    fun test_deposit_coin_after_turnoff_auto_accept_coin_flag_should_fail(framework: signer, source1: signer, source2: signer,) {
+    #[test(source1 = @0x33, source2 = @0x66)]
+    #[expected_failure(abort_code = 393224, location = rooch_framework::coin)]
+    fun test_deposit_coin_after_turnoff_auto_accept_coin_flag_should_fail(source1: signer, source2: signer,) {
         let ctx = rooch_framework::genesis::init_for_test();
 
         let source1_addr = signer::address_of(&source1);
         let source2_addr = signer::address_of(&source2);
         let source1_ctx = storage_context::new_test_context_random(source1_addr, b"test_tx2");
         let source2_ctx = storage_context::new_test_context_random(source2_addr, b"test_tx3");
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut ctx, &framework, 9);
+        register_fake_coin(&mut ctx, 9);
 
-        let mint_coins1 = mint(&mut ctx, 10, &mint_cap);
-        let mint_coins2 = mint(&mut ctx, 20, &mint_cap);
+        let mint_coins1 = mint_extend<FakeCoin>(&mut ctx, 10);
+        let mint_coins2 = mint_extend<FakeCoin>(&mut ctx, 20);
 
         account::create_account_for_test(&mut source1_ctx, source1_addr);
         account::create_account_for_test(&mut source2_ctx, source2_addr);
@@ -458,28 +345,23 @@ module rooch_framework::coin_test{
         set_auto_accept_coin(&mut source2_ctx, &source2, false);
         deposit(&mut source2_ctx, source2_addr, mint_coins2);
 
-        account_storage::global_move_to(&mut ctx, &framework, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
         moveos_std::storage_context::drop_test_context(ctx);
         moveos_std::storage_context::drop_test_context(source1_ctx);
         moveos_std::storage_context::drop_test_context(source2_ctx);
     }
 
-    #[test(framework = @rooch_framework, source1 = @0x33, source2 = @0x66)]
-    fun test_deposit_coin_after_turnoff_auto_accept_coin_flag_and_accept_coin_should_succ(framework: signer, source1: signer, source2: signer,) {
+    #[test(source1 = @0x33, source2 = @0x66)]
+    fun test_deposit_coin_after_turnoff_auto_accept_coin_flag_and_accept_coin_should_succ(source1: signer, source2: signer,) {
         let ctx = rooch_framework::genesis::init_for_test();
     
         let source1_addr = signer::address_of(&source1);
         let source2_addr = signer::address_of(&source2);
         let source1_ctx = storage_context::new_test_context_random(source1_addr, b"test_tx2");
         let source2_ctx = storage_context::new_test_context_random(source2_addr, b"test_tx3");
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_init_coin_store(&mut ctx, &framework, 9);
+        register_fake_coin(&mut ctx, 9);
 
-        let mint_coins1 = mint(&mut ctx, 10, &mint_cap);
-        let mint_coins2 = mint(&mut ctx, 20, &mint_cap);
+        let mint_coins1 = mint_extend<FakeCoin>(&mut ctx, 10);
+        let mint_coins2 = mint_extend<FakeCoin>(&mut ctx, 20);
 
         account::create_account_for_test(&mut source1_ctx, source1_addr);
         account::create_account_for_test(&mut source2_ctx, source2_addr);
@@ -494,117 +376,10 @@ module rooch_framework::coin_test{
         do_accept_coin<FakeCoin>(&mut source2_ctx, &source2);
         deposit(&mut source2_ctx, source2_addr, mint_coins2);
 
-        account_storage::global_move_to(&mut ctx, &framework, FakeCoinCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+
         moveos_std::storage_context::drop_test_context(ctx);
         moveos_std::storage_context::drop_test_context(source1_ctx);
         moveos_std::storage_context::drop_test_context(source2_ctx);
     }
 
-
-    #[test(source = @0xa0a, destination = @0xb0b, mod_account = @rooch_framework)]
-    public entry fun test_end_to_end_entry(
-        source: &signer,
-        destination: &signer,
-        mod_account: &signer
-    ) {
-        let source_addr = signer::address_of(source);
-        let destination_addr = signer::address_of(destination);
-
-        let mod_account_ctx = rooch_framework::genesis::init_for_test();
-        let source_ctx = storage_context::new_test_context_random(signer::address_of(source), b"test_tx1");
-        let destination_ctx = storage_context::new_test_context_random(signer::address_of(destination), b"test_tx2");
-        
-        coin::initialize_entry<FakeCoin>(
-            &mut mod_account_ctx,
-            mod_account,
-            b"Fake Coin",
-            b"FCD",
-            9,
-        );
-        assert!(coin::is_coin_initialized<FakeCoin>(&source_ctx), 0);
-
-        account::create_account_for_test(&mut source_ctx, source_addr);
-        account::create_account_for_test(&mut destination_ctx, destination_addr);
-
-        coin::mint_entry<FakeCoin>(&mut mod_account_ctx, mod_account, source_addr, 50);
-        coin::mint_entry<FakeCoin>(&mut mod_account_ctx, mod_account, destination_addr, 10);
-        assert!(coin::balance<FakeCoin>(&source_ctx, source_addr) == 50, 1);
-        assert!(coin::balance<FakeCoin>(&destination_ctx, destination_addr) == 10, 2);
-
-        let supply = supply<FakeCoin>(&mod_account_ctx);
-        assert!(supply == 60, 3);
-
-        coin::transfer<FakeCoin>(&mut source_ctx, source, destination_addr, 10);
-        assert!(coin::balance<FakeCoin>(&source_ctx, source_addr) == 40, 4);
-        assert!(coin::balance<FakeCoin>(&destination_ctx, destination_addr) == 20, 5);
-
-        coin::transfer<FakeCoin>(&mut source_ctx, source, signer::address_of(mod_account), 40);
-        coin::burn_entry<FakeCoin>(&mut mod_account_ctx, mod_account, 40);
-
-        assert!(coin::balance<FakeCoin>(&source_ctx, source_addr) == 0, 1);
-
-        let new_supply = coin::supply<FakeCoin>(&source_ctx);
-        assert!(new_supply == 20, 2);
-
-        moveos_std::storage_context::drop_test_context(source_ctx);
-        moveos_std::storage_context::drop_test_context(destination_ctx);
-        moveos_std::storage_context::drop_test_context(mod_account_ctx);
-    }
-
-    #[test(source = @0xa11ce, destination = @0xb0b, mod_account = @rooch_framework)]
-    #[expected_failure(abort_code = 393228, location = rooch_framework::coin)]
-    public entry fun fail_mint(
-        source: &signer,
-        destination: &signer,
-        mod_account: &signer,
-    ) {
-        let mod_account_ctx = rooch_framework::genesis::init_for_test();
-        let source_addr = signer::address_of(source);
-        let destination_addr = signer::address_of(destination);
-
-        let source_ctx = storage_context::new_test_context(signer::address_of(source));
-        let destination_ctx = storage_context::new_test_context_random(signer::address_of(destination), b"test_tx1");
-
-        coin::initialize_entry<FakeCoin>(&mut mod_account_ctx, mod_account, b"Fake Coin", b"FCD", 9);
-        
-        account::create_account_for_test(&mut source_ctx, source_addr);
-        account::create_account_for_test(&mut destination_ctx, destination_addr);
-
-        coin::mint_entry<FakeCoin>(&mut destination_ctx, destination, source_addr, 100);
-
-        moveos_std::storage_context::drop_test_context(source_ctx);
-        moveos_std::storage_context::drop_test_context(destination_ctx);
-        moveos_std::storage_context::drop_test_context(mod_account_ctx);
-    }
-
-    #[test(source = @0xa11ce, destination = @0xb0b, mod_account = @rooch_framework)]
-    #[expected_failure(abort_code = 393228, location = rooch_framework::coin)]
-    public entry fun fail_burn(
-        source: &signer,
-        destination: &signer,
-        mod_account: &signer,
-    ) {
-        let mod_account_ctx = rooch_framework::genesis::init_for_test();
-        let source_addr = signer::address_of(source);
-        let destination_addr = signer::address_of(destination);
-
-        let source_ctx = storage_context::new_test_context(signer::address_of(source));
-        let destination_ctx = storage_context::new_test_context_random(signer::address_of(destination), b"test_tx1");
-
-        coin::initialize_entry<FakeCoin>(&mut mod_account_ctx, mod_account, b"Fake Coin", b"FCD", 9);
-        
-        account::create_account_for_test(&mut source_ctx, source_addr);
-        account::create_account_for_test(&mut destination_ctx, destination_addr);
-
-        coin::mint_entry<FakeCoin>(&mut mod_account_ctx, mod_account, source_addr, 100);
-        coin::burn_entry<FakeCoin>(&mut destination_ctx, destination, 10);
-
-        moveos_std::storage_context::drop_test_context(source_ctx);
-        moveos_std::storage_context::drop_test_context(destination_ctx);
-        moveos_std::storage_context::drop_test_context(mod_account_ctx);
-    }
 }

--- a/crates/rooch-framework/sources/tests/coin_test.move
+++ b/crates/rooch-framework/sources/tests/coin_test.move
@@ -13,7 +13,7 @@ module rooch_framework::coin_test{
     };
 
     #[test_only]
-    struct FakeCoin {}
+    struct FakeCoin has key, store {}
 
     #[test_only]
     fun register_fake_coin(

--- a/crates/rooch-framework/sources/tests/gas_coin_test.move
+++ b/crates/rooch-framework/sources/tests/gas_coin_test.move
@@ -9,7 +9,7 @@ module rooch_framework::gas_coin_test{
     #[test]
     fun test_gas_coin_init(){
         let genesis_ctx = rooch_framework::genesis::init_for_test();
-        assert!(coin::is_coin_initialized<GasCoin>(&genesis_ctx), 1000);
+        assert!(coin::is_coin_registered<GasCoin>(&genesis_ctx), 1000);
         moveos_std::storage_context::drop_test_context(genesis_ctx);
     }
 

--- a/crates/rooch-framework/sources/tests/gas_coin_test.move
+++ b/crates/rooch-framework/sources/tests/gas_coin_test.move
@@ -22,17 +22,6 @@ module rooch_framework::gas_coin_test{
     }
 
     #[test(user = @0x42)]
-    fun test_gas_deposit(user: address){
-        let genesis_ctx = rooch_framework::genesis::init_for_test();
-        account::create_account_for_test(&mut genesis_ctx, user);
-        let init_gas = 9999u256;
-        let gas_coin = gas_coin::mint_for_test(&mut genesis_ctx, init_gas);
-        coin::deposit(&mut genesis_ctx, user, gas_coin);
-        assert!(gas_coin::balance(&genesis_ctx, user) == init_gas, 1000);
-        moveos_std::storage_context::drop_test_context(genesis_ctx);
-    }
-
-    #[test(user = @0x42)]
     fun test_faucet(user: address){
         let genesis_ctx = rooch_framework::genesis::init_for_test();
         account::create_account_for_test(&mut genesis_ctx, user);


### PR DESCRIPTION
## Summary

part of #13  

Refactor coin module. follow #738

1. Remove capability from the coin module, simply the token logic.
2. Change the `initialize` function to `register_extend`.
3. Add `key` ability to `CoinType`, prevent call like `coin::zero<u64>()`.
4. Add `store` ability requirement to `transfer`,`withdraw`,`deposit`. A CoinType should have `key` and `store` abilities if it is public. Otherwise, it is a private coin, The users only can operate the coin through the methods defined by the CoinType module.

TODO give some coin examples #741