### PR TITLE
[gh-791] move coin_id to multichain_id.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7378,6 +7378,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bip32",
+ "clap 3.2.25",
  "derive_more",
  "enum_dispatch",
  "ethers",

--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -58,11 +58,7 @@ fn test_submit_block() {
     let action = MoveAction::Function(rooch_types::framework::ethereum_light_client::EthereumLightClientModule::create_submit_new_block_call(&block_header));
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(
-            &sender,
-            tx_data,
-            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-        )
+        .sign_transaction(&sender, tx_data, RoochMultiChainID::Rooch)
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -6,7 +6,6 @@ use ethers::prelude::*;
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
-use rooch_types::chain_id::{BuiltinChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::ethereum_light_client::BlockHeader;
 use rooch_types::multichain_id::RoochMultiChainID;

--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -4,11 +4,11 @@
 use crate::binding_test;
 use ethers::prelude::*;
 use moveos_types::transaction::MoveAction;
+use rooch_key::keypair::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::ethereum_light_client::BlockHeader;
-use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::rooch::RoochTransactionData;
 
 #[test]
@@ -57,7 +57,7 @@ fn test_submit_block() {
     let action = MoveAction::Function(rooch_types::framework::ethereum_light_client::EthereumLightClientModule::create_submit_new_block_call(&block_header));
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, RoochMultiChainID::Rooch)
+        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -6,9 +6,10 @@ use ethers::prelude::*;
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
-use rooch_types::coin_type::CoinID;
+use rooch_types::chain_id::{BuiltinChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::ethereum_light_client::BlockHeader;
+use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::rooch::RoochTransactionData;
 
 #[test]
@@ -57,7 +58,11 @@ fn test_submit_block() {
     let action = MoveAction::Function(rooch_types::framework::ethereum_light_client::EthereumLightClientModule::create_submit_new_block_call(&block_header));
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, CoinID::Rooch)
+        .sign_transaction(
+            &sender,
+            tx_data,
+            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
+        )
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -31,7 +31,7 @@ fn test_validate() {
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     keystore
-        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::ETHER)
+        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::Ether)
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -4,10 +4,10 @@
 use ethers::types::{Bytes, U256};
 use fastcrypto::secp256k1::recoverable::Secp256k1RecoverableKeyPair;
 use moveos_types::transaction::MoveAction;
+use rooch_key::keypair::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress};
 use rooch_types::framework::empty::Empty;
-use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::ethereum::EthereumTransactionData;
 use rooch_types::transaction::AbstractTransaction;
 
@@ -31,7 +31,7 @@ fn test_validate() {
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     keystore
-        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::Ether)
+        .sign_transaction(&sender, tx_data.clone(), KeyPairType::EthereumKeyPairType)
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -6,7 +6,7 @@ use fastcrypto::secp256k1::recoverable::Secp256k1RecoverableKeyPair;
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress};
-use rooch_types::coin_type::CoinID;
+use rooch_types::chain_id::{CustomChainID, RoochChainID};
 use rooch_types::framework::empty::Empty;
 use rooch_types::transaction::ethereum::EthereumTransactionData;
 use rooch_types::transaction::AbstractTransaction;
@@ -31,7 +31,11 @@ fn test_validate() {
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     keystore
-        .sign_transaction(&sender, tx_data.clone(), CoinID::Ether)
+        .sign_transaction(
+            &sender,
+            tx_data.clone(),
+            RoochChainID::from(CustomChainID::ethereum()),
+        )
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -6,8 +6,8 @@ use fastcrypto::secp256k1::recoverable::Secp256k1RecoverableKeyPair;
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress};
-use rooch_types::chain_id::{CustomChainID, RoochChainID};
 use rooch_types::framework::empty::Empty;
+use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::ethereum::EthereumTransactionData;
 use rooch_types::transaction::AbstractTransaction;
 
@@ -31,11 +31,7 @@ fn test_validate() {
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     keystore
-        .sign_transaction(
-            &sender,
-            tx_data.clone(),
-            RoochChainID::from(CustomChainID::ethereum()),
-        )
+        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::ETHEREUM)
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -31,7 +31,7 @@ fn test_validate() {
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     keystore
-        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::ETHEREUM)
+        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::ETHER)
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);

--- a/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
@@ -4,7 +4,7 @@
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
-use rooch_types::coin_type::CoinID;
+use rooch_types::chain_id::RoochChainID;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::empty::Empty;
 use rooch_types::transaction::{rooch::RoochTransactionData, AbstractTransaction};
@@ -24,7 +24,7 @@ fn test_validate() {
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, CoinID::Rooch)
+        .sign_transaction(&sender, tx_data, RoochChainID::DEV)
         .unwrap();
     let auth_info = tx.authenticator_info().unwrap();
     let move_tx = tx.construct_moveos_transaction(sender.into()).unwrap();

--- a/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
@@ -4,7 +4,6 @@
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
-use rooch_types::chain_id::{BuiltinChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::empty::Empty;
 use rooch_types::multichain_id::RoochMultiChainID;

--- a/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use moveos_types::transaction::MoveAction;
+use rooch_key::keypair::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::empty::Empty;
-use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::{rooch::RoochTransactionData, AbstractTransaction};
 
 use crate::binding_test;
@@ -24,7 +24,7 @@ fn test_validate() {
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, RoochMultiChainID::Rooch)
+        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
         .unwrap();
     let auth_info = tx.authenticator_info().unwrap();
     let move_tx = tx.construct_moveos_transaction(sender.into()).unwrap();

--- a/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
@@ -4,9 +4,10 @@
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
-use rooch_types::chain_id::RoochChainID;
+use rooch_types::chain_id::{BuiltinChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::empty::Empty;
+use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::{rooch::RoochTransactionData, AbstractTransaction};
 
 use crate::binding_test;
@@ -24,7 +25,11 @@ fn test_validate() {
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, RoochChainID::DEV)
+        .sign_transaction(
+            &sender,
+            tx_data,
+            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
+        )
         .unwrap();
     let auth_info = tx.authenticator_info().unwrap();
     let move_tx = tx.construct_moveos_transaction(sender.into()).unwrap();

--- a/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
@@ -25,11 +25,7 @@ fn test_validate() {
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(
-            &sender,
-            tx_data,
-            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-        )
+        .sign_transaction(&sender, tx_data, RoochMultiChainID::Rooch)
         .unwrap();
     let auth_info = tx.authenticator_info().unwrap();
     let move_tx = tx.construct_moveos_transaction(sender.into()).unwrap();

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -10,6 +10,7 @@ use move_core_types::value::MoveValue;
 use move_core_types::vm_status::{AbortLocation, VMStatus};
 use moveos_types::move_types::FunctionId;
 use moveos_types::{module_binding::ModuleBinding, transaction::MoveAction};
+use rooch_key::keypair::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress, RoochAddress};
 use rooch_types::crypto::RoochKeyPair;
@@ -38,7 +39,7 @@ fn test_validate_rooch() {
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, RoochMultiChainID::Rooch)
+        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
         .unwrap();
     let auth_info = tx.authenticator_info().unwrap();
     let move_tx = tx.construct_moveos_transaction(sender.into()).unwrap();
@@ -68,7 +69,7 @@ fn test_validate_ethereum() {
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     let (_, _sig) = keystore
-        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::Ether)
+        .sign_transaction(&sender, tx_data.clone(), KeyPairType::EthereumKeyPairType)
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);
@@ -110,7 +111,7 @@ fn test_session_key_rooch() {
     );
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, RoochMultiChainID::Rooch)
+        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -39,11 +39,7 @@ fn test_validate_rooch() {
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(
-            &sender,
-            tx_data,
-            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-        )
+        .sign_transaction(&sender, tx_data, RoochMultiChainID::Rooch)
         .unwrap();
     let auth_info = tx.authenticator_info().unwrap();
     let move_tx = tx.construct_moveos_transaction(sender.into()).unwrap();
@@ -73,7 +69,7 @@ fn test_validate_ethereum() {
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     let (_, _sig) = keystore
-        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::ETHER)
+        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::Ether)
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);
@@ -115,11 +111,7 @@ fn test_session_key_rooch() {
     );
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(
-            &sender,
-            tx_data,
-            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-        )
+        .sign_transaction(&sender, tx_data, RoochMultiChainID::Rooch)
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -12,7 +12,6 @@ use moveos_types::move_types::FunctionId;
 use moveos_types::{module_binding::ModuleBinding, transaction::MoveAction};
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress, RoochAddress};
-use rooch_types::chain_id::{BuiltinChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::session_key::SessionKeyModule;
 use rooch_types::framework::timestamp::TimestampModule;

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -12,7 +12,7 @@ use moveos_types::move_types::FunctionId;
 use moveos_types::{module_binding::ModuleBinding, transaction::MoveAction};
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress, RoochAddress};
-use rooch_types::coin_type::CoinID;
+use rooch_types::chain_id::{CustomChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::session_key::SessionKeyModule;
 use rooch_types::framework::timestamp::TimestampModule;
@@ -38,7 +38,7 @@ fn test_validate_rooch() {
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, CoinID::Rooch)
+        .sign_transaction(&sender, tx_data, RoochChainID::DEV)
         .unwrap();
     let auth_info = tx.authenticator_info().unwrap();
     let move_tx = tx.construct_moveos_transaction(sender.into()).unwrap();
@@ -68,7 +68,11 @@ fn test_validate_ethereum() {
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     keystore
-        .sign_transaction(&sender, tx_data.clone(), CoinID::Ether)
+        .sign_transaction(
+            &sender,
+            tx_data.clone(),
+            RoochChainID::from(CustomChainID::ethereum()),
+        )
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);
@@ -110,7 +114,7 @@ fn test_session_key_rooch() {
     );
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, CoinID::Rooch)
+        .sign_transaction(&sender, tx_data, RoochChainID::DEV)
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -12,7 +12,7 @@ use moveos_types::move_types::FunctionId;
 use moveos_types::{module_binding::ModuleBinding, transaction::MoveAction};
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress, RoochAddress};
-use rooch_types::chain_id::{BuiltinChainID, CustomChainID, RoochChainID, RoochMultiChainID};
+use rooch_types::chain_id::{BuiltinChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::session_key::SessionKeyModule;
 use rooch_types::framework::timestamp::TimestampModule;
@@ -72,8 +72,8 @@ fn test_validate_ethereum() {
     let action_bytes =
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
-    keystore
-        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::ETHEREUM)
+    let (_, _sig) = keystore
+        .sign_transaction(&sender, tx_data.clone(), RoochMultiChainID::ETHER)
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);
@@ -115,7 +115,11 @@ fn test_session_key_rooch() {
     );
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, RoochMultiCh)
+        .sign_transaction(
+            &sender,
+            tx_data,
+            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
+        )
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -16,7 +16,6 @@ use rooch_types::address::{EthereumAddress, MultiChainAddress, RoochAddress};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::session_key::SessionKeyModule;
 use rooch_types::framework::timestamp::TimestampModule;
