### PR TITLE
fix(cli): update execute method of Test to handle account args

### DIFF
--- a/crates/rooch/src/commands/move_cli/commands/unit_test.rs
+++ b/crates/rooch/src/commands/move_cli/commands/unit_test.rs
@@ -6,7 +6,6 @@ use codespan_reporting::diagnostic::Severity;
 use move_cli::base::test;
 use move_command_line_common::address::NumericalAddress;
 use move_command_line_common::parser::NumberFormat;
-use move_core_types::account_address::AccountAddress;
 use move_package::BuildConfig;
 use move_unit_test::extensions::set_extension_hook;
 use move_vm_runtime::native_extensions::NativeContextExtensions;
@@ -24,6 +23,8 @@ use rooch_framework::natives::{all_natives, GasParameters};
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 use termcolor::Buffer;
 
+use crate::cli_types::WalletContextOptions;
+
 #[derive(Parser)]
 pub struct Test {
     #[clap(flatten)]
@@ -36,17 +37,22 @@ pub struct Test {
     /// Note: This will fail if there are duplicates in the Move.toml file remove those first.
     #[clap(long, parse(try_from_str = crate::utils::parse_map), default_value = "")]
     pub(crate) named_addresses: BTreeMap<String, String>,
+
+    #[clap(flatten)]
+    config_options: WalletContextOptions,
 }
 
 impl Test {
-    pub fn execute(self, path: Option<PathBuf>, build_config: BuildConfig) -> anyhow::Result<()> {
+    pub async fn execute(
+        self,
+        path: Option<PathBuf>,
+        build_config: BuildConfig,
+    ) -> anyhow::Result<()> {
+        let context = self.config_options.build().await?;
+
         let mut build_config = build_config;
-        build_config.additional_named_addresses = self
-            .named_addresses
-            .clone()
-            .into_iter()
-            .map(|(key, value)| (key, AccountAddress::from_hex_literal(&value).unwrap()))
-            .collect();
+        build_config.additional_named_addresses =
+            context.parse_account_args(self.named_addresses)?;
 
         let root_path = path.clone().unwrap_or_else(|| PathBuf::from("."));
 

--- a/crates/rooch/src/commands/move_cli/mod.rs
+++ b/crates/rooch/src/commands/move_cli/mod.rs
@@ -88,6 +88,7 @@ impl CommandAction<String> for MoveCli {
                 .map_err(RoochError::from),
             MoveCommand::Test(c) => c
                 .execute(move_args.package_path, move_args.build_config)
+                .await
                 .map(|_| "Success".to_owned())
                 .map_err(RoochError::from),
             MoveCommand::Publish(c) => c.execute_serialized().await,


### PR DESCRIPTION
Hi, I'm new in Rooch.
I'm interested in this project and I'm reading docs and some codes.
I want to contribute and learn. Thanks.

## Summary

added `config_options` field into Test.
updated `execute` method to handle account args like `build ` command.

- Closes #575 