### PR TITLE
[Relayer] Implement Relayer, support relayer Ethereum block to rooch and update RoochFramework timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7253,6 +7253,7 @@ dependencies = [
  "rooch-types",
  "serde 1.0.188",
  "serde_bytes",
+ "serde_json",
  "sha3 0.9.1",
  "smallvec 1.11.0",
  "tracing",
@@ -7501,6 +7502,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rooch-relayer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bcs",
+ "chrono",
+ "clap 3.2.25",
+ "coerce",
+ "derive_builder",
+ "ethers",
+ "fastcrypto",
+ "futures",
+ "jsonrpsee",
+ "move-core-types",
+ "move-resource-viewer",
+ "moveos",
+ "moveos-store",
+ "moveos-types",
+ "parking_lot 0.12.1",
+ "rooch-key",
+ "rooch-rpc-api",
+ "rooch-rpc-client",
+ "rooch-store",
+ "rooch-types",
+ "schemars",
+ "serde 1.0.188",
+ "serde_json",
+ "serde_with",
+ "serde_yaml 0.9.25",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "rooch-rpc-api"
 version = "0.1.0"
 dependencies = [
@@ -7597,6 +7636,7 @@ dependencies = [
  "rooch-executor",
  "rooch-key",
  "rooch-proposer",
+ "rooch-relayer",
  "rooch-rpc-api",
  "rooch-sequencer",
  "rooch-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/rooch-genesis",
     "crates/rooch-genesis-builder",
     "crates/rooch-integration-test-runner",
+    "crates/rooch-relayer",
     "crates/rooch-rpc-server",
     "crates/rooch-rpc-client",
     "crates/rooch-rpc-api",
@@ -82,6 +83,7 @@ rooch-framework-tests = { path = "crates/rooch-framework-tests" }
 rooch-integration-test-runner = { path = "crates/rooch-integration-test-runner" }
 rooch-genesis = { path = "crates/rooch-genesis" }
 rooch-genesis-builder = { path = "crates/rooch-genesis-builder" }
+rooch-relayer = { path = "crates/rooch-relayer" }
 rooch-rpc-server = { path = "crates/rooch-rpc-server" }
 rooch-rpc-client = { path = "crates/rooch-rpc-client" }
 rooch-rpc-api = { path = "crates/rooch-rpc-api" }

--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -56,7 +56,6 @@ pub static R_OPT_NET_HELP: &str = r#"Chain Network
     Use rooch_generator command to generate a genesis config."#;
 
 #[derive(Clone, Debug, Parser, Default, Serialize, Deserialize)]
-#[clap(name = "rooch", about = "Rooch")]
 pub struct RoochOpt {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[clap(long = "data-dir", short = 'd', parse(from_os_str))]
@@ -66,18 +65,23 @@ pub struct RoochOpt {
     /// If dev chainid, start the service with a temporary data store.
     /// All data will be deleted when the service is stopped.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[clap(long, short = 'n', help = R_OPT_NET_HELP)]
     pub chain_id: Option<RoochChainID>,
 
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // #[clap(long = "genesis-config")]
-    // /// Init chain by a custom genesis config. if want to reuse builtin network config, just pass a builtin network name.
-    // /// This option only work for node init start.
-    // pub genesis_config: Option<String>,
-    pub store: Option<StoreConfig>,
+    #[clap(flatten)]
+    pub store: StoreConfig,
 
     /// Optional custom port, which the rooch server should listen on.
+    /// The port on which the server should listen defaults to `50051`
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[clap(long, short = 'p')]
     pub port: Option<u16>,
+
+    /// The Ethereum RPC URL to connect to for relay L1 block and transaction to L2.
+    /// If not set, the relayer service will not start.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[clap(long)]
+    pub eth_rpc_url: Option<String>,
 }
 
 impl std::fmt::Display for RoochOpt {
@@ -95,8 +99,9 @@ impl RoochOpt {
         RoochOpt {
             base_data_dir: None,
             chain_id: Some(RoochChainID::DEV),
-            store: None,
+            store: StoreConfig::default(),
             port: None,
+            eth_rpc_url: None,
         }
     }
 }

--- a/crates/rooch-config/src/store_config.rs
+++ b/crates/rooch-config/src/store_config.rs
@@ -123,24 +123,24 @@ impl StoreConfig {
 impl ConfigModule for StoreConfig {
     fn merge_with_opt(&mut self, opt: &RoochOpt, base: Arc<BaseConfig>) -> Result<()> {
         self.base = Some(base);
-        if opt.store.is_some() {
-            let store_config = opt.store.clone().unwrap();
-            if store_config.max_open_files.is_some() {
-                self.max_open_files = store_config.max_open_files;
-            }
-            if store_config.max_total_wal_size.is_some() {
-                self.max_total_wal_size = store_config.max_total_wal_size;
-            }
-            if store_config.cache_size.is_some() {
-                self.cache_size = store_config.cache_size;
-            }
-            if store_config.bytes_per_sync.is_some() {
-                self.bytes_per_sync = store_config.bytes_per_sync;
-            }
-            if store_config.wal_bytes_per_sync.is_some() {
-                self.wal_bytes_per_sync = store_config.wal_bytes_per_sync;
-            }
+
+        let store_config = opt.store.clone();
+        if store_config.max_open_files.is_some() {
+            self.max_open_files = store_config.max_open_files;
         }
+        if store_config.max_total_wal_size.is_some() {
+            self.max_total_wal_size = store_config.max_total_wal_size;
+        }
+        if store_config.cache_size.is_some() {
+            self.cache_size = store_config.cache_size;
+        }
+        if store_config.bytes_per_sync.is_some() {
+            self.bytes_per_sync = store_config.bytes_per_sync;
+        }
+        if store_config.wal_bytes_per_sync.is_some() {
+            self.wal_bytes_per_sync = store_config.wal_bytes_per_sync;
+        }
+
         Ok(())
     }
 }

--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -41,6 +41,7 @@ use rooch_types::address::MultiChainAddress;
 use rooch_types::framework::address_mapping::AddressMapping;
 use rooch_types::framework::auth_validator::AuthValidatorCaller;
 use rooch_types::framework::auth_validator::TxValidateResult;
+use rooch_types::framework::genesis::GenesisContext;
 use rooch_types::framework::transaction_validator::TransactionValidator;
 use rooch_types::framework::{system_post_execute_functions, system_pre_execute_functions};
 use rooch_types::transaction::AuthenticatorInfo;
@@ -57,8 +58,12 @@ type ValidateAuthenticatorResult =
     Result<(TxValidateResult, Vec<FunctionCall>, Vec<FunctionCall>), VMStatus>;
 
 impl ExecutorActor {
-    pub fn new(chain_id: u64, moveos_store: MoveOSStore, rooch_store: RoochStore) -> Result<Self> {
-        let genesis: RoochGenesis = rooch_genesis::RoochGenesis::build(chain_id)?;
+    pub fn new(
+        genesis_ctx: GenesisContext,
+        moveos_store: MoveOSStore,
+        rooch_store: RoochStore,
+    ) -> Result<Self> {
+        let genesis: RoochGenesis = rooch_genesis::RoochGenesis::build(genesis_ctx)?;
         let moveos = MoveOS::new(
             moveos_store,
             genesis.all_natives(),

--- a/crates/rooch-framework-tests/Cargo.toml
+++ b/crates/rooch-framework-tests/Cargo.toml
@@ -16,15 +16,16 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 better_any = { workspace = true }
+ethers = { workspace = true }
 fastcrypto = { workspace = true }
 linked-hash-map = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+serde_json = { workspace = true }
 sha3 = { workspace = true }
 smallvec = { workspace = true }
 hex = { workspace = true }
-ethers = { workspace = true }
 bcs = { workspace = true }
 
 move-binary-format = { workspace = true }

--- a/crates/rooch-framework-tests/src/binding_test.rs
+++ b/crates/rooch-framework-tests/src/binding_test.rs
@@ -18,7 +18,7 @@ impl RustBindingTest {
         let moveos_store = MoveOSStore::mock_moveos_store()?;
         let rooch_store = RoochStore::mock_rooch_store()?;
         let executor =
-            ExecutorActor::new(RoochChainID::DEV.chain_id().id(), moveos_store, rooch_store)?;
+            ExecutorActor::new(RoochChainID::DEV.genesis_ctx(), moveos_store, rooch_store)?;
         Ok(Self { executor })
     }
 

--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -1,0 +1,72 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::binding_test;
+use ethers::prelude::*;
+use moveos_types::transaction::MoveAction;
+use rooch_key::keystore::{AccountKeystore, InMemKeystore};
+use rooch_types::crypto::BuiltinScheme;
+use rooch_types::framework::ethereum_light_client::BlockHeader;
+use rooch_types::transaction::rooch::RoochTransactionData;
+
+#[test]
+fn test_submit_block() {
+    tracing_subscriber::fmt::init();
+    let mut binding_test = binding_test::RustBindingTest::new().unwrap();
+
+    let keystore = InMemKeystore::new_ed25519_insecure_for_tests(1);
+    let sender = keystore.addresses()[0];
+    let sequence_number = 0;
+
+    let json = serde_json::json!(
+    {
+        "baseFeePerGas": "0x7",
+        "miner": "0x0000000000000000000000000000000000000001",
+        "number": "0x1b4",
+        "hash": "0x0e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331",
+        "parentHash": "0x9646252be9520f6e71339a8df9c55e4d7619deeb018d2a3f2d21fc165dde5eb5",
+        "mixHash": "0x1010101010101010101010101010101010101010101010101010101010101010",
+        "nonce": "0x0000000000000000",
+        "sealFields": [
+          "0xe04d296d2460cfb8472af2c5fd05b5a214109c25688d3704aed5484f9a7792f2",
+          "0x0000000000000042"
+        ],
+        "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "logsBloom":  "0x0e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273310e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273310e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273310e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273310e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273310e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273310e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273310e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331",
+        "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+        "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+        "stateRoot": "0xd5855eb08b3387c0af375e9cdb6acfc05eb8f519e419b874b6ff2ffda7ed1dff",
+        "difficulty": "0x27f07",
+        "totalDifficulty": "0x27f07",
+        "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "size": "0x27f07",
+        "gasLimit": "0x9f759",
+        "minGasPrice": "0x9f759",
+        "gasUsed": "0x9f759",
+        "timestamp": "0x54e34e8e",
+        "transactions": [],
+        "uncles": []
+      }
+    );
+
+    let ethereum_block: Block<()> = serde_json::from_value(json).unwrap();
+
+    let block_header = BlockHeader::try_from(&ethereum_block).unwrap();
+    let action = MoveAction::Function(rooch_types::framework::ethereum_light_client::EthereumLightClientModule::create_submit_new_block_call(&block_header));
+    let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
+    let tx = keystore
+        .sign_transaction(&sender, tx_data, BuiltinScheme::Ed25519)
+        .unwrap();
+    binding_test.execute(tx).unwrap();
+
+    let timestamp_module =
+        binding_test.as_module_bundle::<rooch_types::framework::timestamp::TimestampModule>();
+
+    let now_microseconds = timestamp_module.now_microseconds().unwrap();
+    let duration = std::time::Duration::from_secs(block_header.timestamp.unchecked_as_u64());
+    println!(
+        "now_microseconds: {}, header_timestamp: {}",
+        now_microseconds, block_header.timestamp
+    );
+    assert_eq!(now_microseconds, duration.as_micros() as u64);
+}

--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -5,7 +5,9 @@ use crate::binding_test;
 use ethers::prelude::*;
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
-use rooch_types::crypto::BuiltinScheme;
+use rooch_types::address::RoochAddress;
+use rooch_types::coin_type::CoinID;
+use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::ethereum_light_client::BlockHeader;
 use rooch_types::transaction::rooch::RoochTransactionData;
 
@@ -14,7 +16,7 @@ fn test_submit_block() {
     tracing_subscriber::fmt::init();
     let mut binding_test = binding_test::RustBindingTest::new().unwrap();
 
-    let keystore = InMemKeystore::new_ed25519_insecure_for_tests(1);
+    let keystore = InMemKeystore::<RoochAddress, RoochKeyPair>::new_insecure_for_tests(1);
     let sender = keystore.addresses()[0];
     let sequence_number = 0;
 
@@ -55,7 +57,7 @@ fn test_submit_block() {
     let action = MoveAction::Function(rooch_types::framework::ethereum_light_client::EthereumLightClientModule::create_submit_new_block_call(&block_header));
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, BuiltinScheme::Ed25519)
+        .sign_transaction(&sender, tx_data, CoinID::Rooch)
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework-tests/src/tests/mod.rs
+++ b/crates/rooch-framework-tests/src/tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod empty_tests;
+mod ethereum_light_client_test;
 mod ethereum_validator_tests;
 mod native_validator_tests;
 mod transaction_validator_tests;

--- a/crates/rooch-framework/doc/README.md
+++ b/crates/rooch-framework/doc/README.md
@@ -29,6 +29,7 @@ This is the reference documentation of the Rooch Framework.
 -  [`0x3::empty`](empty.md#0x3_empty)
 -  [`0x3::encoding`](encoding.md#0x3_encoding)
 -  [`0x3::ethereum_address`](ethereum_address.md#0x3_ethereum_address)
+-  [`0x3::ethereum_light_client`](ethereum_light_client.md#0x3_ethereum_light_client)
 -  [`0x3::ethereum_validator`](ethereum_validator.md#0x3_ethereum_validator)
 -  [`0x3::gas_coin`](gas_coin.md#0x3_gas_coin)
 -  [`0x3::genesis`](genesis.md#0x3_genesis)
@@ -36,6 +37,7 @@ This is the reference documentation of the Rooch Framework.
 -  [`0x3::native_validator`](native_validator.md#0x3_native_validator)
 -  [`0x3::schnorr`](schnorr.md#0x3_schnorr)
 -  [`0x3::session_key`](session_key.md#0x3_session_key)
+-  [`0x3::timestamp`](timestamp.md#0x3_timestamp)
 -  [`0x3::transaction_fee`](transaction_fee.md#0x3_transaction_fee)
 -  [`0x3::transaction_validator`](transaction_validator.md#0x3_transaction_validator)
 

--- a/crates/rooch-framework/doc/ethereum_address.md
+++ b/crates/rooch-framework/doc/ethereum_address.md
@@ -25,7 +25,7 @@
 
 
 
-<pre><code><b>struct</b> <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a> <b>has</b> drop, store
+<pre><code><b>struct</b> <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/crates/rooch-framework/doc/ethereum_light_client.md
+++ b/crates/rooch-framework/doc/ethereum_light_client.md
@@ -1,0 +1,252 @@
+
+<a name="0x3_ethereum_light_client"></a>
+
+# Module `0x3::ethereum_light_client`
+
+
+
+-  [Struct `BlockHeader`](#0x3_ethereum_light_client_BlockHeader)
+-  [Resource `BlockStore`](#0x3_ethereum_light_client_BlockStore)
+-  [Constants](#@Constants_0)
+-  [Function `genesis_init`](#0x3_ethereum_light_client_genesis_init)
+-  [Function `submit_new_block`](#0x3_ethereum_light_client_submit_new_block)
+-  [Function `get_block`](#0x3_ethereum_light_client_get_block)
+
+
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::bcs</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
+<b>use</b> <a href="">0x2::table</a>;
+<b>use</b> <a href="">0x2::tx_context</a>;
+<b>use</b> <a href="ethereum_address.md#0x3_ethereum_address">0x3::ethereum_address</a>;
+<b>use</b> <a href="timestamp.md#0x3_timestamp">0x3::timestamp</a>;
+</code></pre>
+
+
+
+<a name="0x3_ethereum_light_client_BlockHeader"></a>
+
+## Struct `BlockHeader`
+
+
+
+<pre><code><b>struct</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_BlockHeader">BlockHeader</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="">hash</a>: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ Hash of the block
+</dd>
+<dt>
+<code>parent_hash: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ Hash of the parent
+</dd>
+<dt>
+<code>uncles_hash: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ Hash of the uncles
+</dd>
+<dt>
+<code>author: <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a></code>
+</dt>
+<dd>
+ Miner/author's address.
+</dd>
+<dt>
+<code>state_root: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ State root hash
+</dd>
+<dt>
+<code>transactions_root: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ Transactions root hash
+</dd>
+<dt>
+<code>receipts_root: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ Transactions receipts root hash
+</dd>
+<dt>
+<code>logs_bloom: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ Logs bloom
+</dd>
+<dt>
+<code>difficulty: u256</code>
+</dt>
+<dd>
+ Difficulty
+</dd>
+<dt>
+<code>number: u64</code>
+</dt>
+<dd>
+ Block number.
+</dd>
+<dt>
+<code>gas_limit: u256</code>
+</dt>
+<dd>
+ Gas Limit
+</dd>
+<dt>
+<code>gas_used: u256</code>
+</dt>
+<dd>
+ Gas Used
+</dd>
+<dt>
+<code><a href="timestamp.md#0x3_timestamp">timestamp</a>: u256</code>
+</dt>
+<dd>
+ Timestamp
+</dd>
+<dt>
+<code>extra_data: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ Extra data
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x3_ethereum_light_client_BlockStore"></a>
+
+## Resource `BlockStore`
+
+
+
+<pre><code><b>struct</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_BlockStore">BlockStore</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>blocks: <a href="_Table">table::Table</a>&lt;u64, <a href="ethereum_light_client.md#0x3_ethereum_light_client_BlockHeader">ethereum_light_client::BlockHeader</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x3_ethereum_light_client_ErrorBlockNotFound"></a>
+
+
+
+<pre><code><b>const</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_ErrorBlockNotFound">ErrorBlockNotFound</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x3_ethereum_light_client_genesis_init"></a>
+
+## Function `genesis_init`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, genesis_account: &<a href="">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, genesis_account: &<a href="">signer</a>){
+    <b>let</b> tx_ctx = <a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
+    <b>let</b> block_store = <a href="ethereum_light_client.md#0x3_ethereum_light_client_BlockStore">BlockStore</a>{
+        blocks: <a href="_new">table::new</a>(tx_ctx),
+    };
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, block_store);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_ethereum_light_client_submit_new_block"></a>
+
+## Function `submit_new_block`
+
+The relay server submit a new Ethereum block to the light client.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_submit_new_block">submit_new_block</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, block_header_bytes: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_submit_new_block">submit_new_block</a>(ctx: &<b>mut</b> StorageContext, block_header_bytes: <a href="">vector</a>&lt;u8&gt;){
+    <a href="ethereum_light_client.md#0x3_ethereum_light_client_process_block">process_block</a>(ctx, block_header_bytes);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_ethereum_light_client_get_block"></a>
+
+## Function `get_block`
+
+Get block via block_number
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_get_block">get_block</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, block_number: u64): &<a href="ethereum_light_client.md#0x3_ethereum_light_client_BlockHeader">ethereum_light_client::BlockHeader</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_get_block">get_block</a>(ctx: &StorageContext, block_number: u64): &<a href="ethereum_light_client.md#0x3_ethereum_light_client_BlockHeader">BlockHeader</a>{
+    <b>let</b> block_store = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="ethereum_light_client.md#0x3_ethereum_light_client_BlockStore">BlockStore</a>&gt;(ctx, @rooch_framework);
+    <b>assert</b>!(<a href="_contains">table::contains</a>(&block_store.blocks, block_number), <a href="_invalid_argument">error::invalid_argument</a>(<a href="ethereum_light_client.md#0x3_ethereum_light_client_ErrorBlockNotFound">ErrorBlockNotFound</a>));
+    <a href="_borrow">table::borrow</a>(&block_store.blocks, block_number)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/rooch-framework/doc/genesis.md
+++ b/crates/rooch-framework/doc/genesis.md
@@ -17,7 +17,9 @@
 <b>use</b> <a href="builtin_validators.md#0x3_builtin_validators">0x3::builtin_validators</a>;
 <b>use</b> <a href="chain_id.md#0x3_chain_id">0x3::chain_id</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
+<b>use</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client">0x3::ethereum_light_client</a>;
 <b>use</b> <a href="gas_coin.md#0x3_gas_coin">0x3::gas_coin</a>;
+<b>use</b> <a href="timestamp.md#0x3_timestamp">0x3::timestamp</a>;
 <b>use</b> <a href="transaction_fee.md#0x3_transaction_fee">0x3::transaction_fee</a>;
 </code></pre>
 
@@ -45,6 +47,12 @@ GenesisContext is a genesis init parameters in the TxContext.
 </dt>
 <dd>
 
+</dd>
+<dt>
+<code><a href="timestamp.md#0x3_timestamp">timestamp</a>: u64</code>
+</dt>
+<dd>
+ genesis timestamp in microseconds
 </dd>
 </dl>
 

--- a/crates/rooch-framework/doc/session_key.md
+++ b/crates/rooch-framework/doc/session_key.md
@@ -432,7 +432,7 @@ If the session key is expired or invalid, abort the tx, otherwise return option:
     <b>let</b> session_keys = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr);
     <b>assert</b>!(<a href="_contains">table::contains</a>(&session_keys.keys, authentication_key), <a href="_not_found">error::not_found</a>(<a href="session_key.md#0x3_session_key_ErrorSessionKeyIsInvalid">ErrorSessionKeyIsInvalid</a>));
     <b>let</b> <a href="session_key.md#0x3_session_key">session_key</a> = <a href="_borrow_mut">table::borrow_mut</a>(&<b>mut</b> session_keys.keys, authentication_key);
-    //TODO set the last active time <b>to</b> now when the timestamp is supported
+    //TODO set the last active time <b>to</b> now when the <a href="timestamp.md#0x3_timestamp">timestamp</a> is supported
     <a href="session_key.md#0x3_session_key">session_key</a>.last_active_time = <a href="session_key.md#0x3_session_key">session_key</a>.last_active_time + 1;
 }
 </code></pre>

--- a/crates/rooch-framework/doc/timestamp.md
+++ b/crates/rooch-framework/doc/timestamp.md
@@ -1,0 +1,240 @@
+
+<a name="0x3_timestamp"></a>
+
+# Module `0x3::timestamp`
+
+This module keeps a global wall clock that stores the current Unix time in microseconds.
+It interacts with the other modules in the following ways:
+* genesis: to initialize the timestamp
+* L1 block: update the timestamp via L1s block header timestamp
+* TickTransaction: update the timestamp via the time offset in the TickTransaction(TODO)
+
+
+-  [Resource `CurrentTimeMicroseconds`](#0x3_timestamp_CurrentTimeMicroseconds)
+-  [Constants](#@Constants_0)
+-  [Function `genesis_init`](#0x3_timestamp_genesis_init)
+-  [Function `update_global_time`](#0x3_timestamp_update_global_time)
+-  [Function `try_update_global_time`](#0x3_timestamp_try_update_global_time)
+-  [Function `now_microseconds`](#0x3_timestamp_now_microseconds)
+-  [Function `now_seconds`](#0x3_timestamp_now_seconds)
+-  [Function `seconds_to_microseconds`](#0x3_timestamp_seconds_to_microseconds)
+
+
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x2::account_storage</a>;
+<b>use</b> <a href="">0x2::storage_context</a>;
+</code></pre>
+
+
+
+<a name="0x3_timestamp_CurrentTimeMicroseconds"></a>
+
+## Resource `CurrentTimeMicroseconds`
+
+A singleton resource holding the current Unix time in microseconds
+
+
+<pre><code><b>struct</b> <a href="timestamp.md#0x3_timestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>microseconds: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x3_timestamp_ErrorInvalidTimestamp"></a>
+
+An invalid timestamp was provided
+
+
+<pre><code><b>const</b> <a href="timestamp.md#0x3_timestamp_ErrorInvalidTimestamp">ErrorInvalidTimestamp</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x3_timestamp_MICRO_CONVERSION_FACTOR"></a>
+
+Conversion factor between seconds and microseconds
+
+
+<pre><code><b>const</b> <a href="timestamp.md#0x3_timestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>: u64 = 1000000;
+</code></pre>
+
+
+
+<a name="0x3_timestamp_genesis_init"></a>
+
+## Function `genesis_init`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, genesis_account: &<a href="">signer</a>, initial_time_microseconds: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, genesis_account: &<a href="">signer</a>, initial_time_microseconds: u64) {
+    <b>let</b> current_time = <a href="timestamp.md#0x3_timestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a> { microseconds: initial_time_microseconds };
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, current_time);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_timestamp_update_global_time"></a>
+
+## Function `update_global_time`
+
+Updates the wall clock time, if the new time is smaller than the current time, aborts.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_update_global_time">update_global_time</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="timestamp.md#0x3_timestamp">timestamp</a>: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_update_global_time">update_global_time</a>(ctx: &<b>mut</b> StorageContext,<a href="timestamp.md#0x3_timestamp">timestamp</a>: u64) {
+    <b>let</b> global_timer = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="timestamp.md#0x3_timestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(ctx, @rooch_framework);
+    <b>let</b> now = global_timer.microseconds;
+    <b>assert</b>!(now &lt; <a href="timestamp.md#0x3_timestamp">timestamp</a>, <a href="_invalid_argument">error::invalid_argument</a>(<a href="timestamp.md#0x3_timestamp_ErrorInvalidTimestamp">ErrorInvalidTimestamp</a>));
+    global_timer.microseconds = <a href="timestamp.md#0x3_timestamp">timestamp</a>;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_timestamp_try_update_global_time"></a>
+
+## Function `try_update_global_time`
+
+Tries to update the wall clock time, if the new time is smaller than the current time, ignores the update, and returns false.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_try_update_global_time">try_update_global_time</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, <a href="timestamp.md#0x3_timestamp">timestamp</a>: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_try_update_global_time">try_update_global_time</a>(ctx: &<b>mut</b> StorageContext, <a href="timestamp.md#0x3_timestamp">timestamp</a>: u64) : bool {
+    <b>let</b> global_timer = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="timestamp.md#0x3_timestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(ctx, @rooch_framework);
+    <b>let</b> now = global_timer.microseconds;
+    <b>if</b>(now &lt; <a href="timestamp.md#0x3_timestamp">timestamp</a>) {
+        global_timer.microseconds = <a href="timestamp.md#0x3_timestamp">timestamp</a>;
+        <b>true</b>
+    }<b>else</b>{
+        <b>false</b>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_timestamp_now_microseconds"></a>
+
+## Function `now_microseconds`
+
+Gets the current time in microseconds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_now_microseconds">now_microseconds</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_now_microseconds">now_microseconds</a>(ctx: &StorageContext): u64 {
+    <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="timestamp.md#0x3_timestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a>&gt;(ctx, @rooch_framework).microseconds
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_timestamp_now_seconds"></a>
+
+## Function `now_seconds`
+
+Gets the current time in seconds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_now_seconds">now_seconds</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_now_seconds">now_seconds</a>(ctx: &StorageContext): u64 {
+    <a href="timestamp.md#0x3_timestamp_now_microseconds">now_microseconds</a>(ctx) / <a href="timestamp.md#0x3_timestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_timestamp_seconds_to_microseconds"></a>
+
+## Function `seconds_to_microseconds`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_seconds_to_microseconds">seconds_to_microseconds</a>(seconds: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_seconds_to_microseconds">seconds_to_microseconds</a>(seconds: u64): u64 {
+    seconds * <a href="timestamp.md#0x3_timestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/rooch-framework/sources/address_type/ethereum_address.move
+++ b/crates/rooch-framework/sources/address_type/ethereum_address.move
@@ -11,7 +11,7 @@ module rooch_framework::ethereum_address {
     const ErrorMalformedPublicKey: u64 = 0;
     const ErrorDecompressPublicKey: u64 = 1;
 
-    struct ETHAddress has store, drop {
+    struct ETHAddress has store,copy,drop {
         bytes: vector<u8>,
     }
 

--- a/crates/rooch-framework/sources/ethereum_light_client.move
+++ b/crates/rooch-framework/sources/ethereum_light_client.move
@@ -1,0 +1,87 @@
+module rooch_framework::ethereum_light_client{
+
+    use std::error;
+    use moveos_std::bcs;
+    use moveos_std::storage_context::{Self, StorageContext};
+    use moveos_std::account_storage;
+    use moveos_std::table::{Self, Table};
+    use rooch_framework::ethereum_address::ETHAddress;
+    use rooch_framework::timestamp;
+
+    friend rooch_framework::genesis;
+
+    const ErrorBlockNotFound:u64 = 1;
+
+    struct BlockHeader has store, copy, drop {
+        /// Hash of the block
+        hash: vector<u8>,
+        /// Hash of the parent
+        parent_hash: vector<u8>,
+        /// Hash of the uncles
+        uncles_hash: vector<u8>,
+        /// Miner/author's address.
+        author: ETHAddress,
+        /// State root hash
+        state_root: vector<u8>,
+        /// Transactions root hash
+        transactions_root: vector<u8>,
+        /// Transactions receipts root hash
+        receipts_root: vector<u8>,
+        /// Logs bloom
+        logs_bloom: vector<u8>,
+        /// Difficulty
+        difficulty: u256,
+        /// Block number.
+        number: u64,
+        /// Gas Limit
+        gas_limit: u256,
+        /// Gas Used
+        gas_used: u256,
+        /// Timestamp
+        timestamp: u256,
+        /// Extra data
+        extra_data: vector<u8>,
+    }
+
+    struct BlockStore has key{
+        blocks: Table<u64, BlockHeader>,
+    }
+
+    public(friend) fun genesis_init(ctx: &mut StorageContext, genesis_account: &signer){
+        let tx_ctx = storage_context::tx_context_mut(ctx);
+        let block_store = BlockStore{
+            blocks: table::new(tx_ctx),
+        };
+        account_storage::global_move_to(ctx, genesis_account, block_store);
+    }
+
+    fun process_block(ctx: &mut StorageContext, block_header_bytes: vector<u8>){
+        //TODO find a way to deserialize the block header, do not use bcs::from_bytes
+        let block_header = bcs::from_bytes<BlockHeader>(block_header_bytes);
+        //TODO validate the block hash
+        //TODO validate the block via ethereum consensus(pos validators)
+        let block_store = account_storage::global_borrow_mut<BlockStore>(ctx, @rooch_framework);
+        if(table::contains(&block_store.blocks, block_header.number)){
+            //repeat block number
+            //TODO check if it is a soft fork.
+            return
+        };
+        table::add(&mut block_store.blocks, block_header.number, block_header);
+
+        let timestamp_seconds = (block_header.timestamp as u64);
+        timestamp::try_update_global_time(ctx, timestamp::seconds_to_microseconds(timestamp_seconds));        
+    }
+
+    /// The relay server submit a new Ethereum block to the light client.
+    public entry fun submit_new_block(ctx: &mut StorageContext, block_header_bytes: vector<u8>){
+        process_block(ctx, block_header_bytes);
+    }
+
+    #[view]
+    /// Get block via block_number
+    public fun get_block(ctx: &StorageContext, block_number: u64): &BlockHeader{
+        let block_store = account_storage::global_borrow<BlockStore>(ctx, @rooch_framework);
+        assert!(table::contains(&block_store.blocks, block_number), error::invalid_argument(ErrorBlockNotFound));
+        table::borrow(&block_store.blocks, block_number)
+    }
+}

--- a/crates/rooch-framework/sources/genesis.move
+++ b/crates/rooch-framework/sources/genesis.move
@@ -3,7 +3,6 @@ module rooch_framework::genesis {
     use std::error;
     use std::option;
     use moveos_std::storage_context::{Self, StorageContext};
-    //use moveos_std::signe;
     use rooch_framework::account;
     use rooch_framework::auth_validator_registry;
     use rooch_framework::builtin_validators;
@@ -11,12 +10,16 @@ module rooch_framework::genesis {
     use rooch_framework::coin;
     use rooch_framework::gas_coin;
     use rooch_framework::transaction_fee;
+    use rooch_framework::timestamp;
+    use rooch_framework::ethereum_light_client;
 
     const ErrorGenesisInit: u64 = 1;
 
     /// GenesisContext is a genesis init parameters in the TxContext.
     struct GenesisContext has copy,store,drop{
         chain_id: u64,
+        /// genesis timestamp in microseconds
+        timestamp: u64,
     }
 
     fun init(ctx: &mut StorageContext){
@@ -31,6 +34,8 @@ module rooch_framework::genesis {
         coin::genesis_init(ctx, genesis_account);
         gas_coin::genesis_init(ctx, genesis_account);
         transaction_fee::genesis_init(ctx, genesis_account);
+        timestamp::genesis_init(ctx, genesis_account, genesis_context.timestamp);
+        ethereum_light_client::genesis_init(ctx, genesis_account);
     }
 
 
@@ -38,7 +43,7 @@ module rooch_framework::genesis {
     /// init the genesis context for test, and return the StorageContext with @rooch_framework genesis account
     public fun init_for_test(): StorageContext{
         let ctx = moveos_std::storage_context::new_test_context(@rooch_framework);
-        storage_context::add(&mut ctx, GenesisContext{chain_id: 20230103});
+        storage_context::add(&mut ctx, GenesisContext{chain_id: 20230103, timestamp: 0});
         init(&mut ctx);
         ctx
     }

--- a/crates/rooch-framework/sources/timestamp.move
+++ b/crates/rooch-framework/sources/timestamp.move
@@ -1,0 +1,84 @@
+/// This module keeps a global wall clock that stores the current Unix time in microseconds.
+/// It interacts with the other modules in the following ways:
+/// * genesis: to initialize the timestamp
+/// * L1 block: update the timestamp via L1s block header timestamp
+/// * TickTransaction: update the timestamp via the time offset in the TickTransaction(TODO)
+module rooch_framework::timestamp {
+   
+    use std::error;
+    use moveos_std::account_storage;
+    use moveos_std::storage_context::StorageContext;
+
+    friend rooch_framework::genesis;
+    friend rooch_framework::ethereum_light_client;
+
+    /// A singleton resource holding the current Unix time in microseconds
+    struct CurrentTimeMicroseconds has key {
+        microseconds: u64,
+    }
+
+    /// Conversion factor between seconds and microseconds
+    const MICRO_CONVERSION_FACTOR: u64 = 1000000;
+
+    /// An invalid timestamp was provided
+    const ErrorInvalidTimestamp: u64 = 1;
+
+    public(friend) fun genesis_init(ctx: &mut StorageContext, genesis_account: &signer, initial_time_microseconds: u64) {
+        let current_time = CurrentTimeMicroseconds { microseconds: initial_time_microseconds };
+        account_storage::global_move_to(ctx, genesis_account, current_time);
+    }
+
+    /// Updates the wall clock time, if the new time is smaller than the current time, aborts.
+    public(friend) fun update_global_time(ctx: &mut StorageContext,timestamp: u64) {
+        let global_timer = account_storage::global_borrow_mut<CurrentTimeMicroseconds>(ctx, @rooch_framework);
+        let now = global_timer.microseconds;
+        assert!(now < timestamp, error::invalid_argument(ErrorInvalidTimestamp));
+        global_timer.microseconds = timestamp;
+    }
+
+    /// Tries to update the wall clock time, if the new time is smaller than the current time, ignores the update, and returns false.
+    public(friend) fun try_update_global_time(ctx: &mut StorageContext, timestamp: u64) : bool {
+        let global_timer = account_storage::global_borrow_mut<CurrentTimeMicroseconds>(ctx, @rooch_framework);
+        let now = global_timer.microseconds;
+        if(now < timestamp) {
+            global_timer.microseconds = timestamp;
+            true
+        }else{
+            false
+        }
+    }
+
+    #[view]
+    /// Gets the current time in microseconds.
+    public fun now_microseconds(ctx: &StorageContext): u64 {
+        account_storage::global_borrow<CurrentTimeMicroseconds>(ctx, @rooch_framework).microseconds
+    }
+
+    #[view]
+    /// Gets the current time in seconds.
+    public fun now_seconds(ctx: &StorageContext): u64 {
+        now_microseconds(ctx) / MICRO_CONVERSION_FACTOR
+    }
+
+    public fun seconds_to_microseconds(seconds: u64): u64 {
+        seconds * MICRO_CONVERSION_FACTOR
+    }
+
+    #[test_only]
+    public fun update_global_time_for_test(ctx: &mut StorageContext, timestamp_microsecs: u64){
+        let global_timer = account_storage::global_borrow_mut<CurrentTimeMicroseconds>(ctx, @rooch_framework);
+        let now = global_timer.microseconds;
+        assert!(now < timestamp_microsecs, error::invalid_argument(ErrorInvalidTimestamp));
+        global_timer.microseconds = timestamp_microsecs;
+    }
+
+    #[test_only]
+    public fun update_global_time_for_test_secs(ctx: &mut StorageContext, timestamp_seconds: u64) {
+        update_global_time_for_test(ctx, timestamp_seconds * MICRO_CONVERSION_FACTOR);
+    }
+
+    #[test_only]
+    public fun fast_forward_seconds(ctx: &mut StorageContext, timestamp_seconds: u64) {
+        update_global_time_for_test_secs(ctx, now_seconds() + timestamp_seconds);
+    }
+}

--- a/crates/rooch-framework/sources/timestamp.move
+++ b/crates/rooch-framework/sources/timestamp.move
@@ -79,6 +79,7 @@ module rooch_framework::timestamp {
 
     #[test_only]
     public fun fast_forward_seconds(ctx: &mut StorageContext, timestamp_seconds: u64) {
-        update_global_time_for_test_secs(ctx, now_seconds() + timestamp_seconds);
+        let now_seconds = now_seconds(ctx);
+        update_global_time_for_test_secs(ctx, now_seconds + timestamp_seconds);
     }
 }

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -264,7 +264,7 @@ mod tests {
     #[test]
     fn test_genesis_init() {
         let genesis = super::RoochGenesis::build_with_option(
-            RoochChainID::DEV.chain_id().id(),
+            RoochChainID::DEV.genesis_ctx(),
             crate::BuildOption::Fresh,
         )
         .expect("build rooch framework failed");

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -16,7 +16,6 @@ use once_cell::sync::Lazy;
 use rooch_framework::natives::gas_parameter::gas_member::InitialGasSchedule;
 use rooch_types::chain_id::RoochChainID;
 use rooch_types::error::GenesisError;
-use rooch_types::framework::genesis;
 use rooch_types::framework::genesis::GenesisContext;
 use rooch_types::transaction::rooch::RoochTransaction;
 use serde::{Deserialize, Serialize};
@@ -29,7 +28,7 @@ use std::{
 pub static ROOCH_DEV_GENESIS: Lazy<RoochGenesis> = Lazy::new(|| {
     // genesis for integration test, we need to build the stdlib every time for `private_generic` check
     // see moveos/moveos-verifier/src/metadata.rs#L27-L30
-    RoochGenesis::build_with_option(RoochChainID::DEV.chain_id().id(), BuildOption::Fresh)
+    RoochGenesis::build_with_option(RoochChainID::DEV.genesis_ctx(), BuildOption::Fresh)
         .expect("build rooch genesis failed")
 });
 
@@ -57,11 +56,11 @@ pub enum BuildOption {
 }
 
 impl RoochGenesis {
-    pub fn build(chain_id: u64) -> Result<Self> {
-        Self::build_with_option(chain_id, BuildOption::Release)
+    pub fn build(genesis_ctx: GenesisContext) -> Result<Self> {
+        Self::build_with_option(genesis_ctx, BuildOption::Release)
     }
 
-    pub fn build_with_option(chain_id: u64, option: BuildOption) -> Result<Self> {
+    pub fn build_with_option(genesis_ctx: GenesisContext, option: BuildOption) -> Result<Self> {
         let config = MoveOSConfig {
             vm_config: VMConfig::default(),
         };
@@ -71,7 +70,7 @@ impl RoochGenesis {
         };
 
         let gas_params = rooch_framework::natives::GasParameters::zeros();
-        let genesis_package = GenesisPackage::build(chain_id, option)?;
+        let genesis_package = GenesisPackage::build(genesis_ctx, option)?;
 
         Ok(RoochGenesis {
             config,
@@ -147,7 +146,7 @@ impl RoochGenesis {
 static GENESIS_STDLIB_BYTES: &[u8] = include_bytes!("../generated/stdlib");
 
 impl GenesisPackage {
-    fn build(chain_id: u64, build_option: BuildOption) -> Result<Self> {
+    fn build(genesis_ctx: GenesisContext, build_option: BuildOption) -> Result<Self> {
         let stdlib = match build_option {
             BuildOption::Fresh => Self::build_stdlib()?,
             BuildOption::Release => Self::load_stdlib()?,
@@ -160,7 +159,7 @@ impl GenesisPackage {
             .map(|(genesis_account, bundle)| {
                 RoochTransaction::new_genesis_tx(
                     genesis_account.into(),
-                    chain_id,
+                    genesis_ctx.chain_id,
                     MoveAction::ModuleBundle(bundle),
                 )
             })
@@ -177,7 +176,6 @@ impl GenesisPackage {
             vec![],
             vec![],
         )?;
-        let genesis_ctx = genesis::GenesisContext::new(chain_id);
         let genesis_result = moveos.init_genesis(genesis_txs.clone(), genesis_ctx.clone())?;
         let state_root = genesis_result
             .last()

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -126,6 +126,17 @@
       }
     },
     {
+      "name": "rooch_getChainID",
+      "params": [],
+      "result": {
+        "name": "StrView<u64>",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/u64"
+        }
+      }
+    },
+    {
       "name": "rooch_getEvents",
       "description": "Get the events by event filter",
       "params": [

--- a/crates/rooch-relayer/Cargo.toml
+++ b/crates/rooch-relayer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rooch-rpc-server"
+name = "rooch-relayer"
 version = "0.1.0"
 
 # Workspace inherited keys
@@ -20,15 +20,12 @@ clap = { workspace = true }
 coerce = { workspace = true }
 derive_builder = { workspace = true }
 ethers = { workspace = true }
+fastcrypto = { workspace = true }
 futures = { workspace = true }
-hex = { workspace = true }
-rustc-hex = { workspace = true }
 jsonrpsee = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
-tower = { workspace = true }
-tower-http = { workspace = true }
 thiserror = { workspace = true }
 tokio = { features = ["full"], workspace = true }
 tonic = { workspace = true }
@@ -36,29 +33,17 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 schemars = { workspace = true }
 serde_with = { workspace = true }
-rand = { workspace = true }
-fastcrypto = { workspace = true }
-hyper = { workspace = true }
-log = { workspace = true }
-lazy_static = { workspace = true }
-
+parking_lot = { workspace = true }
 
 move-core-types = { workspace = true }
 move-resource-viewer = { workspace = true }
-move-binary-format = { workspace = true }
 
+moveos = { workspace = true }
 moveos-store = { workspace = true }
 moveos-types = { workspace = true }
-move-bytecode-utils = { workspace = true }
-raw-store = { workspace = true }
-moveos-config = { workspace = true }
 
-rooch-config = { workspace = true }
 rooch-types = { workspace = true }
-rooch-executor = { workspace = true }
-rooch-sequencer = { workspace = true }
-rooch-proposer = { workspace = true }
 rooch-key = { workspace = true }
 rooch-store = { workspace = true }
+rooch-rpc-client = { workspace = true }
 rooch-rpc-api = { workspace = true }
-rooch-relayer = { workspace = true }

--- a/crates/rooch-relayer/src/actor/ethereum_relayer.rs
+++ b/crates/rooch-relayer/src/actor/ethereum_relayer.rs
@@ -1,0 +1,64 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Relayer;
+use anyhow::Result;
+use async_trait::async_trait;
+use ethers::prelude::*;
+use moveos_types::transaction::FunctionCall;
+use rooch_types::framework::ethereum_light_client::{BlockHeader, EthereumLightClientModule};
+use std::collections::BTreeMap;
+use tracing::info;
+
+pub struct EthereumRelayer {
+    rpc_client: Provider<Http>,
+    processed_blocks: BTreeMap<H256, Block<H256>>,
+}
+
+impl EthereumRelayer {
+    pub fn new(eth_rpc_url: &str) -> Result<Self> {
+        let rpc_client = Provider::<Http>::try_from(eth_rpc_url)?;
+        Ok(Self {
+            rpc_client,
+            //TODO load processed block from Move state
+            processed_blocks: BTreeMap::new(),
+        })
+    }
+
+    async fn relay_ethereum(&mut self) -> Result<Option<FunctionCall>> {
+        let block = self
+            .rpc_client
+            .get_block(BlockId::Number(BlockNumber::Latest))
+            .await?;
+        match block {
+            Some(block) => {
+                let block_hash = block
+                    .hash
+                    .ok_or_else(|| anyhow::format_err!("The block is a pending block"))?;
+                if self.processed_blocks.contains_key(&block_hash) {
+                    info!("The block {} has already been processed", block_hash);
+                    return Ok(None);
+                }
+                let block_header = BlockHeader::try_from(&block)?;
+                let call = EthereumLightClientModule::create_submit_new_block_call(&block_header);
+                info!(
+                    "EthereumRelayer process block, hash: {}, number: {}, timestamp: {}",
+                    block_hash, block_header.number, block_header.timestamp
+                );
+                self.processed_blocks.insert(block_hash, block);
+                Ok(Some(call))
+            }
+            None => {
+                info!("The RPC returned no block");
+                Ok(None)
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Relayer for EthereumRelayer {
+    async fn relay(&mut self) -> Result<Option<FunctionCall>> {
+        self.relay_ethereum().await
+    }
+}

--- a/crates/rooch-relayer/src/actor/messages.rs
+++ b/crates/rooch-relayer/src/actor/messages.rs
@@ -1,0 +1,13 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use coerce::actor::{message::Message, scheduler::timer::TimerTick};
+
+#[derive(Clone)]
+pub struct RelayTick {}
+
+impl Message for RelayTick {
+    type Result = ();
+}
+
+impl TimerTick for RelayTick {}

--- a/crates/rooch-relayer/src/actor/mod.rs
+++ b/crates/rooch-relayer/src/actor/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod ethereum_relayer;
+pub mod messages;
+pub mod relayer;

--- a/crates/rooch-relayer/src/actor/relayer.rs
+++ b/crates/rooch-relayer/src/actor/relayer.rs
@@ -1,0 +1,115 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use super::ethereum_relayer::EthereumRelayer;
+use super::messages::RelayTick;
+use crate::{Relayer, TxSubmiter};
+use anyhow::Result;
+use async_trait::async_trait;
+use coerce::actor::{context::ActorContext, message::Handler, Actor};
+use moveos_types::{gas_config::GasConfig, transaction::MoveAction};
+use rooch_rpc_api::jsonrpc_types::KeptVMStatusView;
+use rooch_rpc_client::ClientBuilder;
+use rooch_types::{
+    address::RoochAddress,
+    crypto::RoochKeyPair,
+    transaction::{rooch::RoochTransactionData, AbstractTransaction},
+};
+use tracing::{info, warn};
+
+pub struct RelayerActor {
+    chain_id: u64,
+    relayer_address: RoochAddress,
+    max_gas_amount: u64,
+    relayer_key: RoochKeyPair,
+    tx_submiter: Box<dyn TxSubmiter>,
+    relayers: Vec<Box<dyn Relayer>>,
+}
+
+impl RelayerActor {
+    /// Create a new RelayerActor, use rooch_rpc_client::Client as TxSubmiter
+    pub async fn new_for_client(
+        relayer_key: RoochKeyPair,
+        eth_rpc_url: &str,
+        rooch_rpc_url: &str,
+    ) -> Result<Self> {
+        let rooch_rpc_client = ClientBuilder::default().build(rooch_rpc_url).await?;
+        Self::new(relayer_key, eth_rpc_url, rooch_rpc_client).await
+    }
+
+    pub async fn new<T: TxSubmiter + 'static>(
+        relayer_key: RoochKeyPair,
+        eth_rpc_url: &str,
+        tx_submiter: T,
+    ) -> Result<Self> {
+        let chain_id = tx_submiter.get_chain_id().await?;
+        let relayer_address = relayer_key.public().address();
+        let eth_relayer = EthereumRelayer::new(eth_rpc_url)?;
+        let relayers: Vec<Box<dyn Relayer>> = vec![Box::new(eth_relayer)];
+        Ok(Self {
+            chain_id,
+            relayer_address,
+            max_gas_amount: GasConfig::DEFAULT_MAX_GAS_AMOUNT,
+            relayer_key,
+            relayers,
+            tx_submiter: Box::new(tx_submiter),
+        })
+    }
+
+    async fn tick(&mut self) -> Result<()> {
+        for relayer in &mut self.relayers {
+            let relayer_name = relayer.name();
+            match relayer.relay().await {
+                Ok(Some(function_call)) => {
+                    let sequence_number = self
+                        .tx_submiter
+                        .get_sequence_number(self.relayer_address)
+                        .await?;
+                    let action = MoveAction::Function(function_call);
+                    let tx_data = RoochTransactionData::new(
+                        self.relayer_address,
+                        sequence_number,
+                        self.chain_id,
+                        self.max_gas_amount,
+                        action,
+                    );
+                    let tx = tx_data.sign(&self.relayer_key);
+                    let tx_hash = tx.tx_hash();
+                    let result = self.tx_submiter.submit_tx(tx).await?;
+                    match result.execution_info.status {
+                        KeptVMStatusView::Executed => {
+                            info!(
+                                "Relayer {} execute relay tx({}) success",
+                                relayer_name, tx_hash
+                            );
+                        }
+                        _ => {
+                            warn!(
+                                "Relayer {} execute relay tx({}) failed, status: {:?}",
+                                relayer_name, tx_hash, result.execution_info.status
+                            );
+                        }
+                    }
+                }
+                Ok(None) => {
+                    //skip
+                }
+                Err(err) => {
+                    warn!("Relayer {} error: {:?}", relayer_name, err);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Actor for RelayerActor {}
+
+#[async_trait]
+impl Handler<RelayTick> for RelayerActor {
+    async fn handle(&mut self, _message: RelayTick, _ctx: &mut ActorContext) {
+        if let Err(err) = self.tick().await {
+            warn!("Relayer tick task error: {:?}", err);
+        }
+    }
+}

--- a/crates/rooch-relayer/src/lib.rs
+++ b/crates/rooch-relayer/src/lib.rs
@@ -1,0 +1,40 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use async_trait::async_trait;
+use moveos_types::transaction::FunctionCall;
+use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
+use rooch_rpc_client::Client;
+use rooch_types::{address::RoochAddress, transaction::rooch::RoochTransaction};
+
+pub mod actor;
+
+#[async_trait]
+pub trait Relayer: Send + Sync {
+    fn name(&self) -> &'static str {
+        return std::any::type_name::<Self>();
+    }
+
+    async fn relay(&mut self) -> Result<Option<FunctionCall>>;
+}
+
+#[async_trait]
+pub trait TxSubmiter: Send + Sync {
+    async fn get_chain_id(&self) -> Result<u64>;
+    async fn get_sequence_number(&self, address: RoochAddress) -> Result<u64>;
+    async fn submit_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponseView>;
+}
+
+#[async_trait]
+impl TxSubmiter for Client {
+    async fn get_chain_id(&self) -> Result<u64> {
+        self.get_chain_id().await
+    }
+    async fn get_sequence_number(&self, address: RoochAddress) -> Result<u64> {
+        self.get_sequence_number(address).await
+    }
+    async fn submit_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponseView> {
+        self.execute_tx(tx).await
+    }
+}

--- a/crates/rooch-rpc-api/src/api/eth_api.rs
+++ b/crates/rooch-rpc-api/src/api/eth_api.rs
@@ -34,7 +34,7 @@ pub trait EthAPI {
 
     /// Returns the chain ID of the current network.
     #[method(name = "eth_chainId")]
-    async fn get_chain_id(&self) -> RpcResult<String>;
+    async fn eth_chain_id(&self) -> RpcResult<String>;
 
     /// Returns the number of most recent block.
     #[method(name = "eth_blockNumber")]

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -15,6 +15,9 @@ use rooch_open_rpc_macros::open_rpc;
 #[open_rpc(namespace = "rooch")]
 #[rpc(server, client, namespace = "rooch")]
 pub trait RoochAPI {
+    #[method(name = "getChainID")]
+    async fn get_chain_id(&self) -> RpcResult<StrView<u64>>;
+
     /// Send the signed transaction in bcs hex format
     /// This method does not block waiting for the transaction to be executed.
     #[method(name = "sendRawTransaction")]

--- a/crates/rooch-rpc-client/src/lib.rs
+++ b/crates/rooch-rpc-client/src/lib.rs
@@ -96,6 +96,10 @@ pub struct Client {
 // TODO: call args are uniformly defined in jsonrpc types?
 // example execute_view_function get_events_by_event_handle
 impl Client {
+    pub async fn get_chain_id(&self) -> Result<u64> {
+        Ok(self.rpc.http.get_chain_id().await?.0)
+    }
+
     pub async fn execute_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponseView> {
         let tx_payload = bcs::to_bytes(&tx)?;
         self.rpc

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -11,7 +11,6 @@ use coerce::actor::scheduler::timer::Timer;
 use coerce::actor::{system::ActorSystem, IntoActor};
 use hyper::header::HeaderValue;
 use hyper::Method;
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::RpcModule;
 use moveos_store::{MoveOSDB, MoveOSStore};
@@ -27,6 +26,8 @@ use rooch_key::key_derive::generate_new_key_pair;
 use rooch_proposer::actor::messages::ProposeBlock;
 use rooch_proposer::actor::proposer::ProposerActor;
 use rooch_proposer::proxy::ProposerProxy;
+use rooch_relayer::actor::messages::RelayTick;
+use rooch_relayer::actor::relayer::RelayerActor;
 use rooch_rpc_api::api::RoochRpcModule;
 use rooch_sequencer::actor::sequencer::SequencerActor;
 use rooch_sequencer::proxy::SequencerProxy;
@@ -50,21 +51,18 @@ pub mod service;
 /// This exit code means is that the server failed to start and required human intervention.
 static R_EXIT_CODE_NEED_HELP: i32 = 120;
 
-pub fn http_client(url: impl AsRef<str>) -> Result<HttpClient> {
-    let client = HttpClientBuilder::default().build(url)?;
-    Ok(client)
-}
-
 pub struct ServerHandle {
     handle: jsonrpsee::server::ServerHandle,
-    timer: Timer,
+    timers: Vec<Timer>,
     _store_config: StoreConfig,
 }
 
 impl ServerHandle {
     fn stop(self) -> Result<()> {
         self.handle.stop()?;
-        self.timer.stop();
+        for timer in self.timers {
+            timer.stop();
+        }
         Ok(())
     }
 }
@@ -154,7 +152,7 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
     let config = opt.port.map_or(ServerConfig::default(), |port| {
         ServerConfig::new_with_port(port)
     });
-    let chain_id = opt.chain_id.clone().unwrap_or_default().chain_id();
+    let chain_id_opt = opt.chain_id.clone().unwrap_or_default();
 
     let addr: SocketAddr = format!("{}:{}", config.host, config.port).parse()?;
     let actor_system = ActorSystem::global_system();
@@ -166,9 +164,13 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
     let (moveos_store, rooch_store) = init_storage(&store_config)?;
 
     // Init executor
-    let executor = ExecutorActor::new(chain_id.id(), moveos_store, rooch_store.clone())?
-        .into_actor(Some("Executor"), &actor_system)
-        .await?;
+    let executor = ExecutorActor::new(
+        chain_id_opt.genesis_ctx(),
+        moveos_store,
+        rooch_store.clone(),
+    )?
+    .into_actor(Some("Executor"), &actor_system)
+    .await?;
     let executor_proxy = ExecutorProxy::new(executor.into());
 
     // Init sequencer
@@ -189,15 +191,38 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
     let proposer_proxy = ProposerProxy::new(proposer.clone().into());
     //TODO load from config
     let block_propose_duration_in_seconds: u64 = 5;
-    //TODO stop timer
-    let timer = Timer::start(
+    let mut timers = vec![];
+    let proposer_timer = Timer::start(
         proposer,
         Duration::from_secs(block_propose_duration_in_seconds),
         ProposeBlock {},
     );
+    timers.push(proposer_timer);
 
-    let rpc_service = RpcService::new(executor_proxy, sequencer_proxy, proposer_proxy);
+    let rpc_service = RpcService::new(
+        chain_id_opt.chain_id().id(),
+        executor_proxy,
+        sequencer_proxy,
+        proposer_proxy,
+    );
     let aggregate_service = AggregateService::new(rpc_service.clone());
+
+    if let Some(eth_rpc_url) = &opt.eth_rpc_url {
+        //TODO load from config
+        let (_, kp, _, _) =
+            generate_new_key_pair::<RoochAddress, RoochKeyPair>(CoinID::Rooch, None, None)?;
+        let relayer = RelayerActor::new(kp, eth_rpc_url, rpc_service.clone())
+            .await?
+            .into_actor(Some("Relayer"), &actor_system)
+            .await?;
+        let relay_tick_in_seconds: u64 = 5;
+        let relayer_timer = Timer::start(
+            relayer,
+            Duration::from_secs(relay_tick_in_seconds),
+            RelayTick {},
+        );
+        timers.push(relayer_timer);
+    }
 
     let acl = match env::var("ACCESS_CONTROL_ALLOW_ORIGIN") {
         Ok(value) => {
@@ -234,7 +259,8 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
     ))?;
     rpc_module_builder.register_module(WalletServer::new(rpc_service.clone()))?;
 
-    rpc_module_builder.register_module(EthServer::new(chain_id, rpc_service.clone()))?;
+    rpc_module_builder
+        .register_module(EthServer::new(chain_id_opt.chain_id(), rpc_service.clone()))?;
 
     // let rpc_api = build_rpc_api(rpc_api);
     let methods_names = rpc_module_builder.module.method_names().collect::<Vec<_>>();
@@ -245,7 +271,7 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
 
     Ok(ServerHandle {
         handle,
-        timer,
+        timers,
         _store_config: store_config,
     })
 }

--- a/crates/rooch-rpc-server/src/server/eth_server.rs
+++ b/crates/rooch-rpc-server/src/server/eth_server.rs
@@ -52,7 +52,7 @@ impl EthAPIServer for EthServer {
         Ok(String::from("1"))
     }
 
-    async fn get_chain_id(&self) -> RpcResult<String> {
+    async fn eth_chain_id(&self) -> RpcResult<String> {
         Ok(format!("0x{:x}", self.chain_id.id()))
     }
 

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -43,6 +43,11 @@ impl RoochServer {
 
 #[async_trait]
 impl RoochAPIServer for RoochServer {
+    async fn get_chain_id(&self) -> RpcResult<StrView<u64>> {
+        let chain_id = self.rpc_service.get_chain_id();
+        Ok(StrView(chain_id))
+    }
+
     async fn send_raw_transaction(&self, payload: StrView<Vec<u8>>) -> RpcResult<H256View> {
         info!("send_raw_transaction payload: {:?}", payload);
         let tx = bcs::from_bytes::<RoochTransaction>(&payload.0).map_err(anyhow::Error::from)?;

--- a/crates/rooch-types/src/framework/ethereum_address.rs
+++ b/crates/rooch-types/src/framework/ethereum_address.rs
@@ -1,0 +1,39 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
+use ethers::types::H160;
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use moveos_types::state::{MoveStructState, MoveStructType};
+use serde::{Deserialize, Serialize};
+
+pub const MODULE_NAME: &IdentStr = ident_str!("ethereum_address");
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
+pub struct ETHAddress {
+    pub bytes: Vec<u8>,
+}
+
+impl MoveStructType for ETHAddress {
+    const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ETHAddress");
+}
+
+impl MoveStructState for ETHAddress {
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            move_core_types::value::MoveTypeLayout::Vector(Box::new(
+                move_core_types::value::MoveTypeLayout::U8,
+            )),
+        ])
+    }
+}
+
+impl From<H160> for ETHAddress {
+    fn from(value: H160) -> Self {
+        ETHAddress {
+            bytes: value.as_bytes().to_vec(),
+        }
+    }
+}

--- a/crates/rooch-types/src/framework/ethereum_light_client.rs
+++ b/crates/rooch-types/src/framework/ethereum_light_client.rs
@@ -1,0 +1,147 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use super::ethereum_address::ETHAddress;
+use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
+use anyhow::Result;
+use ethers::types::Block;
+use move_core_types::{
+    account_address::AccountAddress,
+    ident_str,
+    identifier::IdentStr,
+    u256::{U256, U256_NUM_BYTES},
+    value::MoveValue,
+};
+use moveos_types::{
+    module_binding::{ModuleBinding, MoveFunctionCaller},
+    transaction::FunctionCall,
+    tx_context::TxContext,
+};
+use serde::{Deserialize, Serialize};
+
+pub const MODULE_NAME: &IdentStr = ident_str!("ethereum_light_client");
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockHeader {
+    /// Hash of the block
+    pub hash: Vec<u8>,
+    /// Hash of the parent
+    pub parent_hash: Vec<u8>,
+    /// Hash of the uncles
+    pub uncles_hash: Vec<u8>,
+    /// Miner/author's address.
+    pub author: ETHAddress,
+    /// State root hash
+    pub state_root: Vec<u8>,
+    /// Transactions root hash
+    pub transactions_root: Vec<u8>,
+    /// Transactions receipts root hash
+    pub receipts_root: Vec<u8>,
+    /// Logs bloom
+    pub logs_bloom: Vec<u8>,
+    /// Difficulty
+    pub difficulty: U256,
+    /// Block number.
+    pub number: u64,
+    /// Gas Limit
+    pub gas_limit: U256,
+    /// Gas Used
+    pub gas_used: U256,
+    /// Timestamp
+    pub timestamp: U256,
+    /// Extra data
+    pub extra_data: Vec<u8>,
+}
+
+impl<T> TryFrom<&Block<T>> for BlockHeader {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &Block<T>) -> std::result::Result<Self, Self::Error> {
+        let block_header = BlockHeader {
+            hash: value
+                .hash
+                .ok_or_else(|| anyhow::format_err!("Unexpected pending block"))?
+                .as_bytes()
+                .to_vec(),
+            parent_hash: value.parent_hash.as_bytes().to_vec(),
+            uncles_hash: value.uncles_hash.as_bytes().to_vec(),
+            author: value
+                .author
+                .ok_or_else(|| anyhow::format_err!("Unexpected pending block"))?
+                .into(),
+            state_root: value.state_root.as_bytes().to_vec(),
+            transactions_root: value.transactions_root.as_bytes().to_vec(),
+            receipts_root: value.receipts_root.as_bytes().to_vec(),
+            logs_bloom: value.logs_bloom.map(|b| b.0.to_vec()).unwrap_or(vec![]),
+            difficulty: eth_u256_to_move_u256(value.difficulty),
+            number: value
+                .number
+                .ok_or_else(|| anyhow::format_err!("Unexpected pending block"))?
+                .as_u64(),
+            gas_limit: eth_u256_to_move_u256(value.gas_limit),
+            gas_used: eth_u256_to_move_u256(value.gas_used),
+            timestamp: eth_u256_to_move_u256(value.timestamp),
+            extra_data: value.extra_data.to_vec(),
+        };
+        Ok(block_header)
+    }
+}
+
+/// Rust bindings for RoochFramework session_key module
+pub struct EthereumLightClientModule<'a> {
+    caller: &'a dyn MoveFunctionCaller,
+}
+
+impl<'a> EthereumLightClientModule<'a> {
+    pub const GET_BLOCK_FUNCTION_NAME: &'static IdentStr = ident_str!("get_block");
+    pub const SUBMIT_NEW_BLOCK_ENTRY_FUNCTION_NAME: &'static IdentStr =
+        ident_str!("submit_new_block");
+
+    pub fn get_block(&self, block_number: u64) -> Result<BlockHeader> {
+        let call = FunctionCall::new(
+            Self::function_id(Self::GET_BLOCK_FUNCTION_NAME),
+            vec![],
+            vec![MoveValue::U64(block_number).simple_serialize().unwrap()],
+        );
+        let ctx = TxContext::new_readonly_ctx(AccountAddress::ZERO);
+        let block_header =
+            self.caller
+                .call_function(&ctx, call)?
+                .into_result()
+                .map(|mut values| {
+                    let value = values.pop().expect("should have one return value");
+                    bcs::from_bytes::<BlockHeader>(&value.value)
+                        .expect("should be a valid BlockHeader")
+                })?;
+        Ok(block_header)
+    }
+
+    pub fn create_submit_new_block_call(block_header: &BlockHeader) -> FunctionCall {
+        Self::create_function_call(
+            Self::SUBMIT_NEW_BLOCK_ENTRY_FUNCTION_NAME,
+            vec![],
+            vec![MoveValue::vector_u8(
+                bcs::to_bytes(&block_header).expect("Serialize BlockHeader should success."),
+            )],
+        )
+    }
+}
+
+impl<'a> ModuleBinding<'a> for EthereumLightClientModule<'a> {
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const MODULE_ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+
+    fn new(caller: &'a impl MoveFunctionCaller) -> Self
+    where
+        Self: Sized,
+    {
+        Self { caller }
+    }
+}
+
+//TODO implement From<PrimitiveU256> for U256 in move side
+fn eth_u256_to_move_u256(value: ethers::types::U256) -> U256 {
+    let mut bytes = [0u8; U256_NUM_BYTES];
+    value.to_little_endian(&mut bytes);
+    U256::from_le_bytes(&bytes)
+}

--- a/crates/rooch-types/src/framework/genesis.rs
+++ b/crates/rooch-types/src/framework/genesis.rs
@@ -11,6 +11,8 @@ pub const MODULE_NAME: &IdentStr = ident_str!("genesis");
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GenesisContext {
     pub chain_id: u64,
+    /// The timestamp of the genesis, in microseconds
+    pub timestamp: u64,
 }
 
 impl MoveStructType for GenesisContext {
@@ -23,12 +25,16 @@ impl MoveStructState for GenesisContext {
     fn struct_layout() -> move_core_types::value::MoveStructLayout {
         move_core_types::value::MoveStructLayout::new(vec![
             move_core_types::value::MoveTypeLayout::U64,
+            move_core_types::value::MoveTypeLayout::U64,
         ])
     }
 }
 
 impl GenesisContext {
-    pub fn new(chain_id: u64) -> Self {
-        Self { chain_id }
+    pub fn new(chain_id: u64, timestamp: u64) -> Self {
+        Self {
+            chain_id,
+            timestamp,
+        }
     }
 }

--- a/crates/rooch-types/src/framework/mod.rs
+++ b/crates/rooch-types/src/framework/mod.rs
@@ -12,10 +12,13 @@ pub mod address_mapping;
 pub mod auth_validator;
 pub mod coin;
 pub mod empty;
+pub mod ethereum_address;
+pub mod ethereum_light_client;
 pub mod ethereum_validator;
 pub mod genesis;
 pub mod native_validator;
 pub mod session_key;
+pub mod timestamp;
 pub mod transaction_validator;
 
 /// MoveOS system pre_execute functions registry.

--- a/crates/rooch-types/src/framework/timestamp.rs
+++ b/crates/rooch-types/src/framework/timestamp.rs
@@ -1,0 +1,92 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
+use anyhow::Result;
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use moveos_types::{
+    module_binding::{ModuleBinding, MoveFunctionCaller},
+    state::{MoveStructState, MoveStructType},
+    transaction::FunctionCall,
+    tx_context::TxContext,
+};
+use serde::{Deserialize, Serialize};
+
+pub const MODULE_NAME: &IdentStr = ident_str!("timestamp");
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct CurrentTimeMicroseconds {
+    pub microseconds: u64,
+}
+
+impl MoveStructType for CurrentTimeMicroseconds {
+    const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("CurrentTimeMicroseconds");
+}
+
+impl MoveStructState for CurrentTimeMicroseconds {
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            move_core_types::value::MoveTypeLayout::U64,
+        ])
+    }
+}
+
+/// Rust bindings for RoochFramework timestamp module
+pub struct TimestampModule<'a> {
+    caller: &'a dyn MoveFunctionCaller,
+}
+
+impl<'a> TimestampModule<'a> {
+    pub const NOW_MICROSECONDS_FUNCTION_NAME: &'static IdentStr = ident_str!("now_microseconds");
+    pub const NOW_SECONDS_FUNCTION_NAME: &'static IdentStr = ident_str!("now_seconds");
+
+    pub fn now_microseconds(&self) -> Result<u64> {
+        let call = FunctionCall::new(
+            Self::function_id(Self::NOW_MICROSECONDS_FUNCTION_NAME),
+            vec![],
+            vec![],
+        );
+        let ctx = TxContext::zero();
+        let session_key =
+            self.caller
+                .call_function(&ctx, call)?
+                .into_result()
+                .map(|mut values| {
+                    let value = values.pop().expect("should have one return value");
+                    bcs::from_bytes::<u64>(&value.value).expect("should be a valid u64")
+                })?;
+        Ok(session_key)
+    }
+
+    pub fn now_seconds(&self) -> Result<u64> {
+        let call = FunctionCall::new(
+            Self::function_id(Self::NOW_SECONDS_FUNCTION_NAME),
+            vec![],
+            vec![],
+        );
+        let ctx = TxContext::zero();
+        let session_key =
+            self.caller
+                .call_function(&ctx, call)?
+                .into_result()
+                .map(|mut values| {
+                    let value = values.pop().expect("should have one return value");
+                    bcs::from_bytes::<u64>(&value.value).expect("should be a valid u64")
+                })?;
+        Ok(session_key)
+    }
+}
+
+impl<'a> ModuleBinding<'a> for TimestampModule<'a> {
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const MODULE_ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+
+    fn new(caller: &'a impl MoveFunctionCaller) -> Self
+    where
+        Self: Sized,
+    {
+        Self { caller }
+    }
+}

--- a/crates/rooch-types/src/transaction/rooch.rs
+++ b/crates/rooch-types/src/transaction/rooch.rs
@@ -4,7 +4,7 @@
 use super::{
     authenticator::Authenticator, AbstractTransaction, AuthenticatorInfo, TransactionType,
 };
-use crate::crypto::{Ed25519RoochSignature, Signature};
+use crate::crypto::{Ed25519RoochSignature, RoochKeyPair, Signature};
 use crate::H256;
 use crate::{address::RoochAddress, chain_id::RoochChainID};
 use anyhow::Result;
@@ -64,6 +64,13 @@ impl RoochTransactionData {
 
     pub fn hash(&self) -> H256 {
         moveos_types::h256::sha3_256_of(self.encode().as_slice())
+    }
+
+    pub fn sign(self, kp: &RoochKeyPair) -> RoochTransaction {
+        let signature = Signature::new_hashed(self.hash().as_bytes(), kp);
+        //TODO implement Signature into Authenticator
+        let authenticator = Authenticator::rooch(signature);
+        RoochTransaction::new(self, authenticator)
     }
 }
 

--- a/crates/rooch/src/commands/server/commands/clean.rs
+++ b/crates/rooch/src/commands/server/commands/clean.rs
@@ -3,9 +3,7 @@
 
 use clap::Parser;
 use rooch_config::store_config::StoreConfig;
-use rooch_config::R_OPT_NET_HELP;
 use rooch_config::{BaseConfig, RoochOpt};
-use rooch_types::chain_id::RoochChainID;
 use rooch_types::error::{RoochError, RoochResult};
 use std::sync::Arc;
 use std::{fs, path::Path};
@@ -13,21 +11,15 @@ use std::{fs, path::Path};
 /// Clean the Rooch server storage
 #[derive(Debug, Parser)]
 pub struct CleanCommand {
-    #[clap(long, short = 'n', help = R_OPT_NET_HELP)]
-    pub chain_id: Option<RoochChainID>,
+    #[clap(flatten)]
+    opt: RoochOpt,
 }
 
 impl CleanCommand {
     pub fn execute(self) -> RoochResult<()> {
-        let opt = RoochOpt {
-            base_data_dir: None,
-            chain_id: self.chain_id.clone(),
-            store: None,
-            port: None,
-        };
-        let base_config = BaseConfig::load_with_opt(&opt)?;
+        let base_config = BaseConfig::load_with_opt(&self.opt)?;
         let mut store_config = StoreConfig::default();
-        store_config.merge_with_opt_then_init(&opt, Arc::new(base_config))?;
+        store_config.merge_with_opt_then_init(&self.opt, Arc::new(base_config))?;
 
         let rooch_store_dir = store_config.get_rooch_store_dir();
         let moveos_store_dir = store_config.get_moveos_store_dir();

--- a/crates/rooch/src/commands/server/commands/start.rs
+++ b/crates/rooch/src/commands/server/commands/start.rs
@@ -5,9 +5,7 @@ use crate::cli_types::CommandAction;
 use async_trait::async_trait;
 use clap::Parser;
 use rooch_config::RoochOpt;
-use rooch_config::R_OPT_NET_HELP;
 use rooch_rpc_server::Service;
-use rooch_types::chain_id::RoochChainID;
 use rooch_types::error::{RoochError, RoochResult};
 use tokio::signal::ctrl_c;
 #[cfg(unix)]
@@ -17,26 +15,15 @@ use tracing::info;
 /// Start service
 #[derive(Debug, Parser)]
 pub struct StartCommand {
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    #[clap(long, short = 'n', help = R_OPT_NET_HELP)]
-    pub chain_id: Option<RoochChainID>,
-
-    /// The port on which the server should listen defaults to `50051`
-    #[clap(long, short = 'p')]
-    pub port: Option<u16>,
+    #[clap(flatten)]
+    opt: RoochOpt,
 }
 
 #[async_trait]
 impl CommandAction<()> for StartCommand {
     async fn execute(self) -> RoochResult<()> {
         let mut service = Service::new();
-        let rooch_opt = RoochOpt {
-            base_data_dir: None,
-            chain_id: self.chain_id,
-            store: None,
-            port: self.port,
-        };
-        service.start(&rooch_opt).await.map_err(RoochError::from)?;
+        service.start(&self.opt).await.map_err(RoochError::from)?;
 
         #[cfg(unix)]
         {

--- a/moveos/moveos-types/src/module_binding.rs
+++ b/moveos/moveos-types/src/module_binding.rs
@@ -53,13 +53,22 @@ pub trait ModuleBinding<'a> {
         ty_args: Vec<TypeTag>,
         args: Vec<MoveValue>,
     ) -> MoveAction {
-        MoveAction::Function(FunctionCall::new(
+        MoveAction::Function(Self::create_function_call(function_name, ty_args, args))
+    }
+
+    /// Çonstruct a FunctionCall
+    fn create_function_call(
+        function_name: &IdentStr,
+        ty_args: Vec<TypeTag>,
+        args: Vec<MoveValue>,
+    ) -> FunctionCall {
+        FunctionCall::new(
             Self::function_id(function_name),
             ty_args,
             args.into_iter()
                 .map(|v| v.simple_serialize().expect("Failed to serialize MoveValue"))
                 .collect(),
-        ))
+        )
     }
 
     fn new(caller: &'a impl MoveFunctionCaller) -> Self

--- a/scripts/pr.sh
+++ b/scripts/pr.sh
@@ -95,8 +95,8 @@ fi
 cargo build
 
 if [ ! -z "$ALSO_TEST" ]; then
-    cargo run --package rooch-genesis
-    cargo nextest run --workspace --all-features
+    cargo nextest run --workspace --all-features --exclude rooch-framework-tests --exclude rooch-integration-test-runner -v
+    cargo nextest run -p rooch-framework-tests -p rooch-integration-test-runner -v -j 1
     cargo test -p testsuite --test integration
 fi
 


### PR DESCRIPTION
## Summary

* Introduce the Timestamp module.
* Implement Relayer and relay Ethereum block header to rooch, and update the timestamp.
* Refactor the `rooch server start` CLI option, directly flatten the `RoochOpt`.
* Add the `eth_rpc_url` option to the `server start` command. If the option is provided, the relayer server will be started.

```bash
rooch server start -n dev --eth-rpc-url https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161
```

<img width="1496" alt="Screen Shot 2023-09-13 at 11 33 40" src="https://github.com/rooch-network/rooch/assets/77268/50dd71f6-20ef-4278-a90c-fee20bf383d8">

Get the timestamp
```bash
rooch state --access-path /resource/0x3/0x3::timestamp::CurrentTimeMicroseconds
```
```json
[
  {
    "state": {
      "value": "0x009f313a35050600",
      "value_type": "0x3::timestamp::CurrentTimeMicroseconds"
    },
    "move_value": {
      "abilities": 8,
      "type": "0x3::timestamp::CurrentTimeMicroseconds",
      "value": {
        "microseconds": "1694576028000000"
      }
    }
  }
]
```

TODO:

1. Support a method for dev network update timestamp.
2. Implement session key expiration based on timestamp.

- Closes #534 

Part of #779 