-use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::ethereum::EthereumTransactionData;
 use rooch_types::{addresses::ROOCH_FRAMEWORK_ADDRESS, framework::empty::Empty};
 use rooch_types::{
@@ -184,7 +183,7 @@ fn test_session_key_rooch() {
     let tx_data =
         RoochTransactionData::new_for_test(sender, sequence_number + 2, update_time_action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, CoinID::Rooch)
+        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework/doc/address_mapping.md
+++ b/crates/rooch-framework/doc/address_mapping.md
@@ -95,6 +95,15 @@
 ## Constants
 
 
+<a name="0x3_address_mapping_CHAIN_ID_ROOCH"></a>
+
+
+
+<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_CHAIN_ID_ROOCH">CHAIN_ID_ROOCH</a>: u64 = 20230103;
+</code></pre>
+
+
+
 <a name="0x3_address_mapping_MULTICHAIN_ID_BITCOIN"></a>
 
 
@@ -104,11 +113,11 @@
 
 
 
-<a name="0x3_address_mapping_MULTICHAIN_ID_ETHER"></a>
+<a name="0x3_address_mapping_MULTICHAIN_ID_ETHEREUM"></a>
 
 
 
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ETHER">MULTICHAIN_ID_ETHER</a>: u64 = 60;
+<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ETHEREUM">MULTICHAIN_ID_ETHEREUM</a>: u64 = 60;
 </code></pre>
 
 
@@ -118,15 +127,6 @@
 
 
 <pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_NOSTR">MULTICHAIN_ID_NOSTR</a>: u64 = 1237;
-</code></pre>
-
-
-
-<a name="0x3_address_mapping_MULTICHAIN_ID_ROOCH"></a>
-
-
-
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>: u64 = 20230103;
 </code></pre>
 
 
@@ -147,7 +147,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(maddress: &<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) : bool{
-    maddress.multichain_id == <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>
+    maddress.multichain_id == <a href="address_mapping.md#0x3_address_mapping_CHAIN_ID_ROOCH">CHAIN_ID_ROOCH</a>
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/address_mapping.md
+++ b/crates/rooch-framework/doc/address_mapping.md
@@ -47,7 +47,7 @@
 
 <dl>
 <dt>
-<code>coin_id: u64</code>
+<code>multichain_id: u64</code>
 </dt>
 <dd>
 
@@ -95,38 +95,38 @@
 ## Constants
 
 
-<a name="0x3_address_mapping_COIN_ID_BITCOIN"></a>
+<a name="0x3_address_mapping_MULTICHAIN_ID_BITCOIN"></a>
 
 
 
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_COIN_ID_BITCOIN">COIN_ID_BITCOIN</a>: u64 = 0;
+<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_BITCOIN">MULTICHAIN_ID_BITCOIN</a>: u64 = 0;
 </code></pre>
 
 
 
-<a name="0x3_address_mapping_COIN_ID_ETHER"></a>
+<a name="0x3_address_mapping_MULTICHAIN_ID_ETHER"></a>
 
 
 
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_COIN_ID_ETHER">COIN_ID_ETHER</a>: u64 = 60;
+<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ETHER">MULTICHAIN_ID_ETHER</a>: u64 = 60;
 </code></pre>
 
 
 
-<a name="0x3_address_mapping_COIN_ID_NOSTR"></a>
+<a name="0x3_address_mapping_MULTICHAIN_ID_NOSTR"></a>
 
 
 
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_COIN_ID_NOSTR">COIN_ID_NOSTR</a>: u64 = 1237;
+<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_NOSTR">MULTICHAIN_ID_NOSTR</a>: u64 = 1237;
 </code></pre>
 
 
 
-<a name="0x3_address_mapping_COIN_ID_ROOCH"></a>
+<a name="0x3_address_mapping_MULTICHAIN_ID_ROOCH"></a>
 
 
 
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_COIN_ID_ROOCH">COIN_ID_ROOCH</a>: u64 = 20230101;
+<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>: u64 = 20230103;
 </code></pre>
 
 
@@ -147,7 +147,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(maddress: &<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) : bool{
-    maddress.coin_id == <a href="address_mapping.md#0x3_address_mapping_COIN_ID_ROOCH">COIN_ID_ROOCH</a>
+    maddress.multichain_id == <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/address_mapping.md
+++ b/crates/rooch-framework/doc/address_mapping.md
@@ -95,15 +95,6 @@
 ## Constants
 
 
-<a name="0x3_address_mapping_CHAIN_ID_ROOCH"></a>
-
-
-
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_CHAIN_ID_ROOCH">CHAIN_ID_ROOCH</a>: u64 = 20230103;
-</code></pre>
-
-
-
 <a name="0x3_address_mapping_MULTICHAIN_ID_BITCOIN"></a>
 
 
@@ -113,11 +104,11 @@
 
 
 
-<a name="0x3_address_mapping_MULTICHAIN_ID_ETHEREUM"></a>
+<a name="0x3_address_mapping_MULTICHAIN_ID_ETHER"></a>
 
 
 
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ETHEREUM">MULTICHAIN_ID_ETHEREUM</a>: u64 = 60;
+<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ETHER">MULTICHAIN_ID_ETHER</a>: u64 = 60;
 </code></pre>
 
 
@@ -127,6 +118,15 @@
 
 
 <pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_NOSTR">MULTICHAIN_ID_NOSTR</a>: u64 = 1237;
+</code></pre>
+
+
+
+<a name="0x3_address_mapping_MULTICHAIN_ID_ROOCH"></a>
+
+
+
+<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>: u64 = 20230103;
 </code></pre>
 
 
@@ -147,7 +147,7 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(maddress: &<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) : bool{
-    maddress.multichain_id == <a href="address_mapping.md#0x3_address_mapping_CHAIN_ID_ROOCH">CHAIN_ID_ROOCH</a>
+    maddress.multichain_id == <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/address_mapping.md
+++ b/crates/rooch-framework/doc/address_mapping.md
@@ -126,7 +126,7 @@
 
 
 
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>: u64 = 20230103;
+<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>: u64 = 20230101;
 </code></pre>
 
 

--- a/crates/rooch-framework/doc/auth_validator.md
+++ b/crates/rooch-framework/doc/auth_validator.md
@@ -21,7 +21,7 @@ fun post_execute(ctx: &mut StorageContext)
 -  [Function `validator_module_name`](#0x3_auth_validator_validator_module_name)
 -  [Function `new_tx_validate_result`](#0x3_auth_validator_new_tx_validate_result)
 -  [Function `get_validate_result_from_tx_ctx`](#0x3_auth_validator_get_validate_result_from_tx_ctx)
--  [Function `get_validator_scheme_from_tx_ctx`](#0x3_auth_validator_get_validator_scheme_from_tx_ctx)
+-  [Function `get_validator_multichain_id_from_tx_ctx`](#0x3_auth_validator_get_validator_multichain_id_from_tx_ctx)
 -  [Function `get_session_key_from_tx_ctx_option`](#0x3_auth_validator_get_session_key_from_tx_ctx_option)
 -  [Function `is_validate_via_session_key`](#0x3_auth_validator_is_validate_via_session_key)
 -  [Function `get_session_key_from_tx_ctx`](#0x3_auth_validator_get_session_key_from_tx_ctx)
@@ -94,10 +94,10 @@ this result will be stored in the TxContext
 
 <dl>
 <dt>
-<code>scheme: u64</code>
+<code>multichain_id: u64</code>
 </dt>
 <dd>
- The auth validator's scheme that validate the transaction
+ The auth validator's multichain id that validate the transaction
 </dd>
 <dt>
 <code><a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;</code>
@@ -309,7 +309,7 @@ InvalidAuthenticator, include invalid signature
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(scheme: u64, <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;, <a href="session_key.md#0x3_session_key">session_key</a>: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(multichain_id: u64, <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;, <a href="session_key.md#0x3_session_key">session_key</a>: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
 </code></pre>
 
 
@@ -319,12 +319,12 @@ InvalidAuthenticator, include invalid signature
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(
-    scheme: u64,
+    multichain_id: u64,
     <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: Option&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">AuthValidator</a>&gt;,
     <a href="session_key.md#0x3_session_key">session_key</a>: Option&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 ): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a> {
     <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a> {
-        scheme: scheme,
+        multichain_id: multichain_id,
         <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>,
         <a href="session_key.md#0x3_session_key">session_key</a>: <a href="session_key.md#0x3_session_key">session_key</a>,
     }
@@ -362,14 +362,14 @@ Get the TxValidateResult from the TxContext, Only can be called after the transa
 
 </details>
 
-<a name="0x3_auth_validator_get_validator_scheme_from_tx_ctx"></a>
+<a name="0x3_auth_validator_get_validator_multichain_id_from_tx_ctx"></a>
 
-## Function `get_validator_scheme_from_tx_ctx`
+## Function `get_validator_multichain_id_from_tx_ctx`
 
-Get the auth validator's scheme from the TxValidateResult in the TxContext
+Get the auth validator's multichain id from the TxValidateResult in the TxContext
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_scheme_from_tx_ctx">get_validator_scheme_from_tx_ctx</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_multichain_id_from_tx_ctx">get_validator_multichain_id_from_tx_ctx</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
 </code></pre>
 
 
@@ -378,9 +378,9 @@ Get the auth validator's scheme from the TxValidateResult in the TxContext
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_scheme_from_tx_ctx">get_validator_scheme_from_tx_ctx</a>(ctx: &StorageContext): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_multichain_id_from_tx_ctx">get_validator_multichain_id_from_tx_ctx</a>(ctx: &StorageContext): u64 {
     <b>let</b> validate_result = <a href="auth_validator.md#0x3_auth_validator_get_validate_result_from_tx_ctx">get_validate_result_from_tx_ctx</a>(ctx);
-    validate_result.scheme
+    validate_result.multichain_id
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/auth_validator.md
+++ b/crates/rooch-framework/doc/auth_validator.md
@@ -21,7 +21,7 @@ fun post_execute(ctx: &mut StorageContext)
 -  [Function `validator_module_name`](#0x3_auth_validator_validator_module_name)
 -  [Function `new_tx_validate_result`](#0x3_auth_validator_new_tx_validate_result)
 -  [Function `get_validate_result_from_tx_ctx`](#0x3_auth_validator_get_validate_result_from_tx_ctx)
--  [Function `get_validator_scheme_from_tx_ctx`](#0x3_auth_validator_get_validator_scheme_from_tx_ctx)
+-  [Function `get_validator_id_from_tx_ctx`](#0x3_auth_validator_get_validator_id_from_tx_ctx)
 -  [Function `get_session_key_from_tx_ctx_option`](#0x3_auth_validator_get_session_key_from_tx_ctx_option)
 -  [Function `is_validate_via_session_key`](#0x3_auth_validator_is_validate_via_session_key)
 -  [Function `get_session_key_from_tx_ctx`](#0x3_auth_validator_get_session_key_from_tx_ctx)
@@ -94,10 +94,10 @@ this result will be stored in the TxContext
 
 <dl>
 <dt>
-<code>scheme: u64</code>
+<code>auth_validator_id: u64</code>
 </dt>
 <dd>
- The auth validator's scheme that validate the transaction
+ The auth validator's auth validator id that validate the transaction
 </dd>
 <dt>
 <code><a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;</code>
@@ -309,7 +309,7 @@ InvalidAuthenticator, include invalid signature
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(scheme: u64, <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;, <a href="session_key.md#0x3_session_key">session_key</a>: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(auth_validator_id: u64, <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;, <a href="session_key.md#0x3_session_key">session_key</a>: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
 </code></pre>
 
 
@@ -319,12 +319,12 @@ InvalidAuthenticator, include invalid signature
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(
-    scheme: u64,
+    auth_validator_id: u64,
     <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: Option&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">AuthValidator</a>&gt;,
     <a href="session_key.md#0x3_session_key">session_key</a>: Option&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 ): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a> {
     <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a> {
-        scheme: scheme,
+        auth_validator_id: auth_validator_id,
         <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>,
         <a href="session_key.md#0x3_session_key">session_key</a>: <a href="session_key.md#0x3_session_key">session_key</a>,
     }
@@ -362,14 +362,14 @@ Get the TxValidateResult from the TxContext, Only can be called after the transa
 
 </details>
 
-<a name="0x3_auth_validator_get_validator_scheme_from_tx_ctx"></a>
+<a name="0x3_auth_validator_get_validator_id_from_tx_ctx"></a>
 
-## Function `get_validator_scheme_from_tx_ctx`
+## Function `get_validator_id_from_tx_ctx`
 
-Get the auth validator's scheme from the TxValidateResult in the TxContext
+Get the auth validator's auth validator id from the TxValidateResult in the TxContext
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_scheme_from_tx_ctx">get_validator_scheme_from_tx_ctx</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_id_from_tx_ctx">get_validator_id_from_tx_ctx</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
 </code></pre>
 
 
@@ -378,9 +378,9 @@ Get the auth validator's scheme from the TxValidateResult in the TxContext
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_scheme_from_tx_ctx">get_validator_scheme_from_tx_ctx</a>(ctx: &StorageContext): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_id_from_tx_ctx">get_validator_id_from_tx_ctx</a>(ctx: &StorageContext): u64 {
     <b>let</b> validate_result = <a href="auth_validator.md#0x3_auth_validator_get_validate_result_from_tx_ctx">get_validate_result_from_tx_ctx</a>(ctx);
-    validate_result.scheme
+    validate_result.auth_validator_id
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/auth_validator.md
+++ b/crates/rooch-framework/doc/auth_validator.md
@@ -21,7 +21,7 @@ fun post_execute(ctx: &mut StorageContext)
 -  [Function `validator_module_name`](#0x3_auth_validator_validator_module_name)
 -  [Function `new_tx_validate_result`](#0x3_auth_validator_new_tx_validate_result)
 -  [Function `get_validate_result_from_tx_ctx`](#0x3_auth_validator_get_validate_result_from_tx_ctx)
--  [Function `get_validator_multichain_id_from_tx_ctx`](#0x3_auth_validator_get_validator_multichain_id_from_tx_ctx)
+-  [Function `get_validator_scheme_from_tx_ctx`](#0x3_auth_validator_get_validator_scheme_from_tx_ctx)
 -  [Function `get_session_key_from_tx_ctx_option`](#0x3_auth_validator_get_session_key_from_tx_ctx_option)
 -  [Function `is_validate_via_session_key`](#0x3_auth_validator_is_validate_via_session_key)
 -  [Function `get_session_key_from_tx_ctx`](#0x3_auth_validator_get_session_key_from_tx_ctx)
@@ -94,10 +94,10 @@ this result will be stored in the TxContext
 
 <dl>
 <dt>
-<code>multichain_id: u64</code>
+<code>scheme: u64</code>
 </dt>
 <dd>
- The auth validator's multichain id that validate the transaction
+ The auth validator's scheme that validate the transaction
 </dd>
 <dt>
 <code><a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;</code>
@@ -309,7 +309,7 @@ InvalidAuthenticator, include invalid signature
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(multichain_id: u64, <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;, <a href="session_key.md#0x3_session_key">session_key</a>: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(scheme: u64, <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="_Option">option::Option</a>&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">auth_validator::AuthValidator</a>&gt;, <a href="session_key.md#0x3_session_key">session_key</a>: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
 </code></pre>
 
 
@@ -319,12 +319,12 @@ InvalidAuthenticator, include invalid signature
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">new_tx_validate_result</a>(
-    multichain_id: u64,
+    scheme: u64,
     <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: Option&lt;<a href="auth_validator.md#0x3_auth_validator_AuthValidator">AuthValidator</a>&gt;,
     <a href="session_key.md#0x3_session_key">session_key</a>: Option&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 ): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a> {
     <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">TxValidateResult</a> {
-        multichain_id: multichain_id,
+        scheme: scheme,
         <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>: <a href="auth_validator.md#0x3_auth_validator">auth_validator</a>,
         <a href="session_key.md#0x3_session_key">session_key</a>: <a href="session_key.md#0x3_session_key">session_key</a>,
     }
@@ -362,14 +362,14 @@ Get the TxValidateResult from the TxContext, Only can be called after the transa
 
 </details>
 
-<a name="0x3_auth_validator_get_validator_multichain_id_from_tx_ctx"></a>
+<a name="0x3_auth_validator_get_validator_scheme_from_tx_ctx"></a>
 
-## Function `get_validator_multichain_id_from_tx_ctx`
+## Function `get_validator_scheme_from_tx_ctx`
 
-Get the auth validator's multichain id from the TxValidateResult in the TxContext
+Get the auth validator's scheme from the TxValidateResult in the TxContext
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_multichain_id_from_tx_ctx">get_validator_multichain_id_from_tx_ctx</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_scheme_from_tx_ctx">get_validator_scheme_from_tx_ctx</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): u64
 </code></pre>
 
 
@@ -378,9 +378,9 @@ Get the auth validator's multichain id from the TxValidateResult in the TxContex
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_multichain_id_from_tx_ctx">get_validator_multichain_id_from_tx_ctx</a>(ctx: &StorageContext): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="auth_validator.md#0x3_auth_validator_get_validator_scheme_from_tx_ctx">get_validator_scheme_from_tx_ctx</a>(ctx: &StorageContext): u64 {
     <b>let</b> validate_result = <a href="auth_validator.md#0x3_auth_validator_get_validate_result_from_tx_ctx">get_validate_result_from_tx_ctx</a>(ctx);
-    validate_result.multichain_id
+    validate_result.scheme
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/builtin_validators.md
+++ b/crates/rooch-framework/doc/builtin_validators.md
@@ -7,7 +7,7 @@
 
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x3_builtin_validators_genesis_init)
--  [Function `is_builtin_scheme`](#0x3_builtin_validators_is_builtin_scheme)
+-  [Function `is_builtin_auth_validator`](#0x3_builtin_validators_is_builtin_auth_validator)
 
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
@@ -48,14 +48,14 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, _genesis_account: &<a href="">signer</a>){
-    // SCHEME_NATIVE: u64 = 0;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, _genesis_account: &<a href="">signer</a>) {
+    // NATIVE_AUTH_VALIDATOR_ID: u64 = 0;
     <b>let</b> id = <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">auth_validator_registry::register_internal</a>&lt;<a href="native_validator.md#0x3_native_validator_NativeValidator">native_validator::NativeValidator</a>&gt;(ctx);
-    <b>assert</b>!(id == <a href="native_validator.md#0x3_native_validator_scheme">native_validator::scheme</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
+    <b>assert</b>!(id == <a href="native_validator.md#0x3_native_validator_auth_validator_id">native_validator::auth_validator_id</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
 
-    // SCHEME_ETHEREUM: u64 = 1;
+    // ETHEREUM_AUTH_VALIDATOR_ID: u64 = 1;
     <b>let</b> id = <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">auth_validator_registry::register_internal</a>&lt;<a href="ethereum_validator.md#0x3_ethereum_validator_EthereumValidator">ethereum_validator::EthereumValidator</a>&gt;(ctx);
-    <b>assert</b>!(id == <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">ethereum_validator::scheme</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
+    <b>assert</b>!(id == <a href="ethereum_validator.md#0x3_ethereum_validator_auth_validator_id">ethereum_validator::auth_validator_id</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
 }
 </code></pre>
 
@@ -63,13 +63,13 @@
 
 </details>
 
-<a name="0x3_builtin_validators_is_builtin_scheme"></a>
+<a name="0x3_builtin_validators_is_builtin_auth_validator"></a>
 
-## Function `is_builtin_scheme`
+## Function `is_builtin_auth_validator`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_scheme">is_builtin_scheme</a>(scheme: u64): bool
+<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_auth_validator">is_builtin_auth_validator</a>(auth_validator_id: u64): bool
 </code></pre>
 
 
@@ -78,9 +78,9 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_scheme">is_builtin_scheme</a>(scheme: u64): bool {
-    scheme == <a href="native_validator.md#0x3_native_validator_scheme">native_validator::scheme</a>()
-    || scheme == <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">ethereum_validator::scheme</a>()
+<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_auth_validator">is_builtin_auth_validator</a>(auth_validator_id: u64): bool {
+    auth_validator_id == <a href="native_validator.md#0x3_native_validator_auth_validator_id">native_validator::auth_validator_id</a>()
+    || auth_validator_id == <a href="ethereum_validator.md#0x3_ethereum_validator_auth_validator_id">ethereum_validator::auth_validator_id</a>()
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/builtin_validators.md
+++ b/crates/rooch-framework/doc/builtin_validators.md
@@ -7,7 +7,7 @@
 
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x3_builtin_validators_genesis_init)
--  [Function `is_builtin_multichain_id`](#0x3_builtin_validators_is_builtin_multichain_id)
+-  [Function `is_builtin_scheme`](#0x3_builtin_validators_is_builtin_scheme)
 
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
@@ -49,13 +49,13 @@
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, _genesis_account: &<a href="">signer</a>){
-    // CHAIN_ID_ROOCH: u64 = 20230103;
+    // SCHEME_NATIVE: u64 = 0;
     <b>let</b> id = <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">auth_validator_registry::register_internal</a>&lt;<a href="native_validator.md#0x3_native_validator_NativeValidator">native_validator::NativeValidator</a>&gt;(ctx);
-    <b>assert</b>!(id == <a href="native_validator.md#0x3_native_validator_chain_id">native_validator::chain_id</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
+    <b>assert</b>!(id == <a href="native_validator.md#0x3_native_validator_scheme">native_validator::scheme</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
 
-    // MULTICHAIN_ID_ETHEREUM: u64 = 60;
+    // SCHEME_ETHEREUM: u64 = 1;
     <b>let</b> id = <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">auth_validator_registry::register_internal</a>&lt;<a href="ethereum_validator.md#0x3_ethereum_validator_EthereumValidator">ethereum_validator::EthereumValidator</a>&gt;(ctx);
-    <b>assert</b>!(id == <a href="ethereum_validator.md#0x3_ethereum_validator_multichain_id">ethereum_validator::multichain_id</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
+    <b>assert</b>!(id == <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">ethereum_validator::scheme</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
 }
 </code></pre>
 
@@ -63,13 +63,13 @@
 
 </details>
 
-<a name="0x3_builtin_validators_is_builtin_multichain_id"></a>
+<a name="0x3_builtin_validators_is_builtin_scheme"></a>
 
-## Function `is_builtin_multichain_id`
+## Function `is_builtin_scheme`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_multichain_id">is_builtin_multichain_id</a>(multichain_id: u64): bool
+<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_scheme">is_builtin_scheme</a>(scheme: u64): bool
 </code></pre>
 
 
@@ -78,9 +78,9 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_multichain_id">is_builtin_multichain_id</a>(multichain_id: u64): bool {
-    multichain_id == <a href="native_validator.md#0x3_native_validator_chain_id">native_validator::chain_id</a>()
-    || multichain_id == <a href="ethereum_validator.md#0x3_ethereum_validator_multichain_id">ethereum_validator::multichain_id</a>()
+<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_scheme">is_builtin_scheme</a>(scheme: u64): bool {
+    scheme == <a href="native_validator.md#0x3_native_validator_scheme">native_validator::scheme</a>()
+    || scheme == <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">ethereum_validator::scheme</a>()
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/builtin_validators.md
+++ b/crates/rooch-framework/doc/builtin_validators.md
@@ -7,7 +7,7 @@
 
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x3_builtin_validators_genesis_init)
--  [Function `is_builtin_scheme`](#0x3_builtin_validators_is_builtin_scheme)
+-  [Function `is_builtin_multichain_id`](#0x3_builtin_validators_is_builtin_multichain_id)
 
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
@@ -49,13 +49,13 @@
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, _genesis_account: &<a href="">signer</a>){
-    // SCHEME_NATIVE: u64 = 0;
+    // CHAIN_ID_ROOCH: u64 = 20230103;
     <b>let</b> id = <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">auth_validator_registry::register_internal</a>&lt;<a href="native_validator.md#0x3_native_validator_NativeValidator">native_validator::NativeValidator</a>&gt;(ctx);
-    <b>assert</b>!(id == <a href="native_validator.md#0x3_native_validator_scheme">native_validator::scheme</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
+    <b>assert</b>!(id == <a href="native_validator.md#0x3_native_validator_chain_id">native_validator::chain_id</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
 
-    // SCHEME_ETHEREUM: u64 = 1;
+    // MULTICHAIN_ID_ETHEREUM: u64 = 60;
     <b>let</b> id = <a href="auth_validator_registry.md#0x3_auth_validator_registry_register_internal">auth_validator_registry::register_internal</a>&lt;<a href="ethereum_validator.md#0x3_ethereum_validator_EthereumValidator">ethereum_validator::EthereumValidator</a>&gt;(ctx);
-    <b>assert</b>!(id == <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">ethereum_validator::scheme</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
+    <b>assert</b>!(id == <a href="ethereum_validator.md#0x3_ethereum_validator_multichain_id">ethereum_validator::multichain_id</a>(), std::error::internal(<a href="builtin_validators.md#0x3_builtin_validators_ErrorGenesisInit">ErrorGenesisInit</a>));
 }
 </code></pre>
 
@@ -63,13 +63,13 @@
 
 </details>
 
-<a name="0x3_builtin_validators_is_builtin_scheme"></a>
+<a name="0x3_builtin_validators_is_builtin_multichain_id"></a>
 
-## Function `is_builtin_scheme`
+## Function `is_builtin_multichain_id`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_scheme">is_builtin_scheme</a>(scheme: u64): bool
+<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_multichain_id">is_builtin_multichain_id</a>(multichain_id: u64): bool
 </code></pre>
 
 
@@ -78,9 +78,9 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_scheme">is_builtin_scheme</a>(scheme: u64): bool {
-    scheme == <a href="native_validator.md#0x3_native_validator_scheme">native_validator::scheme</a>()
-    || scheme == <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">ethereum_validator::scheme</a>()
+<pre><code><b>public</b> <b>fun</b> <a href="builtin_validators.md#0x3_builtin_validators_is_builtin_multichain_id">is_builtin_multichain_id</a>(multichain_id: u64): bool {
+    multichain_id == <a href="native_validator.md#0x3_native_validator_chain_id">native_validator::chain_id</a>()
+    || multichain_id == <a href="ethereum_validator.md#0x3_ethereum_validator_multichain_id">ethereum_validator::multichain_id</a>()
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/ecdsa_k1.md
+++ b/crates/rooch-framework/doc/ecdsa_k1.md
@@ -9,11 +9,8 @@
 -  [Function `auth_validator_id_length`](#0x3_ecdsa_k1_auth_validator_id_length)
 -  [Function `public_key_length`](#0x3_ecdsa_k1_public_key_length)
 -  [Function `signature_length`](#0x3_ecdsa_k1_signature_length)
--  [Function `keccak256`](#0x3_ecdsa_k1_keccak256)
 -  [Function `sha256`](#0x3_ecdsa_k1_sha256)
 -  [Function `ripemd160`](#0x3_ecdsa_k1_ripemd160)
--  [Function `get_public_key_from_authenticator_payload`](#0x3_ecdsa_k1_get_public_key_from_authenticator_payload)
--  [Function `get_signature_from_authenticator_payload`](#0x3_ecdsa_k1_get_signature_from_authenticator_payload)
 -  [Function `verify`](#0x3_ecdsa_k1_verify)
 
 
@@ -24,6 +21,36 @@
 <a name="@Constants_0"></a>
 
 ## Constants
+
+
+<a name="0x3_ecdsa_k1_ErrorInvalidPubKey"></a>
+
+Error if the public key is invalid.
+
+
+<pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_ErrorInvalidPubKey">ErrorInvalidPubKey</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x3_ecdsa_k1_ErrorInvalidSignature"></a>
+
+Error if the signature is invalid.
+
+
+<pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_ErrorInvalidSignature">ErrorInvalidSignature</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x3_ecdsa_k1_SHA256"></a>
+
+Hash function name that are valid for ecrecover and verify.
+
+
+<pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_SHA256">SHA256</a>: u8 = 1;
+</code></pre>
+
 
 
 <a name="0x3_ecdsa_k1_ECDSA_K1_COMPRESSED_PUBKEY_LENGTH"></a>
@@ -54,50 +81,11 @@ constant codes
 
 
 
-<a name="0x3_ecdsa_k1_ErrorInvalidPubKey"></a>
-
-Error if the public key is invalid.
-
-
-<pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_ErrorInvalidPubKey">ErrorInvalidPubKey</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x3_ecdsa_k1_ErrorInvalidSignature"></a>
-
-Error if the signature is invalid.
-
-
-<pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_ErrorInvalidSignature">ErrorInvalidSignature</a>: u64 = 0;
-</code></pre>
-
-
-
-<a name="0x3_ecdsa_k1_KECCAK256"></a>
-
-Hash function name that are valid for ecrecover and verify.
-
-
-<pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_KECCAK256">KECCAK256</a>: u8 = 0;
-</code></pre>
-
-
-
 <a name="0x3_ecdsa_k1_RIPEMD160"></a>
 
 
 
 <pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_RIPEMD160">RIPEMD160</a>: u8 = 2;
-</code></pre>
-
-
-
-<a name="0x3_ecdsa_k1_SHA256"></a>
-
-
-
-<pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_SHA256">SHA256</a>: u8 = 1;
 </code></pre>
 
 
@@ -175,30 +163,6 @@ built-in functions
 
 </details>
 
-<a name="0x3_ecdsa_k1_keccak256"></a>
-
-## Function `keccak256`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_keccak256">keccak256</a>(): u8
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_keccak256">keccak256</a>(): u8 {
-    <a href="ecdsa_k1.md#0x3_ecdsa_k1_KECCAK256">KECCAK256</a>
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x3_ecdsa_k1_sha256"></a>
 
 ## Function `sha256`
@@ -240,70 +204,6 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_ripemd160">ripemd160</a>(): u8 {
     <a href="ecdsa_k1.md#0x3_ecdsa_k1_RIPEMD160">RIPEMD160</a>
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_ecdsa_k1_get_public_key_from_authenticator_payload"></a>
-
-## Function `get_public_key_from_authenticator_payload`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ecdsa_k1.md#0x3_ecdsa_k1_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>();
-    <b>let</b> public_key_position = <a href="ecdsa_k1.md#0x3_ecdsa_k1_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">public_key_length</a>();
-    <b>while</b> (i &lt; public_key_position) {
-        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
-        i = i + 1;
-    };
-    public_key
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_ecdsa_k1_get_signature_from_authenticator_payload"></a>
-
-## Function `get_signature_from_authenticator_payload`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ecdsa_k1.md#0x3_ecdsa_k1_auth_validator_id_length">auth_validator_id_length</a>();
-    <b>let</b> signature_position = <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>() + 1;
-    <b>while</b> (i &lt; signature_position) {
-        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
-        i = i + 1;
-    };
-    sign
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/ecdsa_k1.md
+++ b/crates/rooch-framework/doc/ecdsa_k1.md
@@ -6,7 +6,7 @@
 
 
 -  [Constants](#@Constants_0)
--  [Function `scheme_length`](#0x3_ecdsa_k1_scheme_length)
+-  [Function `auth_validator_id_length`](#0x3_ecdsa_k1_auth_validator_id_length)
 -  [Function `public_key_length`](#0x3_ecdsa_k1_public_key_length)
 -  [Function `signature_length`](#0x3_ecdsa_k1_signature_length)
 -  [Function `keccak256`](#0x3_ecdsa_k1_keccak256)
@@ -44,12 +44,12 @@
 
 
 
-<a name="0x3_ecdsa_k1_ECDSA_K1_TO_SCHEME_BITCOIN_LENGTH"></a>
+<a name="0x3_ecdsa_k1_ECDSA_K1_TO_BITCOIN_VALIDATOR_ID_LENGTH"></a>
 
 constant codes
 
 
-<pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_ECDSA_K1_TO_SCHEME_BITCOIN_LENGTH">ECDSA_K1_TO_SCHEME_BITCOIN_LENGTH</a>: u64 = 1;
+<pre><code><b>const</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_ECDSA_K1_TO_BITCOIN_VALIDATOR_ID_LENGTH">ECDSA_K1_TO_BITCOIN_VALIDATOR_ID_LENGTH</a>: u64 = 1;
 </code></pre>
 
 
@@ -102,14 +102,14 @@ Hash function name that are valid for ecrecover and verify.
 
 
 
-<a name="0x3_ecdsa_k1_scheme_length"></a>
+<a name="0x3_ecdsa_k1_auth_validator_id_length"></a>
 
-## Function `scheme_length`
+## Function `auth_validator_id_length`
 
 built-in functions
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_scheme_length">scheme_length</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_auth_validator_id_length">auth_validator_id_length</a>(): u64
 </code></pre>
 
 
@@ -118,8 +118,8 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_scheme_length">scheme_length</a>(): u64 {
-    <a href="ecdsa_k1.md#0x3_ecdsa_k1_ECDSA_K1_TO_SCHEME_BITCOIN_LENGTH">ECDSA_K1_TO_SCHEME_BITCOIN_LENGTH</a>
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_auth_validator_id_length">auth_validator_id_length</a>(): u64 {
+    <a href="ecdsa_k1.md#0x3_ecdsa_k1_ECDSA_K1_TO_BITCOIN_VALIDATOR_ID_LENGTH">ECDSA_K1_TO_BITCOIN_VALIDATOR_ID_LENGTH</a>
 }
 </code></pre>
 
@@ -264,8 +264,8 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ecdsa_k1.md#0x3_ecdsa_k1_scheme_length">scheme_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>();
-    <b>let</b> public_key_position = <a href="ecdsa_k1.md#0x3_ecdsa_k1_scheme_length">scheme_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">public_key_length</a>();
+    <b>let</b> i = <a href="ecdsa_k1.md#0x3_ecdsa_k1_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>();
+    <b>let</b> public_key_position = <a href="ecdsa_k1.md#0x3_ecdsa_k1_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>() + <a href="ecdsa_k1.md#0x3_ecdsa_k1_public_key_length">public_key_length</a>();
     <b>while</b> (i &lt; public_key_position) {
         <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
         <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
@@ -296,7 +296,7 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1.md#0x3_ecdsa_k1_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ecdsa_k1.md#0x3_ecdsa_k1_scheme_length">scheme_length</a>();
+    <b>let</b> i = <a href="ecdsa_k1.md#0x3_ecdsa_k1_auth_validator_id_length">auth_validator_id_length</a>();
     <b>let</b> signature_position = <a href="ecdsa_k1.md#0x3_ecdsa_k1_signature_length">signature_length</a>() + 1;
     <b>while</b> (i &lt; signature_position) {
         <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);

--- a/crates/rooch-framework/doc/ecdsa_k1_recoverable.md
+++ b/crates/rooch-framework/doc/ecdsa_k1_recoverable.md
@@ -6,14 +6,10 @@
 
 
 -  [Constants](#@Constants_0)
--  [Function `auth_validator_id_length`](#0x3_ecdsa_k1_recoverable_auth_validator_id_length)
 -  [Function `public_key_length`](#0x3_ecdsa_k1_recoverable_public_key_length)
 -  [Function `uncompressed_public_key_length`](#0x3_ecdsa_k1_recoverable_uncompressed_public_key_length)
 -  [Function `signature_length`](#0x3_ecdsa_k1_recoverable_signature_length)
 -  [Function `keccak256`](#0x3_ecdsa_k1_recoverable_keccak256)
--  [Function `sha256`](#0x3_ecdsa_k1_recoverable_sha256)
--  [Function `get_public_key_from_authenticator_payload`](#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload)
--  [Function `get_signature_from_authenticator_payload`](#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload)
 -  [Function `ecrecover`](#0x3_ecdsa_k1_recoverable_ecrecover)
 -  [Function `decompress_pubkey`](#0x3_ecdsa_k1_recoverable_decompress_pubkey)
 -  [Function `verify`](#0x3_ecdsa_k1_recoverable_verify)
@@ -49,27 +45,9 @@ Error if the signature is invalid.
 
 
 
-<a name="0x3_ecdsa_k1_recoverable_KECCAK256"></a>
-
-Hash function name that are valid for ecrecover and verify.
-
-
-<pre><code><b>const</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_KECCAK256">KECCAK256</a>: u8 = 0;
-</code></pre>
-
-
-
-<a name="0x3_ecdsa_k1_recoverable_SHA256"></a>
-
-
-
-<pre><code><b>const</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_SHA256">SHA256</a>: u8 = 1;
-</code></pre>
-
-
-
 <a name="0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_COMPRESSED_PUBKEY_LENGTH"></a>
 
+constant codes
 
 
 <pre><code><b>const</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_COMPRESSED_PUBKEY_LENGTH">ECDSA_K1_RECOVERABLE_COMPRESSED_PUBKEY_LENGTH</a>: u64 = 33;
@@ -82,16 +60,6 @@ Hash function name that are valid for ecrecover and verify.
 
 
 <pre><code><b>const</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_SIG_LENGTH">ECDSA_K1_RECOVERABLE_SIG_LENGTH</a>: u64 = 65;
-</code></pre>
-
-
-
-<a name="0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH"></a>
-
-constant codes
-
-
-<pre><code><b>const</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH">ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH</a>: u64 = 1;
 </code></pre>
 
 
@@ -115,35 +83,21 @@ Error if the public key cannot be recovered from the signature.
 
 
 
-<a name="0x3_ecdsa_k1_recoverable_auth_validator_id_length"></a>
+<a name="0x3_ecdsa_k1_recoverable_KECCAK256"></a>
 
-## Function `auth_validator_id_length`
-
-built-in functions
+Hash function name that are valid for ecrecover and verify.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_auth_validator_id_length">auth_validator_id_length</a>(): u64
+<pre><code><b>const</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_KECCAK256">KECCAK256</a>: u8 = 0;
 </code></pre>
 
 
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_auth_validator_id_length">auth_validator_id_length</a>(): u64 {
-    <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH">ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH</a>
-}
-</code></pre>
-
-
-
-</details>
 
 <a name="0x3_ecdsa_k1_recoverable_public_key_length"></a>
 
 ## Function `public_key_length`
 
+built-in functions
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">public_key_length</a>(): u64
@@ -229,94 +183,6 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_keccak256">keccak256</a>(): u8 {
     <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_KECCAK256">KECCAK256</a>
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_ecdsa_k1_recoverable_sha256"></a>
-
-## Function `sha256`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_sha256">sha256</a>(): u8
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_sha256">sha256</a>(): u8 {
-    <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_SHA256">SHA256</a>
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload"></a>
-
-## Function `get_public_key_from_authenticator_payload`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>();
-    <b>let</b> public_key_position = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">public_key_length</a>();
-    <b>while</b> (i &lt; public_key_position) {
-        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
-        i = i + 1;
-    };
-    public_key
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload"></a>
-
-## Function `get_signature_from_authenticator_payload`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = 0;
-    <b>let</b> signature_position = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>();
-    <b>while</b> (i &lt; signature_position) {
-        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
-        i = i + 1;
-    };
-    sign
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/ecdsa_k1_recoverable.md
+++ b/crates/rooch-framework/doc/ecdsa_k1_recoverable.md
@@ -6,7 +6,7 @@
 
 
 -  [Constants](#@Constants_0)
--  [Function `scheme_length`](#0x3_ecdsa_k1_recoverable_scheme_length)
+-  [Function `auth_validator_id_length`](#0x3_ecdsa_k1_recoverable_auth_validator_id_length)
 -  [Function `public_key_length`](#0x3_ecdsa_k1_recoverable_public_key_length)
 -  [Function `uncompressed_public_key_length`](#0x3_ecdsa_k1_recoverable_uncompressed_public_key_length)
 -  [Function `signature_length`](#0x3_ecdsa_k1_recoverable_signature_length)
@@ -86,12 +86,12 @@ Hash function name that are valid for ecrecover and verify.
 
 
 
-<a name="0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_TO_SCHEME_ETHEREUM_LENGTH"></a>
+<a name="0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH"></a>
 
 constant codes
 
 
-<pre><code><b>const</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_TO_SCHEME_ETHEREUM_LENGTH">ECDSA_K1_RECOVERABLE_TO_SCHEME_ETHEREUM_LENGTH</a>: u64 = 1;
+<pre><code><b>const</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH">ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH</a>: u64 = 1;
 </code></pre>
 
 
@@ -115,14 +115,14 @@ Error if the public key cannot be recovered from the signature.
 
 
 
-<a name="0x3_ecdsa_k1_recoverable_scheme_length"></a>
+<a name="0x3_ecdsa_k1_recoverable_auth_validator_id_length"></a>
 
-## Function `scheme_length`
+## Function `auth_validator_id_length`
 
 built-in functions
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_scheme_length">scheme_length</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_auth_validator_id_length">auth_validator_id_length</a>(): u64
 </code></pre>
 
 
@@ -131,8 +131,8 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_scheme_length">scheme_length</a>(): u64 {
-    <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_TO_SCHEME_ETHEREUM_LENGTH">ECDSA_K1_RECOVERABLE_TO_SCHEME_ETHEREUM_LENGTH</a>
+<pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_auth_validator_id_length">auth_validator_id_length</a>(): u64 {
+    <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH">ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH</a>
 }
 </code></pre>
 
@@ -277,8 +277,8 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_scheme_length">scheme_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>();
-    <b>let</b> public_key_position = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_scheme_length">scheme_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">public_key_length</a>();
+    <b>let</b> i = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>();
+    <b>let</b> public_key_position = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">public_key_length</a>();
     <b>while</b> (i &lt; public_key_position) {
         <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
         <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
@@ -309,7 +309,7 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = 0; // TODO: do we need scheme_length here?
+    <b>let</b> i = 0;
     <b>let</b> signature_position = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">signature_length</a>();
     <b>while</b> (i &lt; signature_position) {
         <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);

--- a/crates/rooch-framework/doc/ed25519.md
+++ b/crates/rooch-framework/doc/ed25519.md
@@ -6,11 +6,8 @@
 
 
 -  [Constants](#@Constants_0)
--  [Function `auth_validator_id_length`](#0x3_ed25519_auth_validator_id_length)
 -  [Function `public_key_length`](#0x3_ed25519_public_key_length)
 -  [Function `signature_length`](#0x3_ed25519_signature_length)
--  [Function `get_public_key_from_authenticator_payload`](#0x3_ed25519_get_public_key_from_authenticator_payload)
--  [Function `get_signature_from_authenticator_payload`](#0x3_ed25519_get_signature_from_authenticator_payload)
 -  [Function `verify`](#0x3_ed25519_verify)
 
 
@@ -25,6 +22,7 @@
 
 <a name="0x3_ed25519_ED25519_PUBKEY_LENGTH"></a>
 
+constant codes
 
 
 <pre><code><b>const</b> <a href="ed25519.md#0x3_ed25519_ED25519_PUBKEY_LENGTH">ED25519_PUBKEY_LENGTH</a>: u64 = 32;
@@ -41,45 +39,11 @@
 
 
 
-<a name="0x3_ed25519_ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH"></a>
-
-constant codes
-
-
-<pre><code><b>const</b> <a href="ed25519.md#0x3_ed25519_ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH">ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x3_ed25519_auth_validator_id_length"></a>
-
-## Function `auth_validator_id_length`
-
-built-in functions
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>(): u64
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>(): u64 {
-    <a href="ed25519.md#0x3_ed25519_ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH">ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH</a>
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x3_ed25519_public_key_length"></a>
 
 ## Function `public_key_length`
 
+built-in functions
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_public_key_length">public_key_length</a>(): u64
@@ -117,70 +81,6 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>(): u64 {
     <a href="ed25519.md#0x3_ed25519_ED25519_SIG_LENGTH">ED25519_SIG_LENGTH</a>
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_ed25519_get_public_key_from_authenticator_payload"></a>
-
-## Function `get_public_key_from_authenticator_payload`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>();
-    <b>let</b> public_key_position = <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>() + <a href="ed25519.md#0x3_ed25519_public_key_length">public_key_length</a>();
-    <b>while</b> (i &lt; public_key_position) {
-        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
-        i = i + 1;
-    };
-    public_key
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_ed25519_get_signature_from_authenticator_payload"></a>
-
-## Function `get_signature_from_authenticator_payload`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>();
-    <b>let</b> signature_position = <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>() + 1;
-    <b>while</b> (i &lt; signature_position) {
-        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
-        i = i + 1;
-    };
-    sign
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/ed25519.md
+++ b/crates/rooch-framework/doc/ed25519.md
@@ -6,7 +6,7 @@
 
 
 -  [Constants](#@Constants_0)
--  [Function `scheme_length`](#0x3_ed25519_scheme_length)
+-  [Function `auth_validator_id_length`](#0x3_ed25519_auth_validator_id_length)
 -  [Function `public_key_length`](#0x3_ed25519_public_key_length)
 -  [Function `signature_length`](#0x3_ed25519_signature_length)
 -  [Function `get_public_key_from_authenticator_payload`](#0x3_ed25519_get_public_key_from_authenticator_payload)
@@ -41,24 +41,24 @@
 
 
 
-<a name="0x3_ed25519_ED25519_TO_SCHEME_NATIVE_LENGTH"></a>
+<a name="0x3_ed25519_ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH"></a>
 
 constant codes
 
 
-<pre><code><b>const</b> <a href="ed25519.md#0x3_ed25519_ED25519_TO_SCHEME_NATIVE_LENGTH">ED25519_TO_SCHEME_NATIVE_LENGTH</a>: u64 = 1;
+<pre><code><b>const</b> <a href="ed25519.md#0x3_ed25519_ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH">ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH</a>: u64 = 1;
 </code></pre>
 
 
 
-<a name="0x3_ed25519_scheme_length"></a>
+<a name="0x3_ed25519_auth_validator_id_length"></a>
 
-## Function `scheme_length`
+## Function `auth_validator_id_length`
 
 built-in functions
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_scheme_length">scheme_length</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>(): u64
 </code></pre>
 
 
@@ -67,8 +67,8 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_scheme_length">scheme_length</a>(): u64 {
-    <a href="ed25519.md#0x3_ed25519_ED25519_TO_SCHEME_NATIVE_LENGTH">ED25519_TO_SCHEME_NATIVE_LENGTH</a>
+<pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>(): u64 {
+    <a href="ed25519.md#0x3_ed25519_ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH">ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH</a>
 }
 </code></pre>
 
@@ -141,8 +141,8 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ed25519.md#0x3_ed25519_scheme_length">scheme_length</a>() + <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>();
-    <b>let</b> public_key_position = <a href="ed25519.md#0x3_ed25519_scheme_length">scheme_length</a>() + <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>() + <a href="ed25519.md#0x3_ed25519_public_key_length">public_key_length</a>();
+    <b>let</b> i = <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>();
+    <b>let</b> public_key_position = <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>() + <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>() + <a href="ed25519.md#0x3_ed25519_public_key_length">public_key_length</a>();
     <b>while</b> (i &lt; public_key_position) {
         <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
         <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
@@ -173,7 +173,7 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="ed25519.md#0x3_ed25519_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="ed25519.md#0x3_ed25519_scheme_length">scheme_length</a>();
+    <b>let</b> i = <a href="ed25519.md#0x3_ed25519_auth_validator_id_length">auth_validator_id_length</a>();
     <b>let</b> signature_position = <a href="ed25519.md#0x3_ed25519_signature_length">signature_length</a>() + 1;
     <b>while</b> (i &lt; signature_position) {
         <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);

--- a/crates/rooch-framework/doc/ethereum_validator.md
+++ b/crates/rooch-framework/doc/ethereum_validator.md
@@ -3,12 +3,12 @@
 
 # Module `0x3::ethereum_validator`
 
-This module implements Ethereum validator with the ECDSA recoverable signature over Secp256k1 crypto scheme.
+This module implements Ethereum validator with the ECDSA recoverable signature over Secp256k1.
 
 
 -  [Struct `EthereumValidator`](#0x3_ethereum_validator_EthereumValidator)
 -  [Constants](#@Constants_0)
--  [Function `scheme`](#0x3_ethereum_validator_scheme)
+-  [Function `auth_validator_id`](#0x3_ethereum_validator_auth_validator_id)
 -  [Function `rotate_authentication_key_entry`](#0x3_ethereum_validator_rotate_authentication_key_entry)
 -  [Function `remove_authentication_key_entry`](#0x3_ethereum_validator_remove_authentication_key_entry)
 -  [Function `get_authentication_key_from_authenticator_payload`](#0x3_ethereum_validator_get_authentication_key_from_authenticator_payload)
@@ -76,23 +76,23 @@ error code
 
 
 
-<a name="0x3_ethereum_validator_SCHEME_ETHEREUM"></a>
+<a name="0x3_ethereum_validator_ETHEREUM_AUTH_VALIDATOR_ID"></a>
 
-there defines scheme for each blockchain
+there defines auth validator id for each blockchain
 
 
-<pre><code><b>const</b> <a href="ethereum_validator.md#0x3_ethereum_validator_SCHEME_ETHEREUM">SCHEME_ETHEREUM</a>: u64 = 1;
+<pre><code><b>const</b> <a href="ethereum_validator.md#0x3_ethereum_validator_ETHEREUM_AUTH_VALIDATOR_ID">ETHEREUM_AUTH_VALIDATOR_ID</a>: u64 = 1;
 </code></pre>
 
 
 
-<a name="0x3_ethereum_validator_scheme"></a>
+<a name="0x3_ethereum_validator_auth_validator_id"></a>
 
-## Function `scheme`
+## Function `auth_validator_id`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">scheme</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_auth_validator_id">auth_validator_id</a>(): u64
 </code></pre>
 
 
@@ -101,8 +101,8 @@ there defines scheme for each blockchain
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">scheme</a>(): u64 {
-    <a href="ethereum_validator.md#0x3_ethereum_validator_SCHEME_ETHEREUM">SCHEME_ETHEREUM</a>
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_auth_validator_id">auth_validator_id</a>(): u64 {
+    <a href="ethereum_validator.md#0x3_ethereum_validator_ETHEREUM_AUTH_VALIDATOR_ID">ETHEREUM_AUTH_VALIDATOR_ID</a>
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/ethereum_validator.md
+++ b/crates/rooch-framework/doc/ethereum_validator.md
@@ -8,7 +8,7 @@ This module implements Ethereum validator with the ECDSA recoverable signature o
 
 -  [Struct `EthereumValidator`](#0x3_ethereum_validator_EthereumValidator)
 -  [Constants](#@Constants_0)
--  [Function `scheme`](#0x3_ethereum_validator_scheme)
+-  [Function `multichain_id`](#0x3_ethereum_validator_multichain_id)
 -  [Function `rotate_authentication_key_entry`](#0x3_ethereum_validator_rotate_authentication_key_entry)
 -  [Function `remove_authentication_key_entry`](#0x3_ethereum_validator_remove_authentication_key_entry)
 -  [Function `get_authentication_key_from_authenticator_payload`](#0x3_ethereum_validator_get_authentication_key_from_authenticator_payload)
@@ -66,6 +66,16 @@ This module implements Ethereum validator with the ECDSA recoverable signature o
 ## Constants
 
 
+<a name="0x3_ethereum_validator_MULTICHAIN_ID_ETHEREUM"></a>
+
+there defines multichain id for ethereum
+
+
+<pre><code><b>const</b> <a href="ethereum_validator.md#0x3_ethereum_validator_MULTICHAIN_ID_ETHEREUM">MULTICHAIN_ID_ETHEREUM</a>: u64 = 1;
+</code></pre>
+
+
+
 <a name="0x3_ethereum_validator_ErrorInvalidPublicKeyLength"></a>
 
 error code
@@ -76,23 +86,13 @@ error code
 
 
 
-<a name="0x3_ethereum_validator_SCHEME_ETHEREUM"></a>
+<a name="0x3_ethereum_validator_multichain_id"></a>
 
-there defines scheme for each blockchain
-
-
-<pre><code><b>const</b> <a href="ethereum_validator.md#0x3_ethereum_validator_SCHEME_ETHEREUM">SCHEME_ETHEREUM</a>: u64 = 1;
-</code></pre>
+## Function `multichain_id`
 
 
 
-<a name="0x3_ethereum_validator_scheme"></a>
-
-## Function `scheme`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">scheme</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_multichain_id">multichain_id</a>(): u64
 </code></pre>
 
 
@@ -101,8 +101,8 @@ there defines scheme for each blockchain
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">scheme</a>(): u64 {
-    <a href="ethereum_validator.md#0x3_ethereum_validator_SCHEME_ETHEREUM">SCHEME_ETHEREUM</a>
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_multichain_id">multichain_id</a>(): u64 {
+    <a href="ethereum_validator.md#0x3_ethereum_validator_MULTICHAIN_ID_ETHEREUM">MULTICHAIN_ID_ETHEREUM</a>
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/ethereum_validator.md
+++ b/crates/rooch-framework/doc/ethereum_validator.md
@@ -11,6 +11,8 @@ This module implements Ethereum validator with the ECDSA recoverable signature o
 -  [Function `auth_validator_id`](#0x3_ethereum_validator_auth_validator_id)
 -  [Function `rotate_authentication_key_entry`](#0x3_ethereum_validator_rotate_authentication_key_entry)
 -  [Function `remove_authentication_key_entry`](#0x3_ethereum_validator_remove_authentication_key_entry)
+-  [Function `get_public_key_from_authenticator_payload`](#0x3_ethereum_validator_get_public_key_from_authenticator_payload)
+-  [Function `get_signature_from_authenticator_payload`](#0x3_ethereum_validator_get_signature_from_authenticator_payload)
 -  [Function `get_authentication_key_from_authenticator_payload`](#0x3_ethereum_validator_get_authentication_key_from_authenticator_payload)
 -  [Function `public_key_to_address`](#0x3_ethereum_validator_public_key_to_address)
 -  [Function `public_key_to_authentication_key`](#0x3_ethereum_validator_public_key_to_authentication_key)
@@ -171,6 +173,70 @@ there defines auth validator id for each blockchain
 
 </details>
 
+<a name="0x3_ethereum_validator_get_public_key_from_authenticator_payload"></a>
+
+## Function `get_public_key_from_authenticator_payload`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
+    <b>let</b> i = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">ecdsa_k1_recoverable::signature_length</a>();
+    <b>let</b> public_key_position = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">ecdsa_k1_recoverable::signature_length</a>() + <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_public_key_length">ecdsa_k1_recoverable::public_key_length</a>();
+    <b>while</b> (i &lt; public_key_position) {
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
+        i = i + 1;
+    };
+    public_key
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_ethereum_validator_get_signature_from_authenticator_payload"></a>
+
+## Function `get_signature_from_authenticator_payload`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
+    <b>let</b> i = 0;
+    <b>let</b> signature_position = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_signature_length">ecdsa_k1_recoverable::signature_length</a>();
+    <b>while</b> (i &lt; signature_position) {
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
+        i = i + 1;
+    };
+    sign
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x3_ethereum_validator_get_authentication_key_from_authenticator_payload"></a>
 
 ## Function `get_authentication_key_from_authenticator_payload`
@@ -188,7 +254,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_public_key_from_authenticator_payload">ecdsa_k1_recoverable::get_public_key_from_authenticator_payload</a>(authenticator_payload);
+    <b>let</b> public_key = <a href="ethereum_validator.md#0x3_ethereum_validator_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload);
     <b>let</b> addr = <a href="ethereum_validator.md#0x3_ethereum_validator_public_key_to_address">public_key_to_address</a>(public_key);
     <a href="ethereum_address.md#0x3_ethereum_address_into_bytes">ethereum_address::into_bytes</a>(addr)
 }
@@ -342,7 +408,7 @@ Only validate the authenticator's signature.
 <pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
         <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_verify">ecdsa_k1_recoverable::verify</a>(
-            &<a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_get_signature_from_authenticator_payload">ecdsa_k1_recoverable::get_signature_from_authenticator_payload</a>(authenticator_payload),
+            &<a href="ethereum_validator.md#0x3_ethereum_validator_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload),
             tx_hash,
             <a href="ecdsa_k1_recoverable.md#0x3_ecdsa_k1_recoverable_keccak256">ecdsa_k1_recoverable::keccak256</a>()
         ),

--- a/crates/rooch-framework/doc/ethereum_validator.md
+++ b/crates/rooch-framework/doc/ethereum_validator.md
@@ -8,7 +8,7 @@ This module implements Ethereum validator with the ECDSA recoverable signature o
 
 -  [Struct `EthereumValidator`](#0x3_ethereum_validator_EthereumValidator)
 -  [Constants](#@Constants_0)
--  [Function `multichain_id`](#0x3_ethereum_validator_multichain_id)
+-  [Function `scheme`](#0x3_ethereum_validator_scheme)
 -  [Function `rotate_authentication_key_entry`](#0x3_ethereum_validator_rotate_authentication_key_entry)
 -  [Function `remove_authentication_key_entry`](#0x3_ethereum_validator_remove_authentication_key_entry)
 -  [Function `get_authentication_key_from_authenticator_payload`](#0x3_ethereum_validator_get_authentication_key_from_authenticator_payload)
@@ -66,16 +66,6 @@ This module implements Ethereum validator with the ECDSA recoverable signature o
 ## Constants
 
 
-<a name="0x3_ethereum_validator_MULTICHAIN_ID_ETHEREUM"></a>
-
-there defines multichain id for ethereum
-
-
-<pre><code><b>const</b> <a href="ethereum_validator.md#0x3_ethereum_validator_MULTICHAIN_ID_ETHEREUM">MULTICHAIN_ID_ETHEREUM</a>: u64 = 1;
-</code></pre>
-
-
-
 <a name="0x3_ethereum_validator_ErrorInvalidPublicKeyLength"></a>
 
 error code
@@ -86,13 +76,23 @@ error code
 
 
 
-<a name="0x3_ethereum_validator_multichain_id"></a>
+<a name="0x3_ethereum_validator_SCHEME_ETHEREUM"></a>
 
-## Function `multichain_id`
+there defines scheme for each blockchain
+
+
+<pre><code><b>const</b> <a href="ethereum_validator.md#0x3_ethereum_validator_SCHEME_ETHEREUM">SCHEME_ETHEREUM</a>: u64 = 1;
+</code></pre>
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_multichain_id">multichain_id</a>(): u64
+<a name="0x3_ethereum_validator_scheme"></a>
+
+## Function `scheme`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">scheme</a>(): u64
 </code></pre>
 
 
@@ -101,8 +101,8 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_multichain_id">multichain_id</a>(): u64 {
-    <a href="ethereum_validator.md#0x3_ethereum_validator_MULTICHAIN_ID_ETHEREUM">MULTICHAIN_ID_ETHEREUM</a>
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_validator.md#0x3_ethereum_validator_scheme">scheme</a>(): u64 {
+    <a href="ethereum_validator.md#0x3_ethereum_validator_SCHEME_ETHEREUM">SCHEME_ETHEREUM</a>
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/genesis.md
+++ b/crates/rooch-framework/doc/genesis.md
@@ -9,8 +9,7 @@
 -  [Constants](#@Constants_0)
 
 
-<pre><code><b>use</b> <a href="">0x1::debug</a>;
-<b>use</b> <a href="">0x1::error</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account.md#0x3_account">0x3::account</a>;

--- a/crates/rooch-framework/doc/genesis.md
+++ b/crates/rooch-framework/doc/genesis.md
@@ -9,7 +9,8 @@
 -  [Constants](#@Constants_0)
 
 
-<pre><code><b>use</b> <a href="">0x1::error</a>;
+<pre><code><b>use</b> <a href="">0x1::debug</a>;
+<b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account.md#0x3_account">0x3::account</a>;

--- a/crates/rooch-framework/doc/native_validator.md
+++ b/crates/rooch-framework/doc/native_validator.md
@@ -8,7 +8,7 @@ This module implements the native validator scheme.
 
 -  [Struct `NativeValidator`](#0x3_native_validator_NativeValidator)
 -  [Constants](#@Constants_0)
--  [Function `scheme`](#0x3_native_validator_scheme)
+-  [Function `chain_id`](#0x3_native_validator_chain_id)
 -  [Function `rotate_authentication_key_entry`](#0x3_native_validator_rotate_authentication_key_entry)
 -  [Function `remove_authentication_key_entry`](#0x3_native_validator_remove_authentication_key_entry)
 -  [Function `get_authentication_key_from_authenticator_payload`](#0x3_native_validator_get_authentication_key_from_authenticator_payload)
@@ -66,6 +66,16 @@ This module implements the native validator scheme.
 ## Constants
 
 
+<a name="0x3_native_validator_CHAIN_ID_ROOCH"></a>
+
+there defines chain id for rooch
+
+
+<pre><code><b>const</b> <a href="native_validator.md#0x3_native_validator_CHAIN_ID_ROOCH">CHAIN_ID_ROOCH</a>: u64 = 0;
+</code></pre>
+
+
+
 <a name="0x3_native_validator_ErrorInvalidPublicKeyLength"></a>
 
 error code
@@ -76,23 +86,13 @@ error code
 
 
 
-<a name="0x3_native_validator_SCHEME_NATIVE"></a>
+<a name="0x3_native_validator_chain_id"></a>
 
-there defines scheme for each blockchain
-
-
-<pre><code><b>const</b> <a href="native_validator.md#0x3_native_validator_SCHEME_NATIVE">SCHEME_NATIVE</a>: u64 = 0;
-</code></pre>
+## Function `chain_id`
 
 
 
-<a name="0x3_native_validator_scheme"></a>
-
-## Function `scheme`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_scheme">scheme</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id">chain_id</a>(): u64
 </code></pre>
 
 
@@ -101,8 +101,8 @@ there defines scheme for each blockchain
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_scheme">scheme</a>(): u64 {
-    <a href="native_validator.md#0x3_native_validator_SCHEME_NATIVE">SCHEME_NATIVE</a>
+<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id">chain_id</a>(): u64 {
+    <a href="native_validator.md#0x3_native_validator_CHAIN_ID_ROOCH">CHAIN_ID_ROOCH</a>
 }
 </code></pre>
 
@@ -239,7 +239,7 @@ Get the authentication key of the given public key.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> bytes = <a href="_singleton">vector::singleton</a>((<a href="native_validator.md#0x3_native_validator_scheme">scheme</a>() <b>as</b> u8));
+    <b>let</b> bytes = <a href="_singleton">vector::singleton</a>((<a href="chain_id.md#0x3_chain_id">chain_id</a>() <b>as</b> u8));
     <a href="_append">vector::append</a>(&<b>mut</b> bytes, public_key);
     hash::blake2b256(&bytes)
 }

--- a/crates/rooch-framework/doc/native_validator.md
+++ b/crates/rooch-framework/doc/native_validator.md
@@ -3,12 +3,12 @@
 
 # Module `0x3::native_validator`
 
-This module implements the native validator scheme.
+This module implements the native validator.
 
 
 -  [Struct `NativeValidator`](#0x3_native_validator_NativeValidator)
 -  [Constants](#@Constants_0)
--  [Function `scheme`](#0x3_native_validator_scheme)
+-  [Function `auth_validator_id`](#0x3_native_validator_auth_validator_id)
 -  [Function `rotate_authentication_key_entry`](#0x3_native_validator_rotate_authentication_key_entry)
 -  [Function `remove_authentication_key_entry`](#0x3_native_validator_remove_authentication_key_entry)
 -  [Function `get_authentication_key_from_authenticator_payload`](#0x3_native_validator_get_authentication_key_from_authenticator_payload)
@@ -76,23 +76,23 @@ error code
 
 
 
-<a name="0x3_native_validator_SCHEME_NATIVE"></a>
+<a name="0x3_native_validator_NATIVE_VALIDATOR_ID"></a>
 
-there defines scheme for each blockchain
+there defines auth validator id for each blockchain
 
 
-<pre><code><b>const</b> <a href="native_validator.md#0x3_native_validator_SCHEME_NATIVE">SCHEME_NATIVE</a>: u64 = 0;
+<pre><code><b>const</b> <a href="native_validator.md#0x3_native_validator_NATIVE_VALIDATOR_ID">NATIVE_VALIDATOR_ID</a>: u64 = 0;
 </code></pre>
 
 
 
-<a name="0x3_native_validator_scheme"></a>
+<a name="0x3_native_validator_auth_validator_id"></a>
 
-## Function `scheme`
+## Function `auth_validator_id`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_scheme">scheme</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_auth_validator_id">auth_validator_id</a>(): u64
 </code></pre>
 
 
@@ -101,8 +101,8 @@ there defines scheme for each blockchain
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_scheme">scheme</a>(): u64 {
-    <a href="native_validator.md#0x3_native_validator_SCHEME_NATIVE">SCHEME_NATIVE</a>
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_auth_validator_id">auth_validator_id</a>(): u64 {
+    <a href="native_validator.md#0x3_native_validator_NATIVE_VALIDATOR_ID">NATIVE_VALIDATOR_ID</a>
 }
 </code></pre>
 
@@ -239,7 +239,7 @@ Get the authentication key of the given public key.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> bytes = <a href="_singleton">vector::singleton</a>((<a href="native_validator.md#0x3_native_validator_scheme">scheme</a>() <b>as</b> u8));
+    <b>let</b> bytes = <a href="_singleton">vector::singleton</a>((<a href="native_validator.md#0x3_native_validator_auth_validator_id">auth_validator_id</a>() <b>as</b> u8));
     <a href="_append">vector::append</a>(&<b>mut</b> bytes, public_key);
     hash::blake2b256(&bytes)
 }

--- a/crates/rooch-framework/doc/native_validator.md
+++ b/crates/rooch-framework/doc/native_validator.md
@@ -8,7 +8,7 @@ This module implements the native validator scheme.
 
 -  [Struct `NativeValidator`](#0x3_native_validator_NativeValidator)
 -  [Constants](#@Constants_0)
--  [Function `chain_id`](#0x3_native_validator_chain_id)
+-  [Function `scheme`](#0x3_native_validator_scheme)
 -  [Function `rotate_authentication_key_entry`](#0x3_native_validator_rotate_authentication_key_entry)
 -  [Function `remove_authentication_key_entry`](#0x3_native_validator_remove_authentication_key_entry)
 -  [Function `get_authentication_key_from_authenticator_payload`](#0x3_native_validator_get_authentication_key_from_authenticator_payload)
@@ -66,16 +66,6 @@ This module implements the native validator scheme.
 ## Constants
 
 
-<a name="0x3_native_validator_CHAIN_ID_ROOCH"></a>
-
-there defines chain id for rooch
-
-
-<pre><code><b>const</b> <a href="native_validator.md#0x3_native_validator_CHAIN_ID_ROOCH">CHAIN_ID_ROOCH</a>: u64 = 0;
-</code></pre>
-
-
-
 <a name="0x3_native_validator_ErrorInvalidPublicKeyLength"></a>
 
 error code
@@ -86,13 +76,23 @@ error code
 
 
 
-<a name="0x3_native_validator_chain_id"></a>
+<a name="0x3_native_validator_SCHEME_NATIVE"></a>
 
-## Function `chain_id`
+there defines scheme for each blockchain
+
+
+<pre><code><b>const</b> <a href="native_validator.md#0x3_native_validator_SCHEME_NATIVE">SCHEME_NATIVE</a>: u64 = 0;
+</code></pre>
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id">chain_id</a>(): u64
+<a name="0x3_native_validator_scheme"></a>
+
+## Function `scheme`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_scheme">scheme</a>(): u64
 </code></pre>
 
 
@@ -101,8 +101,8 @@ error code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id">chain_id</a>(): u64 {
-    <a href="native_validator.md#0x3_native_validator_CHAIN_ID_ROOCH">CHAIN_ID_ROOCH</a>
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_scheme">scheme</a>(): u64 {
+    <a href="native_validator.md#0x3_native_validator_SCHEME_NATIVE">SCHEME_NATIVE</a>
 }
 </code></pre>
 
@@ -239,7 +239,7 @@ Get the authentication key of the given public key.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_public_key_to_authentication_key">public_key_to_authentication_key</a>(public_key: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> bytes = <a href="_singleton">vector::singleton</a>((<a href="chain_id.md#0x3_chain_id">chain_id</a>() <b>as</b> u8));
+    <b>let</b> bytes = <a href="_singleton">vector::singleton</a>((<a href="native_validator.md#0x3_native_validator_scheme">scheme</a>() <b>as</b> u8));
     <a href="_append">vector::append</a>(&<b>mut</b> bytes, public_key);
     hash::blake2b256(&bytes)
 }

--- a/crates/rooch-framework/doc/native_validator.md
+++ b/crates/rooch-framework/doc/native_validator.md
@@ -11,6 +11,8 @@ This module implements the native validator.
 -  [Function `auth_validator_id`](#0x3_native_validator_auth_validator_id)
 -  [Function `rotate_authentication_key_entry`](#0x3_native_validator_rotate_authentication_key_entry)
 -  [Function `remove_authentication_key_entry`](#0x3_native_validator_remove_authentication_key_entry)
+-  [Function `get_public_key_from_authenticator_payload`](#0x3_native_validator_get_public_key_from_authenticator_payload)
+-  [Function `get_signature_from_authenticator_payload`](#0x3_native_validator_get_signature_from_authenticator_payload)
 -  [Function `get_authentication_key_from_authenticator_payload`](#0x3_native_validator_get_authentication_key_from_authenticator_payload)
 -  [Function `public_key_to_address`](#0x3_native_validator_public_key_to_address)
 -  [Function `public_key_to_authentication_key`](#0x3_native_validator_public_key_to_authentication_key)
@@ -171,6 +173,72 @@ there defines auth validator id for each blockchain
 
 </details>
 
+<a name="0x3_native_validator_get_public_key_from_authenticator_payload"></a>
+
+## Function `get_public_key_from_authenticator_payload`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
+    // TODO remove auth validator id from payload here <b>to</b> 0
+    <b>let</b> i = 1 + <a href="ed25519.md#0x3_ed25519_signature_length">ed25519::signature_length</a>();
+    <b>let</b> public_key_position = 1 + <a href="ed25519.md#0x3_ed25519_signature_length">ed25519::signature_length</a>() + <a href="ed25519.md#0x3_ed25519_public_key_length">ed25519::public_key_length</a>();
+    <b>while</b> (i &lt; public_key_position) {
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
+        i = i + 1;
+    };
+    public_key
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_native_validator_get_signature_from_authenticator_payload"></a>
+
+## Function `get_signature_from_authenticator_payload`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
+    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
+    // TODO remove auth validator id from payload here <b>to</b> 0
+    <b>let</b> i = 1;
+    <b>let</b> signature_position = <a href="ed25519.md#0x3_ed25519_signature_length">ed25519::signature_length</a>() + 1;
+    <b>while</b> (i &lt; signature_position) {
+        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
+        i = i + 1;
+    };
+    sign
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x3_native_validator_get_authentication_key_from_authenticator_payload"></a>
 
 ## Function `get_authentication_key_from_authenticator_payload`
@@ -188,7 +256,7 @@ Get the authentication key of the given authenticator from authenticator_payload
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_get_authentication_key_from_authenticator_payload">get_authentication_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">ed25519::get_public_key_from_authenticator_payload</a>(authenticator_payload);
+    <b>let</b> public_key = <a href="native_validator.md#0x3_native_validator_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload);
     <b>let</b> addr = <a href="native_validator.md#0x3_native_validator_public_key_to_address">public_key_to_address</a>(public_key);
     moveos_std::bcs::to_bytes(&addr)
 }
@@ -322,8 +390,8 @@ Only validate the authenticator's signature.
 <pre><code><b>public</b> <b>fun</b> <a href="native_validator.md#0x3_native_validator_validate_signature">validate_signature</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;, tx_hash: &<a href="">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
         <a href="ed25519.md#0x3_ed25519_verify">ed25519::verify</a>(
-            &<a href="ed25519.md#0x3_ed25519_get_signature_from_authenticator_payload">ed25519::get_signature_from_authenticator_payload</a>(authenticator_payload),
-            &<a href="ed25519.md#0x3_ed25519_get_public_key_from_authenticator_payload">ed25519::get_public_key_from_authenticator_payload</a>(authenticator_payload),
+            &<a href="native_validator.md#0x3_native_validator_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload),
+            &<a href="native_validator.md#0x3_native_validator_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload),
             tx_hash
         ),
         <a href="auth_validator.md#0x3_auth_validator_error_invalid_authenticator">auth_validator::error_invalid_authenticator</a>()

--- a/crates/rooch-framework/doc/schnorr.md
+++ b/crates/rooch-framework/doc/schnorr.md
@@ -6,12 +6,9 @@
 
 
 -  [Constants](#@Constants_0)
--  [Function `auth_validator_id_length`](#0x3_schnorr_auth_validator_id_length)
 -  [Function `public_key_length`](#0x3_schnorr_public_key_length)
 -  [Function `signature_length`](#0x3_schnorr_signature_length)
 -  [Function `sha256`](#0x3_schnorr_sha256)
--  [Function `get_public_key_from_authenticator_payload`](#0x3_schnorr_get_public_key_from_authenticator_payload)
--  [Function `get_signature_from_authenticator_payload`](#0x3_schnorr_get_signature_from_authenticator_payload)
 -  [Function `verify`](#0x3_schnorr_verify)
 
 
@@ -44,27 +41,9 @@ Error if the signature is invalid.
 
 
 
-<a name="0x3_schnorr_KECCAK256"></a>
-
-Hash function name that are valid for verify.
-
-
-<pre><code><b>const</b> <a href="schnorr.md#0x3_schnorr_KECCAK256">KECCAK256</a>: u8 = 0;
-</code></pre>
-
-
-
-<a name="0x3_schnorr_SHA256"></a>
-
-
-
-<pre><code><b>const</b> <a href="schnorr.md#0x3_schnorr_SHA256">SHA256</a>: u8 = 1;
-</code></pre>
-
-
-
 <a name="0x3_schnorr_SCHNORR_PUBKEY_LENGTH"></a>
 
+constant codes
 
 
 <pre><code><b>const</b> <a href="schnorr.md#0x3_schnorr_SCHNORR_PUBKEY_LENGTH">SCHNORR_PUBKEY_LENGTH</a>: u64 = 32;
@@ -81,45 +60,21 @@ Hash function name that are valid for verify.
 
 
 
-<a name="0x3_schnorr_SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH"></a>
+<a name="0x3_schnorr_SHA256"></a>
 
-constant codes
+Hash function name that are valid for verify.
 
 
-<pre><code><b>const</b> <a href="schnorr.md#0x3_schnorr_SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH">SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH</a>: u64 = 1;
+<pre><code><b>const</b> <a href="schnorr.md#0x3_schnorr_SHA256">SHA256</a>: u8 = 1;
 </code></pre>
 
 
-
-<a name="0x3_schnorr_auth_validator_id_length"></a>
-
-## Function `auth_validator_id_length`
-
-built-in functions
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>(): u64
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>(): u64 {
-    <a href="schnorr.md#0x3_schnorr_SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH">SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH</a>
-}
-</code></pre>
-
-
-
-</details>
 
 <a name="0x3_schnorr_public_key_length"></a>
 
 ## Function `public_key_length`
 
+built-in functions
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_public_key_length">public_key_length</a>(): u64
@@ -181,70 +136,6 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_sha256">sha256</a>(): u8 {
     <a href="schnorr.md#0x3_schnorr_SHA256">SHA256</a>
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_schnorr_get_public_key_from_authenticator_payload"></a>
-
-## Function `get_public_key_from_authenticator_payload`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>() + <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>();
-    <b>let</b> public_key_position = <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>() + <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>() + <a href="schnorr.md#0x3_schnorr_public_key_length">public_key_length</a>();
-    <b>while</b> (i &lt; public_key_position) {
-        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
-        i = i + 1;
-    };
-    public_key
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x3_schnorr_get_signature_from_authenticator_payload"></a>
-
-## Function `get_signature_from_authenticator_payload`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
-    <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>();
-    <b>let</b> signature_position = <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>() + 1;
-    <b>while</b> (i &lt; signature_position) {
-        <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
-        <a href="_push_back">vector::push_back</a>(&<b>mut</b> sign, *value);
-        i = i + 1;
-    };
-    sign
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/schnorr.md
+++ b/crates/rooch-framework/doc/schnorr.md
@@ -6,7 +6,7 @@
 
 
 -  [Constants](#@Constants_0)
--  [Function `scheme_length`](#0x3_schnorr_scheme_length)
+-  [Function `auth_validator_id_length`](#0x3_schnorr_auth_validator_id_length)
 -  [Function `public_key_length`](#0x3_schnorr_public_key_length)
 -  [Function `signature_length`](#0x3_schnorr_signature_length)
 -  [Function `sha256`](#0x3_schnorr_sha256)
@@ -81,24 +81,24 @@ Hash function name that are valid for verify.
 
 
 
-<a name="0x3_schnorr_SCHNORR_TO_SCHEME_NOSTR_LENGTH"></a>
+<a name="0x3_schnorr_SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH"></a>
 
 constant codes
 
 
-<pre><code><b>const</b> <a href="schnorr.md#0x3_schnorr_SCHNORR_TO_SCHEME_NOSTR_LENGTH">SCHNORR_TO_SCHEME_NOSTR_LENGTH</a>: u64 = 1;
+<pre><code><b>const</b> <a href="schnorr.md#0x3_schnorr_SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH">SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH</a>: u64 = 1;
 </code></pre>
 
 
 
-<a name="0x3_schnorr_scheme_length"></a>
+<a name="0x3_schnorr_auth_validator_id_length"></a>
 
-## Function `scheme_length`
+## Function `auth_validator_id_length`
 
 built-in functions
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_scheme_length">scheme_length</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>(): u64
 </code></pre>
 
 
@@ -107,8 +107,8 @@ built-in functions
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_scheme_length">scheme_length</a>(): u64 {
-    <a href="schnorr.md#0x3_schnorr_SCHNORR_TO_SCHEME_NOSTR_LENGTH">SCHNORR_TO_SCHEME_NOSTR_LENGTH</a>
+<pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>(): u64 {
+    <a href="schnorr.md#0x3_schnorr_SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH">SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH</a>
 }
 </code></pre>
 
@@ -205,8 +205,8 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_public_key_from_authenticator_payload">get_public_key_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> public_key = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="schnorr.md#0x3_schnorr_scheme_length">scheme_length</a>() + <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>();
-    <b>let</b> public_key_position = <a href="schnorr.md#0x3_schnorr_scheme_length">scheme_length</a>() + <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>() + <a href="schnorr.md#0x3_schnorr_public_key_length">public_key_length</a>();
+    <b>let</b> i = <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>() + <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>();
+    <b>let</b> public_key_position = <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>() + <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>() + <a href="schnorr.md#0x3_schnorr_public_key_length">public_key_length</a>();
     <b>while</b> (i &lt; public_key_position) {
         <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);
         <a href="_push_back">vector::push_back</a>(&<b>mut</b> public_key, *value);
@@ -237,7 +237,7 @@ built-in functions
 
 <pre><code><b>public</b> <b>fun</b> <a href="schnorr.md#0x3_schnorr_get_signature_from_authenticator_payload">get_signature_from_authenticator_payload</a>(authenticator_payload: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt; {
     <b>let</b> sign = <a href="_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> i = <a href="schnorr.md#0x3_schnorr_scheme_length">scheme_length</a>();
+    <b>let</b> i = <a href="schnorr.md#0x3_schnorr_auth_validator_id_length">auth_validator_id_length</a>();
     <b>let</b> signature_position = <a href="schnorr.md#0x3_schnorr_signature_length">signature_length</a>() + 1;
     <b>while</b> (i &lt; signature_position) {
         <b>let</b> value = <a href="_borrow">vector::borrow</a>(authenticator_payload, i);

--- a/crates/rooch-framework/doc/session_key.md
+++ b/crates/rooch-framework/doc/session_key.md
@@ -406,7 +406,7 @@ If the authentication key is not a session key, return option::none
 If the session key is expired or invalid, abort the tx, otherwise return option::some(authentication key)
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, auth_validator_id: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -415,7 +415,7 @@ If the session key is expired or invalid, abort the tx, otherwise return option:
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &StorageContext, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) : Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &StorageContext, auth_validator_id: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) : Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
     <b>let</b> sender_addr = <a href="_sender">storage_context::sender</a>(ctx);
     <b>if</b> (!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr)){
         <b>return</b> <a href="_none">option::none</a>()

--- a/crates/rooch-framework/doc/session_key.md
+++ b/crates/rooch-framework/doc/session_key.md
@@ -406,7 +406,7 @@ If the authentication key is not a session key, return option::none
 If the session key is expired or invalid, abort the tx, otherwise return option::some(authentication key)
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, multichain_id: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -415,7 +415,7 @@ If the session key is expired or invalid, abort the tx, otherwise return option:
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &StorageContext, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) : Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &StorageContext, multichain_id: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) : Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
     <b>let</b> sender_addr = <a href="_sender">storage_context::sender</a>(ctx);
     <b>if</b> (!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr)){
         <b>return</b> <a href="_none">option::none</a>()

--- a/crates/rooch-framework/doc/session_key.md
+++ b/crates/rooch-framework/doc/session_key.md
@@ -421,7 +421,7 @@ If the session key is expired or invalid, abort the tx, otherwise return option:
         <b>return</b> <a href="_none">option::none</a>()
     };
     // We only support <b>native</b> validator for <a href="session_key.md#0x3_session_key_SessionKey">SessionKey</a> now
-    <b>if</b>(scheme != <a href="native_validator.md#0x3_native_validator_scheme">native_validator::scheme</a>()){
+    <b>if</b>(auth_validator_id != <a href="native_validator.md#0x3_native_validator_auth_validator_id">native_validator::auth_validator_id</a>()){
         <b>return</b> <a href="_none">option::none</a>()
     };
 

--- a/crates/rooch-framework/doc/session_key.md
+++ b/crates/rooch-framework/doc/session_key.md
@@ -406,7 +406,7 @@ If the authentication key is not a session key, return option::none
 If the session key is expired or invalid, abort the tx, otherwise return option::some(authentication key)
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, multichain_id: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -415,7 +415,7 @@ If the session key is expired or invalid, abort the tx, otherwise return option:
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &StorageContext, multichain_id: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) : Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="session_key.md#0x3_session_key_validate">validate</a>(ctx: &StorageContext, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;) : Option&lt;<a href="">vector</a>&lt;u8&gt;&gt; {
     <b>let</b> sender_addr = <a href="_sender">storage_context::sender</a>(ctx);
     <b>if</b> (!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr)){
         <b>return</b> <a href="_none">option::none</a>()

--- a/crates/rooch-framework/doc/transaction_validator.md
+++ b/crates/rooch-framework/doc/transaction_validator.md
@@ -9,8 +9,7 @@
 -  [Function `validate`](#0x3_transaction_validator_validate)
 
 
-<pre><code><b>use</b> <a href="">0x1::debug</a>;
-<b>use</b> <a href="">0x1::error</a>;
+<pre><code><b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="">0x2::tx_result</a>;
@@ -82,7 +81,7 @@ Transaction exceeded its allocated max gas
 
 <a name="0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator"></a>
 
-The authenticator's scheme is not installed to the sender's account
+The authenticator's auth validator id is not installed to the sender's account
 
 
 <pre><code><b>const</b> <a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator">ErrorValidateNotInstalledAuthValidator</a>: u64 = 1010;
@@ -137,7 +136,7 @@ This function is for Rooch to validate the transaction sender's authenticator.
 If the authenticator is invaid, abort this function.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64, auth_validator_id: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
 </code></pre>
 
 
@@ -149,11 +148,9 @@ If the authenticator is invaid, abort this function.
 <pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(
     ctx: &StorageContext,
     <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64,
-    scheme: u64,
+    auth_validator_id: u64,
     authenticator_payload: <a href="">vector</a>&lt;u8&gt;
 ): TxValidateResult {
-    std::debug::print(&<a href="chain_id.md#0x3_chain_id">chain_id</a>);
-    std::debug::print(&scheme);
 
     // === validate the chain id ===
     <b>assert</b>!(
@@ -200,23 +197,22 @@ If the authenticator is invaid, abort this function.
     // === validate the authenticator ===
 
     // <b>if</b> the authenticator authenticator_payload is session key, validate the session key
-    // otherwise <b>return</b> the authentication validator via the scheme
-    <b>let</b> session_key_option = <a href="session_key.md#0x3_session_key_validate">session_key::validate</a>(ctx, scheme, authenticator_payload);
-    std::debug::print(&session_key_option);
+    // otherwise <b>return</b> the authentication validator via the auth validator id
+    <b>let</b> session_key_option = <a href="session_key.md#0x3_session_key_validate">session_key::validate</a>(ctx, auth_validator_id, authenticator_payload);
     <b>if</b> (<a href="_is_some">option::is_some</a>(&session_key_option)) {
-        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="_none">option::none</a>(), session_key_option)
+        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(auth_validator_id, <a href="_none">option::none</a>(), session_key_option)
     }<b>else</b> {
         <b>let</b> sender = <a href="_sender">storage_context::sender</a>(ctx);
-        <b>let</b> <a href="auth_validator.md#0x3_auth_validator">auth_validator</a> = <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">auth_validator_registry::borrow_validator</a>(ctx, scheme);
+        <b>let</b> <a href="auth_validator.md#0x3_auth_validator">auth_validator</a> = <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">auth_validator_registry::borrow_validator</a>(ctx, auth_validator_id);
         <b>let</b> validator_id = <a href="auth_validator.md#0x3_auth_validator_validator_id">auth_validator::validator_id</a>(<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>);
-        // builtin scheme do not need <b>to</b> install
-        <b>if</b> (!rooch_framework::builtin_validators::is_builtin_scheme(scheme)) {
+        // builtin auth validator id do not need <b>to</b> install
+        <b>if</b> (!rooch_framework::builtin_validators::is_builtin_auth_validator(auth_validator_id)) {
             <b>assert</b>!(
                 <a href="account_authentication.md#0x3_account_authentication_is_auth_validator_installed">account_authentication::is_auth_validator_installed</a>(ctx, sender, validator_id),
                 <a href="_invalid_state">error::invalid_state</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator">ErrorValidateNotInstalledAuthValidator</a>)
             );
         };
-        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="_some">option::some</a>(*<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>), <a href="_none">option::none</a>())
+        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(auth_validator_id, <a href="_some">option::some</a>(*<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>), <a href="_none">option::none</a>())
     }
 }
 </code></pre>

--- a/crates/rooch-framework/doc/transaction_validator.md
+++ b/crates/rooch-framework/doc/transaction_validator.md
@@ -81,7 +81,7 @@ Transaction exceeded its allocated max gas
 
 <a name="0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator"></a>
 
-The authenticator's scheme is not installed to the sender's account
+The authenticator's multichain id is not installed to the sender's account
 
 
 <pre><code><b>const</b> <a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator">ErrorValidateNotInstalledAuthValidator</a>: u64 = 1010;
@@ -136,7 +136,7 @@ This function is for Rooch to validate the transaction sender's authenticator.
 If the authenticator is invaid, abort this function.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64, multichain_id: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
 </code></pre>
 
 
@@ -148,7 +148,7 @@ If the authenticator is invaid, abort this function.
 <pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(
     ctx: &StorageContext,
     <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64,
-    scheme: u64,
+    multichain_id: u64,
     authenticator_payload: <a href="">vector</a>&lt;u8&gt;
 ): TxValidateResult {
 
@@ -197,22 +197,22 @@ If the authenticator is invaid, abort this function.
     // === validate the authenticator ===
 
     // <b>if</b> the authenticator authenticator_payload is session key, validate the session key
-    // otherwise <b>return</b> the authentication validator via the scheme
-    <b>let</b> session_key_option = <a href="session_key.md#0x3_session_key_validate">session_key::validate</a>(ctx, scheme, authenticator_payload);
+    // otherwise <b>return</b> the authentication validator via the multichain_id
+    <b>let</b> session_key_option = <a href="session_key.md#0x3_session_key_validate">session_key::validate</a>(ctx, multichain_id, authenticator_payload);
     <b>if</b> (<a href="_is_some">option::is_some</a>(&session_key_option)) {
-        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="_none">option::none</a>(), session_key_option)
+        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(multichain_id, <a href="_none">option::none</a>(), session_key_option)
     }<b>else</b> {
         <b>let</b> sender = <a href="_sender">storage_context::sender</a>(ctx);
-        <b>let</b> <a href="auth_validator.md#0x3_auth_validator">auth_validator</a> = <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">auth_validator_registry::borrow_validator</a>(ctx, scheme);
+        <b>let</b> <a href="auth_validator.md#0x3_auth_validator">auth_validator</a> = <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">auth_validator_registry::borrow_validator</a>(ctx, multichain_id);
         <b>let</b> validator_id = <a href="auth_validator.md#0x3_auth_validator_validator_id">auth_validator::validator_id</a>(<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>);
-        // builtin scheme do not need <b>to</b> install
-        <b>if</b> (!rooch_framework::builtin_validators::is_builtin_scheme(scheme)) {
+        // builtin multichain id do not need <b>to</b> install
+        <b>if</b> (!rooch_framework::builtin_validators::is_builtin_multichain_id(multichain_id)) {
             <b>assert</b>!(
                 <a href="account_authentication.md#0x3_account_authentication_is_auth_validator_installed">account_authentication::is_auth_validator_installed</a>(ctx, sender, validator_id),
                 <a href="_invalid_state">error::invalid_state</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator">ErrorValidateNotInstalledAuthValidator</a>)
             );
         };
-        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="_some">option::some</a>(*<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>), <a href="_none">option::none</a>())
+        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(multichain_id, <a href="_some">option::some</a>(*<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>), <a href="_none">option::none</a>())
     }
 }
 </code></pre>

--- a/crates/rooch-framework/doc/transaction_validator.md
+++ b/crates/rooch-framework/doc/transaction_validator.md
@@ -9,7 +9,8 @@
 -  [Function `validate`](#0x3_transaction_validator_validate)
 
 
-<pre><code><b>use</b> <a href="">0x1::error</a>;
+<pre><code><b>use</b> <a href="">0x1::debug</a>;
+<b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="">0x2::tx_result</a>;
@@ -81,7 +82,7 @@ Transaction exceeded its allocated max gas
 
 <a name="0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator"></a>
 
-The authenticator's multichain id is not installed to the sender's account
+The authenticator's scheme is not installed to the sender's account
 
 
 <pre><code><b>const</b> <a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator">ErrorValidateNotInstalledAuthValidator</a>: u64 = 1010;
@@ -136,7 +137,7 @@ This function is for Rooch to validate the transaction sender's authenticator.
 If the authenticator is invaid, abort this function.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64, multichain_id: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64, scheme: u64, authenticator_payload: <a href="">vector</a>&lt;u8&gt;): <a href="auth_validator.md#0x3_auth_validator_TxValidateResult">auth_validator::TxValidateResult</a>
 </code></pre>
 
 
@@ -148,9 +149,11 @@ If the authenticator is invaid, abort this function.
 <pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x3_transaction_validator_validate">validate</a>(
     ctx: &StorageContext,
     <a href="chain_id.md#0x3_chain_id">chain_id</a>: u64,
-    multichain_id: u64,
+    scheme: u64,
     authenticator_payload: <a href="">vector</a>&lt;u8&gt;
 ): TxValidateResult {
+    std::debug::print(&<a href="chain_id.md#0x3_chain_id">chain_id</a>);
+    std::debug::print(&scheme);
 
     // === validate the chain id ===
     <b>assert</b>!(
@@ -197,22 +200,23 @@ If the authenticator is invaid, abort this function.
     // === validate the authenticator ===
 
     // <b>if</b> the authenticator authenticator_payload is session key, validate the session key
-    // otherwise <b>return</b> the authentication validator via the multichain_id
-    <b>let</b> session_key_option = <a href="session_key.md#0x3_session_key_validate">session_key::validate</a>(ctx, multichain_id, authenticator_payload);
+    // otherwise <b>return</b> the authentication validator via the scheme
+    <b>let</b> session_key_option = <a href="session_key.md#0x3_session_key_validate">session_key::validate</a>(ctx, scheme, authenticator_payload);
+    std::debug::print(&session_key_option);
     <b>if</b> (<a href="_is_some">option::is_some</a>(&session_key_option)) {
-        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(multichain_id, <a href="_none">option::none</a>(), session_key_option)
+        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="_none">option::none</a>(), session_key_option)
     }<b>else</b> {
         <b>let</b> sender = <a href="_sender">storage_context::sender</a>(ctx);
-        <b>let</b> <a href="auth_validator.md#0x3_auth_validator">auth_validator</a> = <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">auth_validator_registry::borrow_validator</a>(ctx, multichain_id);
+        <b>let</b> <a href="auth_validator.md#0x3_auth_validator">auth_validator</a> = <a href="auth_validator_registry.md#0x3_auth_validator_registry_borrow_validator">auth_validator_registry::borrow_validator</a>(ctx, scheme);
         <b>let</b> validator_id = <a href="auth_validator.md#0x3_auth_validator_validator_id">auth_validator::validator_id</a>(<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>);
-        // builtin multichain id do not need <b>to</b> install
-        <b>if</b> (!rooch_framework::builtin_validators::is_builtin_multichain_id(multichain_id)) {
+        // builtin scheme do not need <b>to</b> install
+        <b>if</b> (!rooch_framework::builtin_validators::is_builtin_scheme(scheme)) {
             <b>assert</b>!(
                 <a href="account_authentication.md#0x3_account_authentication_is_auth_validator_installed">account_authentication::is_auth_validator_installed</a>(ctx, sender, validator_id),
                 <a href="_invalid_state">error::invalid_state</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateNotInstalledAuthValidator">ErrorValidateNotInstalledAuthValidator</a>)
             );
         };
-        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(multichain_id, <a href="_some">option::some</a>(*<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>), <a href="_none">option::none</a>())
+        <a href="auth_validator.md#0x3_auth_validator_new_tx_validate_result">auth_validator::new_tx_validate_result</a>(scheme, <a href="_some">option::some</a>(*<a href="auth_validator.md#0x3_auth_validator">auth_validator</a>), <a href="_none">option::none</a>())
     }
 }
 </code></pre>

--- a/crates/rooch-framework/sources/address_mapping.move
+++ b/crates/rooch-framework/sources/address_mapping.move
@@ -10,7 +10,7 @@ module rooch_framework::address_mapping{
 
     friend rooch_framework::transaction_validator;
 
-    //The coin id standard is defined in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+    //The multichain id standard is defined in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
     //Please keep consistent with rust Symbol
     const MULTICHAIN_ID_BITCOIN: u64 = 0;
     const MULTICHAIN_ID_ETHER: u64 = 60;

--- a/crates/rooch-framework/sources/address_mapping.move
+++ b/crates/rooch-framework/sources/address_mapping.move
@@ -101,7 +101,7 @@ module rooch_framework::address_mapping{
         let ctx = storage_context::new_test_context(sender_addr);
         account_storage::create_account_storage(&mut ctx, @rooch_framework);
         init(&mut ctx);
-        let multi_chain_address =  MultiChainAddress{
+        let multi_chain_address = MultiChainAddress{
             multichain_id: MULTICHAIN_ID_BITCOIN,
             raw_address: x"1234567890abcdef",
         };

--- a/crates/rooch-framework/sources/address_mapping.move
+++ b/crates/rooch-framework/sources/address_mapping.move
@@ -15,7 +15,7 @@ module rooch_framework::address_mapping{
     const MULTICHAIN_ID_BITCOIN: u64 = 0;
     const MULTICHAIN_ID_ETHER: u64 = 60;
     const MULTICHAIN_ID_NOSTR: u64 = 1237;
-    const MULTICHAIN_ID_ROOCH: u64 = 20230103;
+    const MULTICHAIN_ID_ROOCH: u64 = 20230101; // placeholder for MULTICHAIN_ID_ROOCH pending for actual id from slip-0044
 
     struct MultiChainAddress has copy, store, drop {
         multichain_id: u64,

--- a/crates/rooch-framework/sources/address_mapping.move
+++ b/crates/rooch-framework/sources/address_mapping.move
@@ -12,13 +12,13 @@ module rooch_framework::address_mapping{
 
     //The coin id standard is defined in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
     //Please keep consistent with rust Symbol
-    const COIN_ID_BITCOIN: u64 = 0;
-    const COIN_ID_ETHER: u64 = 60;
-    const COIN_ID_NOSTR: u64 = 1237;
-    const COIN_ID_ROOCH: u64 = 20230101;
+    const MULTICHAIN_ID_BITCOIN: u64 = 0;
+    const MULTICHAIN_ID_ETHER: u64 = 60;
+    const MULTICHAIN_ID_NOSTR: u64 = 1237;
+    const MULTICHAIN_ID_ROOCH: u64 = 20230103;
 
     struct MultiChainAddress has copy, store, drop {
-        coin_id: u64,
+        multichain_id: u64,
         raw_address: vector<u8>,
     }
     
@@ -37,7 +37,7 @@ module rooch_framework::address_mapping{
     }
 
     public fun is_rooch_address(maddress: &MultiChainAddress) : bool{
-        maddress.coin_id == COIN_ID_ROOCH
+        maddress.multichain_id == MULTICHAIN_ID_ROOCH
     }
 
     /// Resolve a multi-chain address to a rooch address
@@ -102,7 +102,7 @@ module rooch_framework::address_mapping{
         account_storage::create_account_storage(&mut ctx, @rooch_framework);
         init(&mut ctx);
         let multi_chain_address =  MultiChainAddress{
-            coin_id: COIN_ID_BITCOIN,
+            multichain_id: MULTICHAIN_ID_BITCOIN,
             raw_address: x"1234567890abcdef",
         };
         bind(&mut ctx, &sender, multi_chain_address);

--- a/crates/rooch-framework/sources/auth_validator/auth_validator.move
+++ b/crates/rooch-framework/sources/auth_validator/auth_validator.move
@@ -61,19 +61,19 @@ module rooch_framework::auth_validator {
     /// The Transaction Validate Result
     /// this result will be stored in the TxContext
     struct TxValidateResult has copy, store, drop {
-        /// The auth validator's scheme that validate the transaction
-        scheme: u64,
+        /// The auth validator's auth validator id that validate the transaction
+        auth_validator_id: u64,
         auth_validator: Option<AuthValidator>,
         session_key: Option<vector<u8>>,
     }
 
     public(friend) fun new_tx_validate_result(
-        scheme: u64,
+        auth_validator_id: u64,
         auth_validator: Option<AuthValidator>,
         session_key: Option<vector<u8>>
     ): TxValidateResult {
         TxValidateResult {
-            scheme: scheme,
+            auth_validator_id: auth_validator_id,
             auth_validator: auth_validator,
             session_key: session_key,
         }
@@ -86,10 +86,10 @@ module rooch_framework::auth_validator {
         option::extract(&mut validate_result_opt)
     }
 
-    /// Get the auth validator's scheme from the TxValidateResult in the TxContext
-    public fun get_validator_scheme_from_tx_ctx(ctx: &StorageContext): u64 {
+    /// Get the auth validator's auth validator id from the TxValidateResult in the TxContext
+    public fun get_validator_id_from_tx_ctx(ctx: &StorageContext): u64 {
         let validate_result = get_validate_result_from_tx_ctx(ctx);
-        validate_result.scheme
+        validate_result.auth_validator_id
     }
 
     /// Get the session key from the TxValidateResult in the TxContext

--- a/crates/rooch-framework/sources/auth_validator/builtin_validators.move
+++ b/crates/rooch-framework/sources/auth_validator/builtin_validators.move
@@ -9,18 +9,18 @@ module rooch_framework::builtin_validators{
 
     const ErrorGenesisInit: u64 = 1;
 
-    public(friend) fun genesis_init(ctx: &mut StorageContext, _genesis_account: &signer){
-        // SCHEME_NATIVE: u64 = 0;
+    public(friend) fun genesis_init(ctx: &mut StorageContext, _genesis_account: &signer) {
+        // NATIVE_AUTH_VALIDATOR_ID: u64 = 0;
         let id = auth_validator_registry::register_internal<native_validator::NativeValidator>(ctx);
-        assert!(id == native_validator::scheme(), std::error::internal(ErrorGenesisInit));
+        assert!(id == native_validator::auth_validator_id(), std::error::internal(ErrorGenesisInit));
 
-        // SCHEME_ETHEREUM: u64 = 1;
+        // ETHEREUM_AUTH_VALIDATOR_ID: u64 = 1;
         let id = auth_validator_registry::register_internal<ethereum_validator::EthereumValidator>(ctx);
-        assert!(id == ethereum_validator::scheme(), std::error::internal(ErrorGenesisInit));
+        assert!(id == ethereum_validator::auth_validator_id(), std::error::internal(ErrorGenesisInit));
     }
 
-    public fun is_builtin_scheme(scheme: u64): bool {
-        scheme == native_validator::scheme()
-        || scheme == ethereum_validator::scheme()
+    public fun is_builtin_auth_validator(auth_validator_id: u64): bool {
+        auth_validator_id == native_validator::auth_validator_id()
+        || auth_validator_id == ethereum_validator::auth_validator_id()
     }
 }

--- a/crates/rooch-framework/sources/auth_validator/ethereum_validator.move
+++ b/crates/rooch-framework/sources/auth_validator/ethereum_validator.move
@@ -1,4 +1,4 @@
-/// This module implements Ethereum validator with the ECDSA recoverable signature over Secp256k1 crypto scheme.
+/// This module implements Ethereum validator with the ECDSA recoverable signature over Secp256k1.
 module rooch_framework::ethereum_validator {
 
     use std::error;
@@ -11,16 +11,16 @@ module rooch_framework::ethereum_validator {
     use rooch_framework::auth_validator;
     use rooch_framework::ethereum_address::{Self, ETHAddress};
 
-    /// there defines scheme for each blockchain
-    const SCHEME_ETHEREUM: u64 = 1;
+    /// there defines auth validator id for each blockchain
+    const ETHEREUM_AUTH_VALIDATOR_ID: u64 = 1;
 
     /// error code
     const ErrorInvalidPublicKeyLength: u64 = 0;
 
     struct EthereumValidator has store, drop {}
 
-    public fun scheme(): u64 {
-        SCHEME_ETHEREUM
+    public fun auth_validator_id(): u64 {
+        ETHEREUM_AUTH_VALIDATOR_ID
     }
 
     public entry fun rotate_authentication_key_entry(

--- a/crates/rooch-framework/sources/auth_validator/ethereum_validator.move
+++ b/crates/rooch-framework/sources/auth_validator/ethereum_validator.move
@@ -48,9 +48,33 @@ module rooch_framework::ethereum_validator {
         account_authentication::remove_authentication_key<EthereumValidator>(ctx, signer::address_of(account));
     }
 
+    public fun get_public_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
+        let public_key = vector::empty<u8>();
+        let i = ecdsa_k1_recoverable::signature_length();
+        let public_key_position = ecdsa_k1_recoverable::signature_length() + ecdsa_k1_recoverable::public_key_length();
+        while (i < public_key_position) {
+            let value = vector::borrow(authenticator_payload, i);
+            vector::push_back(&mut public_key, *value);
+            i = i + 1;
+        };
+        public_key
+    }
+
+    public fun get_signature_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
+        let sign = vector::empty<u8>();
+        let i = 0;
+        let signature_position = ecdsa_k1_recoverable::signature_length();
+        while (i < signature_position) {
+            let value = vector::borrow(authenticator_payload, i);
+            vector::push_back(&mut sign, *value);
+            i = i + 1;
+        };
+        sign
+    }
+
     /// Get the authentication key of the given authenticator from authenticator_payload.
     public fun get_authentication_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
-        let public_key = ecdsa_k1_recoverable::get_public_key_from_authenticator_payload(authenticator_payload);
+        let public_key = get_public_key_from_authenticator_payload(authenticator_payload);
         let addr = public_key_to_address(public_key);
         ethereum_address::into_bytes(addr)
     }
@@ -84,7 +108,7 @@ module rooch_framework::ethereum_validator {
     public fun validate_signature(authenticator_payload: &vector<u8>, tx_hash: &vector<u8>) {
         assert!(
             ecdsa_k1_recoverable::verify(
-                &ecdsa_k1_recoverable::get_signature_from_authenticator_payload(authenticator_payload),
+                &get_signature_from_authenticator_payload(authenticator_payload),
                 tx_hash,
                 ecdsa_k1_recoverable::keccak256()
             ),

--- a/crates/rooch-framework/sources/auth_validator/native_validator.move
+++ b/crates/rooch-framework/sources/auth_validator/native_validator.move
@@ -1,4 +1,4 @@
-/// This module implements the native validator scheme.
+/// This module implements the native validator.
 module rooch_framework::native_validator {
 
     use std::error;
@@ -11,16 +11,16 @@ module rooch_framework::native_validator {
     use rooch_framework::ed25519;
     use rooch_framework::auth_validator;
 
-    /// there defines scheme for each blockchain
-    const SCHEME_NATIVE: u64 = 0;
+    /// there defines auth validator id for each blockchain
+    const NATIVE_VALIDATOR_ID: u64 = 0;
 
     /// error code
     const ErrorInvalidPublicKeyLength: u64 = 0;
 
     struct NativeValidator has store, drop {}
 
-    public fun scheme(): u64 {
-        SCHEME_NATIVE
+    public fun auth_validator_id(): u64 {
+        NATIVE_VALIDATOR_ID
     }
 
     public entry fun rotate_authentication_key_entry(
@@ -61,7 +61,7 @@ module rooch_framework::native_validator {
 
     /// Get the authentication key of the given public key.
     public fun public_key_to_authentication_key(public_key: vector<u8>): vector<u8> {
-        let bytes = vector::singleton((scheme() as u8));
+        let bytes = vector::singleton((auth_validator_id() as u8));
         vector::append(&mut bytes, public_key);
         hash::blake2b256(&bytes)
     }

--- a/crates/rooch-framework/sources/crypto/ecdsa_k1.move
+++ b/crates/rooch-framework/sources/crypto/ecdsa_k1.move
@@ -1,13 +1,10 @@
 module rooch_framework::ecdsa_k1 {
-    use std::vector;
-
     /// constant codes
     const ECDSA_K1_TO_BITCOIN_VALIDATOR_ID_LENGTH: u64 = 1;
     const ECDSA_K1_COMPRESSED_PUBKEY_LENGTH: u64 = 33;
     const ECDSA_K1_SIG_LENGTH: u64 = 64;
 
     /// Hash function name that are valid for ecrecover and verify.
-    const KECCAK256: u8 = 0;
     const SHA256: u8 = 1;
     const RIPEMD160: u8 = 2;
 
@@ -30,40 +27,12 @@ module rooch_framework::ecdsa_k1 {
         ECDSA_K1_SIG_LENGTH
     }
 
-    public fun keccak256(): u8 {
-        KECCAK256
-    }
-
     public fun sha256(): u8 {
         SHA256
     }
 
     public fun ripemd160(): u8 {
         RIPEMD160
-    }
-
-    public fun get_public_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
-        let public_key = vector::empty<u8>();
-        let i = auth_validator_id_length() + signature_length();
-        let public_key_position = auth_validator_id_length() + signature_length() + public_key_length();
-        while (i < public_key_position) {
-            let value = vector::borrow(authenticator_payload, i);
-            vector::push_back(&mut public_key, *value);
-            i = i + 1;
-        };
-        public_key
-    }
-
-    public fun get_signature_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
-        let sign = vector::empty<u8>();
-        let i = auth_validator_id_length();
-        let signature_position = signature_length() + 1;
-        while (i < signature_position) {
-            let value = vector::borrow(authenticator_payload, i);
-            vector::push_back(&mut sign, *value);
-            i = i + 1;
-        };
-        sign
     }
 
     /// @param signature: A 64-bytes signature in form (r, s) that is signed using

--- a/crates/rooch-framework/sources/crypto/ecdsa_k1.move
+++ b/crates/rooch-framework/sources/crypto/ecdsa_k1.move
@@ -2,7 +2,7 @@ module rooch_framework::ecdsa_k1 {
     use std::vector;
 
     /// constant codes
-    const ECDSA_K1_TO_SCHEME_BITCOIN_LENGTH: u64 = 1;
+    const ECDSA_K1_TO_BITCOIN_VALIDATOR_ID_LENGTH: u64 = 1;
     const ECDSA_K1_COMPRESSED_PUBKEY_LENGTH: u64 = 33;
     const ECDSA_K1_SIG_LENGTH: u64 = 64;
 
@@ -18,8 +18,8 @@ module rooch_framework::ecdsa_k1 {
     const ErrorInvalidPubKey: u64 = 1;
 
     /// built-in functions
-    public fun scheme_length(): u64 {
-        ECDSA_K1_TO_SCHEME_BITCOIN_LENGTH
+    public fun auth_validator_id_length(): u64 {
+        ECDSA_K1_TO_BITCOIN_VALIDATOR_ID_LENGTH
     }
 
     public fun public_key_length(): u64 {
@@ -44,8 +44,8 @@ module rooch_framework::ecdsa_k1 {
 
     public fun get_public_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
         let public_key = vector::empty<u8>();
-        let i = scheme_length() + signature_length();
-        let public_key_position = scheme_length() + signature_length() + public_key_length();
+        let i = auth_validator_id_length() + signature_length();
+        let public_key_position = auth_validator_id_length() + signature_length() + public_key_length();
         while (i < public_key_position) {
             let value = vector::borrow(authenticator_payload, i);
             vector::push_back(&mut public_key, *value);
@@ -56,7 +56,7 @@ module rooch_framework::ecdsa_k1 {
 
     public fun get_signature_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
         let sign = vector::empty<u8>();
-        let i = scheme_length();
+        let i = auth_validator_id_length();
         let signature_position = signature_length() + 1;
         while (i < signature_position) {
             let value = vector::borrow(authenticator_payload, i);

--- a/crates/rooch-framework/sources/crypto/ecdsa_k1_recoverable.move
+++ b/crates/rooch-framework/sources/crypto/ecdsa_k1_recoverable.move
@@ -2,7 +2,7 @@ module rooch_framework::ecdsa_k1_recoverable {
     use std::vector;
 
     /// constant codes
-    const ECDSA_K1_RECOVERABLE_TO_SCHEME_ETHEREUM_LENGTH: u64 = 1;
+    const ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH: u64 = 1;
     const ECDSA_K1_RECOVERABLE_COMPRESSED_PUBKEY_LENGTH: u64 = 33;
     const ECDSA_K1_RECOVERABLE_UNCOMPRESSED_PUBKEY_LENGTH: u64 = 65;
     const ECDSA_K1_RECOVERABLE_SIG_LENGTH: u64 = 65;
@@ -21,8 +21,8 @@ module rooch_framework::ecdsa_k1_recoverable {
     const ErrorInvalidPubKey: u64 = 2;
 
     /// built-in functions
-    public fun scheme_length(): u64 {
-        ECDSA_K1_RECOVERABLE_TO_SCHEME_ETHEREUM_LENGTH
+    public fun auth_validator_id_length(): u64 {
+        ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH
     }
 
     public fun public_key_length(): u64 {
@@ -47,8 +47,8 @@ module rooch_framework::ecdsa_k1_recoverable {
 
     public fun get_public_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
         let public_key = vector::empty<u8>();
-        let i = scheme_length() + signature_length();
-        let public_key_position = scheme_length() + signature_length() + public_key_length();
+        let i = auth_validator_id_length() + signature_length();
+        let public_key_position = auth_validator_id_length() + signature_length() + public_key_length();
         while (i < public_key_position) {
             let value = vector::borrow(authenticator_payload, i);
             vector::push_back(&mut public_key, *value);
@@ -59,7 +59,7 @@ module rooch_framework::ecdsa_k1_recoverable {
 
     public fun get_signature_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
         let sign = vector::empty<u8>();
-        let i = 0; // TODO: do we need scheme_length here?
+        let i = 0;
         let signature_position = signature_length();
         while (i < signature_position) {
             let value = vector::borrow(authenticator_payload, i);

--- a/crates/rooch-framework/sources/crypto/ecdsa_k1_recoverable.move
+++ b/crates/rooch-framework/sources/crypto/ecdsa_k1_recoverable.move
@@ -1,15 +1,11 @@
 module rooch_framework::ecdsa_k1_recoverable {
-    use std::vector;
-
     /// constant codes
-    const ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH: u64 = 1;
     const ECDSA_K1_RECOVERABLE_COMPRESSED_PUBKEY_LENGTH: u64 = 33;
     const ECDSA_K1_RECOVERABLE_UNCOMPRESSED_PUBKEY_LENGTH: u64 = 65;
     const ECDSA_K1_RECOVERABLE_SIG_LENGTH: u64 = 65;
 
     /// Hash function name that are valid for ecrecover and verify.
     const KECCAK256: u8 = 0;
-    const SHA256: u8 = 1;
 
     /// Error if the public key cannot be recovered from the signature.
     const ErrorFailToRecoverPubKey: u64 = 0;
@@ -21,10 +17,6 @@ module rooch_framework::ecdsa_k1_recoverable {
     const ErrorInvalidPubKey: u64 = 2;
 
     /// built-in functions
-    public fun auth_validator_id_length(): u64 {
-        ECDSA_K1_RECOVERABLE_TO_ETHEREUM_VALIDATOR_ID_LENGTH
-    }
-
     public fun public_key_length(): u64 {
         ECDSA_K1_RECOVERABLE_COMPRESSED_PUBKEY_LENGTH
     }
@@ -39,34 +31,6 @@ module rooch_framework::ecdsa_k1_recoverable {
 
     public fun keccak256(): u8 {
         KECCAK256
-    }
-
-    public fun sha256(): u8 {
-        SHA256
-    }
-
-    public fun get_public_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
-        let public_key = vector::empty<u8>();
-        let i = auth_validator_id_length() + signature_length();
-        let public_key_position = auth_validator_id_length() + signature_length() + public_key_length();
-        while (i < public_key_position) {
-            let value = vector::borrow(authenticator_payload, i);
-            vector::push_back(&mut public_key, *value);
-            i = i + 1;
-        };
-        public_key
-    }
-
-    public fun get_signature_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
-        let sign = vector::empty<u8>();
-        let i = 0;
-        let signature_position = signature_length();
-        while (i < signature_position) {
-            let value = vector::borrow(authenticator_payload, i);
-            vector::push_back(&mut sign, *value);
-            i = i + 1;
-        };
-        sign
     }
 
     /// @param signature: A 65-bytes signature in form (r, s, v) that is signed using
@@ -107,12 +71,6 @@ module rooch_framework::ecdsa_k1_recoverable {
         let pubkey_bytes = x"02337cca2171fdbfcfd657fa59881f46269f1e590b5ffab6023686c7ad2ecc2c1c";
         let pubkey = ecrecover(&sig, &msg, KECCAK256);
         assert!(pubkey == pubkey_bytes, 0);
-
-        // recover with sha256 hash
-        let sig = x"e5847245b38548547f613aaea3421ad47f5b95a222366fb9f9b8c57568feb19c7077fc31e7d83e00acc1347d08c3e1ad50a4eeb6ab044f25c861ddc7be5b8f9f01";
-        let pubkey_bytes = x"02337cca2171fdbfcfd657fa59881f46269f1e590b5ffab6023686c7ad2ecc2c1c";
-        let pubkey = ecrecover(&sig, &msg, SHA256);
-        assert!(pubkey == pubkey_bytes, 0);
     }
 
     #[test]
@@ -120,7 +78,7 @@ module rooch_framework::ecdsa_k1_recoverable {
     fun test_ecrecover_pubkey_fail_to_recover() {
         let msg = x"00";
         let sig = x"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-        ecrecover(&sig, &msg, SHA256);
+        ecrecover(&sig, &msg, KECCAK256);
     }
 
     #[test]
@@ -129,7 +87,7 @@ module rooch_framework::ecdsa_k1_recoverable {
         let msg = b"Hello, world!";
         // incorrect length sig
         let sig = x"7e4237ebfbc36613e166bfc5f6229360a9c1949242da97ca04867e4de57b2df30c8340bcb320328cf46d71bda51fcb519e3ce53b348eec62de852e350edbd886";
-        ecrecover(&sig, &msg, SHA256);
+        ecrecover(&sig, &msg, KECCAK256);
     }
 
     #[test]

--- a/crates/rooch-framework/sources/crypto/ed25519.move
+++ b/crates/rooch-framework/sources/crypto/ed25519.move
@@ -1,46 +1,15 @@
 module rooch_framework::ed25519 {
-    use std::vector;
-
     /// constant codes
-    const ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH: u64 = 1;
     const ED25519_PUBKEY_LENGTH: u64 = 32;
     const ED25519_SIG_LENGTH: u64 = 64;
 
     /// built-in functions
-    public fun auth_validator_id_length(): u64 {
-        ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH
-    }
-
     public fun public_key_length(): u64 {
         ED25519_PUBKEY_LENGTH
     }
 
     public fun signature_length(): u64 {
         ED25519_SIG_LENGTH
-    }
-
-    public fun get_public_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
-        let public_key = vector::empty<u8>();
-        let i = auth_validator_id_length() + signature_length();
-        let public_key_position = auth_validator_id_length() + signature_length() + public_key_length();
-        while (i < public_key_position) {
-            let value = vector::borrow(authenticator_payload, i);
-            vector::push_back(&mut public_key, *value);
-            i = i + 1;
-        };
-        public_key
-    }
-
-    public fun get_signature_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
-        let sign = vector::empty<u8>();
-        let i = auth_validator_id_length();
-        let signature_position = signature_length() + 1;
-        while (i < signature_position) {
-            let value = vector::borrow(authenticator_payload, i);
-            vector::push_back(&mut sign, *value);
-            i = i + 1;
-        };
-        sign
     }
 
     /// @param signature: 32-byte signature that is a point on the Ed25519 elliptic curve.

--- a/crates/rooch-framework/sources/crypto/ed25519.move
+++ b/crates/rooch-framework/sources/crypto/ed25519.move
@@ -2,13 +2,13 @@ module rooch_framework::ed25519 {
     use std::vector;
 
     /// constant codes
-    const ED25519_TO_SCHEME_NATIVE_LENGTH: u64 = 1;
+    const ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH: u64 = 1;
     const ED25519_PUBKEY_LENGTH: u64 = 32;
     const ED25519_SIG_LENGTH: u64 = 64;
 
     /// built-in functions
-    public fun scheme_length(): u64 {
-        ED25519_TO_SCHEME_NATIVE_LENGTH
+    public fun auth_validator_id_length(): u64 {
+        ED25519_TO_NATIVE_VALIDATOR_ID_LENGTH
     }
 
     public fun public_key_length(): u64 {
@@ -21,8 +21,8 @@ module rooch_framework::ed25519 {
 
     public fun get_public_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
         let public_key = vector::empty<u8>();
-        let i = scheme_length() + signature_length();
-        let public_key_position = scheme_length() + signature_length() + public_key_length();
+        let i = auth_validator_id_length() + signature_length();
+        let public_key_position = auth_validator_id_length() + signature_length() + public_key_length();
         while (i < public_key_position) {
             let value = vector::borrow(authenticator_payload, i);
             vector::push_back(&mut public_key, *value);
@@ -33,7 +33,7 @@ module rooch_framework::ed25519 {
 
     public fun get_signature_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
         let sign = vector::empty<u8>();
-        let i = scheme_length();
+        let i = auth_validator_id_length();
         let signature_position = signature_length() + 1;
         while (i < signature_position) {
             let value = vector::borrow(authenticator_payload, i);

--- a/crates/rooch-framework/sources/crypto/schnorr.move
+++ b/crates/rooch-framework/sources/crypto/schnorr.move
@@ -2,7 +2,7 @@ module rooch_framework::schnorr {
     use std::vector;
 
     /// constant codes
-    const SCHNORR_TO_SCHEME_NOSTR_LENGTH: u64 = 1;
+    const SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH: u64 = 1;
     const SCHNORR_PUBKEY_LENGTH: u64 = 32;
     const SCHNORR_SIG_LENGTH: u64 = 64;
 
@@ -17,8 +17,8 @@ module rooch_framework::schnorr {
     const ErrorInvalidPubKey: u64 = 1;
 
     /// built-in functions
-    public fun scheme_length(): u64 {
-        SCHNORR_TO_SCHEME_NOSTR_LENGTH
+    public fun auth_validator_id_length(): u64 {
+        SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH
     }
 
     public fun public_key_length(): u64 {
@@ -35,8 +35,8 @@ module rooch_framework::schnorr {
 
     public fun get_public_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
         let public_key = vector::empty<u8>();
-        let i = scheme_length() + signature_length();
-        let public_key_position = scheme_length() + signature_length() + public_key_length();
+        let i = auth_validator_id_length() + signature_length();
+        let public_key_position = auth_validator_id_length() + signature_length() + public_key_length();
         while (i < public_key_position) {
             let value = vector::borrow(authenticator_payload, i);
             vector::push_back(&mut public_key, *value);
@@ -47,7 +47,7 @@ module rooch_framework::schnorr {
 
     public fun get_signature_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
         let sign = vector::empty<u8>();
-        let i = scheme_length();
+        let i = auth_validator_id_length();
         let signature_position = signature_length() + 1;
         while (i < signature_position) {
             let value = vector::borrow(authenticator_payload, i);

--- a/crates/rooch-framework/sources/crypto/schnorr.move
+++ b/crates/rooch-framework/sources/crypto/schnorr.move
@@ -1,13 +1,9 @@
 module rooch_framework::schnorr {
-    use std::vector;
-
     /// constant codes
-    const SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH: u64 = 1;
     const SCHNORR_PUBKEY_LENGTH: u64 = 32;
     const SCHNORR_SIG_LENGTH: u64 = 64;
 
     /// Hash function name that are valid for verify.
-    const KECCAK256: u8 = 0;
     const SHA256: u8 = 1;
 
     /// Error if the signature is invalid.
@@ -17,10 +13,6 @@ module rooch_framework::schnorr {
     const ErrorInvalidPubKey: u64 = 1;
 
     /// built-in functions
-    public fun auth_validator_id_length(): u64 {
-        SCHNORR_TO_NOSTR_VALIDATOR_ID_LENGTH
-    }
-
     public fun public_key_length(): u64 {
         SCHNORR_PUBKEY_LENGTH
     }
@@ -31,30 +23,6 @@ module rooch_framework::schnorr {
 
     public fun sha256(): u8 {
         SHA256
-    }
-
-    public fun get_public_key_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
-        let public_key = vector::empty<u8>();
-        let i = auth_validator_id_length() + signature_length();
-        let public_key_position = auth_validator_id_length() + signature_length() + public_key_length();
-        while (i < public_key_position) {
-            let value = vector::borrow(authenticator_payload, i);
-            vector::push_back(&mut public_key, *value);
-            i = i + 1;
-        };
-        public_key
-    }
-
-    public fun get_signature_from_authenticator_payload(authenticator_payload: &vector<u8>): vector<u8> {
-        let sign = vector::empty<u8>();
-        let i = auth_validator_id_length();
-        let signature_position = signature_length() + 1;
-        while (i < signature_position) {
-            let value = vector::borrow(authenticator_payload, i);
-            vector::push_back(&mut sign, *value);
-            i = i + 1;
-        };
-        sign
     }
 
     /// @param signature: A 64-bytes signature that is signed using Schnorr over Secpk256k1 key pairs.

--- a/crates/rooch-framework/sources/genesis.move
+++ b/crates/rooch-framework/sources/genesis.move
@@ -28,7 +28,6 @@ module rooch_framework::genesis {
         let genesis_context_option = storage_context::get<GenesisContext>(ctx);
         assert!(option::is_some(&genesis_context_option), error::invalid_argument(ErrorGenesisInit));
         let genesis_context = option::extract(&mut genesis_context_option);
-        std::debug::print(&genesis_context);
         chain_id::genesis_init(ctx, genesis_account, genesis_context.chain_id);
         auth_validator_registry::genesis_init(ctx, genesis_account);
         builtin_validators::genesis_init(ctx, genesis_account);

--- a/crates/rooch-framework/sources/genesis.move
+++ b/crates/rooch-framework/sources/genesis.move
@@ -28,6 +28,7 @@ module rooch_framework::genesis {
         let genesis_context_option = storage_context::get<GenesisContext>(ctx);
         assert!(option::is_some(&genesis_context_option), error::invalid_argument(ErrorGenesisInit));
         let genesis_context = option::extract(&mut genesis_context_option);
+        std::debug::print(&genesis_context);
         chain_id::genesis_init(ctx, genesis_account, genesis_context.chain_id);
         auth_validator_registry::genesis_init(ctx, genesis_account);
         builtin_validators::genesis_init(ctx, genesis_account);

--- a/crates/rooch-framework/sources/session_key.move
+++ b/crates/rooch-framework/sources/session_key.move
@@ -128,7 +128,7 @@ module rooch_framework::session_key {
     /// Validate the current tx via the session key
     /// If the authentication key is not a session key, return option::none
     /// If the session key is expired or invalid, abort the tx, otherwise return option::some(authentication key)
-    public(friend) fun validate(ctx: &StorageContext, scheme: u64, authenticator_payload: vector<u8>) : Option<vector<u8>> {
+    public(friend) fun validate(ctx: &StorageContext, auth_validator_id: u64, authenticator_payload: vector<u8>) : Option<vector<u8>> {
         let sender_addr = storage_context::sender(ctx);
         if (!account_storage::global_exists<SessionKeys>(ctx, sender_addr)){
             return option::none()

--- a/crates/rooch-framework/sources/session_key.move
+++ b/crates/rooch-framework/sources/session_key.move
@@ -134,7 +134,7 @@ module rooch_framework::session_key {
             return option::none()
         };
         // We only support native validator for SessionKey now
-        if(scheme != native_validator::scheme()){
+        if(auth_validator_id != native_validator::auth_validator_id()){
             return option::none()
         };
 

--- a/crates/rooch-framework/sources/transaction_validator.move
+++ b/crates/rooch-framework/sources/transaction_validator.move
@@ -44,6 +44,8 @@ module rooch_framework::transaction_validator {
         scheme: u64,
         authenticator_payload: vector<u8>
     ): TxValidateResult {
+        std::debug::print(&chain_id);
+        std::debug::print(&scheme);
 
         // === validate the chain id ===
         assert!(
@@ -92,6 +94,7 @@ module rooch_framework::transaction_validator {
         // if the authenticator authenticator_payload is session key, validate the session key
         // otherwise return the authentication validator via the scheme
         let session_key_option = session_key::validate(ctx, scheme, authenticator_payload);
+        std::debug::print(&session_key_option);
         if (option::is_some(&session_key_option)) {
             auth_validator::new_tx_validate_result(scheme, option::none(), session_key_option)
         }else {

--- a/crates/rooch-key/Cargo.toml
+++ b/crates/rooch-key/Cargo.toml
@@ -35,6 +35,7 @@ moveos-types = { workspace = true }
 proptest = {optional = true, workspace = true }
 proptest-derive = {optional = true, workspace = true }
 ethers = { workspace = true }
+clap = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/rooch-key/src/key_derive.rs
+++ b/crates/rooch-key/src/key_derive.rs
@@ -11,13 +11,13 @@ use fastcrypto::secp256k1::recoverable::{
 use fastcrypto::traits::KeyPair;
 use fastcrypto::{ed25519::Ed25519PrivateKey, traits::ToFromBytes};
 use rooch_types::address::{EthereumAddress, RoochAddress};
-use rooch_types::coin_type::CoinID;
+use rooch_types::chain_id::{CustomChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::RoochError;
 use slip10_ed25519::derive_ed25519_private_key;
 use std::string::String;
 
-// CoinID type
+// Coin type
 pub const DERIVATION_PATH_COIN_TYPE_BTC: u64 = 0;
 pub const DERIVATION_PATH_COIN_TYPE_ETH: u64 = 60;
 pub const DERIVATION_PATH_COIN_TYPE_SUI: u64 = 784;
@@ -43,13 +43,13 @@ pub trait CoinOperations<Addr, KeyPair> {
     ) -> Result<(Addr, KeyPair), RoochError>;
 }
 
-impl CoinOperations<RoochAddress, RoochKeyPair> for CoinID {
+impl CoinOperations<RoochAddress, RoochKeyPair> for RoochChainID {
     fn derive_key_pair_from_path(
         &self,
         seed: &[u8],
         derivation_path: Option<DerivationPath>,
     ) -> Result<(RoochAddress, RoochKeyPair), RoochError> {
-        let path = validate_path(self, derivation_path)?; // Pass the CoinID itself
+        let path = validate_path(self, derivation_path)?;
         let indexes = path.into_iter().map(|i| i.into()).collect::<Vec<_>>();
         let derived = derive_ed25519_private_key(seed, &indexes);
         let sk = Ed25519PrivateKey::from_bytes(&derived)
@@ -60,7 +60,7 @@ impl CoinOperations<RoochAddress, RoochKeyPair> for CoinID {
     }
 }
 
-impl CoinOperations<EthereumAddress, Secp256k1RecoverableKeyPair> for CoinID {
+impl CoinOperations<EthereumAddress, Secp256k1RecoverableKeyPair> for RoochChainID {
     fn derive_key_pair_from_path(
         &self,
         seed: &[u8],
@@ -81,12 +81,12 @@ impl CoinOperations<EthereumAddress, Secp256k1RecoverableKeyPair> for CoinID {
 }
 
 pub fn validate_path(
-    coin_id: &CoinID,
+    multichain_id: &RoochChainID,
     path: Option<DerivationPath>,
 ) -> Result<DerivationPath, RoochError> {
     // The derivation path must be hardened at all levels with purpose = 44, coin_type = 784
-    match coin_id {
-        CoinID::Rooch => {
+    match multichain_id {
+        RoochChainID::Builtin(_) => {
             match path {
                 Some(p) => {
                     // The derivation path must be hardened at all levels with purpose = 44, coin_type = 784
@@ -118,58 +118,71 @@ pub fn validate_path(
                 .map_err(|_| RoochError::SignatureKeyGenError("Cannot parse path".to_owned()))?),
             }
         }
-        CoinID::Ether => {
-            match path {
-                Some(p) => {
-                    // The derivation path must be hardened at all levels with purpose = 44, coin_type = 784
-                    if let &[purpose, coin_type, account, change, address] = p.as_ref() {
-                        if Some(purpose)
-                            == ChildNumber::new(DERVIATION_PATH_PURPOSE_ECDSA, true).ok()
-                            && Some(coin_type)
-                                == ChildNumber::new(
-                                    DERIVATION_PATH_COIN_TYPE_SUI.try_into().unwrap(),
-                                    true,
-                                )
-                                .ok()
-                            && account.is_hardened()
-                            && change.is_hardened()
-                            && address.is_hardened()
-                        {
-                            Ok(p)
+        RoochChainID::Custom(custom_chain_id) => {
+            if custom_chain_id == &CustomChainID::ethereum() {
+                match path {
+                    Some(p) => {
+                        // The derivation path must be hardened at all levels with purpose = 44, coin_type = 784
+                        if let &[purpose, coin_type, account, change, address] = p.as_ref() {
+                            if Some(purpose)
+                                == ChildNumber::new(DERVIATION_PATH_PURPOSE_ECDSA, true).ok()
+                                && Some(coin_type)
+                                    == ChildNumber::new(
+                                        DERIVATION_PATH_COIN_TYPE_SUI.try_into().unwrap(),
+                                        true,
+                                    )
+                                    .ok()
+                                && account.is_hardened()
+                                && change.is_hardened()
+                                && address.is_hardened()
+                            {
+                                Ok(p)
+                            } else {
+                                Err(RoochError::SignatureKeyGenError("Invalid path".to_owned()))
+                            }
                         } else {
                             Err(RoochError::SignatureKeyGenError("Invalid path".to_owned()))
                         }
-                    } else {
-                        Err(RoochError::SignatureKeyGenError("Invalid path".to_owned()))
                     }
+                    None => Ok(format!(
+                        "m/{DERVIATION_PATH_PURPOSE_ECDSA}'/{DERIVATION_PATH_COIN_TYPE_SUI}'/0'/0'/0'"
+                    )
+                    .parse()
+                    .map_err(|_| RoochError::SignatureKeyGenError("Cannot parse path".to_owned()))?),
                 }
-                None => Ok(format!(
-                    "m/{DERVIATION_PATH_PURPOSE_ECDSA}'/{DERIVATION_PATH_COIN_TYPE_SUI}'/0'/0'/0'"
-                )
-                .parse()
-                .map_err(|_| RoochError::SignatureKeyGenError("Cannot parse path".to_owned()))?),
+            } else if custom_chain_id == &CustomChainID::bitcoin() {
+                todo!()
+            } else if custom_chain_id == &CustomChainID::nostr() {
+                todo!()
+            } else {
+                Err(RoochError::UnexpectedError(
+                    "Unexpected custom chain id".to_owned(),
+                ))
             }
         }
-        CoinID::Bitcoin => todo!(),
-        CoinID::Nostr => todo!(),
     }
 }
 
 pub fn generate_new_key_pair<Addr, KeyPair>(
-    coin_id: CoinID,
+    multichain_id: RoochChainID,
     derivation_path: Option<DerivationPath>,
     word_length: Option<String>,
-) -> Result<(Addr, KeyPair, CoinID, String), anyhow::Error>
+) -> Result<(Addr, KeyPair, RoochChainID, String), anyhow::Error>
 where
-    CoinID: CoinOperations<Addr, KeyPair>,
+    RoochChainID: CoinOperations<Addr, KeyPair>,
 {
     let mnemonic = Mnemonic::new(parse_word_length(word_length)?, Language::English);
     let seed = Seed::new(&mnemonic, "");
 
     let (address, key_pair) =
-        coin_id.derive_key_pair_from_path(seed.as_bytes(), derivation_path)?;
+        multichain_id.derive_key_pair_from_path(seed.as_bytes(), derivation_path)?;
 
-    Ok((address, key_pair, coin_id, mnemonic.phrase().to_string()))
+    Ok((
+        address,
+        key_pair,
+        multichain_id,
+        mnemonic.phrase().to_string(),
+    ))
 }
 
 fn parse_word_length(s: Option<String>) -> Result<MnemonicType, anyhow::Error> {

--- a/crates/rooch-key/src/key_derive.rs
+++ b/crates/rooch-key/src/key_derive.rs
@@ -66,7 +66,7 @@ impl CoinOperations<EthereumAddress, Secp256k1RecoverableKeyPair> for RoochChain
         seed: &[u8],
         derivation_path: Option<DerivationPath>,
     ) -> Result<(EthereumAddress, Secp256k1RecoverableKeyPair), RoochError> {
-        let path = validate_path(self, derivation_path)?; // Pass the CoinID itself
+        let path = validate_path(self, derivation_path)?;
         let child_xprv = XPrv::derive_from_path(seed, &path)
             .map_err(|e| RoochError::SignatureKeyGenError(e.to_string()))?;
         let kp = Secp256k1RecoverableKeyPair::from(

--- a/crates/rooch-key/src/keypair.rs
+++ b/crates/rooch-key/src/keypair.rs
@@ -1,0 +1,60 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::ArgEnum;
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
+use rooch_types::error::RoochError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use strum_macros::EnumString;
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Serialize,
+    Hash,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    JsonSchema,
+    EnumString,
+    ArgEnum,
+)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[strum(serialize_all = "lowercase")]
+pub enum KeyPairType {
+    RoochKeyPairType,
+    EthereumKeyPairType,
+}
+
+impl KeyPairType {
+    const ROOCH_KEY_PAIR_TYPE: &str = "rooch";
+    const ETHEREUM_KEY_PAIR_TYPE: &str = "evm";
+
+    pub fn type_of(&self) -> String {
+        match self {
+            KeyPairType::RoochKeyPairType => Self::ROOCH_KEY_PAIR_TYPE.to_owned(),
+            KeyPairType::EthereumKeyPairType => Self::ETHEREUM_KEY_PAIR_TYPE.to_owned(),
+        }
+    }
+
+    pub fn from_type(type_as: &str) -> Result<KeyPairType, RoochError> {
+        let byte_int = type_as
+            .parse::<String>()
+            .map_err(|_| RoochError::KeyConversionError("Invalid type".to_owned()))?;
+        Self::from_type_byte(byte_int.as_str())
+    }
+
+    pub fn from_type_byte(type_byte: &str) -> Result<KeyPairType, RoochError> {
+        match type_byte {
+            Self::ROOCH_KEY_PAIR_TYPE => Ok(KeyPairType::RoochKeyPairType),
+            Self::ETHEREUM_KEY_PAIR_TYPE => Ok(KeyPairType::EthereumKeyPairType),
+            _ => Err(RoochError::KeyConversionError("Invalid type".to_owned())),
+        }
+    }
+}

--- a/crates/rooch-key/src/keystore.rs
+++ b/crates/rooch-key/src/keystore.rs
@@ -972,7 +972,7 @@ impl
         let (_, kp, _multichain_id, _phrase) = generate_new_key_pair::<
             EthereumAddress,
             Secp256k1RecoverableKeyPair,
-        >(RoochMultiChainID::ETHEREUM, None, None)?;
+        >(RoochMultiChainID::ETHER, None, None)?;
         let authentication_key_bytes = address.0.as_bytes().to_vec();
         let authentication_key = AuthenticationKey::new(authentication_key_bytes);
         let inner_map = self
@@ -1619,7 +1619,7 @@ impl InMemKeystore<EthereumAddress, Secp256k1RecoverableKeyPair> {
         let mut rng = StdRng::from_seed([0; 32]);
         let keys = (0..initial_key_number)
             .map(|_| get_ethereum_key_pair_from_rng(&mut rng))
-            .map(|(ad, k)| (ad, BTreeMap::from_iter(vec![(RoochMultiChainID::ETHEREUM, k)])))
+            .map(|(ad, k)| (ad, BTreeMap::from_iter(vec![(RoochMultiChainID::ETHER, k)])))
             .collect::<BTreeMap<EthereumAddress, BTreeMap<RoochMultiChainID, Secp256k1RecoverableKeyPair>>>();
 
         Self {

--- a/crates/rooch-key/src/lib.rs
+++ b/crates/rooch-key/src/lib.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod key_derive;
+pub mod keypair;
 pub mod keypair_file;
 pub mod keystore;

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -539,15 +539,15 @@
       "AuthenticatorView": {
         "type": "object",
         "required": [
-          "multichain_id",
-          "payload"
+          "payload",
+          "scheme"
         ],
         "properties": {
-          "multichain_id": {
-            "$ref": "#/components/schemas/u64"
-          },
           "payload": {
             "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
+          },
+          "scheme": {
+            "$ref": "#/components/schemas/u64"
           }
         }
       },

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -539,15 +539,15 @@
       "AuthenticatorView": {
         "type": "object",
         "required": [
-          "payload",
-          "scheme"
+          "auth_validator_id",
+          "payload"
         ],
         "properties": {
+          "auth_validator_id": {
+            "$ref": "#/components/schemas/u64"
+          },
           "payload": {
             "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
-          },
-          "scheme": {
-            "$ref": "#/components/schemas/u64"
           }
         }
       },

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -539,11 +539,11 @@
       "AuthenticatorView": {
         "type": "object",
         "required": [
-          "coin_id",
+          "multichain_id",
           "payload"
         ],
         "properties": {
-          "coin_id": {
+          "multichain_id": {
             "$ref": "#/components/schemas/u64"
           },
           "payload": {

--- a/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
@@ -80,14 +80,14 @@ impl From<KeptVMStatus> for KeptVMStatusView {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AuthenticatorView {
-    pub coin_id: StrView<u64>,
+    pub multichain_id: StrView<u64>,
     pub payload: StrView<Vec<u8>>,
 }
 
 impl From<Authenticator> for AuthenticatorView {
     fn from(authenticator: Authenticator) -> Self {
         Self {
-            coin_id: StrView(authenticator.coin_id),
+            multichain_id: StrView(authenticator.multichain_id),
             payload: StrView(authenticator.payload),
         }
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
@@ -80,14 +80,14 @@ impl From<KeptVMStatus> for KeptVMStatusView {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AuthenticatorView {
-    pub multichain_id: StrView<u64>,
+    pub scheme: StrView<u64>,
     pub payload: StrView<Vec<u8>>,
 }
 
 impl From<Authenticator> for AuthenticatorView {
     fn from(authenticator: Authenticator) -> Self {
         Self {
-            multichain_id: StrView(authenticator.multichain_id),
+            scheme: StrView(authenticator.scheme),
             payload: StrView(authenticator.payload),
         }
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
@@ -80,14 +80,14 @@ impl From<KeptVMStatus> for KeptVMStatusView {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AuthenticatorView {
-    pub scheme: StrView<u64>,
+    pub auth_validator_id: StrView<u64>,
     pub payload: StrView<Vec<u8>>,
 }
 
 impl From<Authenticator> for AuthenticatorView {
     fn from(authenticator: Authenticator) -> Self {
         Self {
-            scheme: StrView(authenticator.scheme),
+            auth_validator_id: StrView(authenticator.auth_validator_id),
             payload: StrView(authenticator.payload),
         }
     }

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -114,7 +114,7 @@ impl WalletContext {
         let kp = self
             .config
             .keystore
-            .get_key_pair_by_multichain_id(&sender, multichain_id.clone())
+            .get_key_pair_by_multichain_id(&sender, multichain_id)
             .ok()
             .ok_or_else(|| {
                 RoochError::SignMessageError(format!("Cannot find key for address: [{sender}]"))

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -105,6 +105,7 @@ impl WalletContext {
         Ok(tx_data)
     }
 
+    // TODO: remove key_pair_type: KeyPairType to construct specfic sign implementation based on keys from key store for Rooch and Ethereum transactions
     pub async fn sign(
         &self,
         sender: RoochAddress,

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -9,12 +9,12 @@ use moveos_types::gas_config::GasConfig;
 use moveos_types::transaction::MoveAction;
 use rooch_config::config::{Config, PersistedConfig};
 use rooch_config::{rooch_config_dir, ROOCH_CLIENT_CONFIG};
+use rooch_key::keypair::KeyPairType;
 use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, KeptVMStatusView};
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::{RoochKeyPair, Signature};
 use rooch_types::error::{RoochError, RoochResult};
-use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::{
     authenticator::Authenticator,
     rooch::{RoochTransaction, RoochTransactionData},
@@ -109,26 +109,29 @@ impl WalletContext {
         &self,
         sender: RoochAddress,
         action: MoveAction,
-        multichain_id: RoochMultiChainID,
+        key_pair_type: KeyPairType,
     ) -> RoochResult<RoochTransaction> {
         let kp = self
             .config
             .keystore
-            .get_key_pair_by_multichain_id(&sender, multichain_id)
+            .get_key_pair_by_key_pair_type(&sender, key_pair_type)
             .ok()
             .ok_or_else(|| {
                 RoochError::SignMessageError(format!("Cannot find key for address: [{sender}]"))
             })?;
 
-        if multichain_id.is_ethereum() {
-            todo!()
-        } else {
-            let tx_data = self.build_rooch_tx_data(sender, action).await?;
-            let signature = Signature::new_hashed(tx_data.hash().as_bytes(), kp);
-            Ok(RoochTransaction::new(
-                tx_data,
-                Authenticator::rooch(signature),
-            ))
+        match key_pair_type {
+            KeyPairType::RoochKeyPairType => {
+                let tx_data = self.build_rooch_tx_data(sender, action).await?;
+                let signature = Signature::new_hashed(tx_data.hash().as_bytes(), kp);
+                Ok(RoochTransaction::new(
+                    tx_data,
+                    Authenticator::rooch(signature),
+                ))
+            }
+            KeyPairType::EthereumKeyPairType => {
+                todo!()
+            }
         }
     }
 
@@ -147,9 +150,9 @@ impl WalletContext {
         &self,
         sender: RoochAddress,
         action: MoveAction,
-        multichain_id: RoochMultiChainID,
+        key_pair_type: KeyPairType,
     ) -> RoochResult<ExecuteTransactionResponseView> {
-        let tx = self.sign(sender, action, multichain_id).await?;
+        let tx = self.sign(sender, action, key_pair_type).await?;
         self.execute(tx).await
     }
 

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -23,6 +23,7 @@ use rooch_config::{BaseConfig, RoochOpt};
 use rooch_executor::actor::executor::ExecutorActor;
 use rooch_executor::proxy::ExecutorProxy;
 use rooch_key::key_derive::generate_new_key_pair;
+use rooch_key::keypair::KeyPairType;
 use rooch_proposer::actor::messages::ProposeBlock;
 use rooch_proposer::actor::proposer::ProposerActor;
 use rooch_proposer::proxy::ProposerProxy;
@@ -35,7 +36,6 @@ use rooch_store::RoochStore;
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::GenesisError;
-use rooch_types::multichain_id::RoochMultiChainID;
 use serde_json::json;
 use std::env;
 use std::fmt::Debug;
@@ -176,16 +176,22 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
 
     // Init sequencer
     //TODO load from config
-    let (_, kp, _, _) =
-        generate_new_key_pair::<RoochAddress, RoochKeyPair>(RoochMultiChainID::Rooch, None, None)?;
+    let (_, kp, _, _) = generate_new_key_pair::<RoochAddress, RoochKeyPair>(
+        KeyPairType::RoochKeyPairType,
+        None,
+        None,
+    )?;
     let sequencer = SequencerActor::new(kp, rooch_store, is_genesis)?
         .into_actor(Some("Sequencer"), &actor_system)
         .await?;
     let sequencer_proxy = SequencerProxy::new(sequencer.into());
 
     // Init proposer
-    let (_, kp, _, _) =
-        generate_new_key_pair::<RoochAddress, RoochKeyPair>(RoochMultiChainID::Rooch, None, None)?;
+    let (_, kp, _, _) = generate_new_key_pair::<RoochAddress, RoochKeyPair>(
+        KeyPairType::RoochKeyPairType,
+        None,
+        None,
+    )?;
     let proposer = ProposerActor::new(kp)
         .into_actor(Some("Proposer"), &actor_system)
         .await?;
@@ -211,7 +217,7 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
     if let Some(eth_rpc_url) = &opt.eth_rpc_url {
         //TODO load from config
         let (_, kp, _, _) = generate_new_key_pair::<RoochAddress, RoochKeyPair>(
-            RoochMultiChainID::Rooch,
+            KeyPairType::RoochKeyPairType,
             None,
             None,
         )?;

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -33,7 +33,6 @@ use rooch_sequencer::actor::sequencer::SequencerActor;
 use rooch_sequencer::proxy::SequencerProxy;
 use rooch_store::RoochStore;
 use rooch_types::address::RoochAddress;
-use rooch_types::chain_id::{BuiltinChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::GenesisError;
 use rooch_types::multichain_id::RoochMultiChainID;
@@ -177,22 +176,16 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
 
     // Init sequencer
     //TODO load from config
-    let (_, kp, _, _) = generate_new_key_pair::<RoochAddress, RoochKeyPair>(
-        RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-        None,
-        None,
-    )?;
+    let (_, kp, _, _) =
+        generate_new_key_pair::<RoochAddress, RoochKeyPair>(RoochMultiChainID::Rooch, None, None)?;
     let sequencer = SequencerActor::new(kp, rooch_store, is_genesis)?
         .into_actor(Some("Sequencer"), &actor_system)
         .await?;
     let sequencer_proxy = SequencerProxy::new(sequencer.into());
 
     // Init proposer
-    let (_, kp, _, _) = generate_new_key_pair::<RoochAddress, RoochKeyPair>(
-        RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-        None,
-        None,
-    )?;
+    let (_, kp, _, _) =
+        generate_new_key_pair::<RoochAddress, RoochKeyPair>(RoochMultiChainID::Rooch, None, None)?;
     let proposer = ProposerActor::new(kp)
         .into_actor(Some("Proposer"), &actor_system)
         .await?;
@@ -218,7 +211,7 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
     if let Some(eth_rpc_url) = &opt.eth_rpc_url {
         //TODO load from config
         let (_, kp, _, _) = generate_new_key_pair::<RoochAddress, RoochKeyPair>(
-            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
+            RoochMultiChainID::Rooch,
             None,
             None,
         )?;

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -33,7 +33,7 @@ use rooch_sequencer::actor::sequencer::SequencerActor;
 use rooch_sequencer::proxy::SequencerProxy;
 use rooch_store::RoochStore;
 use rooch_types::address::RoochAddress;
-use rooch_types::coin_type::CoinID;
+use rooch_types::chain_id::RoochChainID;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::GenesisError;
 use serde_json::json;
@@ -185,7 +185,7 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
 
     // Init proposer
     let (_, kp, _, _) =
-        generate_new_key_pair::<RoochAddress, RoochKeyPair>(CoinID::Rooch, None, None)?;
+        generate_new_key_pair::<RoochAddress, RoochKeyPair>(RoochChainID::DEV, None, None)?;
     let proposer = ProposerActor::new(kp)
         .into_actor(Some("Proposer"), &actor_system)
         .await?;

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -182,7 +182,7 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
         None,
         None,
     )?;
-    let sequencer = SequencerActor::new(kp, rooch_store, is_genesis)
+    let sequencer = SequencerActor::new(kp, rooch_store, is_genesis)?
         .into_actor(Some("Sequencer"), &actor_system)
         .await?;
     let sequencer_proxy = SequencerProxy::new(sequencer.into());

--- a/crates/rooch-types/proptest-regressions/transaction/authenticator.txt
+++ b/crates/rooch-types/proptest-regressions/transaction/authenticator.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 225146d5c56f73d0c7caa99833b140f348bd6ed9c7079afb707b5fccef62c7f6 # shrinks to authenticator = RoochAuthenticator { signature: Ed25519RoochSignature(Ed25519RoochSignature([0, 13, 214, 181, 238, 125, 199, 44, 69, 26, 117, 187, 139, 168, 197, 121, 148, 245, 109, 226, 247, 15, 28, 183, 237, 209, 125, 97, 236, 218, 212, 207, 207, 146, 124, 242, 142, 240, 103, 40, 194, 8, 5, 78, 185, 108, 37, 28, 65, 151, 46, 185, 78, 196, 220, 169, 44, 129, 2, 54, 84, 4, 203, 136, 6, 238, 26, 164, 154, 68, 89, 223, 232, 19, 163, 207, 110, 184, 130, 4, 18, 48, 199, 178, 85, 132, 105, 222, 129, 248, 124, 155, 242, 59, 241, 10, 3])) }

--- a/crates/rooch-types/proptest-regressions/transaction/authenticator.txt
+++ b/crates/rooch-types/proptest-regressions/transaction/authenticator.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 225146d5c56f73d0c7caa99833b140f348bd6ed9c7079afb707b5fccef62c7f6 # shrinks to authenticator = RoochAuthenticator { signature: Ed25519RoochSignature(Ed25519RoochSignature([0, 13, 214, 181, 238, 125, 199, 44, 69, 26, 117, 187, 139, 168, 197, 121, 148, 245, 109, 226, 247, 15, 28, 183, 237, 209, 125, 97, 236, 218, 212, 207, 207, 146, 124, 242, 142, 240, 103, 40, 194, 8, 5, 78, 185, 108, 37, 28, 65, 151, 46, 185, 78, 196, 220, 169, 44, 129, 2, 54, 84, 4, 203, 136, 6, 238, 26, 164, 154, 68, 89, 223, 232, 19, 163, 207, 110, 184, 130, 4, 18, 48, 199, 178, 85, 132, 105, 222, 129, 248, 124, 155, 242, 59, 241, 10, 3])) }

--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     addresses::ROOCH_FRAMEWORK_ADDRESS,
-    chain_id::{BuiltinChainID, RoochChainID},
+    chain_id::BuiltinChainID,
     multichain_id::{MultiChainID, RoochMultiChainID},
 };
 use anyhow::Result;
@@ -204,11 +204,8 @@ impl From<RoochAddress> for AccountAddress {
 
 impl From<RoochAddress> for MultiChainAddress {
     fn from(address: RoochAddress) -> Self {
-        Self::new(
-            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-            address.0.as_bytes().to_vec(),
-        )
-        .expect("RoochAddress to MultiChainAddress should success")
+        Self::new(RoochMultiChainID::Rooch, address.0.as_bytes().to_vec())
+            .expect("RoochAddress to MultiChainAddress should success")
     }
 }
 
@@ -216,9 +213,7 @@ impl TryFrom<MultiChainAddress> for RoochAddress {
     type Error = anyhow::Error;
 
     fn try_from(value: MultiChainAddress) -> Result<Self, Self::Error> {
-        if value.multichain_id
-            != RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev))
-        {
+        if value.multichain_id != RoochMultiChainID::Rooch {
             return Err(anyhow::anyhow!(
                 "multichain_id type {} is invalid",
                 value.multichain_id
@@ -319,7 +314,7 @@ impl RoochSupportedAddress for EthereumAddress {
 
 impl From<EthereumAddress> for MultiChainAddress {
     fn from(address: EthereumAddress) -> Self {
-        Self::new(RoochMultiChainID::ETHER, address.0.as_bytes().to_vec())
+        Self::new(RoochMultiChainID::Ether, address.0.as_bytes().to_vec())
             .expect("EthereumAddress to MultiChainAddress should success")
     }
 }
@@ -328,7 +323,7 @@ impl TryFrom<MultiChainAddress> for EthereumAddress {
     type Error = anyhow::Error;
 
     fn try_from(value: MultiChainAddress) -> Result<Self, Self::Error> {
-        if value.multichain_id != RoochMultiChainID::ETHER {
+        if value.multichain_id != RoochMultiChainID::Ether {
             return Err(anyhow::anyhow!(
                 "multichain_id type {} is invalid",
                 value.multichain_id
@@ -397,7 +392,7 @@ impl RoochSupportedAddress for BitcoinAddress {
 impl From<BitcoinAddress> for MultiChainAddress {
     fn from(address: BitcoinAddress) -> Self {
         Self::new(
-            RoochMultiChainID::BITCOIN,
+            RoochMultiChainID::Bitcoin,
             address.0.to_string().into_bytes(),
         )
         .expect("BitcoinAddress to MultiChainAddress should succeed")
@@ -408,7 +403,7 @@ impl TryFrom<MultiChainAddress> for BitcoinAddress {
     type Error = anyhow::Error;
 
     fn try_from(value: MultiChainAddress) -> Result<Self, Self::Error> {
-        if value.multichain_id != RoochMultiChainID::BITCOIN {
+        if value.multichain_id != RoochMultiChainID::Bitcoin {
             return Err(anyhow::anyhow!(
                 "multichain_id type {} is invalid",
                 value.multichain_id
@@ -434,7 +429,7 @@ impl RoochSupportedAddress for NostrAddress {
 
 impl From<NostrAddress> for MultiChainAddress {
     fn from(address: NostrAddress) -> Self {
-        Self::new(RoochMultiChainID::NOSTR, address.0.serialize().to_vec())
+        Self::new(RoochMultiChainID::Nostr, address.0.serialize().to_vec())
             .expect("NostrAddress to MultiChainAddress should succeed")
     }
 }
@@ -443,7 +438,7 @@ impl TryFrom<MultiChainAddress> for NostrAddress {
     type Error = anyhow::Error;
 
     fn try_from(value: MultiChainAddress) -> Result<Self, Self::Error> {
-        if value.multichain_id != RoochMultiChainID::NOSTR {
+        if value.multichain_id != RoochMultiChainID::Nostr {
             return Err(anyhow::anyhow!(
                 "multichain_id type {} is invalid",
                 value.multichain_id

--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -3,7 +3,6 @@
 
 use crate::{
     addresses::ROOCH_FRAMEWORK_ADDRESS,
-    chain_id::BuiltinChainID,
     multichain_id::{MultiChainID, RoochMultiChainID},
 };
 use anyhow::Result;
@@ -65,9 +64,7 @@ impl MultiChainAddress {
     }
 
     pub fn is_rooch_address(&self) -> bool {
-        self.multichain_id.multichain_id().id() == BuiltinChainID::Dev.chain_id().id()
-            || self.multichain_id.multichain_id().id() == BuiltinChainID::Test.chain_id().id()
-            || self.multichain_id.multichain_id().id() == BuiltinChainID::Main.chain_id().id()
+        self.multichain_id.is_rooch()
     }
 
     pub fn from_bech32(bech32: &str) -> Result<Self> {

--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -65,7 +65,9 @@ impl MultiChainAddress {
     }
 
     pub fn is_rooch_address(&self) -> bool {
-        self.multichain_id.is_builtin()
+        self.multichain_id.multichain_id().id() == BuiltinChainID::Dev.chain_id().id()
+            || self.multichain_id.multichain_id().id() == BuiltinChainID::Test.chain_id().id()
+            || self.multichain_id.multichain_id().id() == BuiltinChainID::Main.chain_id().id()
     }
 
     pub fn from_bech32(bech32: &str) -> Result<Self> {
@@ -317,7 +319,7 @@ impl RoochSupportedAddress for EthereumAddress {
 
 impl From<EthereumAddress> for MultiChainAddress {
     fn from(address: EthereumAddress) -> Self {
-        Self::new(RoochMultiChainID::ETHEREUM, address.0.as_bytes().to_vec())
+        Self::new(RoochMultiChainID::ETHER, address.0.as_bytes().to_vec())
             .expect("EthereumAddress to MultiChainAddress should success")
     }
 }
@@ -326,7 +328,7 @@ impl TryFrom<MultiChainAddress> for EthereumAddress {
     type Error = anyhow::Error;
 
     fn try_from(value: MultiChainAddress) -> Result<Self, Self::Error> {
-        if value.multichain_id != RoochMultiChainID::ETHEREUM {
+        if value.multichain_id != RoochMultiChainID::ETHER {
             return Err(anyhow::anyhow!(
                 "multichain_id type {} is invalid",
                 value.multichain_id

--- a/crates/rooch-types/src/chain_id.rs
+++ b/crates/rooch-types/src/chain_id.rs
@@ -84,9 +84,9 @@ pub enum BuiltinChainID {
 impl Display for BuiltinChainID {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            BuiltinChainID::Dev => write!(f, "Dev"),
-            BuiltinChainID::Test => write!(f, "Test"),
-            BuiltinChainID::Main => write!(f, "Main"),
+            BuiltinChainID::Dev => write!(f, "dev"),
+            BuiltinChainID::Test => write!(f, "test"),
+            BuiltinChainID::Main => write!(f, "main"),
         }
     }
 }

--- a/crates/rooch-types/src/chain_id.rs
+++ b/crates/rooch-types/src/chain_id.rs
@@ -3,8 +3,6 @@
 
 use crate::framework::genesis::GenesisContext;
 use anyhow::{bail, format_err, Result};
-#[cfg(any(test, feature = "fuzzing"))]
-use proptest_derive::Arbitrary;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -15,10 +13,7 @@ pub const CHAIN_ID_DEV: u64 = 20230103;
 pub const CHAIN_ID_TEST: u64 = 20230102;
 pub const CHAIN_ID_MAIN: u64 = 20230101;
 
-#[derive(
-    Clone, Copy, Debug, Deserialize, Serialize, Hash, Eq, PartialEq, PartialOrd, Ord, JsonSchema,
-)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Hash, Eq, PartialEq, JsonSchema)]
 pub struct ChainID {
     id: u64,
 }
@@ -73,21 +68,7 @@ impl Into<u64> for ChainID {
     }
 }
 
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    Default,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    JsonSchema,
-)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[repr(u64)]
 pub enum BuiltinChainID {
     /// A ephemeral network just for developer test.
@@ -216,11 +197,8 @@ impl BuiltinChainID {
     }
 }
 
-#[derive(
-    Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize, JsonSchema,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema)]
 #[allow(clippy::upper_case_acronyms)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct CustomChainID {
     chain_name: String,
     chain_id: ChainID,
@@ -272,11 +250,8 @@ impl FromStr for CustomChainID {
     }
 }
 
-#[derive(
-    Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, JsonSchema, Serialize, Deserialize,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, JsonSchema, Serialize, Deserialize)]
 #[allow(clippy::upper_case_acronyms)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum RoochChainID {
     Builtin(BuiltinChainID),
     Custom(CustomChainID),
@@ -355,6 +330,13 @@ impl RoochChainID {
             }
         }
         Ok(Self::Custom(CustomChainID::new(chain_name, chain_id)))
+    }
+
+    pub fn chain_name(&self) -> String {
+        match self {
+            Self::Builtin(b) => b.chain_name(),
+            Self::Custom(c) => c.chain_name().to_owned(),
+        }
     }
 
     pub fn chain_id(&self) -> ChainID {

--- a/crates/rooch-types/src/coin_type.rs
+++ b/crates/rooch-types/src/coin_type.rs
@@ -1,11 +1,9 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::ArgEnum;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
 
 /// The symbol standard is defined in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
 /// The rooch's symbol is not added to the slip-0044 yet.
@@ -51,47 +49,6 @@ impl std::fmt::Display for Symbol {
             Symbol::BTC => write!(f, "BTC"),
             Symbol::ETH => write!(f, "ETH"),
             Symbol::ROH => write!(f, "ROH"),
-        }
-    }
-}
-
-/// The coin standard is defined in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
-/// The rooch's coin is not added to the slip-0044 yet.
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ArgEnum,
-    Ord,
-    PartialOrd,
-)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-#[repr(u64)]
-#[strum(serialize_all = "lowercase")]
-pub enum CoinID {
-    Rooch = 0,
-    Ether = 1,
-    Bitcoin = 2,
-    Nostr = 3,
-}
-
-impl TryFrom<u64> for CoinID {
-    type Error = anyhow::Error;
-
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(CoinID::Rooch),
-            1 => Ok(CoinID::Ether),
-            2 => Ok(CoinID::Bitcoin),
-            3 => Ok(CoinID::Nostr),
-            _ => Err(anyhow::anyhow!("coin id {} is invalid", value)),
         }
     }
 }

--- a/crates/rooch-types/src/framework/auth_validator.rs
+++ b/crates/rooch-types/src/framework/auth_validator.rs
@@ -68,7 +68,7 @@ impl AuthValidator {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TxValidateResult {
-    pub scheme: u64,
+    pub auth_validator_id: u64,
     pub auth_validator: MoveOption<AuthValidator>,
     pub session_key: MoveOption<Vec<u8>>,
 }

--- a/crates/rooch-types/src/framework/auth_validator.rs
+++ b/crates/rooch-types/src/framework/auth_validator.rs
@@ -1,15 +1,20 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use super::ethereum_validator::EthereumValidatorModule;
+use super::native_validator::NativeValidatorModule;
 use super::transaction_validator::TransactionValidator;
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
+use crate::error::RoochError;
 use anyhow::{ensure, Result};
+use clap::ArgEnum;
 use move_core_types::value::MoveValue;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::ModuleId,
 };
 use moveos_types::function_return_value::DecodedFunctionResult;
 use moveos_types::move_option::MoveOption;
+use moveos_types::transaction::MoveAction;
 use moveos_types::{
     module_binding::MoveFunctionCaller,
     move_string::MoveAsciiString,
@@ -19,6 +24,83 @@ use moveos_types::{
     tx_context::TxContext,
 };
 use serde::{Deserialize, Serialize};
+use strum_macros::{Display, EnumString};
+
+/// The Authenticator auth validator which has builtin Rooch and Ethereum
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    EnumString,
+    PartialEq,
+    Eq,
+    ArgEnum,
+    Display,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+)]
+#[strum(serialize_all = "lowercase")]
+pub enum BuiltinAuthValidator {
+    Rooch,
+    Ethereum,
+}
+
+impl BuiltinAuthValidator {
+    const ROOCH_FLAG: u8 = 0x00;
+    const ETHEREUM_FLAG: u8 = 0x00;
+
+    pub fn flag(&self) -> u8 {
+        match self {
+            BuiltinAuthValidator::Rooch => Self::ROOCH_FLAG,
+            BuiltinAuthValidator::Ethereum => Self::ETHEREUM_FLAG,
+        }
+    }
+
+    pub fn from_flag(flag: &str) -> Result<BuiltinAuthValidator, RoochError> {
+        let byte_int = flag
+            .parse::<u8>()
+            .map_err(|_| RoochError::KeyConversionError("Invalid key auth validator".to_owned()))?;
+        Self::from_flag_byte(byte_int)
+    }
+
+    pub fn from_flag_byte(byte_int: u8) -> Result<BuiltinAuthValidator, RoochError> {
+        match byte_int {
+            Self::ROOCH_FLAG => Ok(BuiltinAuthValidator::Rooch),
+            _ => Err(RoochError::KeyConversionError(
+                "Invalid key auth validator".to_owned(),
+            )),
+        }
+    }
+
+    pub fn create_rotate_authentication_key_action(
+        &self,
+        public_key: Vec<u8>,
+    ) -> Result<MoveAction, RoochError> {
+        let action = match self {
+            BuiltinAuthValidator::Rooch => {
+                NativeValidatorModule::rotate_authentication_key_action(public_key)
+            }
+            BuiltinAuthValidator::Ethereum => {
+                EthereumValidatorModule::rotate_authentication_key_action(public_key)
+            }
+        };
+        Ok(action)
+    }
+
+    pub fn create_remove_authentication_key_action(&self) -> Result<MoveAction, RoochError> {
+        let action = match self {
+            BuiltinAuthValidator::Rooch => {
+                NativeValidatorModule::remove_authentication_key_action()
+            }
+            BuiltinAuthValidator::Ethereum => {
+                EthereumValidatorModule::remove_authentication_key_action()
+            }
+        };
+        Ok(action)
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthValidator {

--- a/crates/rooch-types/src/framework/ethereum_validator.rs
+++ b/crates/rooch-types/src/framework/ethereum_validator.rs
@@ -17,7 +17,7 @@ pub struct EthereumValidator {}
 
 impl EthereumValidator {
     pub fn multichain_id() -> RoochMultiChainID {
-        RoochMultiChainID::ETHEREUM
+        RoochMultiChainID::ETHER
     }
 }
 

--- a/crates/rooch-types/src/framework/ethereum_validator.rs
+++ b/crates/rooch-types/src/framework/ethereum_validator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, multichain_id::RoochMultiChainID};
+use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
 use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
@@ -16,8 +16,9 @@ use moveos_types::{
 pub struct EthereumValidator {}
 
 impl EthereumValidator {
-    pub fn auth_validator_id() -> RoochMultiChainID {
-        RoochMultiChainID::Ether
+    // TODO: consider use variable
+    pub fn auth_validator_id() -> u64 {
+        1
     }
 }
 

--- a/crates/rooch-types/src/framework/ethereum_validator.rs
+++ b/crates/rooch-types/src/framework/ethereum_validator.rs
@@ -1,10 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    addresses::ROOCH_FRAMEWORK_ADDRESS,
-    chain_id::{CustomChainID, RoochChainID},
-};
+use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, multichain_id::RoochMultiChainID};
 use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
@@ -19,8 +16,8 @@ use moveos_types::{
 pub struct EthereumValidator {}
 
 impl EthereumValidator {
-    pub fn multichain_id() -> RoochChainID {
-        RoochChainID::from(CustomChainID::ethereum())
+    pub fn multichain_id() -> RoochMultiChainID {
+        RoochMultiChainID::ETHEREUM
     }
 }
 

--- a/crates/rooch-types/src/framework/ethereum_validator.rs
+++ b/crates/rooch-types/src/framework/ethereum_validator.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use super::auth_validator::BuiltinAuthValidator;
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
 use anyhow::Result;
 use move_core_types::{
@@ -16,9 +17,8 @@ use moveos_types::{
 pub struct EthereumValidator {}
 
 impl EthereumValidator {
-    // TODO: consider use variable
     pub fn auth_validator_id() -> u64 {
-        1
+        BuiltinAuthValidator::Ethereum.flag().into()
     }
 }
 

--- a/crates/rooch-types/src/framework/ethereum_validator.rs
+++ b/crates/rooch-types/src/framework/ethereum_validator.rs
@@ -17,7 +17,7 @@ pub struct EthereumValidator {}
 
 impl EthereumValidator {
     pub fn multichain_id() -> RoochMultiChainID {
-        RoochMultiChainID::ETHER
+        RoochMultiChainID::Ether
     }
 }
 

--- a/crates/rooch-types/src/framework/ethereum_validator.rs
+++ b/crates/rooch-types/src/framework/ethereum_validator.rs
@@ -16,7 +16,7 @@ use moveos_types::{
 pub struct EthereumValidator {}
 
 impl EthereumValidator {
-    pub fn multichain_id() -> RoochMultiChainID {
+    pub fn auth_validator_id() -> RoochMultiChainID {
         RoochMultiChainID::Ether
     }
 }

--- a/crates/rooch-types/src/framework/ethereum_validator.rs
+++ b/crates/rooch-types/src/framework/ethereum_validator.rs
@@ -1,7 +1,10 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, coin_type::CoinID};
+use crate::{
+    addresses::ROOCH_FRAMEWORK_ADDRESS,
+    chain_id::{CustomChainID, RoochChainID},
+};
 use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
@@ -16,8 +19,8 @@ use moveos_types::{
 pub struct EthereumValidator {}
 
 impl EthereumValidator {
-    pub fn coin_id() -> CoinID {
-        CoinID::Ether
+    pub fn multichain_id() -> RoochChainID {
+        RoochChainID::from(CustomChainID::ethereum())
     }
 }
 

--- a/crates/rooch-types/src/framework/native_validator.rs
+++ b/crates/rooch-types/src/framework/native_validator.rs
@@ -16,7 +16,7 @@ use moveos_types::{
 pub struct NativeValidator {}
 
 impl NativeValidator {
-    pub fn multichain_id() -> RoochMultiChainID {
+    pub fn auth_validator_id() -> RoochMultiChainID {
         RoochMultiChainID::Rooch
     }
 }

--- a/crates/rooch-types/src/framework/native_validator.rs
+++ b/crates/rooch-types/src/framework/native_validator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, coin_type::CoinID};
+use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, chain_id::RoochChainID};
 use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
@@ -16,8 +16,8 @@ use moveos_types::{
 pub struct NativeValidator {}
 
 impl NativeValidator {
-    pub fn coin_id() -> CoinID {
-        CoinID::Rooch
+    pub fn multichain_id() -> RoochChainID {
+        RoochChainID::DEV
     }
 }
 

--- a/crates/rooch-types/src/framework/native_validator.rs
+++ b/crates/rooch-types/src/framework/native_validator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, multichain_id::RoochMultiChainID};
+use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, crypto::BuiltinAuthValidator};
 use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
@@ -16,8 +16,8 @@ use moveos_types::{
 pub struct NativeValidator {}
 
 impl NativeValidator {
-    pub fn auth_validator_id() -> RoochMultiChainID {
-        RoochMultiChainID::Rooch
+    pub fn auth_validator_id() -> u64 {
+        BuiltinAuthValidator::Ed25519.flag().into()
     }
 }
 

--- a/crates/rooch-types/src/framework/native_validator.rs
+++ b/crates/rooch-types/src/framework/native_validator.rs
@@ -1,7 +1,11 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, chain_id::RoochChainID};
+use crate::{
+    addresses::ROOCH_FRAMEWORK_ADDRESS,
+    chain_id::{BuiltinChainID, RoochChainID},
+    multichain_id::RoochMultiChainID,
+};
 use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
@@ -16,8 +20,8 @@ use moveos_types::{
 pub struct NativeValidator {}
 
 impl NativeValidator {
-    pub fn multichain_id() -> RoochChainID {
-        RoochChainID::DEV
+    pub fn multichain_id() -> RoochMultiChainID {
+        RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev))
     }
 }
 

--- a/crates/rooch-types/src/framework/native_validator.rs
+++ b/crates/rooch-types/src/framework/native_validator.rs
@@ -1,7 +1,8 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, crypto::BuiltinAuthValidator};
+use super::auth_validator::BuiltinAuthValidator;
+use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
 use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
@@ -17,7 +18,7 @@ pub struct NativeValidator {}
 
 impl NativeValidator {
     pub fn auth_validator_id() -> u64 {
-        BuiltinAuthValidator::Ed25519.flag().into()
+        BuiltinAuthValidator::Rooch.flag().into()
     }
 }
 

--- a/crates/rooch-types/src/framework/native_validator.rs
+++ b/crates/rooch-types/src/framework/native_validator.rs
@@ -1,11 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    addresses::ROOCH_FRAMEWORK_ADDRESS,
-    chain_id::{BuiltinChainID, RoochChainID},
-    multichain_id::RoochMultiChainID,
-};
+use crate::{addresses::ROOCH_FRAMEWORK_ADDRESS, multichain_id::RoochMultiChainID};
 use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
@@ -21,7 +17,7 @@ pub struct NativeValidator {}
 
 impl NativeValidator {
     pub fn multichain_id() -> RoochMultiChainID {
-        RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev))
+        RoochMultiChainID::Rooch
     }
 }
 

--- a/crates/rooch-types/src/framework/transaction_validator.rs
+++ b/crates/rooch-types/src/framework/transaction_validator.rs
@@ -36,7 +36,7 @@ impl<'a> TransactionValidator<'a> {
             vec![],
             vec![
                 MoveValue::U64(auth.chain_id).simple_serialize().unwrap(),
-                MoveValue::U64(auth.authenticator.coin_id)
+                MoveValue::U64(auth.authenticator.multichain_id)
                     .simple_serialize()
                     .unwrap(),
                 MoveValue::vector_u8(auth.authenticator.payload)

--- a/crates/rooch-types/src/framework/transaction_validator.rs
+++ b/crates/rooch-types/src/framework/transaction_validator.rs
@@ -36,7 +36,7 @@ impl<'a> TransactionValidator<'a> {
             vec![],
             vec![
                 MoveValue::U64(auth.chain_id).simple_serialize().unwrap(),
-                MoveValue::U64(auth.authenticator.multichain_id)
+                MoveValue::U64(auth.authenticator.scheme)
                     .simple_serialize()
                     .unwrap(),
                 MoveValue::vector_u8(auth.authenticator.payload)

--- a/crates/rooch-types/src/framework/transaction_validator.rs
+++ b/crates/rooch-types/src/framework/transaction_validator.rs
@@ -36,7 +36,7 @@ impl<'a> TransactionValidator<'a> {
             vec![],
             vec![
                 MoveValue::U64(auth.chain_id).simple_serialize().unwrap(),
-                MoveValue::U64(auth.authenticator.scheme)
+                MoveValue::U64(auth.authenticator.auth_validator_id)
                     .simple_serialize()
                     .unwrap(),
                 MoveValue::vector_u8(auth.authenticator.payload)

--- a/crates/rooch-types/src/lib.rs
+++ b/crates/rooch-types/src/lib.rs
@@ -11,8 +11,8 @@ pub mod coin_type;
 pub mod crypto;
 pub mod error;
 pub mod framework;
-pub mod sequencer;
 pub mod multichain_id;
+pub mod sequencer;
 pub mod transaction;
 
 pub use ethers::types::{H160, H256, H512};

--- a/crates/rooch-types/src/lib.rs
+++ b/crates/rooch-types/src/lib.rs
@@ -12,6 +12,7 @@ pub mod crypto;
 pub mod error;
 pub mod framework;
 pub mod sequencer;
+pub mod multichain_id;
 pub mod transaction;
 
 pub use ethers::types::{H160, H256, H512};

--- a/crates/rooch-types/src/multichain_id.rs
+++ b/crates/rooch-types/src/multichain_id.rs
@@ -16,7 +16,7 @@ pub const BITCOIN: u64 = 0;
 pub const ETHER: u64 = 60;
 pub const SUI: u64 = 784;
 pub const NOSTR: u64 = 1237;
-pub const ROOCH: u64 = 20230103; // Dev
+pub const ROOCH: u64 = 20230101; // place holder for slip-0044 needs to replace later
 
 #[derive(
     Clone, Copy, Debug, Deserialize, Serialize, Hash, Eq, PartialEq, PartialOrd, Ord, JsonSchema,

--- a/crates/rooch-types/src/multichain_id.rs
+++ b/crates/rooch-types/src/multichain_id.rs
@@ -14,6 +14,7 @@ use crate::chain_id::ChainID;
 
 pub const BITCOIN: u64 = 0;
 pub const ETHER: u64 = 60;
+pub const SUI: u64 = 784;
 pub const NOSTR: u64 = 1237;
 pub const ROOCH: u64 = 20230103; // Dev
 
@@ -36,6 +37,10 @@ impl MultiChainID {
 
     pub fn is_ethereum(self) -> bool {
         self.id == ETHER
+    }
+
+    pub fn is_sui(self) -> bool {
+        self.id == SUI
     }
 
     pub fn is_bitcoin(self) -> bool {
@@ -90,6 +95,7 @@ impl Into<u64> for MultiChainID {
 pub enum RoochMultiChainID {
     Bitcoin = BITCOIN,
     Ether = ETHER,
+    Sui = SUI,
     Nostr = NOSTR,
     Rooch = ROOCH,
 }
@@ -99,6 +105,7 @@ impl Display for RoochMultiChainID {
         match self {
             RoochMultiChainID::Bitcoin => write!(f, "bitcoin"),
             RoochMultiChainID::Ether => write!(f, "ether"),
+            RoochMultiChainID::Sui => write!(f, "sui"),
             RoochMultiChainID::Nostr => write!(f, "nostr"),
             RoochMultiChainID::Rooch => write!(f, "rooch"),
         }
@@ -118,6 +125,7 @@ impl TryFrom<u64> for RoochMultiChainID {
         match value {
             BITCOIN => Ok(RoochMultiChainID::Bitcoin),
             ETHER => Ok(RoochMultiChainID::Ether),
+            SUI => Ok(RoochMultiChainID::Sui),
             NOSTR => Ok(RoochMultiChainID::Nostr),
             ROOCH => Ok(RoochMultiChainID::Rooch),
             _ => Err(anyhow::anyhow!("multichain id {} is invalid", value)),
@@ -132,6 +140,7 @@ impl FromStr for RoochMultiChainID {
         match s {
             "bitcoin" => Ok(RoochMultiChainID::Bitcoin),
             "ether" => Ok(RoochMultiChainID::Ether),
+            "sui" => Ok(RoochMultiChainID::Sui),
             "nostr" => Ok(RoochMultiChainID::Nostr),
             "rooch" => Ok(RoochMultiChainID::Rooch),
             s => Err(format_err!("Unknown multichain: {}", s)),
@@ -145,6 +154,7 @@ impl TryFrom<MultiChainID> for RoochMultiChainID {
         Ok(match multichain_id.id() {
             BITCOIN => Self::Bitcoin,
             ETHER => Self::Ether,
+            SUI => Self::Sui,
             NOSTR => Self::Nostr,
             ROOCH => Self::Rooch,
             id => bail!("{} is not a builtin multichain id", id),
@@ -169,6 +179,10 @@ impl RoochMultiChainID {
         matches!(self, RoochMultiChainID::Ether)
     }
 
+    pub fn is_sui(self) -> bool {
+        matches!(self, RoochMultiChainID::Sui)
+    }
+
     pub fn is_nostr(self) -> bool {
         matches!(self, RoochMultiChainID::Nostr)
     }
@@ -181,6 +195,7 @@ impl RoochMultiChainID {
         vec![
             RoochMultiChainID::Bitcoin,
             RoochMultiChainID::Ether,
+            RoochMultiChainID::Sui,
             RoochMultiChainID::Nostr,
             RoochMultiChainID::Rooch,
         ]

--- a/crates/rooch-types/src/multichain_id.rs
+++ b/crates/rooch-types/src/multichain_id.rs
@@ -1,0 +1,367 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, format_err, Result};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+use crate::chain_id::{ChainID, RoochChainID};
+
+pub const BITCOIN: u64 = 0;
+pub const ETHEREUM: u64 = 60;
+pub const NOSTR: u64 = 1237;
+
+#[derive(
+    Clone, Copy, Debug, Deserialize, Serialize, Hash, Eq, PartialEq, PartialOrd, Ord, JsonSchema,
+)]
+pub struct MultiChainID {
+    id: u64,
+}
+
+impl MultiChainID {
+    pub fn new(id: u64) -> Self {
+        Self { id }
+    }
+
+    pub fn id(self) -> u64 {
+        self.id
+    }
+
+    pub fn is_ethereum(self) -> bool {
+        self.id == ETHEREUM
+    }
+
+    pub fn is_bitcoin(self) -> bool {
+        self.id == BITCOIN
+    }
+
+    pub fn is_nostr(self) -> bool {
+        self.id == NOSTR
+    }
+}
+
+impl Display for MultiChainID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
+
+impl FromStr for MultiChainID {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let id: u64 = s.parse()?;
+        Ok(MultiChainID::new(id))
+    }
+}
+
+impl From<u64> for MultiChainID {
+    fn from(id: u64) -> Self {
+        Self::new(id)
+    }
+}
+
+impl From<ChainID> for MultiChainID {
+    fn from(chain_id: ChainID) -> Self {
+        Self::new(chain_id.id())
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<u64> for MultiChainID {
+    fn into(self) -> u64 {
+        self.id
+    }
+}
+
+// BuiltinMultiChainID is following coin standard: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
+#[repr(u64)]
+pub enum BuiltinMultiChainID {
+    Bitcoin = BITCOIN,
+    Ether = ETHEREUM,
+    Nostr = NOSTR,
+}
+
+impl Display for BuiltinMultiChainID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            BuiltinMultiChainID::Bitcoin => write!(f, "bitcoin"),
+            BuiltinMultiChainID::Ether => write!(f, "ether"),
+            BuiltinMultiChainID::Nostr => write!(f, "nostr"),
+        }
+    }
+}
+
+impl From<BuiltinMultiChainID> for u64 {
+    fn from(multichain_id: BuiltinMultiChainID) -> Self {
+        multichain_id as u64
+    }
+}
+
+impl TryFrom<u64> for BuiltinMultiChainID {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            BITCOIN => Ok(BuiltinMultiChainID::Bitcoin),
+            ETHEREUM => Ok(BuiltinMultiChainID::Ether),
+            NOSTR => Ok(BuiltinMultiChainID::Nostr),
+            _ => Err(anyhow::anyhow!("multichain id {} is invalid", value)),
+        }
+    }
+}
+
+impl FromStr for BuiltinMultiChainID {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bitcoin" => Ok(BuiltinMultiChainID::Bitcoin),
+            "ether" => Ok(BuiltinMultiChainID::Ether),
+            "nostr" => Ok(BuiltinMultiChainID::Nostr),
+            s => Err(format_err!("Unknown multichain: {}", s)),
+        }
+    }
+}
+
+impl TryFrom<MultiChainID> for BuiltinMultiChainID {
+    type Error = anyhow::Error;
+    fn try_from(multichain_id: MultiChainID) -> Result<Self, Self::Error> {
+        Ok(match multichain_id.id() {
+            BITCOIN => Self::Bitcoin,
+            ETHEREUM => Self::Ether,
+            NOSTR => Self::Nostr,
+            id => bail!("{} is not a builtin multichain id", id),
+        })
+    }
+}
+
+impl BuiltinMultiChainID {
+    pub fn multichain_name(self) -> String {
+        self.to_string()
+    }
+
+    pub fn multichain_id(self) -> MultiChainID {
+        MultiChainID::new(self.into())
+    }
+
+    pub fn is_bitcoin(self) -> bool {
+        matches!(self, BuiltinMultiChainID::Bitcoin)
+    }
+
+    pub fn is_ethereum(self) -> bool {
+        matches!(self, BuiltinMultiChainID::Ether)
+    }
+
+    pub fn is_nostr(self) -> bool {
+        matches!(self, BuiltinMultiChainID::Nostr)
+    }
+
+    pub fn multichain_ids() -> Vec<BuiltinMultiChainID> {
+        vec![
+            BuiltinMultiChainID::Bitcoin,
+            BuiltinMultiChainID::Ether,
+            BuiltinMultiChainID::Nostr,
+        ]
+    }
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, JsonSchema,
+)]
+#[allow(clippy::upper_case_acronyms)]
+pub struct CustomMultiChainID {
+    multichain_name: String,
+    multichain_id: MultiChainID,
+}
+
+impl Display for CustomMultiChainID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.multichain_name, self.multichain_id)
+    }
+}
+
+impl CustomMultiChainID {
+    fn new(multichain_name: String, multichain_id: MultiChainID) -> Self {
+        Self {
+            multichain_name,
+            multichain_id,
+        }
+    }
+
+    pub fn multichain_id(&self) -> MultiChainID {
+        self.multichain_id
+    }
+
+    pub fn multichain_name(&self) -> &str {
+        self.multichain_name.as_str()
+    }
+}
+
+impl FromStr for CustomMultiChainID {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(':').collect();
+        if parts.len() != 2 {
+            bail!(
+                "Invalid Custom multichain id {}, custom multichain id format is: multichain_name:multichain_id",
+                s
+            );
+        }
+        let multichain_name = parts[0].to_string();
+        let multichain_id = MultiChainID::from_str(parts[1])?;
+        Ok(Self::new(multichain_name, multichain_id))
+    }
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, JsonSchema, Serialize, Deserialize,
+)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum RoochMultiChainID {
+    Builtin(BuiltinMultiChainID),
+    Custom(CustomMultiChainID),
+}
+
+impl Display for RoochMultiChainID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Builtin(b) => b.to_string(),
+            Self::Custom(c) => c.to_string(),
+        };
+        write!(f, "{}", name)
+    }
+}
+
+impl From<BuiltinMultiChainID> for RoochMultiChainID {
+    fn from(multichain_id: BuiltinMultiChainID) -> Self {
+        RoochMultiChainID::Builtin(multichain_id)
+    }
+}
+
+impl From<CustomMultiChainID> for RoochMultiChainID {
+    fn from(multichain_id: CustomMultiChainID) -> Self {
+        RoochMultiChainID::Custom(multichain_id)
+    }
+}
+
+impl TryFrom<MultiChainID> for RoochMultiChainID {
+    type Error = anyhow::Error;
+
+    fn try_from(multichain_id: MultiChainID) -> Result<Self, Self::Error> {
+        Ok(match multichain_id.id() {
+            BITCOIN => RoochMultiChainID::BITCOIN,
+            ETHEREUM => RoochMultiChainID::ETHEREUM,
+            NOSTR => RoochMultiChainID::NOSTR,
+            id => RoochMultiChainID::Custom(CustomMultiChainID::from_str(id.to_string().as_str())?),
+        })
+    }
+}
+
+impl FromStr for RoochMultiChainID {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match BuiltinMultiChainID::from_str(s) {
+            Ok(multichain_id) => Ok(Self::Builtin(multichain_id)),
+            Err(_e) => Ok(Self::Custom(CustomMultiChainID::from_str(s)?)),
+        }
+    }
+}
+
+impl RoochMultiChainID {
+    pub const BITCOIN: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Bitcoin);
+    pub const ETHEREUM: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Ether);
+    pub const NOSTR: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Nostr);
+
+    pub fn new_builtin(multichain_id: BuiltinMultiChainID) -> Self {
+        Self::Builtin(multichain_id)
+    }
+
+    pub fn new_custom(multichain_name: String, multichain_id: MultiChainID) -> Result<Self> {
+        for builtin_multichain_id in BuiltinMultiChainID::multichain_ids() {
+            if builtin_multichain_id.multichain_id() == multichain_id {
+                bail!(
+                    "MultiChain id {} has used for builtin {}",
+                    multichain_id,
+                    builtin_multichain_id
+                );
+            }
+            if builtin_multichain_id.multichain_name() == multichain_name {
+                bail!(
+                    "MultiChain name {} has used for builtin {}",
+                    multichain_name,
+                    builtin_multichain_id
+                );
+            }
+        }
+        Ok(Self::Custom(CustomMultiChainID::new(
+            multichain_name,
+            multichain_id,
+        )))
+    }
+
+    pub fn multichain_id(&self) -> MultiChainID {
+        match self {
+            Self::Builtin(b) => b.multichain_id(),
+            Self::Custom(c) => c.multichain_id(),
+        }
+    }
+
+    pub fn is_builtin(&self) -> bool {
+        self.is_bitcoin() || self.is_ethereum() || self.is_nostr()
+    }
+
+    pub fn is_bitcoin(&self) -> bool {
+        matches!(self, Self::Builtin(BuiltinMultiChainID::Bitcoin))
+    }
+
+    pub fn is_ethereum(&self) -> bool {
+        matches!(self, Self::Builtin(BuiltinMultiChainID::Ether))
+    }
+
+    pub fn is_nostr(&self) -> bool {
+        matches!(self, Self::Builtin(BuiltinMultiChainID::Nostr))
+    }
+
+    pub fn is_custom(&self) -> bool {
+        matches!(self, Self::Custom(_))
+    }
+
+    /// Default data dir name of this multichain_id
+    pub fn dir_name(&self) -> String {
+        match self {
+            Self::Builtin(b) => b.multichain_name().to_lowercase(),
+            Self::Custom(c) => c.multichain_name().to_string().to_lowercase(),
+        }
+    }
+
+    pub fn as_builtin(&self) -> Option<&BuiltinMultiChainID> {
+        match self {
+            Self::Builtin(b) => Some(b),
+            _ => None,
+        }
+    }
+
+    pub fn as_custom(&self) -> Option<&CustomMultiChainID> {
+        match self {
+            Self::Custom(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    pub fn as_multichain(rooch_chain_id: &RoochChainID) -> Self {
+        Self::new_custom(
+            rooch_chain_id.chain_name(),
+            MultiChainID::from(rooch_chain_id.chain_id()),
+        )
+        .unwrap()
+    }
+}

--- a/crates/rooch-types/src/multichain_id.rs
+++ b/crates/rooch-types/src/multichain_id.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, format_err, Result};
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -11,12 +13,13 @@ use std::str::FromStr;
 use crate::chain_id::{ChainID, RoochChainID};
 
 pub const BITCOIN: u64 = 0;
-pub const ETHEREUM: u64 = 60;
+pub const ETHER: u64 = 60;
 pub const NOSTR: u64 = 1237;
 
 #[derive(
     Clone, Copy, Debug, Deserialize, Serialize, Hash, Eq, PartialEq, PartialOrd, Ord, JsonSchema,
 )]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct MultiChainID {
     id: u64,
 }
@@ -31,7 +34,7 @@ impl MultiChainID {
     }
 
     pub fn is_ethereum(self) -> bool {
-        self.id == ETHEREUM
+        self.id == ETHER
     }
 
     pub fn is_bitcoin(self) -> bool {
@@ -82,9 +85,10 @@ impl Into<u64> for MultiChainID {
     Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
 )]
 #[repr(u64)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum BuiltinMultiChainID {
     Bitcoin = BITCOIN,
-    Ether = ETHEREUM,
+    Ether = ETHER,
     Nostr = NOSTR,
 }
 
@@ -110,7 +114,7 @@ impl TryFrom<u64> for BuiltinMultiChainID {
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
             BITCOIN => Ok(BuiltinMultiChainID::Bitcoin),
-            ETHEREUM => Ok(BuiltinMultiChainID::Ether),
+            ETHER => Ok(BuiltinMultiChainID::Ether),
             NOSTR => Ok(BuiltinMultiChainID::Nostr),
             _ => Err(anyhow::anyhow!("multichain id {} is invalid", value)),
         }
@@ -135,7 +139,7 @@ impl TryFrom<MultiChainID> for BuiltinMultiChainID {
     fn try_from(multichain_id: MultiChainID) -> Result<Self, Self::Error> {
         Ok(match multichain_id.id() {
             BITCOIN => Self::Bitcoin,
-            ETHEREUM => Self::Ether,
+            ETHER => Self::Ether,
             NOSTR => Self::Nostr,
             id => bail!("{} is not a builtin multichain id", id),
         })
@@ -176,6 +180,7 @@ impl BuiltinMultiChainID {
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, JsonSchema,
 )]
 #[allow(clippy::upper_case_acronyms)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct CustomMultiChainID {
     multichain_name: String,
     multichain_id: MultiChainID,
@@ -225,6 +230,7 @@ impl FromStr for CustomMultiChainID {
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, JsonSchema, Serialize, Deserialize,
 )]
 #[allow(clippy::upper_case_acronyms)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum RoochMultiChainID {
     Builtin(BuiltinMultiChainID),
     Custom(CustomMultiChainID),
@@ -258,7 +264,7 @@ impl TryFrom<MultiChainID> for RoochMultiChainID {
     fn try_from(multichain_id: MultiChainID) -> Result<Self, Self::Error> {
         Ok(match multichain_id.id() {
             BITCOIN => RoochMultiChainID::BITCOIN,
-            ETHEREUM => RoochMultiChainID::ETHEREUM,
+            ETHER => RoochMultiChainID::ETHER,
             NOSTR => RoochMultiChainID::NOSTR,
             id => RoochMultiChainID::Custom(CustomMultiChainID::from_str(id.to_string().as_str())?),
         })
@@ -278,7 +284,7 @@ impl FromStr for RoochMultiChainID {
 
 impl RoochMultiChainID {
     pub const BITCOIN: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Bitcoin);
-    pub const ETHEREUM: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Ether);
+    pub const ETHER: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Ether);
     pub const NOSTR: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Nostr);
 
     pub fn new_builtin(multichain_id: BuiltinMultiChainID) -> Self {

--- a/crates/rooch-types/src/multichain_id.rs
+++ b/crates/rooch-types/src/multichain_id.rs
@@ -10,11 +10,12 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-use crate::chain_id::{ChainID, RoochChainID};
+use crate::chain_id::ChainID;
 
 pub const BITCOIN: u64 = 0;
 pub const ETHER: u64 = 60;
 pub const NOSTR: u64 = 1237;
+pub const ROOCH: u64 = 20230103; // Dev
 
 #[derive(
     Clone, Copy, Debug, Deserialize, Serialize, Hash, Eq, PartialEq, PartialOrd, Ord, JsonSchema,
@@ -86,67 +87,72 @@ impl Into<u64> for MultiChainID {
 )]
 #[repr(u64)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub enum BuiltinMultiChainID {
+pub enum RoochMultiChainID {
     Bitcoin = BITCOIN,
     Ether = ETHER,
     Nostr = NOSTR,
+    Rooch = ROOCH,
 }
 
-impl Display for BuiltinMultiChainID {
+impl Display for RoochMultiChainID {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            BuiltinMultiChainID::Bitcoin => write!(f, "bitcoin"),
-            BuiltinMultiChainID::Ether => write!(f, "ether"),
-            BuiltinMultiChainID::Nostr => write!(f, "nostr"),
+            RoochMultiChainID::Bitcoin => write!(f, "bitcoin"),
+            RoochMultiChainID::Ether => write!(f, "ether"),
+            RoochMultiChainID::Nostr => write!(f, "nostr"),
+            RoochMultiChainID::Rooch => write!(f, "rooch"),
         }
     }
 }
 
-impl From<BuiltinMultiChainID> for u64 {
-    fn from(multichain_id: BuiltinMultiChainID) -> Self {
+impl From<RoochMultiChainID> for u64 {
+    fn from(multichain_id: RoochMultiChainID) -> Self {
         multichain_id as u64
     }
 }
 
-impl TryFrom<u64> for BuiltinMultiChainID {
+impl TryFrom<u64> for RoochMultiChainID {
     type Error = anyhow::Error;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
-            BITCOIN => Ok(BuiltinMultiChainID::Bitcoin),
-            ETHER => Ok(BuiltinMultiChainID::Ether),
-            NOSTR => Ok(BuiltinMultiChainID::Nostr),
+            BITCOIN => Ok(RoochMultiChainID::Bitcoin),
+            ETHER => Ok(RoochMultiChainID::Ether),
+            NOSTR => Ok(RoochMultiChainID::Nostr),
+            ROOCH => Ok(RoochMultiChainID::Rooch),
             _ => Err(anyhow::anyhow!("multichain id {} is invalid", value)),
         }
     }
 }
 
-impl FromStr for BuiltinMultiChainID {
+impl FromStr for RoochMultiChainID {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "bitcoin" => Ok(BuiltinMultiChainID::Bitcoin),
-            "ether" => Ok(BuiltinMultiChainID::Ether),
-            "nostr" => Ok(BuiltinMultiChainID::Nostr),
+            "bitcoin" => Ok(RoochMultiChainID::Bitcoin),
+            "ether" => Ok(RoochMultiChainID::Ether),
+            "nostr" => Ok(RoochMultiChainID::Nostr),
+            "rooch" => Ok(RoochMultiChainID::Rooch),
             s => Err(format_err!("Unknown multichain: {}", s)),
         }
     }
 }
 
-impl TryFrom<MultiChainID> for BuiltinMultiChainID {
+impl TryFrom<MultiChainID> for RoochMultiChainID {
     type Error = anyhow::Error;
     fn try_from(multichain_id: MultiChainID) -> Result<Self, Self::Error> {
         Ok(match multichain_id.id() {
             BITCOIN => Self::Bitcoin,
             ETHER => Self::Ether,
             NOSTR => Self::Nostr,
+            ROOCH => Self::Rooch,
             id => bail!("{} is not a builtin multichain id", id),
         })
     }
 }
 
-impl BuiltinMultiChainID {
+impl RoochMultiChainID {
     pub fn multichain_name(self) -> String {
         self.to_string()
     }
@@ -156,218 +162,27 @@ impl BuiltinMultiChainID {
     }
 
     pub fn is_bitcoin(self) -> bool {
-        matches!(self, BuiltinMultiChainID::Bitcoin)
+        matches!(self, RoochMultiChainID::Bitcoin)
     }
 
     pub fn is_ethereum(self) -> bool {
-        matches!(self, BuiltinMultiChainID::Ether)
+        matches!(self, RoochMultiChainID::Ether)
     }
 
     pub fn is_nostr(self) -> bool {
-        matches!(self, BuiltinMultiChainID::Nostr)
+        matches!(self, RoochMultiChainID::Nostr)
     }
 
-    pub fn multichain_ids() -> Vec<BuiltinMultiChainID> {
+    pub fn is_rooch(self) -> bool {
+        matches!(self, RoochMultiChainID::Rooch)
+    }
+
+    pub fn multichain_ids() -> Vec<RoochMultiChainID> {
         vec![
-            BuiltinMultiChainID::Bitcoin,
-            BuiltinMultiChainID::Ether,
-            BuiltinMultiChainID::Nostr,
+            RoochMultiChainID::Bitcoin,
+            RoochMultiChainID::Ether,
+            RoochMultiChainID::Nostr,
+            RoochMultiChainID::Rooch,
         ]
-    }
-}
-
-#[derive(
-    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, JsonSchema,
-)]
-#[allow(clippy::upper_case_acronyms)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub struct CustomMultiChainID {
-    multichain_name: String,
-    multichain_id: MultiChainID,
-}
-
-impl Display for CustomMultiChainID {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.multichain_name, self.multichain_id)
-    }
-}
-
-impl CustomMultiChainID {
-    fn new(multichain_name: String, multichain_id: MultiChainID) -> Self {
-        Self {
-            multichain_name,
-            multichain_id,
-        }
-    }
-
-    pub fn multichain_id(&self) -> MultiChainID {
-        self.multichain_id
-    }
-
-    pub fn multichain_name(&self) -> &str {
-        self.multichain_name.as_str()
-    }
-}
-
-impl FromStr for CustomMultiChainID {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.split(':').collect();
-        if parts.len() != 2 {
-            bail!(
-                "Invalid Custom multichain id {}, custom multichain id format is: multichain_name:multichain_id",
-                s
-            );
-        }
-        let multichain_name = parts[0].to_string();
-        let multichain_id = MultiChainID::from_str(parts[1])?;
-        Ok(Self::new(multichain_name, multichain_id))
-    }
-}
-
-#[derive(
-    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, JsonSchema, Serialize, Deserialize,
-)]
-#[allow(clippy::upper_case_acronyms)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub enum RoochMultiChainID {
-    Builtin(BuiltinMultiChainID),
-    Custom(CustomMultiChainID),
-}
-
-impl Display for RoochMultiChainID {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let name = match self {
-            Self::Builtin(b) => b.to_string(),
-            Self::Custom(c) => c.to_string(),
-        };
-        write!(f, "{}", name)
-    }
-}
-
-impl From<BuiltinMultiChainID> for RoochMultiChainID {
-    fn from(multichain_id: BuiltinMultiChainID) -> Self {
-        RoochMultiChainID::Builtin(multichain_id)
-    }
-}
-
-impl From<CustomMultiChainID> for RoochMultiChainID {
-    fn from(multichain_id: CustomMultiChainID) -> Self {
-        RoochMultiChainID::Custom(multichain_id)
-    }
-}
-
-impl TryFrom<MultiChainID> for RoochMultiChainID {
-    type Error = anyhow::Error;
-
-    fn try_from(multichain_id: MultiChainID) -> Result<Self, Self::Error> {
-        Ok(match multichain_id.id() {
-            BITCOIN => RoochMultiChainID::BITCOIN,
-            ETHER => RoochMultiChainID::ETHER,
-            NOSTR => RoochMultiChainID::NOSTR,
-            id => RoochMultiChainID::Custom(CustomMultiChainID::from_str(id.to_string().as_str())?),
-        })
-    }
-}
-
-impl FromStr for RoochMultiChainID {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match BuiltinMultiChainID::from_str(s) {
-            Ok(multichain_id) => Ok(Self::Builtin(multichain_id)),
-            Err(_e) => Ok(Self::Custom(CustomMultiChainID::from_str(s)?)),
-        }
-    }
-}
-
-impl RoochMultiChainID {
-    pub const BITCOIN: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Bitcoin);
-    pub const ETHER: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Ether);
-    pub const NOSTR: RoochMultiChainID = RoochMultiChainID::Builtin(BuiltinMultiChainID::Nostr);
-
-    pub fn new_builtin(multichain_id: BuiltinMultiChainID) -> Self {
-        Self::Builtin(multichain_id)
-    }
-
-    pub fn new_custom(multichain_name: String, multichain_id: MultiChainID) -> Result<Self> {
-        for builtin_multichain_id in BuiltinMultiChainID::multichain_ids() {
-            if builtin_multichain_id.multichain_id() == multichain_id {
-                bail!(
-                    "MultiChain id {} has used for builtin {}",
-                    multichain_id,
-                    builtin_multichain_id
-                );
-            }
-            if builtin_multichain_id.multichain_name() == multichain_name {
-                bail!(
-                    "MultiChain name {} has used for builtin {}",
-                    multichain_name,
-                    builtin_multichain_id
-                );
-            }
-        }
-        Ok(Self::Custom(CustomMultiChainID::new(
-            multichain_name,
-            multichain_id,
-        )))
-    }
-
-    pub fn multichain_id(&self) -> MultiChainID {
-        match self {
-            Self::Builtin(b) => b.multichain_id(),
-            Self::Custom(c) => c.multichain_id(),
-        }
-    }
-
-    pub fn is_builtin(&self) -> bool {
-        self.is_bitcoin() || self.is_ethereum() || self.is_nostr()
-    }
-
-    pub fn is_bitcoin(&self) -> bool {
-        matches!(self, Self::Builtin(BuiltinMultiChainID::Bitcoin))
-    }
-
-    pub fn is_ethereum(&self) -> bool {
-        matches!(self, Self::Builtin(BuiltinMultiChainID::Ether))
-    }
-
-    pub fn is_nostr(&self) -> bool {
-        matches!(self, Self::Builtin(BuiltinMultiChainID::Nostr))
-    }
-
-    pub fn is_custom(&self) -> bool {
-        matches!(self, Self::Custom(_))
-    }
-
-    /// Default data dir name of this multichain_id
-    pub fn dir_name(&self) -> String {
-        match self {
-            Self::Builtin(b) => b.multichain_name().to_lowercase(),
-            Self::Custom(c) => c.multichain_name().to_string().to_lowercase(),
-        }
-    }
-
-    pub fn as_builtin(&self) -> Option<&BuiltinMultiChainID> {
-        match self {
-            Self::Builtin(b) => Some(b),
-            _ => None,
-        }
-    }
-
-    pub fn as_custom(&self) -> Option<&CustomMultiChainID> {
-        match self {
-            Self::Custom(c) => Some(c),
-            _ => None,
-        }
-    }
-
-    pub fn as_multichain(rooch_chain_id: &RoochChainID) -> Self {
-        Self::new_custom(
-            rooch_chain_id.chain_name(),
-            MultiChainID::from(rooch_chain_id.chain_id()),
-        )
-        .unwrap()
     }
 }

--- a/crates/rooch-types/src/transaction/authenticator.rs
+++ b/crates/rooch-types/src/transaction/authenticator.rs
@@ -7,7 +7,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{chain_id::RoochChainID, crypto::Signature};
+use crate::{
+    chain_id::{BuiltinChainID, RoochChainID},
+    crypto::Signature,
+    multichain_id::RoochMultiChainID,
+};
 use anyhow::Result;
 #[cfg(any(test, feature = "fuzzing"))]
 use fastcrypto::ed25519::Ed25519KeyPair;
@@ -24,7 +28,7 @@ use std::{fmt, str::FromStr};
 /// It is a part of `AccountAbstraction`
 
 pub trait BuiltinAuthenticator {
-    fn multichain_id(&self) -> RoochChainID;
+    fn multichain_id(&self) -> RoochMultiChainID;
     fn payload(&self) -> Vec<u8>;
 }
 
@@ -34,8 +38,8 @@ pub struct RoochAuthenticator {
 }
 
 impl BuiltinAuthenticator for RoochAuthenticator {
-    fn multichain_id(&self) -> RoochChainID {
-        RoochChainID::DEV
+    fn multichain_id(&self) -> RoochMultiChainID {
+        RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev))
     }
     fn payload(&self) -> Vec<u8> {
         self.signature.as_ref().to_vec()
@@ -69,7 +73,7 @@ where
     T: BuiltinAuthenticator,
 {
     fn from(value: T) -> Self {
-        let multichain_id = value.multichain_id().chain_id().id();
+        let multichain_id = value.multichain_id().multichain_id().id();
         let payload = value.payload();
         Authenticator {
             multichain_id,
@@ -91,7 +95,7 @@ pub struct Authenticator {
 }
 
 impl Authenticator {
-    /// Unique identifier for the signature scheme
+    /// Unique identifier for the signature of multichain id
     pub fn multichain_id(&self) -> u64 {
         self.multichain_id
     }

--- a/crates/rooch-types/src/transaction/authenticator.rs
+++ b/crates/rooch-types/src/transaction/authenticator.rs
@@ -7,7 +7,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::crypto::{BuiltinAuthValidator, Signature};
 use anyhow::Result;
 #[cfg(any(test, feature = "fuzzing"))]
 use fastcrypto::ed25519::Ed25519KeyPair;
@@ -19,6 +18,8 @@ use proptest::{collection::vec, prelude::*};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
+
+use crate::{crypto::Signature, framework::auth_validator::BuiltinAuthValidator};
 
 /// A `Authenticator` is an an abstraction of a account authenticator.
 /// It is a part of `AccountAbstraction`
@@ -35,7 +36,7 @@ pub struct RoochAuthenticator {
 
 impl BuiltinAuthenticator for RoochAuthenticator {
     fn auth_validator_id(&self) -> u64 {
-        BuiltinAuthValidator::Ed25519.flag().into()
+        BuiltinAuthValidator::Rooch.flag().into()
     }
     fn payload(&self) -> Vec<u8> {
         self.signature.as_ref().to_vec()

--- a/crates/rooch-types/src/transaction/authenticator.rs
+++ b/crates/rooch-types/src/transaction/authenticator.rs
@@ -91,7 +91,7 @@ pub struct Authenticator {
 }
 
 impl Authenticator {
-    /// Unique identifier for the signature of scheme
+    /// Unique identifier for the signature of auth validator id
     pub fn auth_validator_id(&self) -> u64 {
         self.auth_validator_id
     }

--- a/crates/rooch-types/src/transaction/ethereum.rs
+++ b/crates/rooch-types/src/transaction/ethereum.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{authenticator::Authenticator, AbstractTransaction, AuthenticatorInfo};
-use crate::{address::EthereumAddress, error::RoochError, multichain_id::RoochMultiChainID};
+use crate::{address::EthereumAddress, error::RoochError};
 use anyhow::Result;
 use ethers::{
     types::{Bytes, OtherFields, Transaction, U256, U64},
@@ -48,9 +48,8 @@ impl EthereumTransactionData {
             access_list: None,
             max_priority_fee_per_gas: None,
             max_fee_per_gas: None,
-            chain_id: Some(U256::from(
-                RoochMultiChainID::Rooch.multichain_id().id(), // TODO use Ethereum multichain id and build a multichain genesis init
-            )),
+            // TODO create ethereum chain id in genesis init to pass through transaction validator tests
+            chain_id: Some(U256::from(20230103)), // fixed chain id from Ethereum main network
             other: OtherFields::default(),
         };
 
@@ -155,10 +154,7 @@ impl AbstractTransaction for EthereumTransactionData {
 
     fn authenticator_info(&self) -> Result<AuthenticatorInfo> {
         let chain_id = self.0.chain_id.ok_or(RoochError::InvalidChainID)?.as_u64();
-        let authenticator = Authenticator::new(
-            1, // TODO pass 1 as a scheme method
-            self.into_signature()?.as_bytes().to_vec(),
-        );
+        let authenticator = Authenticator::new(1, self.into_signature()?.as_bytes().to_vec());
         Ok(AuthenticatorInfo::new(chain_id, authenticator))
     }
 }

--- a/crates/rooch-types/src/transaction/ethereum.rs
+++ b/crates/rooch-types/src/transaction/ethereum.rs
@@ -3,7 +3,9 @@
 
 use super::{authenticator::Authenticator, AbstractTransaction, AuthenticatorInfo};
 use crate::{
-    address::EthereumAddress, chain_id::RoochChainID, coin_type::CoinID, error::RoochError,
+    address::EthereumAddress,
+    chain_id::{CustomChainID, RoochChainID},
+    error::RoochError,
 };
 use anyhow::Result;
 use ethers::{
@@ -156,7 +158,7 @@ impl AbstractTransaction for EthereumTransactionData {
     fn authenticator_info(&self) -> Result<AuthenticatorInfo> {
         let chain_id = self.0.chain_id.ok_or(RoochError::InvalidChainID)?.as_u64();
         let authenticator = Authenticator::new(
-            CoinID::Ether as u64,
+            CustomChainID::ethereum().chain_id().id(),
             self.into_signature()?.as_bytes().to_vec(),
         );
         Ok(AuthenticatorInfo::new(chain_id, authenticator))

--- a/crates/rooch-types/src/transaction/ethereum.rs
+++ b/crates/rooch-types/src/transaction/ethereum.rs
@@ -2,16 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{authenticator::Authenticator, AbstractTransaction, AuthenticatorInfo};
-use crate::{address::EthereumAddress, error::RoochError};
+use crate::{
+    address::EthereumAddress, chain_id::RoochChainID, error::RoochError,
+    framework::auth_validator::BuiltinAuthValidator,
+};
 use anyhow::Result;
 use ethers::{
-    types::{Bytes, OtherFields, Transaction, U256, U64},
+    types::{Bytes, OtherFields, Signature, Transaction, U256, U64},
     utils::rlp::{Decodable, Rlp},
-};
-use fastcrypto::{
-    hash::Keccak256,
-    secp256k1::recoverable::Secp256k1RecoverableSignature,
-    traits::{RecoverableSignature, ToFromBytes},
 };
 use move_core_types::account_address::AccountAddress;
 use moveos_types::{
@@ -48,8 +46,7 @@ impl EthereumTransactionData {
             access_list: None,
             max_priority_fee_per_gas: None,
             max_fee_per_gas: None,
-            // TODO create ethereum chain id in genesis init to pass through transaction validator tests
-            chain_id: Some(U256::from(20230103)), // fixed chain id from Ethereum main network
+            chain_id: Some(U256::from(RoochChainID::DEV.chain_id().id())), // build ethereum chain id from rooch chain id as parsed from MetaMask rooch chain id
             other: OtherFields::default(),
         };
 
@@ -63,57 +60,29 @@ impl EthereumTransactionData {
             .map_err(|e| anyhow::anyhow!("decode calldata to action failed: {}", e))
     }
 
-    // Calculate the "recovery byte": The recovery ID (v) contains information about the network and the signature type.
-    fn normalize_recovery_id(v: u64) -> u8 {
-        match v {
-            0 => 0,
-            1 => 1,
-            27 => 0,
-            28 => 1,
-            v if v >= 35 => ((v - 1) % 2) as _,
-            _ => 4,
-        }
-    }
-
-    pub fn into_signature(&self) -> Result<Secp256k1RecoverableSignature, RoochError> {
+    pub fn into_signature(&self) -> Result<Signature, RoochError> {
+        // Extract signature from original transaction
         let r = self.0.r;
         let s = self.0.s;
         let v = self.0.v.as_u64();
 
-        let recovery_id = Self::normalize_recovery_id(v);
-
-        // Convert `U256` values `r` and `s` to arrays of `u8`
-        let mut r_bytes = [0u8; 32];
-        r.to_big_endian(&mut r_bytes);
-        let mut s_bytes = [0u8; 32];
-        s.to_big_endian(&mut s_bytes);
-
-        // Create a new array to store the 65-byte "rsv" signature
-        let mut rsv_signature = [0u8; 65];
-        rsv_signature[..32].copy_from_slice(&r_bytes);
-        rsv_signature[32..64].copy_from_slice(&s_bytes);
-        rsv_signature[64] = recovery_id;
-
-        // Create the recoverable signature from the rsv signature
-        let recoverable_signature: Secp256k1RecoverableSignature =
-            <Secp256k1RecoverableSignature as ToFromBytes>::from_bytes(&rsv_signature)
-                .expect("Invalid signature");
-
-        Ok(recoverable_signature)
+        // Keep original Ethereum signature
+        Ok(Signature { r, s, v })
     }
 
     pub fn into_address(&self) -> Result<EthereumAddress, RoochError> {
         // Prepare the signed message (RLP encoding of the transaction)
         let message = self.tx_hash().to_fixed_bytes();
-        let recoverable_signature = self.into_signature()?;
-        // Recover with Keccak256 hash to a public key
-        let public_key = recoverable_signature
-            .recover_with_hash::<Keccak256>(&message)
-            .expect("Failed to recover public key");
+        // Get the signature
+        let ethereum_signature = self.into_signature()?;
+        // Recover the h160 address using default recover method
+        let h160_address = ethereum_signature
+            .recover(message)
+            .expect("Recover to an Ethereum address should succeed");
         // Get the address
-        let address = EthereumAddress::from(public_key);
+        let ethereum_address = EthereumAddress(h160_address);
 
-        Ok(address)
+        Ok(ethereum_address)
     }
 }
 
@@ -154,7 +123,10 @@ impl AbstractTransaction for EthereumTransactionData {
 
     fn authenticator_info(&self) -> Result<AuthenticatorInfo> {
         let chain_id = self.0.chain_id.ok_or(RoochError::InvalidChainID)?.as_u64();
-        let authenticator = Authenticator::new(1, self.into_signature()?.as_bytes().to_vec());
+        let authenticator = Authenticator::new(
+            BuiltinAuthValidator::Ethereum.flag().into(),
+            self.into_signature()?.to_vec(),
+        );
         Ok(AuthenticatorInfo::new(chain_id, authenticator))
     }
 }

--- a/crates/rooch-types/src/transaction/ethereum.rs
+++ b/crates/rooch-types/src/transaction/ethereum.rs
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{authenticator::Authenticator, AbstractTransaction, AuthenticatorInfo};
-use crate::{
-    address::EthereumAddress,
-    chain_id::{BuiltinChainID, RoochChainID},
-    error::RoochError,
-    multichain_id::RoochMultiChainID,
-};
+use crate::{address::EthereumAddress, error::RoochError, multichain_id::RoochMultiChainID};
 use anyhow::Result;
 use ethers::{
     types::{Bytes, OtherFields, Transaction, U256, U64},
@@ -54,9 +49,7 @@ impl EthereumTransactionData {
             max_priority_fee_per_gas: None,
             max_fee_per_gas: None,
             chain_id: Some(U256::from(
-                RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev))
-                    .multichain_id()
-                    .id(), // TODO use Ethereum multichain id and build a multichain genesis init
+                RoochMultiChainID::Rooch.multichain_id().id(), // TODO use Ethereum multichain id and build a multichain genesis init
             )),
             other: OtherFields::default(),
         };

--- a/crates/rooch-types/src/transaction/ethereum.rs
+++ b/crates/rooch-types/src/transaction/ethereum.rs
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{authenticator::Authenticator, AbstractTransaction, AuthenticatorInfo};
-use crate::{
-    address::EthereumAddress,
-    chain_id::{CustomChainID, RoochChainID},
-    error::RoochError,
-};
+use crate::{address::EthereumAddress, error::RoochError, multichain_id::RoochMultiChainID};
 use anyhow::Result;
 use ethers::{
     types::{Bytes, OtherFields, Transaction, U256, U64},
@@ -52,7 +48,7 @@ impl EthereumTransactionData {
             access_list: None,
             max_priority_fee_per_gas: None,
             max_fee_per_gas: None,
-            chain_id: Some(U256::from(RoochChainID::DEV.chain_id().id())),
+            chain_id: Some(U256::from(RoochMultiChainID::ETHEREUM.multichain_id().id())),
             other: OtherFields::default(),
         };
 
@@ -158,7 +154,7 @@ impl AbstractTransaction for EthereumTransactionData {
     fn authenticator_info(&self) -> Result<AuthenticatorInfo> {
         let chain_id = self.0.chain_id.ok_or(RoochError::InvalidChainID)?.as_u64();
         let authenticator = Authenticator::new(
-            CustomChainID::ethereum().chain_id().id(),
+            RoochMultiChainID::ETHEREUM.multichain_id().id(),
             self.into_signature()?.as_bytes().to_vec(),
         );
         Ok(AuthenticatorInfo::new(chain_id, authenticator))

--- a/crates/rooch/src/cli_types.rs
+++ b/crates/rooch/src/cli_types.rs
@@ -33,7 +33,7 @@ pub trait CommandAction<T: Serialize + Send>: Sized + Send {
 
 #[derive(Debug)]
 pub struct AuthenticatorOptions {
-    pub coin_id: u64,
+    pub multichain_id: u64,
     pub payload: Vec<u8>,
 }
 
@@ -41,10 +41,10 @@ impl FromStr for AuthenticatorOptions {
     type Err = RoochError;
     fn from_str(s: &str) -> RoochResult<Self> {
         let mut split = s.split(':');
-        let coin_id = split.next().ok_or_else(|| {
+        let multichain_id = split.next().ok_or_else(|| {
             RoochError::CommandArgumentError(format!("Invalid authenticator argument: {}", s))
         })?;
-        let coin_id = coin_id.parse::<u64>().map_err(|_| {
+        let multichain_id = multichain_id.parse::<u64>().map_err(|_| {
             RoochError::CommandArgumentError(format!("Invalid authenticator argument: {}", s))
         })?;
         let payload = split.next().ok_or_else(|| {
@@ -53,14 +53,17 @@ impl FromStr for AuthenticatorOptions {
         let payload = hex::decode(payload.strip_prefix("0x").unwrap_or(payload)).map_err(|_| {
             RoochError::CommandArgumentError(format!("Invalid authenticator argument: {}", s))
         })?;
-        Ok(AuthenticatorOptions { coin_id, payload })
+        Ok(AuthenticatorOptions {
+            multichain_id,
+            payload,
+        })
     }
 }
 
 impl From<AuthenticatorOptions> for Authenticator {
     fn from(options: AuthenticatorOptions) -> Self {
         Authenticator {
-            coin_id: options.coin_id,
+            multichain_id: options.multichain_id,
             payload: options.payload,
         }
     }
@@ -77,7 +80,7 @@ pub struct TransactionOptions {
     pub(crate) sender_account: Option<String>,
 
     /// Custom the transaction's authenticator
-    /// format: `coin_id:payload`, coin_id is u64, payload is hex string
+    /// format: `multichain_id:payload`, multichain_id is u64, payload is hex string
     /// example: 123:0x2abc
     #[clap(long)]
     pub(crate) authenticator: Option<AuthenticatorOptions>,

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -4,9 +4,9 @@
 use crate::cli_types::WalletContextOptions;
 use clap::Parser;
 use move_core_types::account_address::AccountAddress;
-use rooch_key::keystore::AccountKeystore;
+use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
-use rooch_types::{account::AccountModule, error::RoochResult, multichain_id::RoochMultiChainID};
+use rooch_types::{account::AccountModule, error::RoochResult};
 
 /// Create a new account on-chain
 ///
@@ -26,12 +26,12 @@ impl CreateCommand {
         let (new_address, phrase, multichain_id) = context
             .config
             .keystore
-            .generate_and_add_new_key(RoochMultiChainID::Rooch, None, None)?;
+            .generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None)?;
 
         println!("{}", AccountAddress::from(new_address).to_hex_literal());
         println!(
             "Generated new keypair for address with multichain id {:?} [{new_address}]",
-            multichain_id.multichain_id().id().to_string()
+            KeyPairType::RoochKeyPairType.type_of()
         );
         println!("Secret Recovery Phrase : [{phrase}]");
 

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use move_core_types::account_address::AccountAddress;
 use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
-use rooch_types::{account::AccountModule, coin_type::CoinID, error::RoochResult};
+use rooch_types::{account::AccountModule, chain_id::RoochChainID, error::RoochResult};
 
 /// Create a new account on-chain
 ///
@@ -27,7 +27,7 @@ impl CreateCommand {
             context
                 .config
                 .keystore
-                .generate_and_add_new_key(CoinID::Rooch, None, None)?;
+                .generate_and_add_new_key(RoochChainID::DEV, None, None)?;
 
         println!("{}", AccountAddress::from(new_address).to_hex_literal());
         println!(

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -6,7 +6,12 @@ use clap::Parser;
 use move_core_types::account_address::AccountAddress;
 use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
-use rooch_types::{account::AccountModule, chain_id::RoochChainID, error::RoochResult};
+use rooch_types::{
+    account::AccountModule,
+    chain_id::{BuiltinChainID, RoochChainID},
+    error::RoochResult,
+    multichain_id::RoochMultiChainID,
+};
 
 /// Create a new account on-chain
 ///
@@ -23,16 +28,17 @@ impl CreateCommand {
     pub async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
         let mut context = self.context_options.build().await?;
 
-        let (new_address, phrase, scheme) =
-            context
-                .config
-                .keystore
-                .generate_and_add_new_key(RoochChainID::DEV, None, None)?;
+        let (new_address, phrase, multichain_id) =
+            context.config.keystore.generate_and_add_new_key(
+                RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
+                None,
+                None,
+            )?;
 
         println!("{}", AccountAddress::from(new_address).to_hex_literal());
         println!(
-            "Generated new keypair for address with scheme {:?} [{new_address}]",
-            scheme.to_string()
+            "Generated new keypair for address with multichain id {:?} [{new_address}]",
+            multichain_id.multichain_id().id().to_string()
         );
         println!("Secret Recovery Phrase : [{phrase}]");
 
@@ -43,7 +49,7 @@ impl CreateCommand {
         let action = AccountModule::create_account_action(address);
 
         let result = context
-            .sign_and_execute(new_address, action, scheme)
+            .sign_and_execute(new_address, action, multichain_id)
             .await?;
         context.assert_execute_success(result)
     }

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -6,12 +6,7 @@ use clap::Parser;
 use move_core_types::account_address::AccountAddress;
 use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
-use rooch_types::{
-    account::AccountModule,
-    chain_id::{BuiltinChainID, RoochChainID},
-    error::RoochResult,
-    multichain_id::RoochMultiChainID,
-};
+use rooch_types::{account::AccountModule, error::RoochResult, multichain_id::RoochMultiChainID};
 
 /// Create a new account on-chain
 ///
@@ -28,12 +23,10 @@ impl CreateCommand {
     pub async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
         let mut context = self.context_options.build().await?;
 
-        let (new_address, phrase, multichain_id) =
-            context.config.keystore.generate_and_add_new_key(
-                RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-                None,
-                None,
-            )?;
+        let (new_address, phrase, multichain_id) = context
+            .config
+            .keystore
+            .generate_and_add_new_key(RoochMultiChainID::Rooch, None, None)?;
 
         println!("{}", AccountAddress::from(new_address).to_hex_literal());
         println!(

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -7,7 +7,6 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use rooch_key::keystore::AccountKeystore;
 use rooch_types::{
-    chain_id::{BuiltinChainID, RoochChainID},
     error::{RoochError, RoochResult},
     multichain_id::RoochMultiChainID,
 };
@@ -33,19 +32,12 @@ impl CommandAction<()> for ImportCommand {
         let address = context
             .config
             .keystore
-            .import_from_mnemonic(
-                &self.mnemonic_phrase,
-                RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-                None,
-            )
+            .import_from_mnemonic(&self.mnemonic_phrase, RoochMultiChainID::Rooch, None)
             .map_err(|e| RoochError::ImportAccountError(e.to_string()))?;
 
         println!(
             "Key imported for address on multichain id {:?}: [{address}]",
-            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev))
-                .multichain_id()
-                .id()
-                .to_string()
+            RoochMultiChainID::Rooch.multichain_id().id().to_string()
         );
 
         Ok(())

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -5,11 +5,8 @@ use clap::Parser;
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use rooch_key::keystore::AccountKeystore;
-use rooch_types::{
-    error::{RoochError, RoochResult},
-    multichain_id::RoochMultiChainID,
-};
+use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
+use rooch_types::error::{RoochError, RoochResult};
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
 
@@ -32,12 +29,12 @@ impl CommandAction<()> for ImportCommand {
         let address = context
             .config
             .keystore
-            .import_from_mnemonic(&self.mnemonic_phrase, RoochMultiChainID::Rooch, None)
+            .import_from_mnemonic(&self.mnemonic_phrase, KeyPairType::RoochKeyPairType, None)
             .map_err(|e| RoochError::ImportAccountError(e.to_string()))?;
 
         println!(
-            "Key imported for address on multichain id {:?}: [{address}]",
-            RoochMultiChainID::Rooch.multichain_id().id().to_string()
+            "Key imported for address on type {:?}: [{address}]",
+            KeyPairType::RoochKeyPairType.type_of()
         );
 
         Ok(())

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -7,8 +7,9 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use rooch_key::keystore::AccountKeystore;
 use rooch_types::{
-    chain_id::RoochChainID,
+    chain_id::{BuiltinChainID, RoochChainID},
     error::{RoochError, RoochResult},
+    multichain_id::RoochMultiChainID,
 };
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
@@ -32,12 +33,19 @@ impl CommandAction<()> for ImportCommand {
         let address = context
             .config
             .keystore
-            .import_from_mnemonic(&self.mnemonic_phrase, RoochChainID::DEV, None)
+            .import_from_mnemonic(
+                &self.mnemonic_phrase,
+                RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
+                None,
+            )
             .map_err(|e| RoochError::ImportAccountError(e.to_string()))?;
 
         println!(
             "Key imported for address on multichain id {:?}: [{address}]",
-            RoochChainID::DEV.chain_id().id()
+            RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev))
+                .multichain_id()
+                .id()
+                .to_string()
         );
 
         Ok(())

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use rooch_key::keystore::AccountKeystore;
 use rooch_types::{
-    coin_type::CoinID,
+    chain_id::RoochChainID,
     error::{RoochError, RoochResult},
 };
 
@@ -32,12 +32,12 @@ impl CommandAction<()> for ImportCommand {
         let address = context
             .config
             .keystore
-            .import_from_mnemonic(&self.mnemonic_phrase, CoinID::Rooch, None)
+            .import_from_mnemonic(&self.mnemonic_phrase, RoochChainID::DEV, None)
             .map_err(|e| RoochError::ImportAccountError(e.to_string()))?;
 
         println!(
-            "Key imported for address on scheme {:?}: [{address}]",
-            CoinID::Rooch.to_owned()
+            "Key imported for address on multichain id {:?}: [{address}]",
+            RoochChainID::DEV.chain_id().id()
         );
 
         Ok(())

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -23,11 +23,11 @@ impl CommandAction<()> for ListCommand {
 
         println!(
             "{0: ^66} | {1: ^48} | {2: ^16} | {3: ^12}",
-            "Rooch Address (Ed25519)", "Public Key (Base64)", "Scheme", "Active Address"
+            "Rooch Address (Ed25519)", "Public Key (Base64)", "Auth Validator ID", "Active Address"
         );
         println!("{}", ["-"; 153].join(""));
         for (address, public_key) in context.config.keystore.get_address_public_keys() {
-            let scheme = public_key.scheme().to_string();
+            let auth_validator_id = public_key.auth_validator().flag().to_string();
             let mut active = "";
             if active_address == Some(address) {
                 active = "True";
@@ -37,7 +37,7 @@ impl CommandAction<()> for ListCommand {
                 "{0: ^66} | {1: ^48} | {2: ^16} | {3: ^12}",
                 address,
                 public_key.encode_base64(),
-                scheme,
+                auth_validator_id,
                 active
             );
         }

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -27,7 +27,7 @@ impl CommandAction<()> for ListCommand {
         );
         println!("{}", ["-"; 153].join(""));
         for (address, public_key) in context.config.keystore.get_address_public_keys() {
-            let auth_validator_id = public_key.auth_validator().flag().to_string();
+            let auth_validator_id = public_key.auth_validator().flag();
             let mut active = "";
             if active_address == Some(address) {
                 active = "True";
@@ -37,7 +37,7 @@ impl CommandAction<()> for ListCommand {
                 "{0: ^66} | {1: ^48} | {2: ^16} | {3: ^12}",
                 address,
                 public_key.encode_base64(),
-                auth_validator_id,
+                auth_validator_id.to_string(),
                 active
             );
         }

--- a/crates/rooch/src/commands/account/commands/nullify.rs
+++ b/crates/rooch/src/commands/account/commands/nullify.rs
@@ -10,7 +10,6 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use rooch_types::{
     address::RoochAddress,
-    chain_id::{BuiltinChainID, RoochChainID},
     error::{RoochError, RoochResult},
     framework::native_validator::NativeValidatorModule,
     multichain_id::RoochMultiChainID,
@@ -54,7 +53,7 @@ impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
 
             // Execute the Move call as a transaction
             let mut result = context
-                .sign_and_execute(existing_address, action, self.multichain_id.clone())
+                .sign_and_execute(existing_address, action, self.multichain_id)
                 .await?;
             result = context.assert_execute_success(result)?;
 
@@ -64,7 +63,7 @@ impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
                 .keystore
                 .nullify_address_with_key_pair_from_multichain_id(
                     &existing_address,
-                    RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
+                    RoochMultiChainID::Rooch,
                 )
                 .map_err(|e| RoochError::NullifyAccountError(e.to_string()))?;
 

--- a/crates/rooch/src/commands/account/commands/nullify.rs
+++ b/crates/rooch/src/commands/account/commands/nullify.rs
@@ -27,7 +27,7 @@ pub struct NullifyCommand {
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
     /// Command line input of multichain ids
-    #[clap(short = 'm', long = "multichain-id")]
+    #[clap(short = 'i', long = "multichain-id")]
     pub multichain_id: RoochMultiChainID,
 }
 

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -49,7 +49,7 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
                 .update_address_with_key_pair_from_multichain_id(
                     &existing_address,
                     self.mnemonic_phrase,
-                    self.multichain_id.clone(),
+                    self.multichain_id,
                     None,
                 )
                 .map_err(|e| RoochError::UpdateAccountError(e.to_string()))?;

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -26,7 +26,7 @@ pub struct UpdateCommand {
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
     /// Command line input of multichain ids
-    #[clap(short = 'm', long = "multichain-id")]
+    #[clap(short = 'i', long = "multichain-id")]
     pub multichain_id: RoochMultiChainID,
 }
 

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -8,6 +8,7 @@ use clap::Parser;
 use regex::Regex;
 use rooch_config::config::Config;
 use rooch_config::{rooch_config_dir, ROOCH_CLIENT_CONFIG, ROOCH_KEYSTORE_FILENAME};
+use rooch_key::keypair::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use rooch_rpc_client::client_config::{ClientConfig, Env};
 use rooch_types::address::RoochAddress;
@@ -15,7 +16,6 @@ use rooch_types::chain_id::RoochChainID;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::RoochError;
 use rooch_types::error::RoochResult;
-use rooch_types::multichain_id::RoochMultiChainID;
 use std::fs;
 
 /// Tool for init with rooch
@@ -52,7 +52,7 @@ impl CommandAction<String> for Init {
                 }),
                 None => {
                     println!(
-                        "Creating config file [{:?}] with server and rooch native validator scheme.",
+                        "Creating config file [{:?}] with server and rooch native validator.",
                         client_config_path
                     );
                     let url = if self.server_url.is_none() {
@@ -109,11 +109,11 @@ impl CommandAction<String> for Init {
                     Err(error) => return Err(RoochError::GenerateKeyError(error.to_string())),
                 };
 
-                let (new_address, phrase, multichain_id) =
-                    keystore.generate_and_add_new_key(RoochMultiChainID::Rooch, None, None)?;
+                let (new_address, phrase, key_pair_type) =
+                    keystore.generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None)?;
                 println!(
-                    "Generated new keypair for address with multichain id {:?} [{new_address}]",
-                    multichain_id.multichain_id().id().to_string()
+                    "Generated new keypair for address with type {:?} [{new_address}]",
+                    key_pair_type.type_of()
                 );
                 println!("Secret Recovery Phrase : [{phrase}]");
                 let alias = env.alias.clone();

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -12,7 +12,6 @@ use rooch_key::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use rooch_rpc_client::client_config::{ClientConfig, Env};
 use rooch_types::address::RoochAddress;
 use rooch_types::chain_id::RoochChainID;
-use rooch_types::coin_type::CoinID;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::RoochError;
 use rooch_types::error::RoochResult;
@@ -110,7 +109,7 @@ impl CommandAction<String> for Init {
                 };
 
                 let (new_address, phrase, scheme) =
-                    keystore.generate_and_add_new_key(CoinID::Rooch, None, None)?;
+                    keystore.generate_and_add_new_key(RoochChainID::DEV, None, None)?;
                 println!(
                     "Generated new keypair for address with scheme {:?} [{new_address}]",
                     scheme.to_string()

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -11,7 +11,7 @@ use rooch_config::{rooch_config_dir, ROOCH_CLIENT_CONFIG, ROOCH_KEYSTORE_FILENAM
 use rooch_key::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use rooch_rpc_client::client_config::{ClientConfig, Env};
 use rooch_types::address::RoochAddress;
-use rooch_types::chain_id::{BuiltinChainID, RoochChainID};
+use rooch_types::chain_id::RoochChainID;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::RoochError;
 use rooch_types::error::RoochResult;
@@ -109,11 +109,8 @@ impl CommandAction<String> for Init {
                     Err(error) => return Err(RoochError::GenerateKeyError(error.to_string())),
                 };
 
-                let (new_address, phrase, multichain_id) = keystore.generate_and_add_new_key(
-                    RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-                    None,
-                    None,
-                )?;
+                let (new_address, phrase, multichain_id) =
+                    keystore.generate_and_add_new_key(RoochMultiChainID::Rooch, None, None)?;
                 println!(
                     "Generated new keypair for address with multichain id {:?} [{new_address}]",
                     multichain_id.multichain_id().id().to_string()

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -11,10 +11,11 @@ use rooch_config::{rooch_config_dir, ROOCH_CLIENT_CONFIG, ROOCH_KEYSTORE_FILENAM
 use rooch_key::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use rooch_rpc_client::client_config::{ClientConfig, Env};
 use rooch_types::address::RoochAddress;
-use rooch_types::chain_id::RoochChainID;
+use rooch_types::chain_id::{BuiltinChainID, RoochChainID};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::RoochError;
 use rooch_types::error::RoochResult;
+use rooch_types::multichain_id::RoochMultiChainID;
 use std::fs;
 
 /// Tool for init with rooch
@@ -108,11 +109,14 @@ impl CommandAction<String> for Init {
                     Err(error) => return Err(RoochError::GenerateKeyError(error.to_string())),
                 };
 
-                let (new_address, phrase, scheme) =
-                    keystore.generate_and_add_new_key(RoochChainID::DEV, None, None)?;
+                let (new_address, phrase, multichain_id) = keystore.generate_and_add_new_key(
+                    RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
+                    None,
+                    None,
+                )?;
                 println!(
-                    "Generated new keypair for address with scheme {:?} [{new_address}]",
-                    scheme.to_string()
+                    "Generated new keypair for address with multichain id {:?} [{new_address}]",
+                    multichain_id.multichain_id().id().to_string()
                 );
                 println!("Secret Recovery Phrase : [{phrase}]");
                 let alias = env.alias.clone();

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -10,7 +10,7 @@ use move_bytecode_utils::Modules;
 use move_cli::Move;
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
-use rooch_types::chain_id::RoochChainID;
+use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::rooch::RoochTransaction;
 
 use crate::cli_types::{CommandAction, TransactionOptions, WalletContextOptions};
@@ -45,7 +45,7 @@ pub struct Publish {
 
     /// Command line input of multichain ids
     #[clap(short = 'm', long = "multichain-id", default_value = "20230103")]
-    pub multichain_id: RoochChainID,
+    pub multichain_id: RoochMultiChainID,
 
     /// Whether publish modules by `MoveAction::ModuleBundle`?
     /// If not set, publish moduels through Move entry function

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -9,8 +9,8 @@ use move_bytecode_utils::dependency_graph::DependencyGraph;
 use move_bytecode_utils::Modules;
 use move_cli::Move;
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use rooch_key::keypair::KeyPairType;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
-use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::rooch::RoochTransaction;
 
 use crate::cli_types::{CommandAction, TransactionOptions, WalletContextOptions};
@@ -42,10 +42,6 @@ pub struct Publish {
     /// Note: This will fail if there are duplicates in the Move.toml file remove those first.
     #[clap(long, parse(try_from_str = crate::utils::parse_map), default_value = "")]
     pub(crate) named_addresses: BTreeMap<String, String>,
-
-    /// Command line input of multichain ids
-    #[clap(short = 'i', long = "multichain-id", default_value = "rooch")]
-    pub multichain_id: RoochMultiChainID,
 
     /// Whether publish modules by `MoveAction::ModuleBundle`?
     /// If not set, publish moduels through Move entry function
@@ -148,14 +144,14 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
                 }
                 None => {
                     context
-                        .sign_and_execute(sender, action, self.multichain_id)
+                        .sign_and_execute(sender, action, KeyPairType::RoochKeyPairType)
                         .await?
                 }
             }
         } else {
             let action = MoveAction::ModuleBundle(bundles);
             context
-                .sign_and_execute(sender, action, self.multichain_id)
+                .sign_and_execute(sender, action, KeyPairType::RoochKeyPairType)
                 .await?
         };
         context.assert_execute_success(tx_result)

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -10,7 +10,7 @@ use move_bytecode_utils::Modules;
 use move_cli::Move;
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
-use rooch_types::coin_type::CoinID;
+use rooch_types::chain_id::RoochChainID;
 use rooch_types::transaction::rooch::RoochTransaction;
 
 use crate::cli_types::{CommandAction, TransactionOptions, WalletContextOptions};
@@ -43,9 +43,9 @@ pub struct Publish {
     #[clap(long, parse(try_from_str = crate::utils::parse_map), default_value = "")]
     pub(crate) named_addresses: BTreeMap<String, String>,
 
-    /// Command line input of coin ids
-    #[clap(short = 'c', long = "coin-id", default_value = "rooch", arg_enum)]
-    pub coin_id: CoinID,
+    /// Command line input of multichain ids
+    #[clap(short = 'm', long = "multichain-id", default_value = "20230103")]
+    pub multichain_id: RoochChainID,
 
     /// Whether publish modules by `MoveAction::ModuleBundle`?
     /// If not set, publish moduels through Move entry function
@@ -148,14 +148,14 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
                 }
                 None => {
                     context
-                        .sign_and_execute(sender, action, self.coin_id)
+                        .sign_and_execute(sender, action, self.multichain_id)
                         .await?
                 }
             }
         } else {
             let action = MoveAction::ModuleBundle(bundles);
             context
-                .sign_and_execute(sender, action, self.coin_id)
+                .sign_and_execute(sender, action, self.multichain_id)
                 .await?
         };
         context.assert_execute_success(tx_result)

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -44,7 +44,7 @@ pub struct Publish {
     pub(crate) named_addresses: BTreeMap<String, String>,
 
     /// Command line input of multichain ids
-    #[clap(short = 'm', long = "multichain-id", default_value = "20230103")]
+    #[clap(short = 'i', long = "multichain-id", default_value = "rooch")]
     pub multichain_id: RoochMultiChainID,
 
     /// Whether publish modules by `MoveAction::ModuleBundle`?

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -5,12 +5,11 @@ use crate::cli_types::{ArgWithType, CommandAction, TransactionOptions, WalletCon
 use async_trait::async_trait;
 use clap::Parser;
 use moveos_types::{move_types::FunctionId, transaction::MoveAction};
-use rooch_key::keystore::AccountKeystore;
+use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, TypeTagView};
 use rooch_types::{
     address::RoochAddress,
     error::{RoochError, RoochResult},
-    multichain_id::RoochMultiChainID,
     transaction::rooch::RoochTransaction,
 };
 
@@ -53,10 +52,6 @@ pub struct RunFunction {
 
     #[clap(flatten)]
     tx_options: TransactionOptions,
-
-    /// Command line input of multichain ids
-    #[clap(short = 'i', long = "multichain-id", default_value = "rooch")]
-    pub multichain_id: RoochMultiChainID,
 }
 
 #[async_trait]
@@ -103,7 +98,7 @@ impl CommandAction<ExecuteTransactionResponseView> for RunFunction {
             }
             (None, None) => {
                 context
-                    .sign_and_execute(sender, action, self.multichain_id)
+                    .sign_and_execute(sender, action, KeyPairType::RoochKeyPairType)
                     .await
             }
         }

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -9,8 +9,8 @@ use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, TypeTagView};
 use rooch_types::{
     address::RoochAddress,
-    chain_id::RoochChainID,
     error::{RoochError, RoochResult},
+    multichain_id::RoochMultiChainID,
     transaction::rooch::RoochTransaction,
 };
 
@@ -56,7 +56,7 @@ pub struct RunFunction {
 
     /// Command line input of multichain ids
     #[clap(short = 'm', long = "multichain-id", default_value = "20230103")]
-    pub multichain_id: RoochChainID,
+    pub multichain_id: RoochMultiChainID,
 }
 
 #[async_trait]

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -55,7 +55,7 @@ pub struct RunFunction {
     tx_options: TransactionOptions,
 
     /// Command line input of multichain ids
-    #[clap(short = 'm', long = "multichain-id", default_value = "20230103")]
+    #[clap(short = 'i', long = "multichain-id", default_value = "rooch")]
     pub multichain_id: RoochMultiChainID,
 }
 

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -9,7 +9,7 @@ use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, TypeTagView};
 use rooch_types::{
     address::RoochAddress,
-    coin_type::CoinID,
+    chain_id::RoochChainID,
     error::{RoochError, RoochResult},
     transaction::rooch::RoochTransaction,
 };
@@ -54,9 +54,9 @@ pub struct RunFunction {
     #[clap(flatten)]
     tx_options: TransactionOptions,
 
-    /// Command line input of coin ids
-    #[clap(short = 'c', long = "coin-id", default_value = "rooch", arg_enum)]
-    pub coin_id: CoinID,
+    /// Command line input of multichain ids
+    #[clap(short = 'm', long = "multichain-id", default_value = "20230103")]
+    pub multichain_id: RoochChainID,
 }
 
 #[async_trait]
@@ -101,7 +101,11 @@ impl CommandAction<ExecuteTransactionResponseView> for RunFunction {
                     .map_err(|e| RoochError::SignMessageError(e.to_string()))?;
                 context.execute(tx).await
             }
-            (None, None) => context.sign_and_execute(sender, action, self.coin_id).await,
+            (None, None) => {
+                context
+                    .sign_and_execute(sender, action, self.multichain_id)
+                    .await
+            }
         }
     }
 }

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -7,7 +7,6 @@ use moveos_types::module_binding::MoveFunctionCaller;
 use rooch_key::keystore::AccountKeystore;
 use rooch_types::{
     address::RoochAddress,
-    chain_id::{BuiltinChainID, RoochChainID},
     error::{RoochError, RoochResult},
     framework::session_key::{SessionKey, SessionKeyModule, SessionScope},
     multichain_id::RoochMultiChainID,
@@ -61,11 +60,7 @@ impl CreateCommand {
         println!("Generated new session key {session_auth_key} for address [{sender}]",);
 
         let result = context
-            .sign_and_execute(
-                sender,
-                action,
-                RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
-            )
+            .sign_and_execute(sender, action, RoochMultiChainID::Rooch)
             .await?;
         context.assert_execute_success(result)?;
         let client = context.get_client().await?;

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -4,12 +4,11 @@
 use crate::cli_types::{TransactionOptions, WalletContextOptions};
 use clap::Parser;
 use moveos_types::module_binding::MoveFunctionCaller;
-use rooch_key::keystore::AccountKeystore;
+use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
 use rooch_types::{
     address::RoochAddress,
     error::{RoochError, RoochResult},
     framework::session_key::{SessionKey, SessionKeyModule, SessionScope},
-    multichain_id::RoochMultiChainID,
 };
 
 /// Create a new session key on-chain
@@ -60,7 +59,7 @@ impl CreateCommand {
         println!("Generated new session key {session_auth_key} for address [{sender}]",);
 
         let result = context
-            .sign_and_execute(sender, action, RoochMultiChainID::Rooch)
+            .sign_and_execute(sender, action, KeyPairType::RoochKeyPairType)
             .await?;
         context.assert_execute_success(result)?;
         let client = context.get_client().await?;

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -7,9 +7,10 @@ use moveos_types::module_binding::MoveFunctionCaller;
 use rooch_key::keystore::AccountKeystore;
 use rooch_types::{
     address::RoochAddress,
-    chain_id::RoochChainID,
+    chain_id::{BuiltinChainID, RoochChainID},
     error::{RoochError, RoochResult},
     framework::session_key::{SessionKey, SessionKeyModule, SessionScope},
+    multichain_id::RoochMultiChainID,
 };
 
 /// Create a new session key on-chain
@@ -60,7 +61,11 @@ impl CreateCommand {
         println!("Generated new session key {session_auth_key} for address [{sender}]",);
 
         let result = context
-            .sign_and_execute(sender, action, RoochChainID::DEV)
+            .sign_and_execute(
+                sender,
+                action,
+                RoochMultiChainID::as_multichain(&RoochChainID::Builtin(BuiltinChainID::Dev)),
+            )
             .await?;
         context.assert_execute_success(result)?;
         let client = context.get_client().await?;

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -7,7 +7,7 @@ use moveos_types::module_binding::MoveFunctionCaller;
 use rooch_key::keystore::AccountKeystore;
 use rooch_types::{
     address::RoochAddress,
-    coin_type::CoinID,
+    chain_id::RoochChainID,
     error::{RoochError, RoochResult},
     framework::session_key::{SessionKey, SessionKeyModule, SessionScope},
 };
@@ -60,7 +60,7 @@ impl CreateCommand {
         println!("Generated new session key {session_auth_key} for address [{sender}]",);
 
         let result = context
-            .sign_and_execute(sender, action, CoinID::Rooch)
+            .sign_and_execute(sender, action, RoochChainID::DEV)
             .await?;
         context.assert_execute_success(result)?;
         let client = context.get_client().await?;

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -11,10 +11,10 @@ Feature: Rooch CLI integration tests
       Then cmd: "account create"
       Then cmd: "account list"
       Then cmd: "account import --mnemonic-phrase "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit""
-      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --multichain-id rooch --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
-      #Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --multichain-id ether --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
-      Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --multichain-id rooch"
-      #Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --multichain-id ether"
+      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
+      #Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
+      Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce"
+      #Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce"
 
       # session key
       Then cmd: "session-key create --sender-account {default} --scope 0x3::empty::empty"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -11,10 +11,10 @@ Feature: Rooch CLI integration tests
       Then cmd: "account create"
       Then cmd: "account list"
       Then cmd: "account import --mnemonic-phrase "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit""
-      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --coin-id rooch --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
-      #Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --coin-id ether --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
-      Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --coin-id rooch"
-      #Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --coin-id ether"
+      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --multichain-id rooch --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
+      #Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --multichain-id ether --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
+      Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --multichain-id rooch"
+      #Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --multichain-id ether"
 
       # session key
       Then cmd: "session-key create --sender-account {default} --scope 0x3::empty::empty"


### PR DESCRIPTION
## Summary

Following discussions on PR #787.

1. Delete CoinID.
2. Create `multichain_id` to use with RoochMultiChainID with built-in ids.

- Closes #791