### PR TITLE
Txcontext respawn

### DIFF
--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -42,7 +42,7 @@ use rooch_types::framework::address_mapping::AddressMapping;
 use rooch_types::framework::auth_validator::AuthValidatorCaller;
 use rooch_types::framework::auth_validator::TxValidateResult;
 use rooch_types::framework::transaction_validator::TransactionValidator;
-use rooch_types::framework::{SYSTEM_POST_EXECUTE_FUNCTIONS, SYSTEM_PRE_EXECUTE_FUNCTIONS};
+use rooch_types::framework::{system_post_execute_functions, system_pre_execute_functions};
 use rooch_types::transaction::AuthenticatorInfo;
 use rooch_types::transaction::{AbstractTransaction, TransactionSequenceMapping};
 use rooch_types::H256;
@@ -63,8 +63,8 @@ impl ExecutorActor {
             moveos_store,
             genesis.all_natives(),
             genesis.config.clone(),
-            SYSTEM_PRE_EXECUTE_FUNCTIONS.clone(),
-            SYSTEM_POST_EXECUTE_FUNCTIONS.clone(),
+            system_pre_execute_functions(),
+            system_post_execute_functions(),
         )?;
 
         let executor = Self {

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -174,6 +174,8 @@ impl GenesisPackage {
             MoveOSStore::mock_moveos_store()?,
             rooch_framework::natives::all_natives(gas_parameters),
             vm_config,
+            vec![],
+            vec![],
         )?;
         let genesis_ctx = genesis::GenesisContext::new(chain_id);
         let genesis_result = moveos.init_genesis(genesis_txs.clone(), genesis_ctx.clone())?;
@@ -274,6 +276,8 @@ mod tests {
             moveos_store,
             all_natives(genesis.gas_params),
             genesis.config,
+            vec![],
+            vec![],
         )
         .expect("init moveos failed");
 

--- a/crates/rooch-integration-test-runner/src/lib.rs
+++ b/crates/rooch-integration-test-runner/src/lib.rs
@@ -97,6 +97,8 @@ impl<'a> MoveOSTestAdapter<'a> for MoveOSTestRunner<'a> {
             moveos_store,
             genesis.all_natives(),
             genesis.config_for_test.clone(),
+            vec![],
+            vec![],
         )
         .unwrap();
 

--- a/crates/rooch-types/src/framework/mod.rs
+++ b/crates/rooch-types/src/framework/mod.rs
@@ -1,6 +1,9 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::framework::transaction_validator::TransactionValidator;
+use moveos_types::transaction::FunctionCall;
+
 pub mod account_authentication;
 /// Types mapping from Framework Move types to Rust types
 /// Module binding for the Framework
@@ -22,13 +25,16 @@ pub mod transaction_validator;
 /// All system pre_execute functions are called before other pre_execute functions.
 /// TODO: is there a better way to construct this registry? Should we register
 /// system pre_execute functions on-chain and dynamically?
-static SYSTEM_PRE_EXECUTE_FUNCTIONS: Lazy<[FunctionCall]> =
-    Lazy::new(|| [TransactionValidator::pre_execute_function_call()]);
-
+#[inline]
+pub fn system_pre_execute_functions() -> Vec<FunctionCall> {
+    vec![TransactionValidator::pre_execute_function_call()]
+}
 /// MoveOS system post_execute functions registry.
 /// The registry is used to filter out system post_execute functions.
 /// All system post_execute functions are called after other post_execute functions.
 /// TODO: is there a better way to construct this registry? Should we register
 /// system pre_execute functions on-chain and dynamically?
-static SYSTEM_POST_EXECUTE_FUNCTIONS: Lazy<[FunctionCall]> =
-    Lazy::new(|| [TransactionValidator::post_execute_function_call()]);
+#[inline]
+pub fn system_post_execute_functions() -> Vec<FunctionCall> {
+    vec![TransactionValidator::post_execute_function_call()]
+}

--- a/crates/rooch-types/src/framework/mod.rs
+++ b/crates/rooch-types/src/framework/mod.rs
@@ -16,3 +16,19 @@ pub mod native_validator;
 pub mod nostr_validator;
 pub mod session_key;
 pub mod transaction_validator;
+
+/// MoveOS system pre_execute functions registry.
+/// The registry is used to filter out system pre_execute functions.
+/// All system pre_execute functions are called before other pre_execute functions.
+/// TODO: is there a better way to construct this registry? Should we register
+/// system pre_execute functions on-chain and dynamically?
+static SYSTEM_PRE_EXECUTE_FUNCTIONS: Lazy<[FunctionCall]> =
+    Lazy::new(|| [TransactionValidator::pre_execute_function_call()]);
+
+/// MoveOS system post_execute functions registry.
+/// The registry is used to filter out system post_execute functions.
+/// All system post_execute functions are called after other post_execute functions.
+/// TODO: is there a better way to construct this registry? Should we register
+/// system pre_execute functions on-chain and dynamically?
+static SYSTEM_POST_EXECUTE_FUNCTIONS: Lazy<[FunctionCall]> =
+    Lazy::new(|| [TransactionValidator::post_execute_function_call()]);

