### PR TITLE
[Framework] Implement session key expired logic based on timestamp

### DIFF
--- a/crates/rooch-framework/doc/chain_id.md
+++ b/crates/rooch-framework/doc/chain_id.md
@@ -6,8 +6,12 @@
 
 
 -  [Resource `ChainID`](#0x3_chain_id_ChainID)
+-  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x3_chain_id_genesis_init)
 -  [Function `chain_id`](#0x3_chain_id_chain_id)
+-  [Function `is_dev`](#0x3_chain_id_is_dev)
+-  [Function `is_test`](#0x3_chain_id_is_test)
+-  [Function `is_main`](#0x3_chain_id_is_main)
 
 
 <pre><code><b>use</b> <a href="">0x2::account_storage</a>;
@@ -43,6 +47,38 @@ The ChainID in the global storage
 
 
 </details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x3_chain_id_CHAIN_ID_DEV"></a>
+
+
+
+<pre><code><b>const</b> <a href="chain_id.md#0x3_chain_id_CHAIN_ID_DEV">CHAIN_ID_DEV</a>: u64 = 20230103;
+</code></pre>
+
+
+
+<a name="0x3_chain_id_CHAIN_ID_MAIN"></a>
+
+
+
+<pre><code><b>const</b> <a href="chain_id.md#0x3_chain_id_CHAIN_ID_MAIN">CHAIN_ID_MAIN</a>: u64 = 20230101;
+</code></pre>
+
+
+
+<a name="0x3_chain_id_CHAIN_ID_TEST"></a>
+
+
+
+<pre><code><b>const</b> <a href="chain_id.md#0x3_chain_id_CHAIN_ID_TEST">CHAIN_ID_TEST</a>: u64 = 20230102;
+</code></pre>
+
+
 
 <a name="0x3_chain_id_genesis_init"></a>
 
@@ -89,6 +125,78 @@ The ChainID in the global storage
 <pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id">chain_id</a>(ctx: &StorageContext) : u64 {
     <b>let</b> <a href="chain_id.md#0x3_chain_id">chain_id</a> = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="chain_id.md#0x3_chain_id_ChainID">ChainID</a>&gt;(ctx, @rooch_framework);
     <a href="chain_id.md#0x3_chain_id">chain_id</a>.id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_chain_id_is_dev"></a>
+
+## Function `is_dev`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id_is_dev">is_dev</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id_is_dev">is_dev</a>(ctx: &StorageContext) : bool {
+    <a href="chain_id.md#0x3_chain_id">chain_id</a>(ctx) == <a href="chain_id.md#0x3_chain_id_CHAIN_ID_DEV">CHAIN_ID_DEV</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_chain_id_is_test"></a>
+
+## Function `is_test`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id_is_test">is_test</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id_is_test">is_test</a>(ctx: &StorageContext) : bool {
+    <a href="chain_id.md#0x3_chain_id">chain_id</a>(ctx) == <a href="chain_id.md#0x3_chain_id_CHAIN_ID_TEST">CHAIN_ID_TEST</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_chain_id_is_main"></a>
+
+## Function `is_main`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id_is_main">is_main</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x3_chain_id_is_main">is_main</a>(ctx: &StorageContext) : bool {
+    <a href="chain_id.md#0x3_chain_id">chain_id</a>(ctx) == <a href="chain_id.md#0x3_chain_id_CHAIN_ID_MAIN">CHAIN_ID_MAIN</a>
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/timestamp.md
+++ b/crates/rooch-framework/doc/timestamp.md
@@ -18,11 +18,13 @@ It interacts with the other modules in the following ways:
 -  [Function `now_microseconds`](#0x3_timestamp_now_microseconds)
 -  [Function `now_seconds`](#0x3_timestamp_now_seconds)
 -  [Function `seconds_to_microseconds`](#0x3_timestamp_seconds_to_microseconds)
+-  [Function `fast_forward_seconds_for_dev`](#0x3_timestamp_fast_forward_seconds_for_dev)
 
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="">0x2::account_storage</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
+<b>use</b> <a href="chain_id.md#0x3_chain_id">0x3::chain_id</a>;
 </code></pre>
 
 
@@ -232,6 +234,32 @@ Gets the current time in seconds.
 
 <pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_seconds_to_microseconds">seconds_to_microseconds</a>(seconds: u64): u64 {
     seconds * <a href="timestamp.md#0x3_timestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_timestamp_fast_forward_seconds_for_dev"></a>
+
+## Function `fast_forward_seconds_for_dev`
+
+Fast forwards the clock by the given number of seconds, but only if the chain is in dev mode.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="timestamp.md#0x3_timestamp_fast_forward_seconds_for_dev">fast_forward_seconds_for_dev</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, timestamp_seconds: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="timestamp.md#0x3_timestamp_fast_forward_seconds_for_dev">fast_forward_seconds_for_dev</a>(ctx: &<b>mut</b> StorageContext, timestamp_seconds: u64) {
+    <b>assert</b>!(rooch_framework::chain_id::is_dev(ctx), <a href="_invalid_argument">error::invalid_argument</a>(<a href="timestamp.md#0x3_timestamp_ErrorInvalidTimestamp">ErrorInvalidTimestamp</a>));
+    <a href="timestamp.md#0x3_timestamp_fast_forward_seconds">fast_forward_seconds</a>(ctx, timestamp_seconds);
 }
 </code></pre>
 

--- a/crates/rooch-framework/sources/chain_id.move
+++ b/crates/rooch-framework/sources/chain_id.move
@@ -5,6 +5,10 @@ module rooch_framework::chain_id {
 
     friend rooch_framework::genesis;
 
+    const CHAIN_ID_DEV: u64 = 20230103;
+    const CHAIN_ID_TEST: u64 = 20230102;
+    const CHAIN_ID_MAIN: u64 = 20230101;
+
     /// The ChainID in the global storage
     struct ChainID has key,store,copy,drop {
         id: u64
@@ -20,5 +24,17 @@ module rooch_framework::chain_id {
     public fun chain_id(ctx: &StorageContext) : u64 {
         let chain_id = account_storage::global_borrow<ChainID>(ctx, @rooch_framework);
         chain_id.id
+    }
+
+    public fun is_dev(ctx: &StorageContext) : bool {
+        chain_id(ctx) == CHAIN_ID_DEV
+    }
+
+    public fun is_test(ctx: &StorageContext) : bool {
+        chain_id(ctx) == CHAIN_ID_TEST
+    }
+
+    public fun is_main(ctx: &StorageContext) : bool {
+        chain_id(ctx) == CHAIN_ID_MAIN
     }
 }

--- a/crates/rooch-framework/sources/tests/session_key_test.move
+++ b/crates/rooch-framework/sources/tests/session_key_test.move
@@ -1,0 +1,39 @@
+#[test_only]
+/// This test module is used to test the session key
+module rooch_framework::session_key_test{
+
+    use std::vector;
+    use std::option;
+    use moveos_std::signer;
+    use moveos_std::storage_context;
+    use moveos_std::bcs;
+    use rooch_framework::session_key;
+    use rooch_framework::timestamp;
+
+    #[test(sender=@0x42)]
+    fun test_session_key_end_to_end(sender:&signer){
+        let genesis_ctx = rooch_framework::genesis::init_for_test();
+        let sender_addr = signer::address_of(sender);
+        let user_ctx = storage_context::new_test_context(sender_addr);
+        let scope = session_key::new_session_scope(@0x1, std::ascii::string(b"*"), std::ascii::string(b"*"));
+        let authentication_key = bcs::to_bytes(&sender_addr);
+        let max_inactive_interval = 10;
+        session_key::create_session_key(&mut user_ctx, sender, authentication_key, vector::singleton(scope), max_inactive_interval);
+        let session_key_opt = session_key::get_session_key(&user_ctx, sender_addr, authentication_key);
+        assert!(option::is_some(&session_key_opt), 1000);
+
+        assert!(!session_key::is_expired_session_key(&mut user_ctx, sender_addr, authentication_key), 1001);
+        timestamp::fast_forward_seconds_for_test(&mut user_ctx, 9);
+        assert!(!session_key::is_expired_session_key(&mut user_ctx, sender_addr, authentication_key), 1002);
+        session_key::active_session_key_for_test(&mut user_ctx, authentication_key);
+        timestamp::fast_forward_seconds_for_test(&mut user_ctx, 9);
+        assert!(!session_key::is_expired_session_key(&mut user_ctx, sender_addr, authentication_key), 1003);
+        timestamp::fast_forward_seconds_for_test(&mut user_ctx, 2);
+        assert!(session_key::is_expired_session_key(&mut user_ctx, sender_addr, authentication_key), 1004);
+        session_key::remove_session_key(&mut user_ctx, sender, authentication_key);
+
+        storage_context::drop_test_context(user_ctx);
+        storage_context::drop_test_context(genesis_ctx);
+    }
+
+}

--- a/crates/rooch-framework/sources/timestamp.move
+++ b/crates/rooch-framework/sources/timestamp.move
@@ -66,20 +66,28 @@ module rooch_framework::timestamp {
 
     #[test_only]
     public fun update_global_time_for_test(ctx: &mut StorageContext, timestamp_microsecs: u64){
-        let global_timer = account_storage::global_borrow_mut<CurrentTimeMicroseconds>(ctx, @rooch_framework);
-        let now = global_timer.microseconds;
-        assert!(now < timestamp_microsecs, error::invalid_argument(ErrorInvalidTimestamp));
-        global_timer.microseconds = timestamp_microsecs;
+        update_global_time(ctx, timestamp_microsecs);
     }
 
     #[test_only]
     public fun update_global_time_for_test_secs(ctx: &mut StorageContext, timestamp_seconds: u64) {
-        update_global_time_for_test(ctx, timestamp_seconds * MICRO_CONVERSION_FACTOR);
+        update_global_time(ctx, timestamp_seconds * MICRO_CONVERSION_FACTOR);
     }
 
     #[test_only]
-    public fun fast_forward_seconds(ctx: &mut StorageContext, timestamp_seconds: u64) {
-        let now_seconds = now_seconds(ctx);
-        update_global_time_for_test_secs(ctx, now_seconds + timestamp_seconds);
+    public fun fast_forward_seconds_for_test(ctx: &mut StorageContext, timestamp_seconds: u64) {
+        fast_forward_seconds(ctx, timestamp_seconds)
+    }
+
+    fun fast_forward_seconds(ctx: &mut StorageContext, timestamp_seconds: u64) {
+        let now_microseconds = now_microseconds(ctx);
+        update_global_time(ctx, now_microseconds + (timestamp_seconds * MICRO_CONVERSION_FACTOR));
+    }
+
+    /// Fast forwards the clock by the given number of seconds, but only if the chain is in dev mode.
+    //TODO find a better way to do this, maybe some module that is only available in dev chain?
+    public entry fun fast_forward_seconds_for_dev(ctx: &mut StorageContext, timestamp_seconds: u64) {
+        assert!(rooch_framework::chain_id::is_dev(ctx), error::invalid_argument(ErrorInvalidTimestamp));
+        fast_forward_seconds(ctx, timestamp_seconds);
     }
 }

--- a/crates/rooch-types/src/framework/session_key.rs
+++ b/crates/rooch-types/src/framework/session_key.rs
@@ -95,7 +95,7 @@ pub struct SessionKey {
     pub authentication_key: Vec<u8>,
     #[serde_as(as = "Vec<Readable<DisplayFromStr, _>>")]
     pub scopes: Vec<SessionScope>,
-    pub expiration_time: u64,
+    pub create_time: u64,
     pub last_active_time: u64,
     pub max_inactive_interval: u64,
 }
@@ -166,7 +166,6 @@ impl<'a> SessionKeyModule<'a> {
     pub fn create_session_key_action(
         authentication_key: Vec<u8>,
         scope: SessionScope,
-        expiration_time: u64,
         max_inactive_interval: u64,
     ) -> MoveAction {
         Self::create_move_action(
@@ -177,7 +176,6 @@ impl<'a> SessionKeyModule<'a> {
                 scope.module_address.to_move_value(),
                 scope.module_name.to_move_value(),
                 scope.function_name.to_move_value(),
-                MoveValue::U64(expiration_time),
                 MoveValue::U64(max_inactive_interval),
             ],
         )

--- a/crates/rooch-types/src/framework/timestamp.rs
+++ b/crates/rooch-types/src/framework/timestamp.rs
@@ -3,11 +3,13 @@
 
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
 use anyhow::Result;
-use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
+};
 use moveos_types::{
     module_binding::{ModuleBinding, MoveFunctionCaller},
     state::{MoveStructState, MoveStructType},
-    transaction::FunctionCall,
+    transaction::{FunctionCall, MoveAction},
     tx_context::TxContext,
 };
 use serde::{Deserialize, Serialize};
@@ -41,6 +43,8 @@ pub struct TimestampModule<'a> {
 impl<'a> TimestampModule<'a> {
     pub const NOW_MICROSECONDS_FUNCTION_NAME: &'static IdentStr = ident_str!("now_microseconds");
     pub const NOW_SECONDS_FUNCTION_NAME: &'static IdentStr = ident_str!("now_seconds");
+    pub const FAST_FORWARD_SECONDS_FOR_DEV_FUNCTION_NAME: &'static IdentStr =
+        ident_str!("fast_forward_seconds_for_dev");
 
     pub fn now_microseconds(&self) -> Result<u64> {
         let call = FunctionCall::new(
@@ -76,6 +80,14 @@ impl<'a> TimestampModule<'a> {
                     bcs::from_bytes::<u64>(&value.value).expect("should be a valid u64")
                 })?;
         Ok(session_key)
+    }
+
+    pub fn create_fast_forward_seconds_for_dev_action(seconds: u64) -> MoveAction {
+        MoveAction::Function(FunctionCall::new(
+            Self::function_id(Self::FAST_FORWARD_SECONDS_FOR_DEV_FUNCTION_NAME),
+            vec![],
+            vec![MoveValue::U64(seconds).simple_serialize().unwrap()],
+        ))
     }
 }
 

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -21,11 +21,8 @@ pub struct CreateCommand {
     #[clap(long)]
     pub scope: SessionScope,
 
-    /// The expiration time of the session key, in seconds.
-    #[clap(long, default_value = "3600")]
-    pub expiration_time: u64,
-
     /// The max inactive interval of the session key, in seconds.
+    /// If the max_inactive_interval is 0, the session key will never expire.
     #[clap(long, default_value = "3600")]
     pub max_inactive_interval: u64,
 
@@ -57,7 +54,6 @@ impl CreateCommand {
             rooch_types::framework::session_key::SessionKeyModule::create_session_key_action(
                 session_auth_key.as_ref().to_vec(),
                 session_scope.clone(),
-                self.expiration_time,
                 self.max_inactive_interval,
             );
 

--- a/sdk/typescript/src/account/account.ts
+++ b/sdk/typescript/src/account/account.ts
@@ -100,7 +100,6 @@ export class Account implements IAccount {
 
   async createSessionAccount(
     scope: string,
-    expirationTime: number,
     maxInactiveInterval: number,
     opts?: CallOption,
   ): Promise<IAccount> {
@@ -108,7 +107,6 @@ export class Account implements IAccount {
     await this.registerSessionKey(
       kp.getPublicKey().toRoochAddress(),
       scope,
-      expirationTime,
       maxInactiveInterval,
       opts,
     )
@@ -119,7 +117,6 @@ export class Account implements IAccount {
   async registerSessionKey(
     authKey: AccountAddress,
     scope: string,
-    expirationTime: number,
     maxInactiveInterval: number,
     opts?: CallOption,
   ): Promise<void> {
@@ -151,10 +148,6 @@ export class Account implements IAccount {
         {
           type: 'Ascii',
           value: scopeFunctionName,
-        },
-        {
-          type: 'U64',
-          value: BigInt(expirationTime),
         },
         {
           type: 'U64',

--- a/sdk/typescript/src/account/interface.ts
+++ b/sdk/typescript/src/account/interface.ts
@@ -27,13 +27,11 @@ export interface IAccount {
    * Create session account with scope
    *
    * @param scope string the scope of created account
-   * @param expirationTime  number The expiration time of created account
    * @param maxInactiveInterval  number The max inactive interval
    * @param opts CallOption
    */
   createSessionAccount(
     scope: string,
-    expirationTime: number,
     maxInactiveInterval: number,
     opts?: CallOption,
   ): Promise<IAccount>

--- a/sdk/typescript/test/e2e/sdk.test.ts
+++ b/sdk/typescript/test/e2e/sdk.test.ts
@@ -105,7 +105,6 @@ describe('SDK', () => {
       await account.registerSessionKey(
         kp2.getPublicKey().toRoochAddress(),
         '0x3::empty::empty',
-        3600,
         100,
       )
       const auth = new PrivateKeyAuth(kp2)
@@ -150,7 +149,7 @@ describe('SDK', () => {
       expect(account).toBeDefined()
 
       // create session account
-      const sessionAccount = await account.createSessionAccount('0x3::empty::empty', 3600, 100)
+      const sessionAccount = await account.createSessionAccount('0x3::empty::empty', 100)
       expect(sessionAccount).toBeDefined()
 
       // run function with sessoin key


### PR DESCRIPTION
## Summary

1. Implement session key expired logic based on timestamp.
2. Remove the `expiration_time` field and add the `create_time` field for `SessionKey`. 
3. Provide a method that lets the developer fast-forward the timestamp on the dev chain for testing.
4. Add a test case for the session key.

- Closes #802 