### PR TITLE
Implements Account balance list cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7673,6 +7673,7 @@ dependencies = [
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
+ "move-resource-viewer",
  "move-stdlib",
  "moveos",
  "moveos-stdlib",

--- a/crates/rooch-framework/doc/coin.md
+++ b/crates/rooch-framework/doc/coin.md
@@ -828,10 +828,10 @@ Return true if the type <code>CoinType1</code> is same with <code>CoinType2</cod
 
 ## Function `coin_store_handle`
 
-Return coin store handle for addr with coin type <code>CoinType</code>
+Return coin store handle for addr
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_handle">coin_store_handle</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="_ObjectID">object_id::ObjectID</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_handle">coin_store_handle</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="_ObjectID">object_id::ObjectID</a>&gt;
 </code></pre>
 
 
@@ -840,11 +840,11 @@ Return coin store handle for addr with coin type <code>CoinType</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_handle">coin_store_handle</a>&lt;CoinType: key&gt;(ctx: &StorageContext, addr: <b>address</b>): Option&lt;ObjectID&gt; {
-    <b>if</b> (<a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx, addr))
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_handle">coin_store_handle</a>(ctx: &StorageContext, addr: <b>address</b>): Option&lt;ObjectID&gt; {
+    <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr))
     {
         <b>let</b> coin_stores = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr);
-        <a href="_some">option::some</a>(*<a href="_handle">type_table::handle</a>&lt;CoinType&gt;(&coin_stores.coin_stores))
+        <a href="_some">option::some</a>(*<a href="_handle">type_table::handle</a>(&coin_stores.coin_stores))
     } <b>else</b> {
         <a href="_none">option::none</a>&lt;ObjectID&gt;()
     }

