### PR TITLE
fix librocksdb-sys build failed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,9 @@ RUN set -eux; \
         libclang-dev clang \
         llvm \
         lld \
+        libsnappy-dev \
+        g++ \
+        cmake \
         protobuf-compiler; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Summary about this PR
apt-get  install the dependency for librocksdb-sys-7e3c2fe0997fa0a5

- Closes #750 