### PR TITLE
unify and rename for RPC and store

### DIFF
--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -137,36 +137,6 @@
       }
     },
     {
-      "name": "rooch_getEvents",
-      "description": "Get the events by event filter",
-      "params": [
-        {
-          "name": "filter",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/EventFilterView"
-          }
-        }
-      ],
-      "result": {
-        "name": "Vec<Option<AnnotatedEventView>>",
-        "required": true,
-        "schema": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/AnnotatedEventView"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
       "name": "rooch_getEventsByEventHandle",
       "description": "Get the events by event handle id",
       "params": [
@@ -303,10 +273,10 @@
         }
       ],
       "result": {
-        "name": "TransactionReturnPageView",
+        "name": "TransactionResultPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_TransactionReturnView_and_uint128"
+          "$ref": "#/components/schemas/PageView_for_TransactionResultView_and_uint128"
         }
       }
     },
@@ -605,177 +575,6 @@
             "type": "string"
           }
         }
-      },
-      "EventFilterView": {
-        "oneOf": [
-          {
-            "description": "Query by sender address.",
-            "type": "object",
-            "required": [
-              "Sender"
-            ],
-            "properties": {
-              "Sender": {
-                "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Return events emitted by the given transaction.",
-            "type": "object",
-            "required": [
-              "Transaction"
-            ],
-            "properties": {
-              "Transaction": {
-                "$ref": "#/components/schemas/H256View"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Return events with the given move event struct name",
-            "type": "object",
-            "required": [
-              "MoveEventType"
-            ],
-            "properties": {
-              "MoveEventType": {
-                "$ref": "#/components/schemas/move_core_types::language_storage::TypeTag"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "MoveEventField"
-            ],
-            "properties": {
-              "MoveEventField": {
-                "type": "object",
-                "required": [
-                  "path",
-                  "value"
-                ],
-                "properties": {
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": true
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Return events emitted in [start_time, end_time) interval",
-            "type": "object",
-            "required": [
-              "TimeRange"
-            ],
-            "properties": {
-              "TimeRange": {
-                "type": "object",
-                "required": [
-                  "end_time",
-                  "start_time"
-                ],
-                "properties": {
-                  "end_time": {
-                    "description": "right endpoint of time interval, milliseconds since epoch, exclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "start_time": {
-                    "description": "left endpoint of time interval, milliseconds since epoch, inclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Return events emitted in [from_block, to_block) interval",
-            "type": "object",
-            "required": [
-              "All"
-            ],
-            "properties": {
-              "All": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilterView"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Any"
-            ],
-            "properties": {
-              "Any": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilterView"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "And"
-            ],
-            "properties": {
-              "And": {
-                "type": "array",
-                "items": [
-                  {
-                    "$ref": "#/components/schemas/EventFilterView"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventFilterView"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Or"
-            ],
-            "properties": {
-              "Or": {
-                "type": "array",
-                "items": [
-                  {
-                    "$ref": "#/components/schemas/EventFilterView"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventFilterView"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
       },
       "EventID": {
         "description": "A struct that represents a globally unique id for an Event stream that a user can listen to. the Unique ID is a combination of event handle id and event seq number. the ID is local to this particular fullnode and will be different from other fullnode.",
@@ -1271,7 +1070,7 @@
           }
         }
       },
-      "PageView_for_TransactionReturnView_and_uint128": {
+      "PageView_for_TransactionResultView_and_uint128": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -1282,7 +1081,7 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TransactionReturnView"
+              "$ref": "#/components/schemas/TransactionResultView"
             }
           },
           "has_next_page": {
@@ -1463,7 +1262,7 @@
           }
         }
       },
-      "TransactionReturnView": {
+      "TransactionResultView": {
         "type": "object",
         "required": [
           "execution_info",

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::{
-    AccessPathView, AccountAddressView, AnnotatedEventView, AnnotatedFunctionResultView,
-    AnnotatedStateView, EventFilterView, EventPageView, ExecuteTransactionResponseView,
-    FunctionCallView, H256View, ListAnnotatedStatesPageView, ListBalanceInfoPageView,
-    ListStatesPageView, StateView, StrView, StructTagView, TransactionReturnPageView,
-    TransactionView,
+    AccessPathView, AccountAddressView, AnnotatedFunctionResultView, AnnotatedStateView,
+    EventPageView, ExecuteTransactionResponseView, FunctionCallView, H256View,
+    ListAnnotatedStatesPageView, ListBalanceInfoPageView, ListStatesPageView, StateView, StrView,
+    StructTagView, TransactionResultPageView, TransactionView,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -79,12 +78,13 @@ pub trait RoochAPI {
         limit: Option<u64>,
     ) -> RpcResult<EventPageView>;
 
-    /// Get the events by event filter
-    #[method(name = "getEvents")]
-    async fn get_events(
-        &self,
-        filter: EventFilterView,
-    ) -> RpcResult<Vec<Option<AnnotatedEventView>>>;
+    // The current scenario of querying events can be satisfied by getEventsByEventHandle. GetEvents by EventFilter will be enabled after Indexer is supported.
+    // /// Get the events by event filter
+    // #[method(name = "getEvents")]
+    // async fn get_events(
+    //     &self,
+    //     filter: EventFilterView,
+    // ) -> RpcResult<Vec<Option<AnnotatedEventView>>>;
 
     #[method(name = "getTransactionByHash")]
     async fn get_transaction_by_hash(&self, hash: H256View) -> RpcResult<Option<TransactionView>>;
@@ -100,7 +100,7 @@ pub trait RoochAPI {
         &self,
         cursor: Option<u128>,
         limit: Option<u64>,
-    ) -> RpcResult<TransactionReturnPageView>;
+    ) -> RpcResult<TransactionResultPageView>;
 
     /// get account balances by AccountAddress
     #[method(name = "getBalances")]

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::account_view::BalanceInfoView;
-use crate::jsonrpc_types::transaction_view::TransactionReturnView;
+use crate::jsonrpc_types::transaction_view::TransactionResultView;
 use crate::jsonrpc_types::{
     move_types::{MoveActionTypeView, MoveActionView},
     AnnotatedMoveStructView, AnnotatedStateView, EventView, H256View, StateView, StrView,
@@ -22,7 +22,7 @@ use std::string::String;
 use super::AccountAddressView;
 
 pub type EventPageView = PageView<Option<AnnotatedEventView>, u64>;
-pub type TransactionReturnPageView = PageView<TransactionReturnView, u128>;
+pub type TransactionResultPageView = PageView<TransactionResultView, u128>;
 pub type ListStatesPageView = PageView<Option<StateView>, StrView<Vec<u8>>>;
 pub type ListAnnotatedStatesPageView = PageView<Option<AnnotatedStateView>, StrView<Vec<u8>>>;
 pub type ListBalanceInfoPageView = PageView<Option<BalanceInfoView>, StrView<Vec<u8>>>;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
@@ -10,21 +10,21 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
-pub struct TransactionReturn {
+pub struct TransactionResult {
     pub transaction: TypedTransaction,
     pub sequence_info: TransactionSequenceInfo,
     pub execution_info: TransactionExecutionInfo,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct TransactionReturnView {
+pub struct TransactionResultView {
     pub transaction: TransactionView,
     pub sequence_info: TransactionSequenceInfoView,
     pub execution_info: TransactionExecutionInfoView,
 }
 
-impl From<TransactionReturn> for TransactionReturnView {
-    fn from(tx: TransactionReturn) -> Self {
+impl From<TransactionResult> for TransactionResultView {
+    fn from(tx: TransactionResult) -> Self {
         Self {
             transaction: tx.transaction.into(),
             sequence_info: tx.sequence_info.into(),

--- a/crates/rooch-rpc-server/src/service/aggregate_service.rs
+++ b/crates/rooch-rpc-server/src/service/aggregate_service.rs
@@ -71,6 +71,7 @@ impl AggregateService {
         }
 
         let coin_store_handle = coin_module.coin_store_handle(account_addr)?;
+        // Handle error due to `coin_store_handle` executed in another tokio Runtime
         let coin_store_handle = match coin_store_handle {
             Some(v) => v,
             None => anyhow::bail!("Coin store handle does not exist"),
@@ -90,7 +91,11 @@ impl AggregateService {
                 .get_annotated_states(AccessPath::table(coin_store_handle, keys))
                 .await?;
 
-            let state = states.pop().flatten().expect("State expected return value");
+            let state = states.pop().flatten();
+            let state = match state {
+                Some(v) => v,
+                None => anyhow::bail!("CoinStore state expected return value"),
+            };
             let annotated_coin_store =
                 AnnotatedCoinStore::new_from_annotated_move_value(state.move_value)?;
 

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -18,7 +18,7 @@ use rooch_sequencer::proxy::SequencerProxy;
 use rooch_types::account::Account;
 use rooch_types::address::{MultiChainAddress, RoochAddress};
 use rooch_types::transaction::rooch::RoochTransaction;
-use rooch_types::transaction::{TransactionSequenceInfo, TransactionSequenceMapping};
+use rooch_types::transaction::{TransactionSequenceInfo, TransactionSequenceInfoMapping};
 use rooch_types::{transaction::TypedTransaction, H256};
 
 /// RpcService is the implementation of the RPC service.
@@ -181,7 +181,7 @@ impl RpcService {
         &self,
         cursor: Option<u128>,
         limit: u64,
-    ) -> Result<Vec<TransactionSequenceMapping>> {
+    ) -> Result<Vec<TransactionSequenceInfoMapping>> {
         let resp = self
             .sequencer
             .get_transaction_sequence_mapping_by_order(cursor, limit)

--- a/crates/rooch-sequencer/src/actor/sequencer.rs
+++ b/crates/rooch-sequencer/src/actor/sequencer.rs
@@ -13,7 +13,7 @@ use rooch_store::meta_store::MetaStore;
 use rooch_store::transaction_store::TransactionStore;
 use rooch_store::RoochStore;
 use rooch_types::sequencer::SequencerOrder;
-use rooch_types::transaction::TransactionSequenceMapping;
+use rooch_types::transaction::TransactionSequenceInfoMapping;
 use rooch_types::{
     crypto::{RoochKeyPair, Signature},
     transaction::AbstractTransaction,
@@ -118,7 +118,7 @@ impl Handler<GetTxSequenceMappingByOrderMessage> for SequencerActor {
         &mut self,
         msg: GetTxSequenceMappingByOrderMessage,
         _ctx: &mut ActorContext,
-    ) -> Result<Vec<TransactionSequenceMapping>> {
+    ) -> Result<Vec<TransactionSequenceInfoMapping>> {
         let GetTxSequenceMappingByOrderMessage { cursor, limit } = msg;
         self.rooch_store
             .get_transaction_store()

--- a/crates/rooch-sequencer/src/messages.rs
+++ b/crates/rooch-sequencer/src/messages.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use coerce::actor::message::Message;
-use rooch_types::transaction::TransactionSequenceMapping;
+use rooch_types::transaction::TransactionSequenceInfoMapping;
 use rooch_types::{
     transaction::{TransactionSequenceInfo, TypedTransaction},
     H256,
@@ -47,7 +47,7 @@ pub struct GetTxSequenceMappingByOrderMessage {
 }
 
 impl Message for GetTxSequenceMappingByOrderMessage {
-    type Result = Result<Vec<TransactionSequenceMapping>>;
+    type Result = Result<Vec<TransactionSequenceInfoMapping>>;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rooch-sequencer/src/proxy/mod.rs
+++ b/crates/rooch-sequencer/src/proxy/mod.rs
@@ -8,7 +8,7 @@ use crate::messages::{
 use crate::{actor::sequencer::SequencerActor, messages::TransactionSequenceMessage};
 use anyhow::Result;
 use coerce::actor::ActorRef;
-use rooch_types::transaction::{TransactionSequenceMapping, TypedTransaction};
+use rooch_types::transaction::{TransactionSequenceInfoMapping, TypedTransaction};
 use rooch_types::{transaction::TransactionSequenceInfo, H256};
 
 #[derive(Clone)]
@@ -47,7 +47,7 @@ impl SequencerProxy {
         &self,
         cursor: Option<u128>,
         limit: u64,
-    ) -> Result<Vec<TransactionSequenceMapping>> {
+    ) -> Result<Vec<TransactionSequenceInfoMapping>> {
         self.actor
             .send(GetTxSequenceMappingByOrderMessage { cursor, limit })
             .await?

--- a/crates/rooch-store/src/lib.rs
+++ b/crates/rooch-store/src/lib.rs
@@ -11,7 +11,7 @@ use raw_store::rocks::RocksDB;
 use raw_store::{ColumnFamilyName, StoreInstance};
 use rooch_types::sequencer::SequencerOrder;
 use rooch_types::transaction::{
-    TransactionSequenceInfo, TransactionSequenceMapping, TypedTransaction,
+    TransactionSequenceInfo, TransactionSequenceInfoMapping, TypedTransaction,
 };
 use rooch_types::H256;
 use std::fmt::{Debug, Display, Formatter};
@@ -21,8 +21,8 @@ pub mod transaction_store;
 
 // pub const DEFAULT_PREFIX_NAME: ColumnFamilyName = "default";
 pub const TYPED_TRANSACTION_PREFIX_NAME: ColumnFamilyName = "typed_transaction";
-pub const SEQ_TRANSACTION_PREFIX_NAME: ColumnFamilyName = "seq_transaction";
-pub const TX_SEQ_MAPPING_PREFIX_NAME: ColumnFamilyName = "tx_sequence_mapping";
+pub const TX_SEQUENCE_INFO_PREFIX_NAME: ColumnFamilyName = "tx_sequence_info";
+pub const TX_SEQUENCE_INFO_MAPPING_PREFIX_NAME: ColumnFamilyName = "tx_sequence_info_mapping";
 
 pub const META_SEQUENCER_ORDER_PREFIX_NAME: ColumnFamilyName = "meta_sequencer_order";
 
@@ -31,8 +31,8 @@ pub const META_SEQUENCER_ORDER_PREFIX_NAME: ColumnFamilyName = "meta_sequencer_o
 static VEC_PREFIX_NAME: Lazy<Vec<ColumnFamilyName>> = Lazy::new(|| {
     vec![
         TYPED_TRANSACTION_PREFIX_NAME,
-        SEQ_TRANSACTION_PREFIX_NAME,
-        TX_SEQ_MAPPING_PREFIX_NAME,
+        TX_SEQUENCE_INFO_PREFIX_NAME,
+        TX_SEQUENCE_INFO_MAPPING_PREFIX_NAME,
         META_SEQUENCER_ORDER_PREFIX_NAME,
     ]
 });
@@ -126,11 +126,11 @@ impl TransactionStore for RoochStore {
             .save_tx_sequence_info_mapping(tx_order, tx_hash)
     }
 
-    fn get_tx_sequence_mapping_by_order(
+    fn get_tx_sequence_info_mapping_by_order(
         &self,
         cursor: Option<u128>,
         limit: u64,
-    ) -> Result<Vec<TransactionSequenceMapping>> {
+    ) -> Result<Vec<TransactionSequenceInfoMapping>> {
         self.transaction_store
             .get_tx_sequence_mapping_by_order(cursor, limit)
     }

--- a/crates/rooch-store/src/meta_store/mod.rs
+++ b/crates/rooch-store/src/meta_store/mod.rs
@@ -23,23 +23,23 @@ pub trait MetaStore {
 
 #[derive(Clone)]
 pub struct MetaDBStore {
-    sequencr_order_store: SequencerOrderStore,
+    sequencer_order_store: SequencerOrderStore,
 }
 
 impl MetaDBStore {
     pub fn new(instance: StoreInstance) -> Self {
         MetaDBStore {
-            sequencr_order_store: SequencerOrderStore::new(instance),
+            sequencer_order_store: SequencerOrderStore::new(instance),
         }
     }
 
     pub fn get_sequencer_order(&self) -> Result<Option<SequencerOrder>> {
-        self.sequencr_order_store
+        self.sequencer_order_store
             .kv_get(SEQUENCER_ORDER_KEY.to_string())
     }
 
     pub fn save_sequencer_order(&self, sequencer_order: SequencerOrder) -> Result<()> {
-        self.sequencr_order_store
+        self.sequencer_order_store
             .put_sync(SEQUENCER_ORDER_KEY.to_string(), sequencer_order)
     }
 }

--- a/crates/rooch-types/src/transaction/mod.rs
+++ b/crates/rooch-types/src/transaction/mod.rs
@@ -173,16 +173,16 @@ impl TransactionSequenceInfo {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct TransactionSequenceMapping {
+pub struct TransactionSequenceInfoMapping {
     /// The tx order
     pub tx_order: u128,
     /// The tx hash.
     pub tx_hash: H256,
 }
 
-impl TransactionSequenceMapping {
-    pub fn new(tx_order: u128, tx_hash: H256) -> TransactionSequenceMapping {
-        TransactionSequenceMapping { tx_order, tx_hash }
+impl TransactionSequenceInfoMapping {
+    pub fn new(tx_order: u128, tx_hash: H256) -> TransactionSequenceInfoMapping {
+        TransactionSequenceInfoMapping { tx_order, tx_hash }
     }
 }
 


### PR DESCRIPTION
Summary:
1. Unify and rename for RPC and store
2. Remove RPC `GetEvents by EventFilter`. The current scenario of querying events can be satisfied by `getEventsByEventHandle`. `GetEvents by EventFilter` will be enabled after the Indexer is supported.