--- a/moveos/moveos-types/src/move_simple_map.rs
+++ b/moveos/moveos-types/src/move_simple_map.rs
@@ -61,10 +61,6 @@ where
         }
         false
     }
-
-    pub fn swap(&mut self, other: &mut Self) {
-        std::mem::swap(self, other);
-    }
 }
 
 impl<Key, Value> MoveStructType for Element<Key, Value>

--- a/moveos/moveos-types/src/move_simple_map.rs
+++ b/moveos/moveos-types/src/move_simple_map.rs
@@ -61,6 +61,10 @@ where
         }
         false
     }
+
+    pub fn swap(&mut self, other: &mut Self) {
+        std::mem::swap(self, other);
+    }
 }
 
 impl<Key, Value> MoveStructType for Element<Key, Value>

--- a/moveos/moveos-types/src/tx_context.rs
+++ b/moveos/moveos-types/src/tx_context.rs
@@ -74,14 +74,14 @@ impl TxContext {
     }
 
     /// Spawn a new TxContext with a new `ids_created` counter and empty map
-    pub fn spawn(self) -> Self {
+    pub fn spawn(self, env: SimpleMap<MoveString, CopyableAny>) -> Self {
         Self {
             sender: self.sender,
             sequence_number: self.sequence_number,
             max_gas_amount: self.max_gas_amount,
             tx_hash: self.tx_hash,
             ids_created: 0,
-            map: SimpleMap::create(),
+            map: env,
         }
     }
 

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -218,11 +218,11 @@ impl MoveOS {
                         // and increment the sequence number or reduce the gas in new session.
                         let mut s = session.respawn(system_env);
                         //Because the session is respawned, the pre_execute function should be called again.
-                        s.execute_function_call(pre_execute_functions.clone(), true)?;
+                        s.execute_function_call(pre_execute_functions, true)?;
                         s
                     }
                 };
-                post_session.execute_function_call(post_execute_functions.clone(), true)?;
+                post_session.execute_function_call(post_execute_functions, true)?;
                 (post_session, status)
             }
             Err(discard_status) => {

--- a/moveos/moveos/src/vm/unit_tests/vm_arguments_tests.rs
+++ b/moveos/moveos/src/vm/unit_tests/vm_arguments_tests.rs
@@ -321,7 +321,7 @@ fn call_script_with_args_ty_args_signers(
     let cost_table = initial_cost_schedule();
     let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
     gas_meter.set_metering(false);
-    let mut session = moveos_vm.new_session(&remote_view, ctx, vec![], vec![], gas_meter);
+    let mut session = moveos_vm.new_session(&remote_view, ctx, gas_meter);
 
     let script_action = MoveAction::new_script_call(
         script,
@@ -352,7 +352,7 @@ fn call_script_function_with_args_ty_args_signers(
     let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
     gas_meter.set_metering(false);
     let mut session: crate::vm::moveos_vm::MoveOSSession<'_, '_, RemoteStore, MoveOSGasMeter> =
-        moveos_vm.new_session(&remote_view, ctx, vec![], vec![], gas_meter);
+        moveos_vm.new_session(&remote_view, ctx, gas_meter);
 
     let function_action = MoveAction::new_function_call(
         FunctionId::new(id, function_name),
@@ -836,7 +836,7 @@ fn call_missing_item() {
     let cost_table = initial_cost_schedule();
     let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
     gas_meter.set_metering(false);
-    let mut session = moveos_vm.new_session(&remote_view, ctx.clone(), vec![], vec![], gas_meter);
+    let mut session = moveos_vm.new_session(&remote_view, ctx.clone(), gas_meter);
     let func_call = FunctionCall::new(
         FunctionId::new(id.clone(), function_name.into()),
         vec![],
@@ -855,7 +855,7 @@ fn call_missing_item() {
     let cost_table = initial_cost_schedule();
     let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
     gas_meter.set_metering(false);
-    let mut session = moveos_vm.new_session(&remote_view, ctx, vec![], vec![], gas_meter);
+    let mut session = moveos_vm.new_session(&remote_view, ctx, gas_meter);
     let error = session
         .execute_function_bypass_visibility(func_call)
         .err()


### PR DESCRIPTION
## Summary

1. Refactor MoveOS and Session to handle pre_execute and post_execute errors.
2. Keep `TxValidateResult` when respawn session.

- Closes #607 