--- a/crates/rooch-framework/doc/coin.md
+++ b/crates/rooch-framework/doc/coin.md
@@ -27,6 +27,7 @@ This module provides the foundation for typesafe Coins.
 -  [Function `decimals`](#0x3_coin_decimals)
 -  [Function `supply`](#0x3_coin_supply)
 -  [Function `is_same_coin`](#0x3_coin_is_same_coin)
+-  [Function `coin_store_handle`](#0x3_coin_coin_store_handle)
 -  [Function `is_account_accept_coin`](#0x3_coin_is_account_accept_coin)
 -  [Function `can_auto_accept_coin`](#0x3_coin_can_auto_accept_coin)
 -  [Function `do_accept_coin`](#0x3_coin_do_accept_coin)
@@ -57,9 +58,11 @@ This module provides the foundation for typesafe Coins.
 
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::string</a>;
 <b>use</b> <a href="">0x2::account_storage</a>;
 <b>use</b> <a href="">0x2::event</a>;
+<b>use</b> <a href="">0x2::object_id</a>;
 <b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="">0x2::table</a>;
@@ -814,6 +817,37 @@ Return true if the type <code>CoinType1</code> is same with <code>CoinType2</cod
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_same_coin">is_same_coin</a>&lt;CoinType1, CoinType2&gt;(): bool {
     <b>return</b> type_of&lt;CoinType1&gt;() == type_of&lt;CoinType2&gt;()
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_coin_store_handle"></a>
+
+## Function `coin_store_handle`
+
+Return coin store handle for addr with coin type <code>CoinType</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_handle">coin_store_handle</a>&lt;CoinType: key&gt;(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="_ObjectID">object_id::ObjectID</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_handle">coin_store_handle</a>&lt;CoinType: key&gt;(ctx: &StorageContext, addr: <b>address</b>): Option&lt;ObjectID&gt; {
+    <b>if</b> (<a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx, addr))
+    {
+        <b>let</b> coin_stores = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr);
+        <a href="_some">option::some</a>(*<a href="_handle">type_table::handle</a>&lt;CoinType&gt;(&coin_stores.coin_stores))
+    } <b>else</b> {
+        <a href="_none">option::none</a>&lt;ObjectID&gt;()
+    }
 }
 </code></pre>
 

--- a/crates/rooch-framework/sources/coin.move
+++ b/crates/rooch-framework/sources/coin.move
@@ -2,9 +2,12 @@
 module rooch_framework::coin {
     use std::string;
     use std::error;
+    use std::option;
+    use std::option::Option;
+    use moveos_std::object_id::ObjectID;
     use moveos_std::table;
     use moveos_std::table::Table;
-    use moveos_std::type_table::TypeTable;
+    use moveos_std::type_table::{TypeTable};
     use moveos_std::storage_context;
     use moveos_std::type_table;
     use moveos_std::account_storage;
@@ -223,6 +226,17 @@ module rooch_framework::coin {
     /// Return true if the type `CoinType1` is same with `CoinType2`
     public fun is_same_coin<CoinType1, CoinType2>(): bool {
         return type_of<CoinType1>() == type_of<CoinType2>()
+    }
+
+    /// Return coin store handle for addr with coin type `CoinType`
+    public fun coin_store_handle<CoinType: key>(ctx: &StorageContext, addr: address): Option<ObjectID> {
+        if (exist_coin_store<CoinType>(ctx, addr))
+        {
+            let coin_stores = account_storage::global_borrow<CoinStores>(ctx, addr);
+            option::some(*type_table::handle<CoinType>(&coin_stores.coin_stores))
+        } else {
+            option::none<ObjectID>()
+        }
     }
 
     //

--- a/crates/rooch-framework/sources/coin.move
+++ b/crates/rooch-framework/sources/coin.move
@@ -228,12 +228,12 @@ module rooch_framework::coin {
         return type_of<CoinType1>() == type_of<CoinType2>()
     }
 
-    /// Return coin store handle for addr with coin type `CoinType`
-    public fun coin_store_handle<CoinType: key>(ctx: &StorageContext, addr: address): Option<ObjectID> {
-        if (exist_coin_store<CoinType>(ctx, addr))
+    /// Return coin store handle for addr
+    public fun coin_store_handle(ctx: &StorageContext, addr: address): Option<ObjectID> {
+        if (account_storage::global_exists<CoinStores>(ctx, addr))
         {
             let coin_stores = account_storage::global_borrow<CoinStores>(ctx, addr);
-            option::some(*type_table::handle<CoinType>(&coin_stores.coin_stores))
+            option::some(*type_table::handle(&coin_stores.coin_stores))
         } else {
             option::none<ObjectID>()
         }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/account_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/account_view.rs
@@ -1,0 +1,81 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::jsonrpc_types::TypeInfoView;
+use move_core_types::u256::U256;
+use rooch_types::account::{AccountInfo, BalanceInfo};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountInfoView {
+    pub sequence_number: u64,
+    pub balances: Vec<Option<BalanceInfoView>>,
+}
+
+impl AccountInfoView {
+    pub fn new(sequence_number: u64, balances: Vec<Option<BalanceInfoView>>) -> Self {
+        Self {
+            sequence_number,
+            balances,
+        }
+    }
+}
+
+impl From<AccountInfo> for AccountInfoView {
+    fn from(account_info: AccountInfo) -> Self {
+        let balances = account_info
+            .balances
+            .iter()
+            .map(|v| v.clone().map(|balance| balance.clone().into()))
+            .collect();
+
+        AccountInfoView {
+            sequence_number: account_info.sequence_number,
+            balances,
+        }
+    }
+}
+
+impl From<AccountInfoView> for AccountInfo {
+    fn from(account_info: AccountInfoView) -> Self {
+        let balances = account_info
+            .balances
+            .iter()
+            .map(|v| v.clone().map(|balance| balance.clone().into()))
+            .collect();
+        AccountInfo {
+            sequence_number: account_info.sequence_number,
+            balances,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BalanceInfoView {
+    pub coin_type: TypeInfoView,
+    pub balance: U256,
+}
+//
+// impl BalanceInfoView {
+//     pub fn new(coin_type: TypeInfo, balance: U256) -> Self {
+//         Self { coin_type, balance }
+//     }
+// }
+
+impl From<BalanceInfo> for BalanceInfoView {
+    fn from(balance_info: BalanceInfo) -> Self {
+        BalanceInfoView {
+            coin_type: balance_info.coin_type.into(),
+            balance: balance_info.balance,
+        }
+    }
+}
+
+impl From<BalanceInfoView> for BalanceInfo {
+    fn from(balance_info: BalanceInfoView) -> Self {
+        BalanceInfo {
+            coin_type: balance_info.coin_type.into(),
+            balance: balance_info.balance,
+        }
+    }
+}

--- a/crates/rooch-rpc-api/src/jsonrpc_types/account_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/account_view.rs
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::jsonrpc_types::TypeInfoView;
+use crate::jsonrpc_types::StructTagView;
 use move_core_types::u256::U256;
 use rooch_types::account::{AccountInfo, BalanceInfo};
 use serde::{Deserialize, Serialize};
@@ -52,12 +52,12 @@ impl From<AccountInfoView> for AccountInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BalanceInfoView {
-    pub coin_type: TypeInfoView,
+    pub coin_type: StructTagView,
     pub balance: U256,
 }
 //
 // impl BalanceInfoView {
-//     pub fn new(coin_type: TypeInfo, balance: U256) -> Self {
+//     pub fn new(coin_type: StructTag, balance: U256) -> Self {
 //         Self { coin_type, balance }
 //     }
 // }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/account_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/account_view.rs
@@ -26,7 +26,7 @@ impl From<AccountInfo> for AccountInfoView {
         let balances = account_info
             .balances
             .iter()
-            .map(|v| v.clone().map(|balance| balance.clone().into()))
+            .map(|v| v.clone().map(|balance| balance.into()))
             .collect();
 
         AccountInfoView {
@@ -41,7 +41,7 @@ impl From<AccountInfoView> for AccountInfo {
         let balances = account_info
             .balances
             .iter()
-            .map(|v| v.clone().map(|balance| balance.clone().into()))
+            .map(|v| v.clone().map(|balance| balance.into()))
             .collect();
         AccountInfo {
             sequence_number: account_info.sequence_number,
@@ -55,12 +55,6 @@ pub struct BalanceInfoView {
     pub coin_type: StructTagView,
     pub balance: U256,
 }
-//
-// impl BalanceInfoView {
-//     pub fn new(coin_type: StructTag, balance: U256) -> Self {
-//         Self { coin_type, balance }
-//     }
-// }
 
 impl From<BalanceInfo> for BalanceInfoView {
     fn from(balance_info: BalanceInfo) -> Self {

--- a/crates/rooch-rpc-api/src/jsonrpc_types/mod.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/mod.rs
@@ -11,8 +11,10 @@ mod rooch_types;
 mod state_view;
 mod transaction_argument_view;
 
+pub mod account_view;
 pub mod bytes;
 pub mod eth;
+
 pub use self::rooch_types::*;
 pub use execute_tx_response::*;
 pub use function_return_value_view::*;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::StrView;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
@@ -26,6 +26,7 @@ use moveos_types::{
 use fastcrypto::encoding::Hex;
 use serde_with::serde_as;
 
+use move_binary_format::file_format::AbilitySet;
 use moveos_types::moveos_std::type_info::TypeInfo;
 use moveos_types::{
     move_string::{MoveAsciiString, MoveString},
@@ -69,24 +70,24 @@ impl From<AnnotatedMoveStruct> for AnnotatedMoveStructView {
     }
 }
 
-// impl TryFrom<AnnotatedMoveStructView> for AnnotatedMoveStruct {
-//     type Error = anyhow::Error;
+impl TryFrom<AnnotatedMoveStructView> for AnnotatedMoveStruct {
+    type Error = anyhow::Error;
 
-//     fn try_from(value: AnnotatedMoveStructView) -> Result<Self, Self::Error> {
-//         Ok(Self {
-//             abilities: AbilitySet::from_u8(value.abilities)
-//                 .ok_or_else(|| anyhow::anyhow!("invalid abilities:{}", value.abilities))?,
-//             type_: value.type_.0,
-//             value: value
-//                 .value
-//                 .into_iter()
-//                 .map(|(k, v)| {
-//                     Ok::<(Identifier, AnnotatedMoveValue), anyhow::Error>((k, v.try_into()?))
-//                 })
-//                 .collect::<Result<_, _>>()?,
-//         })
-//     }
-// }
+    fn try_from(value: AnnotatedMoveStructView) -> Result<Self, Self::Error> {
+        Ok(Self {
+            abilities: AbilitySet::from_u8(value.abilities)
+                .ok_or_else(|| anyhow::anyhow!("invalid abilities:{}", value.abilities))?,
+            type_: value.type_.0,
+            value: value
+                .value
+                .into_iter()
+                .map(|(k, v)| {
+                    Ok::<(Identifier, AnnotatedMoveValue), anyhow::Error>((k, v.try_into()?))
+                })
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
 
 /// Some specific struct that we want to display in a special way for better readability
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -165,35 +166,39 @@ impl From<AnnotatedMoveValue> for AnnotatedMoveValueView {
 // It is not easy to implement because:
 // 1. We need to put type_tag in the Vector
 // 2. We need to support convert SpecificStruct to AnnotatedMoveStruct
-// impl TryFrom<AnnotatedMoveValueView> for AnnotatedMoveValue {
-//     type Error = anyhow::Error;
-//     fn try_from(value: AnnotatedMoveValueView) -> Result<Self, Self::Error> {
-//         Ok(match value {
-//             AnnotatedMoveValueView::U8(u8) => AnnotatedMoveValue::U8(u8),
-//             AnnotatedMoveValueView::U64(u64) => AnnotatedMoveValue::U64(u64.0),
-//             AnnotatedMoveValueView::U128(u128) => AnnotatedMoveValue::U128(u128.0),
-//             AnnotatedMoveValueView::Bool(bool) => AnnotatedMoveValue::Bool(bool),
-//             AnnotatedMoveValueView::Address(address) => AnnotatedMoveValue::Address(address.0),
-//             AnnotatedMoveValueView::Vector(type_tag, data) =>
-//                 AnnotatedMoveValue::Vector(
-//                 type_tag.0,
-//                 data.into_iter()
-//                     .map(AnnotatedMoveValue::try_from)
-//                     .collect::<Result<Vec<_>, Self::Error>>()?,
-//             ),
-//             AnnotatedMoveValueView::Bytes(data) => AnnotatedMoveValue::Bytes(data.0),
-//             AnnotatedMoveValueView::Struct(data) => AnnotatedMoveValue::Struct(data.try_into()?),
-//             AnnotatedMoveValueView::SpecificStruct(data) => match data {
-//                 SpecificStructView::MoveString(string) => AnnotatedMoveValue::Struct(string.into()),
-//                 SpecificStructView::MoveAsciiString(string) => AnnotatedMoveValue::Struct(string.into()),
-//                 SpecificStructView::ObjectID(id) => AnnotatedMoveValue::Struct(id.into()),
-//             },
-//             AnnotatedMoveValueView::U16(u16) => AnnotatedMoveValue::U16(u16),
-//             AnnotatedMoveValueView::U32(u32) => AnnotatedMoveValue::U32(u32),
-//             AnnotatedMoveValueView::U256(u256) => AnnotatedMoveValue::U256(u256.0),
-//         })
-//     }
-// }
+impl TryFrom<AnnotatedMoveValueView> for AnnotatedMoveValue {
+    type Error = anyhow::Error;
+    fn try_from(value: AnnotatedMoveValueView) -> Result<Self, Self::Error> {
+        Ok(match value {
+            AnnotatedMoveValueView::U8(u8) => AnnotatedMoveValue::U8(u8),
+            AnnotatedMoveValueView::U64(u64) => AnnotatedMoveValue::U64(u64.0),
+            AnnotatedMoveValueView::U128(u128) => AnnotatedMoveValue::U128(u128.0),
+            AnnotatedMoveValueView::Bool(bool) => AnnotatedMoveValue::Bool(bool),
+            AnnotatedMoveValueView::Address(address) => AnnotatedMoveValue::Address(address.0),
+            AnnotatedMoveValueView::Vector(_type_tag) =>
+            // AnnotatedMoveValue::Vector(
+            // type_tag.0,
+            // data.into_iter()
+            //     .map(AnnotatedMoveValue::try_from)
+            //     .collect::<Result<Vec<_>, Self::Error>>()?,
+            {
+                bail!("not implements")
+            }
+            AnnotatedMoveValueView::Bytes(data) => AnnotatedMoveValue::Bytes(data.0),
+            AnnotatedMoveValueView::Struct(data) => AnnotatedMoveValue::Struct(data.try_into()?),
+            AnnotatedMoveValueView::SpecificStruct(data) => match data {
+                SpecificStructView::MoveString(string) => AnnotatedMoveValue::Struct(string.into()),
+                SpecificStructView::MoveAsciiString(string) => {
+                    AnnotatedMoveValue::Struct(string.into())
+                }
+                SpecificStructView::ObjectID(id) => AnnotatedMoveValue::Struct(id.into()),
+            },
+            AnnotatedMoveValueView::U16(u16) => AnnotatedMoveValue::U16(u16),
+            AnnotatedMoveValueView::U32(u32) => AnnotatedMoveValue::U32(u32),
+            AnnotatedMoveValueView::U256(u256) => AnnotatedMoveValue::U256(u256.0),
+        })
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AnnotatedObjectView {

--- a/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
@@ -26,6 +26,7 @@ use moveos_types::{
 use fastcrypto::encoding::Hex;
 use serde_with::serde_as;
 
+use moveos_types::moveos_std::type_info::TypeInfo;
 use moveos_types::{
     move_string::{MoveAsciiString, MoveString},
     state::MoveStructState,
@@ -487,6 +488,43 @@ impl From<EventView> for Event {
             type_tag: event.type_tag.into(),
             event_data: event.event_data.0,
             event_index: event.event_index,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TypeInfoView {
+    pub account_address: AccountAddress,
+    pub module_name: StrView<Vec<u8>>,
+    pub struct_name: StrView<Vec<u8>>,
+}
+
+impl std::fmt::Display for TypeInfoView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}::{:?}::{:?}",
+            &self.account_address, self.module_name, &self.struct_name
+        )
+    }
+}
+
+impl From<TypeInfo> for TypeInfoView {
+    fn from(type_info: TypeInfo) -> Self {
+        TypeInfoView {
+            account_address: type_info.account_address,
+            module_name: type_info.module_name.into(),
+            struct_name: type_info.struct_name.into(),
+        }
+    }
+}
+
+impl From<TypeInfoView> for TypeInfo {
+    fn from(type_info: TypeInfoView) -> Self {
+        TypeInfo {
+            account_address: type_info.account_address,
+            module_name: type_info.module_name.into(),
+            struct_name: type_info.struct_name.into(),
         }
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -3,13 +3,18 @@
 
 use crate::jsonrpc_types::{
     move_types::{MoveActionTypeView, MoveActionView},
-    AnnotatedMoveStructView, AnnotatedStateView, EventView, H256View, StateView, StrView,
-    TransactionExecutionInfoView,
+    AnnotatedMoveStructView, AnnotatedMoveValueView, AnnotatedStateView, EventView, H256View,
+    StateView, StrView, StructTagView, TransactionExecutionInfoView,
 };
+use anyhow::bail;
+use anyhow::Result;
+use move_core_types::u256::U256;
 use moveos_types::event::AnnotatedMoveOSEvent;
+use moveos_types::state::MoveState;
 use rooch_types::transaction::{AbstractTransaction, TransactionType, TypedTransaction};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use super::AccountAddressView;
 
@@ -114,3 +119,148 @@ impl From<AnnotatedMoveOSEvent> for AnnotatedEventView {
 //         }
 //     }
 // }
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoinView {
+    value: StrView<U256>,
+}
+
+impl CoinView {
+    pub fn new(value: StrView<U256>) -> Self {
+        CoinView { value }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnotatedCoinView {
+    type_: StructTagView,
+    value: CoinView,
+}
+
+impl AnnotatedCoinView {
+    pub fn new(type_: StructTagView, value: CoinView) -> Self {
+        AnnotatedCoinView { type_, value }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompoundCoinStoreView {
+    coin: AnnotatedCoinView,
+    frozen: bool,
+}
+
+impl CompoundCoinStoreView {
+    pub fn new(coin: AnnotatedCoinView, frozen: bool) -> Self {
+        CompoundCoinStoreView { coin, frozen }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnotatedCoinStoreView {
+    type_: StructTagView,
+    value: CompoundCoinStoreView,
+}
+
+impl AnnotatedCoinStoreView {
+    pub fn new(type_: StructTagView, value: CompoundCoinStoreView) -> Self {
+        AnnotatedCoinStoreView { type_, value }
+    }
+
+    /// Create a new AnnotatedCoinStoreView from a AnnotatedMoveValueView
+    pub fn new_from_annotated_move_value_view(
+        annotated_move_value_view: AnnotatedMoveValueView,
+    ) -> Result<Self> {
+        match annotated_move_value_view {
+            AnnotatedMoveValueView::Struct(annotated_struct_view) => {
+                let annotated_coin_store_type = annotated_struct_view.type_;
+                let mut fields = annotated_struct_view.value.into_iter();
+                let annotated_coin = match fields.next().expect("CoinStore should have coin field")
+                {
+                    (field_name, AnnotatedMoveValueView::Struct(filed_value)) => {
+                        debug_assert!(
+                            field_name.as_str() == "coin",
+                            "CoinStore coin field name should be coin"
+                        );
+
+                        let coin_type_ = filed_value.type_;
+
+                        let mut inner_fields = filed_value.value.into_iter();
+                        let coin_value = match inner_fields
+                            .next()
+                            .expect("CoinValue should have value field")
+                        {
+                            (field_name, AnnotatedMoveValueView::Bytes(inner_filed_value)) => {
+                                debug_assert!(
+                                    field_name.as_str() == "value",
+                                    "CoinValue value field name should be value"
+                                );
+                                U256::from_bytes(inner_filed_value.0.as_slice())?
+                            }
+                            (field_name, AnnotatedMoveValueView::U64(inner_filed_value)) => {
+                                debug_assert!(
+                                    field_name.as_str() == "value",
+                                    "CoinValue value field name should be value"
+                                );
+                                U256::from(inner_filed_value.0)
+                            }
+                            (field_name, AnnotatedMoveValueView::U128(inner_filed_value)) => {
+                                debug_assert!(
+                                    field_name.as_str() == "value",
+                                    "CoinValue value field name should be value"
+                                );
+                                U256::from(inner_filed_value.0)
+                            }
+                            (field_name, AnnotatedMoveValueView::U256(inner_filed_value)) => {
+                                debug_assert!(
+                                    field_name.as_str() == "value",
+                                    "CoinValue value field name should be value"
+                                );
+                                inner_filed_value.0
+                            }
+                            _ => bail!("CoinValue value field should be value"),
+                        };
+                        let coin = CoinView {
+                            value: StrView(coin_value),
+                        };
+                        AnnotatedCoinView {
+                            type_: coin_type_,
+                            value: coin,
+                        }
+                    }
+                    _ => bail!("CoinStore coin field should be struct"),
+                };
+                let frozen = match fields.next().expect("CoinStore should have frozen field") {
+                    (field_name, AnnotatedMoveValueView::Bool(filed_value)) => {
+                        debug_assert!(
+                            field_name.as_str() == "frozen",
+                            "CoinStore field name should be frozen"
+                        );
+                        filed_value
+                    }
+                    _ => bail!("CoinStore frozen field should be bool"),
+                };
+                let compose_coin_store = CompoundCoinStoreView {
+                    coin: annotated_coin,
+                    frozen,
+                };
+
+                let annotated_coin_store_view = AnnotatedCoinStoreView {
+                    type_: annotated_coin_store_type,
+                    value: compose_coin_store,
+                };
+
+                Ok(annotated_coin_store_view)
+            }
+            _ => bail!("CoinValue value field should be value"),
+        }
+    }
+
+    pub fn get_coin_type(&self) -> StructTagView {
+        self.value.coin.type_.clone()
+    }
+
+    pub fn get_coin_value(&self) -> StrView<U256> {
+        self.value.coin.value.value
+    }
+}

--- a/crates/rooch-rpc-client/src/lib.rs
+++ b/crates/rooch-rpc-client/src/lib.rs
@@ -11,7 +11,10 @@ use moveos_types::{
     transaction::FunctionCall,
     tx_context::TxContext,
 };
-use rooch_rpc_api::jsonrpc_types::{AnnotatedFunctionResultView, EventPageView, StructTagView};
+use rooch_rpc_api::jsonrpc_types::{
+    AccessPathView, AnnotatedFunctionResultView, EventPageView, ListAnnotatedStatesPageView,
+    ListStatesPageView, StrView, StructTagView,
+};
 use rooch_rpc_api::{
     api::rooch_api::RoochAPIClient,
     jsonrpc_types::{
@@ -166,6 +169,32 @@ impl Client {
             .get_events_by_event_handle(event_handle_type, cursor, limit)
             .await?;
         Ok(s)
+    }
+
+    pub async fn list_states(
+        &self,
+        access_path: AccessPathView,
+        cursor: Option<StrView<Vec<u8>>>,
+        limit: Option<usize>,
+    ) -> Result<ListStatesPageView> {
+        Ok(self
+            .rpc
+            .http
+            .list_states(access_path, cursor, limit)
+            .await?)
+    }
+
+    pub async fn list_annotated_states(
+        &self,
+        access_path: AccessPathView,
+        cursor: Option<StrView<Vec<u8>>>,
+        limit: Option<usize>,
+    ) -> Result<ListAnnotatedStatesPageView> {
+        Ok(self
+            .rpc
+            .http
+            .list_annotated_states(access_path, cursor, limit)
+            .await?)
     }
 }
 

--- a/crates/rooch-types/Cargo.toml
+++ b/crates/rooch-types/Cargo.toml
@@ -43,6 +43,7 @@ move-core-types = { workspace = true }
 move-stdlib = { workspace = true }
 move-command-line-common = { workspace = true }
 move-binary-format = { workspace = true }
+move-resource-viewer = { workspace = true }
 
 moveos-types = { workspace = true }
 moveos-stdlib = { workspace = true }

--- a/crates/rooch-types/src/account.rs
+++ b/crates/rooch-types/src/account.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
+use move_core_types::u256::U256;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
 };
+use moveos_types::move_types::{random_struct_tag, random_type_tag};
+use moveos_types::moveos_std::type_info::TypeInfo;
 use moveos_types::{
     module_binding::{ModuleBinding, MoveFunctionCaller},
     state::{MoveStructState, MoveStructType},
@@ -66,5 +69,39 @@ impl<'a> ModuleBinding<'a> for AccountModule<'a> {
         Self: Sized,
     {
         Self { caller }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountInfo {
+    pub sequence_number: u64,
+    pub balances: Vec<Option<BalanceInfo>>,
+}
+
+impl AccountInfo {
+    pub fn new(sequence_number: u64, balances: Vec<Option<BalanceInfo>>) -> Self {
+        Self {
+            sequence_number,
+            balances,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BalanceInfo {
+    pub coin_type: TypeInfo,
+    pub balance: U256,
+}
+
+impl BalanceInfo {
+    pub fn new(coin_type: TypeInfo, balance: U256) -> Self {
+        Self { coin_type, balance }
+    }
+
+    pub fn random() -> Self {
+        let struct_tag = random_struct_tag();
+        let coin_type = TypeInfo::new(struct_tag.address, struct_tag.module, struct_tag.name);
+        let balance = U256::zero();
+        BalanceInfo { coin_type, balance }
     }
 }

--- a/crates/rooch-types/src/account.rs
+++ b/crates/rooch-types/src/account.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
+use move_core_types::language_storage::StructTag;
 use move_core_types::u256::U256;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
 };
-use moveos_types::move_types::{random_struct_tag, random_type_tag};
-use moveos_types::moveos_std::type_info::TypeInfo;
+use moveos_types::move_types::random_struct_tag;
 use moveos_types::{
     module_binding::{ModuleBinding, MoveFunctionCaller},
     state::{MoveStructState, MoveStructType},
@@ -89,18 +89,18 @@ impl AccountInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BalanceInfo {
-    pub coin_type: TypeInfo,
+    pub coin_type: StructTag,
     pub balance: U256,
 }
 
 impl BalanceInfo {
-    pub fn new(coin_type: TypeInfo, balance: U256) -> Self {
+    pub fn new(coin_type: StructTag, balance: U256) -> Self {
         Self { coin_type, balance }
     }
 
     pub fn random() -> Self {
-        let struct_tag = random_struct_tag();
-        let coin_type = TypeInfo::new(struct_tag.address, struct_tag.module, struct_tag.name);
+        let coin_type = random_struct_tag();
+        // let coin_type = StructTag::new(struct_tag.address, struct_tag.module, struct_tag.name);
         let balance = U256::zero();
         BalanceInfo { coin_type, balance }
     }

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -66,6 +66,10 @@ pub enum RoochError {
     RotateAuthenticationKeyError(String),
     #[error("Remove authentication key error: {0}")]
     RemoveAuthenticationKeyError(String),
+    #[error("Account not found error: {0}")]
+    AccountNotFoundError(String),
+    #[error("Account balance error: {0}")]
+    AccountBalanceError(String),
 
     //#[error("base64 decode error: {0}")]
     //Base64DecodeError(String),

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use move_core_types::vm_status::VMStatus;
 use moveos_types::genesis_info::GenesisInfo;
 use serde::{Deserialize, Serialize};
 use std::io;
@@ -36,6 +37,8 @@ pub enum RoochError {
     UnableToReadFile(String, String),
     #[error("Error: {0}")]
     UnexpectedError(String),
+    #[error("Error: {0}")]
+    UnexpectedVMStatusError(String),
 
     #[error("Simulation failed with status: {0}")]
     SimulationError(String),
@@ -117,6 +120,12 @@ impl From<bcs::Error> for RoochError {
 impl From<io::Error> for RoochError {
     fn from(e: io::Error) -> Self {
         RoochError::IOError(e.to_string())
+    }
+}
+
+impl From<VMStatus> for RoochError {
+    fn from(e: VMStatus) -> Self {
+        RoochError::UnexpectedVMStatusError(e.to_string())
     }
 }
 

--- a/crates/rooch-types/src/framework/coin.rs
+++ b/crates/rooch-types/src/framework/coin.rs
@@ -1,0 +1,55 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
+use anyhow::{Ok, Result};
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use moveos_types::object::ObjectID;
+use moveos_types::{
+    module_binding::{ModuleBinding, MoveFunctionCaller},
+    move_option::MoveOption,
+    state::MoveStructState,
+    transaction::FunctionCall,
+    tx_context::TxContext,
+};
+
+/// Rust bindings for RoochFramework coin module
+pub struct CoinModule<'a> {
+    caller: &'a dyn MoveFunctionCaller,
+}
+
+impl<'a> CoinModule<'a> {
+    const COIN_STORE_HANDLE_FUNCTION_NAME: &'static IdentStr = ident_str!("coin_store_handle");
+
+    pub fn coin_store_handle(&self, addr: AccountAddress) -> Result<Option<ObjectID>> {
+        let ctx = TxContext::zero();
+        let call = FunctionCall::new(
+            Self::function_id(Self::COIN_STORE_HANDLE_FUNCTION_NAME),
+            vec![],
+            vec![addr.to_vec()],
+        );
+        let result = self
+            .caller
+            .call_function(&ctx, call)?
+            .into_result()
+            .map(|values| {
+                let value = values.get(0).expect("Expected return value");
+                let result = MoveOption::<ObjectID>::from_bytes(&value.value)
+                    .expect("Expected Option<ObjectID>");
+                result.into()
+            })?;
+        Ok(result)
+    }
+}
+
+impl<'a> ModuleBinding<'a> for CoinModule<'a> {
+    const MODULE_NAME: &'static IdentStr = ident_str!("coin");
+    const MODULE_ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+
+    fn new(caller: &'a impl MoveFunctionCaller) -> Self
+    where
+        Self: Sized,
+    {
+        Self { caller }
+    }
+}

--- a/crates/rooch-types/src/framework/coin.rs
+++ b/crates/rooch-types/src/framework/coin.rs
@@ -2,16 +2,154 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
-use anyhow::{Ok, Result};
+use anyhow::{bail, Ok, Result};
+use move_core_types::language_storage::StructTag;
+use move_core_types::u256::U256;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
 use moveos_types::object::ObjectID;
+use moveos_types::state::MoveState;
 use moveos_types::{
     module_binding::{ModuleBinding, MoveFunctionCaller},
     move_option::MoveOption,
-    state::MoveStructState,
     transaction::FunctionCall,
     tx_context::TxContext,
 };
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Coin {
+    value: U256,
+}
+
+impl Coin {
+    pub fn new(value: U256) -> Self {
+        Coin { value }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnotatedCoin {
+    type_: StructTag,
+    value: Coin,
+}
+
+impl AnnotatedCoin {
+    pub fn new(type_: StructTag, value: Coin) -> Self {
+        AnnotatedCoin { type_, value }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompoundCoinStore {
+    coin: AnnotatedCoin,
+    frozen: bool,
+}
+
+impl CompoundCoinStore {
+    pub fn new(coin: AnnotatedCoin, frozen: bool) -> Self {
+        CompoundCoinStore { coin, frozen }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnotatedCoinStore {
+    type_: StructTag,
+    value: CompoundCoinStore,
+}
+
+impl AnnotatedCoinStore {
+    pub fn new(type_: StructTag, value: CompoundCoinStore) -> Self {
+        AnnotatedCoinStore { type_, value }
+    }
+
+    /// Create a new AnnotatedCoinStore from a AnnotatedMoveStruct
+    pub fn new_from_annotated_struct(annotated_struct: AnnotatedMoveStruct) -> Result<Self> {
+        let annotated_coin_store_type = annotated_struct.type_;
+        //         "move_value": {
+        //         "abilities": 8,
+        //         "type": "0x3::coin::CoinStore<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>",
+        //         "value": {
+        //             "coin": {
+        //                 "abilities": 4,
+        //                 "type": "0x3::coin::Coin<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>",
+        //                 "value": {
+        //                     "value": "10000"
+        //                 }
+        //             },
+        //             "frozen": false
+        //         }
+        //     }
+        //     },
+
+        let mut fields = annotated_struct.value.into_iter();
+        // let object_id = ObjectID::try_from(fields.next().expect("Object should have id").1)?;
+        let annotated_coin = match fields.next().expect("CoinStore should have coin field") {
+            (field_name, AnnotatedMoveValue::Struct(filed_value)) => {
+                debug_assert!(
+                    field_name.as_str() == "coin",
+                    "CoinStore coin field name should be coin"
+                );
+
+                let coin_type_ = filed_value.type_;
+                let mut inner_fields = filed_value.value.into_iter();
+                let coin_value = match inner_fields
+                    .next()
+                    .expect("CoinValue should have value field")
+                {
+                    (field_name, AnnotatedMoveValue::Bytes(inner_filed_value)) => {
+                        debug_assert!(
+                            field_name.as_str() == "value",
+                            "CoinValue value field name should be value"
+                        );
+                        // String::from_utf8(inner_filed_value)
+                        U256::from_bytes(inner_filed_value.as_slice())
+                    }
+                    _ => bail!("CoinValue value field should be value"),
+                }?;
+
+                let coin = Coin { value: coin_value };
+                let annotated_coin = AnnotatedCoin {
+                    type_: coin_type_,
+                    value: coin,
+                };
+                annotated_coin
+            }
+            _ => bail!("CoinStore coin field should be struct"),
+        };
+        let frozen = match fields.next().expect("CoinStore should have frozen field") {
+            (field_name, AnnotatedMoveValue::Bool(filed_value)) => {
+                debug_assert!(
+                    field_name.as_str() == "frozen",
+                    "CoinStore field name should be frozen"
+                );
+                filed_value
+            }
+            _ => bail!("CoinStore frozen field should be bool"),
+        };
+        let compose_coin_store = CompoundCoinStore {
+            coin: annotated_coin,
+            frozen,
+        };
+
+        let annotated_coin_store = AnnotatedCoinStore {
+            type_: annotated_coin_store_type,
+            value: compose_coin_store,
+        };
+
+        Ok(annotated_coin_store)
+    }
+
+    pub fn get_coin_type(&self) -> StructTag {
+        self.value.coin.type_.clone()
+    }
+
+    pub fn get_coin_value(&self) -> U256 {
+        self.value.coin.value.value.clone()
+    }
+}
 
 /// Rust bindings for RoochFramework coin module
 pub struct CoinModule<'a> {
@@ -19,7 +157,7 @@ pub struct CoinModule<'a> {
 }
 
 impl<'a> CoinModule<'a> {
-    const COIN_STORE_HANDLE_FUNCTION_NAME: &'static IdentStr = ident_str!("coin_store_handle");
+    pub const COIN_STORE_HANDLE_FUNCTION_NAME: &'static IdentStr = ident_str!("coin_store_handle");
 
     pub fn coin_store_handle(&self, addr: AccountAddress) -> Result<Option<ObjectID>> {
         let ctx = TxContext::zero();

--- a/crates/rooch-types/src/framework/coin.rs
+++ b/crates/rooch-types/src/framework/coin.rs
@@ -68,24 +68,7 @@ impl AnnotatedCoinStore {
     /// Create a new AnnotatedCoinStore from a AnnotatedMoveStruct
     pub fn new_from_annotated_struct(annotated_struct: AnnotatedMoveStruct) -> Result<Self> {
         let annotated_coin_store_type = annotated_struct.type_;
-        //         "move_value": {
-        //         "abilities": 8,
-        //         "type": "0x3::coin::CoinStore<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>",
-        //         "value": {
-        //             "coin": {
-        //                 "abilities": 4,
-        //                 "type": "0x3::coin::Coin<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>",
-        //                 "value": {
-        //                     "value": "10000"
-        //                 }
-        //             },
-        //             "frozen": false
-        //         }
-        //     }
-        //     },
-
         let mut fields = annotated_struct.value.into_iter();
-        // let object_id = ObjectID::try_from(fields.next().expect("Object should have id").1)?;
         let annotated_coin = match fields.next().expect("CoinStore should have coin field") {
             (field_name, AnnotatedMoveValue::Struct(filed_value)) => {
                 debug_assert!(
@@ -104,18 +87,16 @@ impl AnnotatedCoinStore {
                             field_name.as_str() == "value",
                             "CoinValue value field name should be value"
                         );
-                        // String::from_utf8(inner_filed_value)
                         U256::from_bytes(inner_filed_value.as_slice())
                     }
                     _ => bail!("CoinValue value field should be value"),
                 }?;
 
                 let coin = Coin { value: coin_value };
-                let annotated_coin = AnnotatedCoin {
+                AnnotatedCoin {
                     type_: coin_type_,
                     value: coin,
-                };
-                annotated_coin
+                }
             }
             _ => bail!("CoinStore coin field should be struct"),
         };
@@ -147,7 +128,7 @@ impl AnnotatedCoinStore {
     }
 
     pub fn get_coin_value(&self) -> U256 {
-        self.value.coin.value.value.clone()
+        self.value.coin.value.value
     }
 }
 

--- a/crates/rooch-types/src/framework/mod.rs
+++ b/crates/rooch-types/src/framework/mod.rs
@@ -8,6 +8,7 @@ pub mod account_authentication;
 pub mod address_mapping;
 pub mod auth_validator;
 pub mod bitcoin_validator;
+pub mod coin;
 pub mod empty;
 pub mod ethereum_validator;
 pub mod genesis;

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -14,10 +14,10 @@ use moveos_types::transaction::FunctionCall;
 use moveos_types::tx_context::TxContext;
 use rooch_rpc_api::api::MAX_RESULT_LIMIT_USIZE;
 use rooch_rpc_api::jsonrpc_types::account_view::AccountInfoView;
-use rooch_rpc_api::jsonrpc_types::{AccountAddressView, StructTagView};
+use rooch_rpc_api::jsonrpc_types::{AccountAddressView, AnnotatedCoinStoreView, StructTagView};
 use rooch_types::account::BalanceInfo;
 use rooch_types::error::{RoochError, RoochResult};
-use rooch_types::framework::coin::{AnnotatedCoinStore, CoinModule};
+use rooch_types::framework::coin::CoinModule;
 
 /// Show a account info, only the accounts managed by the current node are supported
 #[derive(Debug, Parser)]
@@ -37,8 +37,8 @@ pub struct BalanceCommand {
 }
 
 #[async_trait]
-impl CommandAction<AccountInfoView> for BalanceCommand {
-    async fn execute(self) -> RoochResult<AccountInfoView> {
+impl CommandAction<()> for BalanceCommand {
+    async fn execute(self) -> RoochResult<()> {
         let context = self.context_options.build().await?;
 
         let addr_view: Option<AccountAddress> = if let Some(address) = self.address {
@@ -51,8 +51,6 @@ impl CommandAction<AccountInfoView> for BalanceCommand {
         let addr = addr_view.expect("Account not found error");
 
         let client = context.get_client().await?;
-        // let coin_module = client.as_module_binding::<CoinModule>();
-        // let coin_store_handle = coin_module.coin_store_handle(addr)?;
 
         let ctx = TxContext::new_readonly_ctx(addr);
         let call = FunctionCall::new(
@@ -60,7 +58,7 @@ impl CommandAction<AccountInfoView> for BalanceCommand {
             vec![],
             vec![addr.to_vec()],
         );
-        let coin_store_handle: Option<ObjectID> = client
+        let coin_store_handle_opt: Option<ObjectID> = client
             .call_function(&ctx, call)?
             .into_result()
             .map(|values| {
@@ -68,100 +66,74 @@ impl CommandAction<AccountInfoView> for BalanceCommand {
                 let result = MoveOption::<ObjectID>::from_bytes(&value.value)
                     .expect("Expected Option<ObjectID>");
                 result.into()
-                // result
-            })
-            .expect(format!("Failed to get coin store handle via {}", addr).as_str());
-        // .unwrap_or_else(|_| {
-        //     RoochError::ViewFunctionError(format!(
-        //         "Failed to get coin store handle via {}",
-        //         addr
-        //     ))
-        // });
-        println!("account balance coin_store_handle {:?}", coin_store_handle);
-
-        // let call = FunctionCall::new(
-        //     Self::function_id(Self::GET_AUTHENTICATION_KEY_FUNCTION_NAME),
-        //     vec![V::type_tag()],
-        //     vec![MoveValue::Address(address)
-        //         .simple_serialize()
-        //         .expect("address should serialize")],
-        // );
-        // let ctx = TxContext::new_readonly_ctx(address);
-        // let auth_key =client
-        //     .call_function(&ctx, call)?
-        //     .into_result()
-        //     .map(|values| {
+            })?;
+        let coin_store_handle = coin_store_handle_opt
+            // .expect(format!("Failed to get coin store handle via {}", addr).as_str());
+            .unwrap_or_else(|| panic!("Failed to get coin store handle via {}", addr));
 
         let mut result = AccountInfoView::new(0u64, vec![]);
-        if coin_store_handle.is_some() {
-            let _resp = if let Some(_coin_type) = self.coin_type {
-                client
-                    .list_annotated_states(
-                        AccessPath::table_without_keys(coin_store_handle.clone().unwrap()).into(),
-                        None,
-                        Some(MAX_RESULT_LIMIT_USIZE),
-                    )
-                    .await
-                    .map_err(|e| RoochError::AccountBalanceError(e.to_string()))?;
-                // .pop()
-                // .flatten();
+        if let Some(coin_type_opt) = self.coin_type {
+            let key = resource_tag_to_key(&coin_type_opt.0);
+            let _hex_key = hex::encode(key.clone());
+            let keys = vec![key];
+            let mut states = client
+                .get_annotated_states(AccessPath::table(coin_store_handle, keys))
+                .await
+                .map_err(|e| RoochError::AccountBalanceError(e.to_string()))?;
 
-                // "jsonrpc": "2.0",
-                // "result": {
-                //     "data": [
-                //     {
-                //         "state": {
-                //         "value": "0x102700000000000000000000000000000000000000000000000000000000000000",
-                //         "value_type": "0x3::coin::CoinStore<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>"
-                //     },
-                //         "move_value": {
-                //         "abilities": 8,
-                //         "type": "0x3::coin::CoinStore<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>",
-                //         "value": {
-                //             "coin": {
-                //                 "abilities": 4,
-                //                 "type": "0x3::coin::Coin<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>",
-                //                 "value": {
-                //                     "value": "10000"
-                //                 }
-                //             },
-                //             "frozen": false
-                //         }
-                //     }
-                //     },
+            let state = states
+                .pop()
+                .expect("States expected return value")
+                .expect("State expected return value");
 
-                result.balances.push(Some(BalanceInfo::random().into()))
-            } else {
-                let keys = vec![resource_tag_to_key(&self.coin_type.unwrap().into())];
-                let states = client
-                    .get_annotated_states(
-                        AccessPath::table(coin_store_handle.unwrap(), keys).into(),
-                    )
-                    .await
-                    .map_err(|e| RoochError::AccountBalanceError(e.to_string()))?;
-                // result.balances.append(BalanceInfo {
-                //     coin_type: TypeInfo::,
-                //     balance,
-                // }
+            let annotated_coin_store_view =
+                AnnotatedCoinStoreView::new_from_annotated_move_value_view(state.move_value)?;
 
-                let state = states
-                    .get(0)
-                    .expect("States expected return value")
-                    .expect("State expected return value");
-                // let result = MoveOption::<ObjectID>::from_bytes(&value.value)
-                //     .expect("Expected Option<ObjectID>");
+            let balance_info = BalanceInfo::new(
+                annotated_coin_store_view.get_coin_type().into(),
+                annotated_coin_store_view.get_coin_value().into(),
+            );
+            result.balances.push(Some(balance_info.into()))
+        } else {
+            let states = client
+                .list_annotated_states(
+                    AccessPath::table_without_keys(coin_store_handle).into(),
+                    None,
+                    Some(MAX_RESULT_LIMIT_USIZE),
+                )
+                .await
+                .map_err(|e| RoochError::AccountBalanceError(e.to_string()))?;
 
-                let annotated_coin_store =
-                    AnnotatedCoinStore::new_from_annotated_struct(state.into())?;
+            let mut annotated_coin_store_views = states
+                .data
+                .into_iter()
+                .map(|state| {
+                    let coin_store_view =
+                        AnnotatedCoinStoreView::new_from_annotated_move_value_view(
+                            state.expect("State expected return value").move_value,
+                        )
+                        .expect("AnnotatedCoinStoreView expected return value");
 
-                let balance_info = BalanceInfo::new(
-                    annotated_coin_store.get_coin_type(),
-                    annotated_coin_store.get_coin_value(),
-                );
-                println!("Debug Account balance info {:?}", balance_info);
-                result.balances.push(Some(balance_info.into()))
-            };
+                    let balance_info = BalanceInfo::new(
+                        coin_store_view.get_coin_type().into(),
+                        coin_store_view.get_coin_value().into(),
+                    );
+                    Some(balance_info.into())
+                })
+                .collect();
+
+            result.balances.append(&mut annotated_coin_store_views);
+        };
+
+        println!("{0: ^102} | {1: ^32}", "Coin Type", "Balance");
+        println!("{}", ["-"; 48].join(""));
+        for balance_info in result.balances.into_iter().flatten() {
+            println!(
+                "{0: ^102} | {1: ^32}",
+                balance_info.coin_type, balance_info.balance,
+            );
         }
-        Ok(result)
+
+        Ok(())
     }
 }

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -1,0 +1,83 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::{CommandAction, WalletContextOptions};
+use clap::Parser;
+use move_core_types::account_address::AccountAddress;
+use moveos_types::access_path::AccessPath;
+use moveos_types::module_binding::MoveFunctionCaller;
+use moveos_types::state_resolver::resource_tag_to_key;
+use rooch_rpc_api::api::MAX_RESULT_LIMIT_USIZE;
+use rooch_rpc_api::jsonrpc_types::account_view::AccountInfoView;
+use rooch_rpc_api::jsonrpc_types::{AccountAddressView, StructTagView};
+use rooch_types::account::BalanceInfo;
+use rooch_types::error::{RoochError, RoochResult};
+use rooch_types::framework::coin::CoinModule;
+
+/// Show a account info, only the accounts managed by the current node are supported
+#[derive(Debug, Parser)]
+pub struct BalanceCommand {
+    #[clap(short = 'a', long = "address")]
+    /// The account's address to show balance, if absent, show the default active account.
+    address: Option<AccountAddressView>,
+
+    /// Struct name as `<ADDRESS>::<MODULE_ID>::<STRUCT_NAME><TypeParam1?, TypeParam2?>`
+    /// Example: `0x123::counter::Counter`, `0x123::counter::Box<0x123::counter::Counter>`
+    #[clap(long = "coin_type")]
+    /// The block number or block hash for get state, if absent, use latest block state_root.
+    coin_type: Option<StructTagView>,
+
+    #[clap(flatten)]
+    pub context_options: WalletContextOptions,
+}
+
+#[async_trait]
+impl CommandAction<()> for BalanceCommand {
+    async fn execute(self) -> RoochResult<AccountInfoView> {
+        let mut context = self.context_options.build().await?;
+
+        let addr_view = if let Some(address) = self.address {
+            self.address
+        } else {
+            context.config.active_address.map(|address| address.into().into())
+        };
+
+        // Obtain account address
+        let addr = AccountAddress::from(addr_view.expect("Account not found error"));
+
+        let client = context.get_client().await?;
+        let coin_module = client.as_module_binding::<CoinModule>();
+        let coin_store_handle = coin_module.coin_store_handle(addr)?;
+
+        let mut result = AccountInfoView::new(0u64, vec![]);
+        if coin_store_handle.is_some() {
+            let _resp = if let Some(coin_type) = self.coin_type {
+                client
+                    .list_annotated_states(
+                        AccessPath::table_without_keys(coin_store_handle.unwrap()).into(),
+                        None,
+                        Some(MAX_RESULT_LIMIT_USIZE),
+                    )
+                    .await
+                    .map_err(|e| RoochError::AccountBalanceError(e.to_string()))?;
+                // .pop()
+                // .flatten();
+                result.balances.push(Some(BalanceInfo::random().into()))
+            } else {
+                let keys = vec![resource_tag_to_key(&self.coin_type.unwrap().into())];
+                let _state = client
+                    .get_annotated_states(
+                        AccessPath::table(coin_store_handle.unwrap(), keys).into(),
+                    )
+                    .await
+                    .map_err(|e| RoochError::AccountBalanceError(e.to_string()))?;
+                // result.balances.append(BalanceInfo {
+                //     coin_type: TypeInfo::,
+                //     balance,
+                // }
+                result.balances.push(Some(BalanceInfo::random().into()))
+            };
+        }
+        Ok(result)
+    }
+}

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -5,14 +5,19 @@ use crate::cli_types::{CommandAction, WalletContextOptions};
 use clap::Parser;
 use move_core_types::account_address::AccountAddress;
 use moveos_types::access_path::AccessPath;
-use moveos_types::module_binding::MoveFunctionCaller;
+use moveos_types::module_binding::{ModuleBinding, MoveFunctionCaller};
+use moveos_types::move_option::MoveOption;
+use moveos_types::object::ObjectID;
+use moveos_types::state::MoveStructState;
 use moveos_types::state_resolver::resource_tag_to_key;
+use moveos_types::transaction::FunctionCall;
+use moveos_types::tx_context::TxContext;
 use rooch_rpc_api::api::MAX_RESULT_LIMIT_USIZE;
 use rooch_rpc_api::jsonrpc_types::account_view::AccountInfoView;
 use rooch_rpc_api::jsonrpc_types::{AccountAddressView, StructTagView};
 use rooch_types::account::BalanceInfo;
 use rooch_types::error::{RoochError, RoochResult};
-use rooch_types::framework::coin::CoinModule;
+use rooch_types::framework::coin::{AnnotatedCoinStore, CoinModule};
 
 /// Show a account info, only the accounts managed by the current node are supported
 #[derive(Debug, Parser)]
@@ -32,29 +37,67 @@ pub struct BalanceCommand {
 }
 
 #[async_trait]
-impl CommandAction<()> for BalanceCommand {
+impl CommandAction<AccountInfoView> for BalanceCommand {
     async fn execute(self) -> RoochResult<AccountInfoView> {
-        let mut context = self.context_options.build().await?;
+        let context = self.context_options.build().await?;
 
-        let addr_view = if let Some(address) = self.address {
-            self.address
+        let addr_view: Option<AccountAddress> = if let Some(address) = self.address {
+            Some(address.into())
         } else {
-            context.config.active_address.map(|address| address.into().into())
+            context.config.active_address.map(|address| address.into())
         };
 
         // Obtain account address
-        let addr = AccountAddress::from(addr_view.expect("Account not found error"));
+        let addr = addr_view.expect("Account not found error");
 
         let client = context.get_client().await?;
-        let coin_module = client.as_module_binding::<CoinModule>();
-        let coin_store_handle = coin_module.coin_store_handle(addr)?;
+        // let coin_module = client.as_module_binding::<CoinModule>();
+        // let coin_store_handle = coin_module.coin_store_handle(addr)?;
+
+        let ctx = TxContext::new_readonly_ctx(addr);
+        let call = FunctionCall::new(
+            CoinModule::function_id(CoinModule::COIN_STORE_HANDLE_FUNCTION_NAME),
+            vec![],
+            vec![addr.to_vec()],
+        );
+        let coin_store_handle: Option<ObjectID> = client
+            .call_function(&ctx, call)?
+            .into_result()
+            .map(|values| {
+                let value = values.get(0).expect("Expected return value");
+                let result = MoveOption::<ObjectID>::from_bytes(&value.value)
+                    .expect("Expected Option<ObjectID>");
+                result.into()
+                // result
+            })
+            .expect(format!("Failed to get coin store handle via {}", addr).as_str());
+        // .unwrap_or_else(|_| {
+        //     RoochError::ViewFunctionError(format!(
+        //         "Failed to get coin store handle via {}",
+        //         addr
+        //     ))
+        // });
+        println!("account balance coin_store_handle {:?}", coin_store_handle);
+
+        // let call = FunctionCall::new(
+        //     Self::function_id(Self::GET_AUTHENTICATION_KEY_FUNCTION_NAME),
+        //     vec![V::type_tag()],
+        //     vec![MoveValue::Address(address)
+        //         .simple_serialize()
+        //         .expect("address should serialize")],
+        // );
+        // let ctx = TxContext::new_readonly_ctx(address);
+        // let auth_key =client
+        //     .call_function(&ctx, call)?
+        //     .into_result()
+        //     .map(|values| {
 
         let mut result = AccountInfoView::new(0u64, vec![]);
         if coin_store_handle.is_some() {
-            let _resp = if let Some(coin_type) = self.coin_type {
+            let _resp = if let Some(_coin_type) = self.coin_type {
                 client
                     .list_annotated_states(
-                        AccessPath::table_without_keys(coin_store_handle.unwrap()).into(),
+                        AccessPath::table_without_keys(coin_store_handle.clone().unwrap()).into(),
                         None,
                         Some(MAX_RESULT_LIMIT_USIZE),
                     )
@@ -62,10 +105,35 @@ impl CommandAction<()> for BalanceCommand {
                     .map_err(|e| RoochError::AccountBalanceError(e.to_string()))?;
                 // .pop()
                 // .flatten();
+
+                // "jsonrpc": "2.0",
+                // "result": {
+                //     "data": [
+                //     {
+                //         "state": {
+                //         "value": "0x102700000000000000000000000000000000000000000000000000000000000000",
+                //         "value_type": "0x3::coin::CoinStore<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>"
+                //     },
+                //         "move_value": {
+                //         "abilities": 8,
+                //         "type": "0x3::coin::CoinStore<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>",
+                //         "value": {
+                //             "coin": {
+                //                 "abilities": 4,
+                //                 "type": "0x3::coin::Coin<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>",
+                //                 "value": {
+                //                     "value": "10000"
+                //                 }
+                //             },
+                //             "frozen": false
+                //         }
+                //     }
+                //     },
+
                 result.balances.push(Some(BalanceInfo::random().into()))
             } else {
                 let keys = vec![resource_tag_to_key(&self.coin_type.unwrap().into())];
-                let _state = client
+                let states = client
                     .get_annotated_states(
                         AccessPath::table(coin_store_handle.unwrap(), keys).into(),
                     )
@@ -75,7 +143,23 @@ impl CommandAction<()> for BalanceCommand {
                 //     coin_type: TypeInfo::,
                 //     balance,
                 // }
-                result.balances.push(Some(BalanceInfo::random().into()))
+
+                let state = states
+                    .get(0)
+                    .expect("States expected return value")
+                    .expect("State expected return value");
+                // let result = MoveOption::<ObjectID>::from_bytes(&value.value)
+                //     .expect("Expected Option<ObjectID>");
+
+                let annotated_coin_store =
+                    AnnotatedCoinStore::new_from_annotated_struct(state.into())?;
+
+                let balance_info = BalanceInfo::new(
+                    annotated_coin_store.get_coin_type(),
+                    annotated_coin_store.get_coin_value(),
+                );
+                println!("Debug Account balance info {:?}", balance_info);
+                result.balances.push(Some(balance_info.into()))
             };
         }
         Ok(result)

--- a/crates/rooch/src/commands/account/commands/mod.rs
+++ b/crates/rooch/src/commands/account/commands/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod balance;
 pub mod create;
 pub mod import;
 pub mod list;

--- a/crates/rooch/src/commands/account/mod.rs
+++ b/crates/rooch/src/commands/account/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::cli_types::CommandAction;
+use crate::commands::account::commands::balance::BalanceCommand;
 use async_trait::async_trait;
 use commands::{
     create::CreateCommand, import::ImportCommand, list::ListCommand, nullify::NullifyCommand,
@@ -34,6 +35,7 @@ impl CommandAction<String> for Account {
             AccountCommand::Switch(switch) => switch.execute().await.map(|_| "".to_owned()),
             AccountCommand::Update(update) => update.execute().await.map(|_| "".to_owned()),
             AccountCommand::Nullify(nullify) => nullify.execute().await.map(|_| "".to_owned()),
+            AccountCommand::Balance(balance) => balance.execute().await.map(|_| "".to_owned()),
         }
         .map_err(RoochError::from)
     }
@@ -48,4 +50,5 @@ pub enum AccountCommand {
     Switch(SwitchCommand),
     Update(UpdateCommand),
     Nullify(NullifyCommand),
+    Balance(BalanceCommand),
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md
@@ -244,7 +244,7 @@ Returns true if <code><a href="table.md#0x2_table">table</a></code> contains an 
 Returns table handle of <code><a href="table.md#0x2_table">table</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_handle">handle</a>&lt;V: key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a>): &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_handle">handle</a>(<a href="table.md#0x2_table">table</a>: &<a href="type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a>): &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
 </code></pre>
 
 
@@ -253,7 +253,7 @@ Returns table handle of <code><a href="table.md#0x2_table">table</a></code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_handle">handle</a>&lt;V: key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a>): &ObjectID {
+<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_handle">handle</a>(<a href="table.md#0x2_table">table</a>: &<a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a>): &ObjectID {
     &<a href="table.md#0x2_table">table</a>.handle
 }
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md
@@ -14,6 +14,7 @@ TypeTable is a table use struct Type as Key, struct as Value
 -  [Function `borrow_mut`](#0x2_type_table_borrow_mut)
 -  [Function `remove`](#0x2_type_table_remove)
 -  [Function `contains`](#0x2_type_table_contains)
+-  [Function `handle`](#0x2_type_table_handle)
 -  [Function `destroy_empty`](#0x2_type_table_destroy_empty)
 
 
@@ -229,6 +230,31 @@ Returns true if <code><a href="table.md#0x2_table">table</a></code> contains an 
 
 <pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_contains">contains</a>&lt;V: key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a>): bool {
     <a href="raw_table.md#0x2_raw_table_contains">raw_table::contains</a>&lt;String&gt;(&<a href="table.md#0x2_table">table</a>.handle, <a href="type_table.md#0x2_type_table_key">key</a>&lt;V&gt;())
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_type_table_handle"></a>
+
+## Function `handle`
+
+Returns table handle of <code><a href="table.md#0x2_table">table</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_handle">handle</a>&lt;V: key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a>): &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_handle">handle</a>&lt;V: key&gt;(<a href="table.md#0x2_table">table</a>: &<a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a>): &ObjectID {
+    &<a href="table.md#0x2_table">table</a>.handle
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
@@ -66,7 +66,7 @@ module moveos_std::type_table {
     }
 
     /// Returns table handle of `table`.
-    public fun handle<V: key>(table: &TypeTable): &ObjectID {
+    public fun handle(table: &TypeTable): &ObjectID {
         &table.handle
     }
   

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
@@ -64,6 +64,11 @@ module moveos_std::type_table {
     public fun contains<V: key>(table: &TypeTable): bool {
         raw_table::contains<String>(&table.handle, key<V>())
     }
+
+    /// Returns table handle of `table`.
+    public fun handle<V: key>(table: &TypeTable): &ObjectID {
+        &table.handle
+    }
   
     #[test_only]
     /// Testing only: allows to drop a table even if it is not empty.

--- a/moveos/moveos-types/src/access_path.rs
+++ b/moveos/moveos-types/src/access_path.rs
@@ -235,6 +235,13 @@ impl AccessPath {
         })
     }
 
+    pub fn table_without_keys(table_handle: ObjectID) -> Self {
+        AccessPath(Path::Table {
+            table_handle,
+            keys: None,
+        })
+    }
+
     /// Convert AccessPath to TableQuery, return the table handle and keys
     /// All other AccessPath is a shortcut for TableQuery
     pub fn into_table_query(self) -> (ObjectID, Option<Vec<Vec<u8>>>) {


### PR DESCRIPTION
resolve https://github.com/rooch-network/rooch/issues/744


**Problems**
1, It is hard to support converting from AnnotatedMoveValueView to AnnotatedMoveValue, mainly because of  it hard to support convert SpecificStruct to AnnotatedMoveStruct. As a result, parsing AnnotatedCoinStoreView from the RPC API is very tedious. relative of https://github.com/rooch-network/rooch/issues/758
2, The current implementation of AnnotatedMoveValueView may be flawed. Coin balance defines the U256 type, but the type obtained from AnnotatedMoveValueView is U64(StrView(10000), and the expected type is U256(StrView(10000). May return U128(StrView(value) type.

```
value: {Identifier("value"): U64(StrView(10000))} })
```

**TODO**
1, Coin balance needs to depend on CoinInfo to display the decimal point after processing decimals
2，Add test case for the balance command


**Example**

- Publish coin examples
```
rooch move publish -p examples/coins --sender-account 0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7  --named-addresses coins=0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7
```

- Call faucet to get test coin
```
rooch move run --function 0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::faucet  --sender-account 0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7
```

- Call Account balance cli
```
rooch account balance -a 0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7
```
Result
```
                                              Coin Type                                                |             Balance
------------------------------------------------
0x3::coin::Coin<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC> |              10000
0x3::coin::Coin<0x3::gas_coin::GasCoin> |            9996919761
```

- Call Account balance cli with coin_type
```
rooch account balance -a 0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7 --coin_type "0x3::coin::CoinStore<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC>"
```
Result
```
Coin Type                                                |             Balance
------------------------------------------------
0x3::coin::Coin<0xe1176537c0175d336353dad12f7eb60c658ce526eeb3cd08409e6fd8c2dfa1d7::fixed_supply_coin::FSC> |              10000
```