### PR TITLE
[gh-755] encrypt w/ ChaCha20Poly1305 and password algorithm Argon2id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
@@ -1110,6 +1110,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1185,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -6245,6 +6270,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7379,6 +7415,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bip32",
+ "chacha20poly1305",
  "clap 3.2.25",
  "derive_more",
  "enum_dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7706,6 +7706,7 @@ dependencies = [
  "rooch-sequencer",
  "rooch-store",
  "rooch-types",
+ "rpassword",
  "rustc-hex 1.0.0",
  "schemars",
  "serde 1.0.188",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ba4cac0a46bc1d2912652a751c47f2a9f3a7fe89bcae2275d418f5270402f9"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash 0.5.0",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5900,6 +5912,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5925,7 +5948,7 @@ checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
  "hmac",
- "password-hash",
+ "password-hash 0.4.2",
  "sha2 0.10.7",
 ]
 
@@ -7090,6 +7113,7 @@ name = "rooch"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "async-trait",
  "bcs",
  "bcs-ext",
@@ -7134,6 +7158,7 @@ dependencies = [
  "rooch-rpc-client",
  "rooch-rpc-server",
  "rooch-types",
+ "rpassword",
  "rust-embed",
  "serde 1.0.188",
  "serde-generate",
@@ -7414,6 +7439,7 @@ name = "rooch-key"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "bip32",
  "chacha20poly1305",
  "clap 3.2.25",
@@ -7794,6 +7820,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "winapi",
+]
+
+[[package]]
 name = "rsa"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7812,6 +7849,16 @@ dependencies = [
  "signature 2.1.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7113,7 +7113,6 @@ name = "rooch"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "argon2",
  "async-trait",
  "bcs",
  "bcs-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ bs58 = "0.5.0"
 dirs-next = "2.0.0"
 anstream = { version = "0.3" }
 bigdecimal = { version = "0.3.0", features = ["serde"] }
+chacha20poly1305 = "0.10.1"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,8 @@ dirs-next = "2.0.0"
 anstream = { version = "0.3" }
 bigdecimal = { version = "0.3.0", features = ["serde"] }
 chacha20poly1305 = "0.10.1"
+argon2 = "0.5.2"
+rpassword = "7.2.0"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES

--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -93,10 +93,6 @@ pub struct RoochOpt {
     /// The address of the relayer account
     #[clap(long)]
     pub relayer_account: Option<String>,
-
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    pub password_required: Option<bool>,
 }
 
 impl std::fmt::Display for RoochOpt {
@@ -120,7 +116,6 @@ impl RoochOpt {
             sequencer_account: None,
             proposer_account: None,
             relayer_account: None,
-            password_required: Some(true),
         }
     }
 }

--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -93,6 +93,10 @@ pub struct RoochOpt {
     /// The address of the relayer account
     #[clap(long)]
     pub relayer_account: Option<String>,
+
+    /// Whether a password should be provided
+    #[clap(long = "password")]
+    pub password_required: Option<bool>,
 }
 
 impl std::fmt::Display for RoochOpt {
@@ -116,6 +120,7 @@ impl RoochOpt {
             sequencer_account: None,
             proposer_account: None,
             relayer_account: None,
+            password_required: Some(true),
         }
     }
 }

--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -4,7 +4,6 @@
 use crate::binding_test;
 use ethers::prelude::*;
 use moveos_types::transaction::MoveAction;
-use rooch_key::keypair_type::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::RoochKeyPair;
@@ -18,7 +17,7 @@ fn test_submit_block() {
     let mut binding_test = binding_test::RustBindingTest::new().unwrap();
 
     let keystore = InMemKeystore::<RoochAddress, RoochKeyPair>::new_insecure_for_tests(1);
-    let sender = keystore.addresses()[0];
+    let sender = keystore.addresses(Some("".to_owned()))[0];
     let sequence_number = 0;
 
     let json = serde_json::json!(
@@ -58,7 +57,12 @@ fn test_submit_block() {
     let action = MoveAction::Function(rooch_types::framework::ethereum_light_client::EthereumLightClientModule::create_submit_new_block_call(&block_header));
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
+        .sign_transaction(
+            &sender,
+            tx_data,
+            KeyPairType::RoochKeyPairType,
+            Some("".to_owned()),
+        )
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -6,7 +6,6 @@ use ethers::prelude::*;
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
-use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::ethereum_light_client::BlockHeader;
 use rooch_types::keypair_type::KeyPairType;
 use rooch_types::transaction::rooch::RoochTransactionData;
@@ -16,8 +15,8 @@ fn test_submit_block() {
     tracing_subscriber::fmt::init();
     let mut binding_test = binding_test::RustBindingTest::new().unwrap();
 
-    let keystore = InMemKeystore::<RoochAddress, RoochKeyPair>::new_insecure_for_tests(1);
-    let sender = keystore.addresses(Some("".to_owned()))[0];
+    let keystore = InMemKeystore::<RoochAddress>::new_insecure_for_tests(1);
+    let sender = keystore.addresses()[0];
     let sequence_number = 0;
 
     let json = serde_json::json!(

--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -4,11 +4,12 @@
 use crate::binding_test;
 use ethers::prelude::*;
 use moveos_types::transaction::MoveAction;
-use rooch_key::keypair::KeyPairType;
+use rooch_key::keypair_type::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::ethereum_light_client::BlockHeader;
+use rooch_types::keypair_type::KeyPairType;
 use rooch_types::transaction::rooch::RoochTransactionData;
 
 #[test]

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -4,7 +4,6 @@
 use ethers::types::{Bytes, U256};
 use fastcrypto::secp256k1::recoverable::Secp256k1RecoverableKeyPair;
 use moveos_types::transaction::MoveAction;
-use rooch_key::keypair_type::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress};
 use rooch_types::framework::empty::Empty;
@@ -25,14 +24,19 @@ fn test_validate() {
 
     let keystore =
         InMemKeystore::<EthereumAddress, Secp256k1RecoverableKeyPair>::new_insecure_for_tests(1);
-    let sender = keystore.addresses()[0];
+    let sender = keystore.addresses(Some("".to_owned()))[0];
     let sequence_number = U256::zero();
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let action_bytes =
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     keystore
-        .sign_transaction(&sender, tx_data.clone(), KeyPairType::EthereumKeyPairType)
+        .sign_transaction(
+            &sender,
+            tx_data.clone(),
+            KeyPairType::EthereumKeyPairType,
+            Some("".to_owned()),
+        )
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -4,10 +4,11 @@
 use ethers::types::{Bytes, U256};
 use fastcrypto::secp256k1::recoverable::Secp256k1RecoverableKeyPair;
 use moveos_types::transaction::MoveAction;
-use rooch_key::keypair::KeyPairType;
+use rooch_key::keypair_type::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress};
 use rooch_types::framework::empty::Empty;
+use rooch_types::keypair_type::KeyPairType;
 use rooch_types::transaction::ethereum::EthereumTransactionData;
 use rooch_types::transaction::AbstractTransaction;
 

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use ethers::types::{Bytes, U256};
-use fastcrypto::secp256k1::recoverable::Secp256k1RecoverableKeyPair;
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress};
@@ -22,9 +21,8 @@ fn test_validate() {
     let address_mapping =
         binding_test.as_module_bundle::<rooch_types::framework::address_mapping::AddressMapping>();
 
-    let keystore =
-        InMemKeystore::<EthereumAddress, Secp256k1RecoverableKeyPair>::new_insecure_for_tests(1);
-    let sender = keystore.addresses(Some("".to_owned()))[0];
+    let keystore = InMemKeystore::<EthereumAddress>::new_insecure_for_tests(1);
+    let sender = keystore.addresses()[0];
     let sequence_number = U256::zero();
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let action_bytes =

--- a/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use moveos_types::transaction::MoveAction;
-use rooch_key::keypair_type::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::RoochKeyPair;
@@ -20,12 +19,17 @@ fn test_validate() {
     );
 
     let keystore = InMemKeystore::<RoochAddress, RoochKeyPair>::new_insecure_for_tests(1);
-    let sender = keystore.addresses()[0];
+    let sender = keystore.addresses(Some("".to_owned()))[0];
     let sequence_number = 0;
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
+        .sign_transaction(
+            &sender,
+            tx_data,
+            KeyPairType::RoochKeyPairType,
+            Some("".to_owned()),
+        )
         .unwrap();
     let auth_info = tx.authenticator_info().unwrap();
     let move_tx = tx.construct_moveos_transaction(sender.into()).unwrap();

--- a/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
@@ -4,7 +4,6 @@
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
-use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::empty::Empty;
 use rooch_types::keypair_type::KeyPairType;
 use rooch_types::transaction::{rooch::RoochTransactionData, AbstractTransaction};
@@ -18,8 +17,8 @@ fn test_validate() {
         .as_module_bundle::<rooch_types::framework::native_validator::NativeValidatorModule>(
     );
 
-    let keystore = InMemKeystore::<RoochAddress, RoochKeyPair>::new_insecure_for_tests(1);
-    let sender = keystore.addresses(Some("".to_owned()))[0];
+    let keystore = InMemKeystore::<RoochAddress>::new_insecure_for_tests(1);
+    let sender = keystore.addresses()[0];
     let sequence_number = 0;
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);

--- a/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use moveos_types::transaction::MoveAction;
-use rooch_key::keypair::KeyPairType;
+use rooch_key::keypair_type::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::empty::Empty;
+use rooch_types::keypair_type::KeyPairType;
 use rooch_types::transaction::{rooch::RoochTransactionData, AbstractTransaction};
 
 use crate::binding_test;

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -10,12 +10,13 @@ use move_core_types::value::MoveValue;
 use move_core_types::vm_status::{AbortLocation, VMStatus};
 use moveos_types::move_types::FunctionId;
 use moveos_types::{module_binding::ModuleBinding, transaction::MoveAction};
-use rooch_key::keypair::KeyPairType;
+use rooch_key::keypair_type::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress, RoochAddress};
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::session_key::SessionKeyModule;
 use rooch_types::framework::timestamp::TimestampModule;
+use rooch_types::keypair_type::KeyPairType;
 use rooch_types::transaction::ethereum::EthereumTransactionData;
 use rooch_types::{addresses::ROOCH_FRAMEWORK_ADDRESS, framework::empty::Empty};
 use rooch_types::{

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -10,7 +10,6 @@ use move_core_types::value::MoveValue;
 use move_core_types::vm_status::{AbortLocation, VMStatus};
 use moveos_types::move_types::FunctionId;
 use moveos_types::{module_binding::ModuleBinding, transaction::MoveAction};
-use rooch_key::keypair_type::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, InMemKeystore};
 use rooch_types::address::{EthereumAddress, MultiChainAddress, RoochAddress};
 use rooch_types::crypto::RoochKeyPair;
@@ -34,12 +33,17 @@ fn test_validate_rooch() {
     );
 
     let keystore = InMemKeystore::<RoochAddress, RoochKeyPair>::new_insecure_for_tests(1);
-    let sender = keystore.addresses()[0];
+    let sender = keystore.addresses(Some("".to_owned()))[0];
     let sequence_number = 0;
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
+        .sign_transaction(
+            &sender,
+            tx_data,
+            KeyPairType::RoochKeyPairType,
+            Some("".to_owned()),
+        )
         .unwrap();
     let auth_info = tx.authenticator_info().unwrap();
     let move_tx = tx.construct_moveos_transaction(sender.into()).unwrap();
@@ -62,14 +66,19 @@ fn test_validate_ethereum() {
 
     let keystore =
         InMemKeystore::<EthereumAddress, Secp256k1RecoverableKeyPair>::new_insecure_for_tests(1);
-    let sender = keystore.addresses()[0];
+    let sender = keystore.addresses(Some("".to_owned()))[0];
     let sequence_number = U256::zero();
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
     let action_bytes =
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
     let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
     let (_, _sig) = keystore
-        .sign_transaction(&sender, tx_data.clone(), KeyPairType::EthereumKeyPairType)
+        .sign_transaction(
+            &sender,
+            tx_data.clone(),
+            KeyPairType::EthereumKeyPairType,
+            Some("".to_owned()),
+        )
         .unwrap();
     let auth_info = tx_data.authenticator_info().unwrap();
     let multichain_address = MultiChainAddress::from(sender);
@@ -93,7 +102,7 @@ fn test_session_key_rooch() {
     let mut binding_test = binding_test::RustBindingTest::new().unwrap();
 
     let mut keystore = InMemKeystore::<RoochAddress, RoochKeyPair>::new_insecure_for_tests(1);
-    let sender = keystore.addresses()[0];
+    let sender = keystore.addresses(Some("".to_owned()))[0];
     let sequence_number = 0;
 
     let session_auth_key = keystore.generate_session_key(&sender).unwrap();
@@ -111,7 +120,12 @@ fn test_session_key_rooch() {
     );
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
+        .sign_transaction(
+            &sender,
+            tx_data,
+            KeyPairType::RoochKeyPairType,
+            Some("".to_owned()),
+        )
         .unwrap();
     binding_test.execute(tx).unwrap();
 
@@ -184,7 +198,12 @@ fn test_session_key_rooch() {
     let tx_data =
         RoochTransactionData::new_for_test(sender, sequence_number + 2, update_time_action);
     let tx = keystore
-        .sign_transaction(&sender, tx_data, KeyPairType::RoochKeyPairType)
+        .sign_transaction(
+            &sender,
+            tx_data,
+            KeyPairType::RoochKeyPairType,
+            Some("".to_owned()),
+        )
         .unwrap();
     binding_test.execute(tx).unwrap();
 

--- a/crates/rooch-key/Cargo.toml
+++ b/crates/rooch-key/Cargo.toml
@@ -37,6 +37,7 @@ proptest-derive = {optional = true, workspace = true }
 ethers = { workspace = true }
 clap = { workspace = true }
 chacha20poly1305 = { workspace = true }
+argon2 = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/rooch-key/Cargo.toml
+++ b/crates/rooch-key/Cargo.toml
@@ -36,6 +36,7 @@ proptest = {optional = true, workspace = true }
 proptest-derive = {optional = true, workspace = true }
 ethers = { workspace = true }
 clap = { workspace = true }
+chacha20poly1305 = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/rooch-key/src/key_derive.rs
+++ b/crates/rooch-key/src/key_derive.rs
@@ -503,7 +503,7 @@ fn parse_word_length(s: Option<String>) -> Result<MnemonicType, anyhow::Error> {
 
 /// Get a rooch keypair from a random encryption data
 pub fn get_rooch_key_pair_from_red() -> (RoochAddress, EncryptionData) {
-    let random_encryption_data = EncryptionData::new_random();
+    let random_encryption_data = EncryptionData::new_for_test();
     let key_pair_type = KeyPairType::RoochKeyPairType;
     let kp: RoochKeyPair = key_pair_type
         .retrieve_key_pair(&random_encryption_data, Some("".to_owned()))
@@ -514,12 +514,13 @@ pub fn get_rooch_key_pair_from_red() -> (RoochAddress, EncryptionData) {
 
 /// Get an ethereum keypair from a random encryption data
 pub fn get_ethereum_key_pair_from_red() -> (EthereumAddress, EncryptionData) {
-    let random_encryption_data = EncryptionData::new_random();
+    let random_encryption_data = EncryptionData::new_for_test();
     let key_pair_type = KeyPairType::EthereumKeyPairType;
+
     let kp: Secp256k1RecoverableKeyPair = key_pair_type
         .retrieve_key_pair(&random_encryption_data, Some("".to_owned()))
         .unwrap();
-
     let address = EthereumAddress::from(kp.public().clone());
+
     (address, random_encryption_data)
 }

--- a/crates/rooch-key/src/keystore.rs
+++ b/crates/rooch-key/src/keystore.rs
@@ -113,12 +113,17 @@ pub trait AccountKeystore<Addr: Copy, PubKey, KeyPair, Sig, TransactionData>: Se
         key_pair_type: KeyPairType,
         derivation_path: Option<DerivationPath>,
         word_length: Option<String>,
+        password: Option<String>,
     ) -> Result<(Addr, String, KeyPairType), anyhow::Error>
     where
         KeyPairType: CoinOperations<Addr, KeyPair>,
     {
-        let (address, kp, key_pair_type, phrase) =
-            generate_new_key_pair::<Addr, KeyPair>(key_pair_type, derivation_path, word_length)?;
+        let (address, kp, key_pair_type, phrase) = generate_new_key_pair::<Addr, KeyPair>(
+            key_pair_type,
+            derivation_path,
+            word_length,
+            password,
+        )?;
         self.add_key_pair_by_key_pair_type(kp, key_pair_type)?;
         Ok((address, phrase, key_pair_type))
     }
@@ -773,12 +778,13 @@ impl AccountKeystore<RoochAddress, PublicKey, RoochKeyPair, Signature, RoochTran
         address: &RoochAddress,
     ) -> Result<AuthenticationKey, anyhow::Error> {
         //TODO define derivation_path for session key
-        let (_address, kp, _key_pair_type, _phrase) = generate_new_key_pair::<
-            RoochAddress,
-            RoochKeyPair,
-        >(
-            KeyPairType::RoochKeyPairType, None, None
-        )?;
+        let (_address, kp, _key_pair_type, _phrase) =
+            generate_new_key_pair::<RoochAddress, RoochKeyPair>(
+                KeyPairType::RoochKeyPairType,
+                None,
+                None,
+                None,
+            )?;
         let authentication_key = kp.public().authentication_key();
         let inner_map = self
             .session_keys
@@ -973,12 +979,13 @@ impl
         address: &EthereumAddress,
     ) -> Result<AuthenticationKey, anyhow::Error> {
         //TODO define derivation_path for session key
-        let (_, kp, _key_pair_type, _phrase) = generate_new_key_pair::<
-            EthereumAddress,
-            Secp256k1RecoverableKeyPair,
-        >(
-            KeyPairType::EthereumKeyPairType, None, None
-        )?;
+        let (_, kp, _key_pair_type, _phrase) =
+            generate_new_key_pair::<EthereumAddress, Secp256k1RecoverableKeyPair>(
+                KeyPairType::EthereumKeyPairType,
+                None,
+                None,
+                None,
+            )?;
         let authentication_key_bytes = address.0.as_bytes().to_vec();
         let authentication_key = AuthenticationKey::new(authentication_key_bytes);
         let inner_map = self

--- a/crates/rooch-key/src/keystore.rs
+++ b/crates/rooch-key/src/keystore.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    key_derive::{generate_new_key_pair, CoinOperations, EncryptionResult, GeneratedKeyPair},
+    key_derive::{generate_new_key_pair, CoinOperations, Encryption, GeneratedKeyPair},
     keypair::KeyPairType,
 };
 use anyhow::anyhow;
@@ -44,12 +44,12 @@ use std::path::{Path, PathBuf};
 
 pub struct ImportedMnemonic<Addr> {
     pub address: Addr,
-    pub encryption: EncryptionResult,
+    pub encryption: Encryption,
 }
 
 pub struct UpdatedAddress<KeyPair> {
     pub key_pair: KeyPair,
-    pub encryption: EncryptionResult,
+    pub encryption: Encryption,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -180,7 +180,7 @@ pub trait AccountKeystore<Addr: Copy, PubKey, KeyPair, Sig, TransactionData, Pri
 
         self.add_key_pair_by_key_pair_type(key_pair, key_pair_type)?;
 
-        let encryption = EncryptionResult {
+        let encryption = Encryption {
             hashed_password,
             nonce,
             ciphertext,
@@ -231,7 +231,7 @@ pub trait AccountKeystore<Addr: Copy, PubKey, KeyPair, Sig, TransactionData, Pri
         let (_, key_pair_clone) =
             key_pair_type.derive_key_pair_from_ciphertext(ciphertext.clone())?;
 
-        let encryption = EncryptionResult {
+        let encryption = Encryption {
             hashed_password,
             nonce,
             ciphertext,

--- a/crates/rooch-key/src/keystore.rs
+++ b/crates/rooch-key/src/keystore.rs
@@ -113,17 +113,13 @@ pub trait AccountKeystore<Addr: Copy, PubKey, KeyPair, Sig, TransactionData>: Se
         key_pair_type: KeyPairType,
         derivation_path: Option<DerivationPath>,
         word_length: Option<String>,
-        password: Option<String>,
+        password: String,
     ) -> Result<(Addr, String, KeyPairType), anyhow::Error>
     where
         KeyPairType: CoinOperations<Addr, KeyPair>,
     {
-        let (address, kp, key_pair_type, phrase) = generate_new_key_pair::<Addr, KeyPair>(
-            key_pair_type,
-            derivation_path,
-            word_length,
-            password,
-        )?;
+        let (address, kp, key_pair_type, phrase) =
+            generate_new_key_pair::<Addr, KeyPair>(key_pair_type, derivation_path, word_length, password)?;
         self.add_key_pair_by_key_pair_type(kp, key_pair_type)?;
         Ok((address, phrase, key_pair_type))
     }
@@ -778,13 +774,12 @@ impl AccountKeystore<RoochAddress, PublicKey, RoochKeyPair, Signature, RoochTran
         address: &RoochAddress,
     ) -> Result<AuthenticationKey, anyhow::Error> {
         //TODO define derivation_path for session key
-        let (_address, kp, _key_pair_type, _phrase) =
-            generate_new_key_pair::<RoochAddress, RoochKeyPair>(
-                KeyPairType::RoochKeyPairType,
-                None,
-                None,
-                None,
-            )?;
+        let (_address, kp, _key_pair_type, _phrase) = generate_new_key_pair::<
+            RoochAddress,
+            RoochKeyPair,
+        >(
+            KeyPairType::RoochKeyPairType, None, None
+        )?;
         let authentication_key = kp.public().authentication_key();
         let inner_map = self
             .session_keys
@@ -979,13 +974,12 @@ impl
         address: &EthereumAddress,
     ) -> Result<AuthenticationKey, anyhow::Error> {
         //TODO define derivation_path for session key
-        let (_, kp, _key_pair_type, _phrase) =
-            generate_new_key_pair::<EthereumAddress, Secp256k1RecoverableKeyPair>(
-                KeyPairType::EthereumKeyPairType,
-                None,
-                None,
-                None,
-            )?;
+        let (_, kp, _key_pair_type, _phrase) = generate_new_key_pair::<
+            EthereumAddress,
+            Secp256k1RecoverableKeyPair,
+        >(
+            KeyPairType::EthereumKeyPairType, None, None
+        )?;
         let authentication_key_bytes = address.0.as_bytes().to_vec();
         let authentication_key = AuthenticationKey::new(authentication_key_bytes);
         let inner_map = self

--- a/crates/rooch-key/src/lib.rs
+++ b/crates/rooch-key/src/lib.rs
@@ -2,6 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod key_derive;
-pub mod keypair;
 pub mod keypair_file;
 pub mod keystore;

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -10,12 +10,12 @@ use moveos_types::transaction::MoveAction;
 use rooch_config::config::{Config, PersistedConfig};
 use rooch_config::server_config::ServerConfig;
 use rooch_config::{rooch_config_dir, ROOCH_CLIENT_CONFIG, ROOCH_SERVER_CONFIG};
-use rooch_key::keypair::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, KeptVMStatusView};
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::{RoochKeyPair, Signature};
 use rooch_types::error::{RoochError, RoochResult};
+use rooch_types::keypair_type::KeyPairType;
 use rooch_types::transaction::{
     authenticator::Authenticator,
     rooch::{RoochTransaction, RoochTransactionData},
@@ -132,10 +132,11 @@ impl WalletContext<RoochAddress, RoochKeyPair> {
         sender: RoochAddress,
         action: MoveAction,
         key_pair_type: KeyPairType,
+        password: Option<String>,
     ) -> RoochResult<RoochTransaction> {
         let kp = self
             .keystore
-            .get_key_pair_by_key_pair_type(&sender, key_pair_type)
+            .get_key_pair_by_type_password(&sender, key_pair_type, password)
             .ok()
             .ok_or_else(|| {
                 RoochError::SignMessageError(format!("Cannot find key for address: [{sender}]"))
@@ -144,7 +145,7 @@ impl WalletContext<RoochAddress, RoochKeyPair> {
         match key_pair_type {
             KeyPairType::RoochKeyPairType => {
                 let tx_data = self.build_rooch_tx_data(sender, action).await?;
-                let signature = Signature::new_hashed(tx_data.hash().as_bytes(), kp);
+                let signature = Signature::new_hashed(tx_data.hash().as_bytes(), &kp);
                 Ok(RoochTransaction::new(
                     tx_data,
                     Authenticator::rooch(signature),
@@ -172,8 +173,9 @@ impl WalletContext<RoochAddress, RoochKeyPair> {
         sender: RoochAddress,
         action: MoveAction,
         key_pair_type: KeyPairType,
+        password: Option<String>,
     ) -> RoochResult<ExecuteTransactionResponseView> {
-        let tx = self.sign(sender, action, key_pair_type).await?;
+        let tx = self.sign(sender, action, key_pair_type, password).await?;
         self.execute(tx).await
     }
 

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -13,7 +13,7 @@ use rooch_config::{rooch_config_dir, ROOCH_CLIENT_CONFIG, ROOCH_SERVER_CONFIG};
 use rooch_key::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, KeptVMStatusView};
 use rooch_types::address::RoochAddress;
-use rooch_types::crypto::{RoochKeyPair, Signature};
+use rooch_types::crypto::Signature;
 use rooch_types::error::{RoochError, RoochResult};
 use rooch_types::keypair_type::KeyPairType;
 use rooch_types::transaction::{
@@ -27,14 +27,14 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 
-pub struct WalletContext<K: Ord, V> {
+pub struct WalletContext<K: Ord> {
     client: Arc<RwLock<Option<Client>>>,
     pub client_config: PersistedConfig<ClientConfig>,
     pub server_config: PersistedConfig<ServerConfig>,
-    pub keystore: Keystore<K, V>,
+    pub keystore: Keystore<K>,
 }
 
-impl WalletContext<RoochAddress, RoochKeyPair> {
+impl WalletContext<RoochAddress> {
     pub async fn new(config_path: Option<PathBuf>) -> Result<Self, anyhow::Error> {
         let config_dir = config_path.unwrap_or(rooch_config_dir()?);
         let client_config_path = config_dir.join(ROOCH_CLIENT_CONFIG);
@@ -55,8 +55,7 @@ impl WalletContext<RoochAddress, RoochKeyPair> {
         let client_config = client_config.persisted(&client_config_path);
         let server_config = server_config.persisted(&server_config_path);
 
-        let keystore_result =
-            FileBasedKeystore::<RoochAddress, RoochKeyPair>::load(&client_config.keystore_path);
+        let keystore_result = FileBasedKeystore::<RoochAddress>::load(&client_config.keystore_path);
         let keystore = match keystore_result {
             Ok(file_keystore) => Keystore::File(file_keystore),
             Err(error) => return Err(error),

--- a/crates/rooch-rpc-server/Cargo.toml
+++ b/crates/rooch-rpc-server/Cargo.toml
@@ -41,7 +41,7 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 hyper = { workspace = true }
 log = { workspace = true }
 lazy_static = { workspace = true }
-
+rpassword = { workspace = true }
 
 move-core-types = { workspace = true }
 move-resource-viewer = { workspace = true }

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -187,6 +187,7 @@ pub async fn run_start_server(opt: &RoochOpt, mut server_opt: ServerOpt) -> Resu
                 KeyPairType::RoochKeyPairType,
                 None,
                 None,
+                None,
             )?;
             server_opt.sequencer_keypair = Some(key_keypair.copy());
             server_opt.proposer_keypair = Some(key_keypair.copy());

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -9,6 +9,7 @@ use crate::service::rpc_service::RpcService;
 use anyhow::{Error, Result};
 use coerce::actor::scheduler::timer::Timer;
 use coerce::actor::{system::ActorSystem, IntoActor};
+use fastcrypto::ed25519::Ed25519PrivateKey;
 use hyper::header::HeaderValue;
 use hyper::Method;
 use jsonrpsee::server::ServerBuilder;

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -9,7 +9,6 @@ use crate::service::rpc_service::RpcService;
 use anyhow::{Error, Result};
 use coerce::actor::scheduler::timer::Timer;
 use coerce::actor::{system::ActorSystem, IntoActor};
-use fastcrypto::ed25519::Ed25519PrivateKey;
 use hyper::header::HeaderValue;
 use hyper::Method;
 use jsonrpsee::server::ServerBuilder;
@@ -36,6 +35,7 @@ use rooch_store::RoochStore;
 use rooch_types::address::RoochAddress;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::{GenesisError, RoochError};
+use rooch_types::keypair_type::KeyPairType;
 use serde_json::json;
 use std::env;
 use std::fmt::Debug;
@@ -183,7 +183,7 @@ pub async fn run_start_server(opt: &RoochOpt, mut server_opt: ServerOpt) -> Resu
     {
         // only for integration test, generate test key pairs
         if chain_id_opt.is_test_or_dev_or_local() {
-            let result = generate_new_key_pair::<RoochAddress, RoochKeyPair, Ed25519PrivateKey>(
+            let result = generate_new_key_pair::<RoochAddress, RoochKeyPair>(
                 KeyPairType::RoochKeyPairType,
                 None,
                 None,

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -184,15 +184,15 @@ pub async fn run_start_server(opt: &RoochOpt, mut server_opt: ServerOpt) -> Resu
     {
         // only for integration test, generate test key pairs
         if chain_id_opt.is_test_or_dev_or_local() {
-            let (_, key_keypair, _, _) = generate_new_key_pair::<RoochAddress, RoochKeyPair>(
+            let result = generate_new_key_pair::<RoochAddress, RoochKeyPair, Ed25519PrivateKey>(
                 KeyPairType::RoochKeyPairType,
                 None,
                 None,
                 None,
             )?;
-            server_opt.sequencer_keypair = Some(key_keypair.copy());
-            server_opt.proposer_keypair = Some(key_keypair.copy());
-            server_opt.relayer_keypair = Some(key_keypair.copy());
+            server_opt.sequencer_keypair = Some(result.key_pair.copy());
+            server_opt.proposer_keypair = Some(result.key_pair.copy());
+            server_opt.relayer_keypair = Some(result.key_pair.copy());
         } else {
             return Err(Error::from(
                 RoochError::InvalidSequencerOrProposerOrRelayerKeyPair,

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -176,13 +176,12 @@ pub async fn run_start_server(opt: &RoochOpt, mut server_opt: ServerOpt) -> Resu
     .await?;
     let executor_proxy = ExecutorProxy::new(executor.into());
 
-    let password = if opt.password_required == Some(false) {
-        // Use an empty password if not required
-        String::new()
-    } else {
-        // Prompt for a password if required
-        rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-    };
+    // Use an empty password by default
+    let password = String::new();
+
+    // TODO design a password mechanism
+    // // Prompt for a password if required
+    // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
     // Check for key pairs
     if server_opt.sequencer_keypair.is_none()

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -24,7 +24,6 @@ use rooch_config::{BaseConfig, RoochOpt, ServerOpt};
 use rooch_executor::actor::executor::ExecutorActor;
 use rooch_executor::proxy::ExecutorProxy;
 use rooch_key::key_derive::generate_new_key_pair;
-use rooch_key::keypair::KeyPairType;
 use rooch_proposer::actor::messages::ProposeBlock;
 use rooch_proposer::actor::proposer::ProposerActor;
 use rooch_proposer::proxy::ProposerProxy;

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -97,6 +97,8 @@ pub enum RoochError {
     IncorrectSigner { error: String },
     #[error("Invalid chain ID")]
     InvalidChainID,
+    #[error("Invalid password error: {0}")]
+    InvalidPasswordError(String),
 
     #[error("Clean server error: {0}")]
     CleanServerError(String),

--- a/crates/rooch-types/src/key_struct.rs
+++ b/crates/rooch-types/src/key_struct.rs
@@ -24,8 +24,8 @@ pub struct GeneratedKeyPair<Addr, KeyPair> {
 }
 
 impl EncryptionData {
+    // The data is for test only, please do not use the data for applications.
     pub fn new_for_test() -> EncryptionData {
-        // hashed password from "" string
         let hashed_password = "$argon2id$v=19$m=19456,t=2,p=1$zc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc0$RysE6tj+Zu0lLhtKJIedVHrKn9FspulS3vLj/UPaVvQ".to_owned();
         let nonce = [202, 31, 86, 27, 113, 29, 104, 237, 218, 110, 152, 145].to_vec();
         let ciphertext = [

--- a/crates/rooch-types/src/key_struct.rs
+++ b/crates/rooch-types/src/key_struct.rs
@@ -17,9 +17,8 @@ pub struct GenerateNewKeyPair {
     pub encryption: EncryptionData,
     pub mnemonic: String,
 }
-pub struct GeneratedKeyPair<Addr, KeyPair> {
+pub struct GeneratedKeyPair<Addr> {
     pub address: Addr,
-    pub key_pair: KeyPair,
     pub result: GenerateNewKeyPair,
 }
 

--- a/crates/rooch-types/src/key_struct.rs
+++ b/crates/rooch-types/src/key_struct.rs
@@ -1,7 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::keypair_type::KeyPairType;
@@ -25,11 +24,19 @@ pub struct GeneratedKeyPair<Addr, KeyPair> {
 }
 
 impl EncryptionData {
-    pub fn new_random() -> EncryptionData {
-        let hashed_password = generate_random_string(32);
-        let nonce = generate_random_bytes(12);
-        let ciphertext = generate_random_bytes(32);
-        let tag = generate_random_bytes(16);
+    pub fn new_for_test() -> EncryptionData {
+        // hashed password from "" string
+        let hashed_password = "$argon2id$v=19$m=19456,t=2,p=1$zc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc0$RysE6tj+Zu0lLhtKJIedVHrKn9FspulS3vLj/UPaVvQ".to_owned();
+        let nonce = [202, 31, 86, 27, 113, 29, 104, 237, 218, 110, 152, 145].to_vec();
+        let ciphertext = [
+            86, 255, 133, 44, 42, 219, 86, 153, 245, 192, 200, 93, 172, 157, 89, 211, 13, 158, 128,
+            21, 131, 19, 74, 203, 194, 159, 3, 164, 136, 125, 69, 221,
+        ]
+        .to_vec();
+        let tag = [
+            139, 112, 155, 74, 182, 134, 97, 95, 41, 119, 202, 17, 146, 40, 11, 75,
+        ]
+        .to_vec();
 
         EncryptionData {
             hashed_password,
@@ -38,18 +45,4 @@ impl EncryptionData {
             tag,
         }
     }
-}
-
-fn generate_random_string(length: usize) -> String {
-    let mut rng = rand::thread_rng();
-    let random_string: String = (0..length)
-        .map(|_| rng.gen_range(b'a'..=b'z') as char)
-        .collect();
-    random_string
-}
-
-fn generate_random_bytes(length: usize) -> Vec<u8> {
-    let mut rng = rand::thread_rng();
-    let random_bytes: Vec<u8> = (0..length).map(|_| rng.gen()).collect();
-    random_bytes
 }

--- a/crates/rooch-types/src/key_struct.rs
+++ b/crates/rooch-types/src/key_struct.rs
@@ -1,0 +1,55 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+use crate::keypair_type::KeyPairType;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EncryptionData {
+    pub hashed_password: String,
+    pub nonce: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+    pub tag: Vec<u8>,
+}
+pub struct GenerateNewKeyPair {
+    pub key_pair_type: KeyPairType,
+    pub encryption: EncryptionData,
+    pub mnemonic: String,
+}
+pub struct GeneratedKeyPair<Addr, KeyPair> {
+    pub address: Addr,
+    pub key_pair: KeyPair,
+    pub result: GenerateNewKeyPair,
+}
+
+impl EncryptionData {
+    pub fn new_random() -> EncryptionData {
+        let hashed_password = generate_random_string(32);
+        let nonce = generate_random_bytes(12);
+        let ciphertext = generate_random_bytes(32);
+        let tag = generate_random_bytes(16);
+
+        EncryptionData {
+            hashed_password,
+            nonce,
+            ciphertext,
+            tag,
+        }
+    }
+}
+
+fn generate_random_string(length: usize) -> String {
+    let mut rng = rand::thread_rng();
+    let random_string: String = (0..length)
+        .map(|_| rng.gen_range(b'a'..=b'z') as char)
+        .collect();
+    random_string
+}
+
+fn generate_random_bytes(length: usize) -> Vec<u8> {
+    let mut rng = rand::thread_rng();
+    let random_bytes: Vec<u8> = (0..length).map(|_| rng.gen()).collect();
+    random_bytes
+}

--- a/crates/rooch-types/src/keypair_type.rs
+++ b/crates/rooch-types/src/keypair_type.rs
@@ -5,10 +5,11 @@ use anyhow::Result;
 use clap::ArgEnum;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use rooch_types::error::RoochError;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumString;
+
+use crate::error::RoochError;
 
 #[derive(
     Clone,

--- a/crates/rooch-types/src/lib.rs
+++ b/crates/rooch-types/src/lib.rs
@@ -11,6 +11,8 @@ pub mod coin_type;
 pub mod crypto;
 pub mod error;
 pub mod framework;
+pub mod key_struct;
+pub mod keypair_type;
 pub mod multichain_id;
 pub mod sequencer;
 pub mod transaction;

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -38,6 +38,8 @@ rust-embed = { workspace = true }
 rocket = { workspace = true }
 parking_lot = { workspace = true }
 bcs-ext = { workspace = true }
+rpassword = { workspace = true }
+argon2 = { workspace = true }
 
 move-bytecode-utils = { workspace = true }
 move-binary-format = { workspace = true }

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -39,7 +39,6 @@ rocket = { workspace = true }
 parking_lot = { workspace = true }
 bcs-ext = { workspace = true }
 rpassword = { workspace = true }
-argon2 = { workspace = true }
 
 move-bytecode-utils = { workspace = true }
 move-binary-format = { workspace = true }

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 bcs = { workspace = true }
-clap = { features = [ "derive",], workspace = true }
+clap = { features = [ "derive", ], workspace = true }
 datatest-stable = { git = "https://github.com/rooch-network/diem-devtools", branch = "feature/pub-test-opts" }
 tokio = { features = ["full"], workspace = true }
 dirs  = { workspace = true }

--- a/crates/rooch/src/cli_types.rs
+++ b/crates/rooch/src/cli_types.rs
@@ -16,7 +16,6 @@ use std::ops::Deref;
 use std::path::PathBuf;
 
 use rooch_types::address::RoochAddress;
-use rooch_types::crypto::RoochKeyPair;
 use std::str::FromStr;
 
 #[async_trait]
@@ -101,7 +100,7 @@ pub struct WalletContextOptions {
 }
 
 impl WalletContextOptions {
-    pub async fn build(&self) -> RoochResult<WalletContext<RoochAddress, RoochKeyPair>> {
+    pub async fn build(&self) -> RoochResult<WalletContext<RoochAddress>> {
         WalletContext::new(self.config_dir.clone())
             .await
             .map_err(RoochError::from)

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -16,9 +16,9 @@ use rooch_types::error::RoochResult;
 /// any coins will have to transferred afterwards.
 #[derive(Debug, Parser)]
 pub struct CreateCommand {
-    /// Whether a password should be provided.
+    /// Whether a password should be provided
     #[clap(short = 'p', long = "password")]
-    password_required: bool,
+    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -27,12 +27,12 @@ impl CreateCommand {
     pub async fn execute(self) -> RoochResult<String> {
         let mut context = self.context_options.build().await?;
 
-        let password = if self.password_required {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        } else {
+        let password = if self.password_required == Some(false) {
             // Use an empty password if not required
             String::new()
+        } else {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
         };
         println!("Your password is {}", password);
 

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -15,9 +15,6 @@ use rooch_types::{error::RoochResult, keypair_type::KeyPairType};
 /// any coins will have to transferred afterwards.
 #[derive(Debug, Parser)]
 pub struct CreateCommand {
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -26,14 +23,12 @@ impl CreateCommand {
     pub async fn execute(self) -> RoochResult<String> {
         let mut context = self.context_options.build().await?;
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        };
-        println!("Your password is {}", password);
+        // Use an empty password by default
+        let password = String::new();
+
+        // TODO design a password mechanism
+        // // Prompt for a password if required
+        // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
         let result = context.keystore.generate_and_add_new_key(
             KeyPairType::RoochKeyPairType,

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -26,7 +26,7 @@ impl CreateCommand {
         let (new_address, phrase, multichain_id) = context
             .config
             .keystore
-            .generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None, None)?;
+            .generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None)?;
 
         let address = AccountAddress::from(new_address).to_hex_literal();
         println!(

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -23,10 +23,10 @@ impl CreateCommand {
     pub async fn execute(self) -> RoochResult<String> {
         let mut context = self.context_options.build().await?;
 
-        let (new_address, phrase, multichain_id) =
-            context
-                .keystore
-                .generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None)?;
+        let (new_address, phrase, multichain_id) = context
+            .config
+            .keystore
+            .generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None, None)?;
 
         let address = AccountAddress::from(new_address).to_hex_literal();
         println!(

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -17,7 +17,7 @@ use rooch_types::error::RoochResult;
 #[derive(Debug, Parser)]
 pub struct CreateCommand {
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -40,7 +40,7 @@ impl CreateCommand {
             KeyPairType::RoochKeyPairType,
             None,
             None,
-            Some(password),
+            Some(password.clone()),
         )?;
 
         context.config.password = Some(result.result.encryption.hashed_password);

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -3,10 +3,9 @@
 
 use crate::cli_types::WalletContextOptions;
 use clap::Parser;
-use hex::ToHex;
 use move_core_types::account_address::AccountAddress;
-use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
-use rooch_types::error::RoochResult;
+use rooch_key::keystore::AccountKeystore;
+use rooch_types::{error::RoochResult, keypair_type::KeyPairType};
 
 /// Create a new account off-chain.
 /// If an account not exist on-chain, contract will auto create the account on-chain.
@@ -40,19 +39,13 @@ impl CreateCommand {
             KeyPairType::RoochKeyPairType,
             None,
             None,
-            Some(password.clone()),
+            Some(password),
         )?;
 
-        context.config.password = Some(result.result.encryption.hashed_password);
-        context.config.nonce = Some(result.result.encryption.nonce.encode_hex());
-        context.config.ciphertext = Some(result.result.encryption.ciphertext.encode_hex());
-        context.config.tag = Some(result.result.encryption.tag.encode_hex());
-        context.config.save()?;
-
-        let address = AccountAddress::from(new_address).to_hex_literal();
+        let address = AccountAddress::from(result.address).to_hex_literal();
         println!(
-            "Generated new keypair for address with multichain id {:?} [{new_address}]",
-            multichain_id
+            "Generated new keypair for address with key pair type {:?} [{}]",
+            result.result.key_pair_type, result.address
         );
         println!("Secret Recovery Phrase : [{}]", result.result.mnemonic);
 

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -16,6 +16,9 @@ use rooch_types::error::RoochResult;
 /// any coins will have to transferred afterwards.
 #[derive(Debug, Parser)]
 pub struct CreateCommand {
+    /// Whether a password should be provided.
+    #[clap(short = 'p', long = "password")]
+    password_required: bool,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -24,7 +27,13 @@ impl CreateCommand {
     pub async fn execute(self) -> RoochResult<String> {
         let mut context = self.context_options.build().await?;
 
-        let password = rpassword::prompt_password("Enter a password to encrypt the keys in rooch keystore. Empty password leaves an unencrypted key: ").unwrap();
+        let password = if self.password_required {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
+        } else {
+            // Use an empty password if not required
+            String::new()
+        };
         println!("Your password is {}", password);
 
         let result = context.keystore.generate_and_add_new_key(

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -16,6 +16,9 @@ use crate::cli_types::{CommandAction, WalletContextOptions};
 pub struct ImportCommand {
     #[clap(short = 'm', long = "mnemonic-phrase")]
     mnemonic_phrase: String,
+    /// Whether a password should be provided.
+    #[clap(short = 'p', long = "password")]
+    password_required: bool,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -27,7 +30,13 @@ impl CommandAction<()> for ImportCommand {
 
         let mut context = self.context_options.build().await?;
 
-        let password = rpassword::prompt_password("Enter a password to encrypt the keys in rooch keystore. Empty password leaves an unencrypted key: ").unwrap();
+        let password = if self.password_required {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
+        } else {
+            // Use an empty password if not required
+            String::new()
+        };
         println!("Your password is {}", password);
 
         let (address, password_hash, nonce, ciphertext, tag) = context

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -18,9 +18,6 @@ use crate::cli_types::{CommandAction, WalletContextOptions};
 pub struct ImportCommand {
     #[clap(short = 'm', long = "mnemonic-phrase")]
     mnemonic_phrase: String,
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -32,14 +29,12 @@ impl CommandAction<()> for ImportCommand {
 
         let mut context = self.context_options.build().await?;
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        };
-        println!("Your password is {}", password);
+        // Use an empty password by default
+        let password = String::new();
+
+        // TODO design a password mechanism
+        // // Prompt for a password if required
+        // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
         let result = context
             .keystore

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -16,9 +16,9 @@ use crate::cli_types::{CommandAction, WalletContextOptions};
 pub struct ImportCommand {
     #[clap(short = 'm', long = "mnemonic-phrase")]
     mnemonic_phrase: String,
-    /// Whether a password should be provided.
+    /// Whether a password should be provided
     #[clap(short = 'p', long = "password")]
-    password_required: bool,
+    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -30,12 +30,12 @@ impl CommandAction<()> for ImportCommand {
 
         let mut context = self.context_options.build().await?;
 
-        let password = if self.password_required {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        } else {
+        let password = if self.password_required == Some(false) {
             // Use an empty password if not required
             String::new()
+        } else {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
         };
         println!("Your password is {}", password);
 

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -6,8 +6,11 @@ use hex::ToHex;
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
-use rooch_types::error::{RoochError, RoochResult};
+use rooch_key::keystore::AccountKeystore;
+use rooch_types::{
+    error::{RoochError, RoochResult},
+    keypair_type::KeyPairType,
+};
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
 

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -40,15 +40,16 @@ impl CommandAction<()> for ImportCommand {
             )
             .map_err(|e| RoochError::ImportAccountError(e.to_string()))?;
 
-        context.config.password = Some(password_hash);
-        context.config.nonce = Some(nonce.encode_hex());
-        context.config.ciphertext = Some(ciphertext.encode_hex());
-        context.config.tag = Some(tag.encode_hex());
+        context.config.password = Some(result.encryption.hashed_password);
+        context.config.nonce = Some(result.encryption.nonce.encode_hex());
+        context.config.ciphertext = Some(result.encryption.ciphertext.encode_hex());
+        context.config.tag = Some(result.encryption.tag.encode_hex());
         context.config.save()?;
 
         println!(
-            "Key imported for address on type {:?}: [{address}]",
-            KeyPairType::RoochKeyPairType.type_of()
+            "Key imported for address on type {:?}: [{}]",
+            KeyPairType::RoochKeyPairType.type_of(),
+            result.address
         );
 
         Ok(())

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hex::ToHex;
 use std::fmt::Debug;
 
 use async_trait::async_trait;
@@ -42,7 +41,7 @@ impl CommandAction<()> for ImportCommand {
         };
         println!("Your password is {}", password);
 
-        let (address, password_hash, nonce, ciphertext, tag) = context
+        let result = context
             .keystore
             .import_from_mnemonic(
                 &self.mnemonic_phrase,
@@ -51,12 +50,6 @@ impl CommandAction<()> for ImportCommand {
                 Some(password),
             )
             .map_err(|e| RoochError::ImportAccountError(e.to_string()))?;
-
-        context.config.password = Some(result.encryption.hashed_password);
-        context.config.nonce = Some(result.encryption.nonce.encode_hex());
-        context.config.ciphertext = Some(result.encryption.ciphertext.encode_hex());
-        context.config.tag = Some(result.encryption.tag.encode_hex());
-        context.config.save()?;
 
         println!(
             "Key imported for address on type {:?}: [{}]",

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -20,7 +20,7 @@ pub struct ImportCommand {
     #[clap(short = 'm', long = "mnemonic-phrase")]
     mnemonic_phrase: String,
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 #[derive(Debug, Parser)]
 pub struct ListCommand {
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -31,7 +31,6 @@ impl CommandAction<()> for ListCommand {
             // Prompt for a password if required
             rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
         };
-        println!("Your password is {}", password);
 
         println!(
             "{0: ^66} | {1: ^48} | {2: ^16} | {3: ^12}",

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -11,9 +11,6 @@ use std::fmt::Debug;
 /// List all keys by its Rooch address, Base64 encoded public key
 #[derive(Debug, Parser)]
 pub struct ListCommand {
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -24,13 +21,12 @@ impl CommandAction<()> for ListCommand {
         let context = self.context_options.build().await?;
         let active_address = context.client_config.active_address;
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        };
+        // Use an empty password by default
+        let password = String::new();
+
+        // TODO design a password mechanism
+        // // Prompt for a password if required
+        // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
         println!(
             "{0: ^66} | {1: ^48} | {2: ^16} | {3: ^12}",

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -11,6 +11,9 @@ use std::fmt::Debug;
 /// List all keys by its Rooch address, Base64 encoded public key
 #[derive(Debug, Parser)]
 pub struct ListCommand {
+    /// Whether a password should be provided
+    #[clap(short = 'p', long = "password")]
+    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -21,13 +24,22 @@ impl CommandAction<()> for ListCommand {
         let context = self.context_options.build().await?;
         let active_address = context.client_config.active_address;
 
+        let password = if self.password_required == Some(false) {
+            // Use an empty password if not required
+            String::new()
+        } else {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
+        };
+        println!("Your password is {}", password);
+
         println!(
             "{0: ^66} | {1: ^48} | {2: ^16} | {3: ^12}",
             "Rooch Address (Ed25519)", "Public Key (Base64)", "Auth Validator ID", "Active Address"
         );
         println!("{}", ["-"; 153].join(""));
 
-        for (address, public_key) in context.keystore.get_address_public_keys() {
+        for (address, public_key) in context.keystore.get_address_public_keys(Some(password)) {
             let auth_validator_id = public_key.auth_validator().flag();
             let mut active = "";
             if active_address == Some(address) {

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -38,7 +38,7 @@ impl CommandAction<()> for ListCommand {
         );
         println!("{}", ["-"; 153].join(""));
 
-        for (address, public_key) in context.keystore.get_address_public_keys(Some(password)) {
+        for (address, public_key) in context.keystore.get_address_public_keys(Some(password))? {
             let auth_validator_id = public_key.auth_validator().flag();
             let mut active = "";
             if active_address == Some(address) {

--- a/crates/rooch/src/commands/account/commands/nullify.rs
+++ b/crates/rooch/src/commands/account/commands/nullify.rs
@@ -24,9 +24,6 @@ pub struct NullifyCommand {
     /// Rooch address in string format.
     #[clap(short = 'a', long = "address")]
     address: String,
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -36,13 +33,12 @@ impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
     async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
         let mut context = self.context_options.build().await?;
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        };
+        // Use an empty password by default
+        let password = String::new();
+
+        // TODO design a password mechanism
+        // // Prompt for a password if required
+        // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
         let existing_address = RoochAddress::from_str(self.address.as_str()).map_err(|e| {
             RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))

--- a/crates/rooch/src/commands/account/commands/nullify.rs
+++ b/crates/rooch/src/commands/account/commands/nullify.rs
@@ -25,7 +25,7 @@ pub struct NullifyCommand {
     #[clap(short = 'a', long = "address")]
     address: String,
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,

--- a/crates/rooch/src/commands/account/commands/nullify.rs
+++ b/crates/rooch/src/commands/account/commands/nullify.rs
@@ -43,7 +43,6 @@ impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
             // Prompt for a password if required
             rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
         };
-        println!("Your password is {}", password);
 
         let existing_address = RoochAddress::from_str(self.address.as_str()).map_err(|e| {
             RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))

--- a/crates/rooch/src/commands/account/commands/nullify.rs
+++ b/crates/rooch/src/commands/account/commands/nullify.rs
@@ -3,7 +3,7 @@
 
 use clap::Parser;
 use move_core_types::account_address::AccountAddress;
-use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
+use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
 use std::fmt::Debug;
 
@@ -12,6 +12,7 @@ use rooch_types::{
     address::RoochAddress,
     error::{RoochError, RoochResult},
     framework::native_validator::NativeValidatorModule,
+    keypair_type::KeyPairType,
 };
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
@@ -23,6 +24,9 @@ pub struct NullifyCommand {
     /// Rooch address in string format.
     #[clap(short = 'a', long = "address")]
     address: String,
+    /// Whether a password should be provided
+    #[clap(short = 'p', long = "password")]
+    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -31,6 +35,15 @@ pub struct NullifyCommand {
 impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
     async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
         let mut context = self.context_options.build().await?;
+
+        let password = if self.password_required == Some(false) {
+            // Use an empty password if not required
+            String::new()
+        } else {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
+        };
+        println!("Your password is {}", password);
 
         let existing_address = RoochAddress::from_str(self.address.as_str()).map_err(|e| {
             RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))
@@ -46,7 +59,12 @@ impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
 
         // Execute the Move call as a transaction
         let mut result = context
-            .sign_and_execute(existing_address, action, KeyPairType::RoochKeyPairType)
+            .sign_and_execute(
+                existing_address,
+                action,
+                KeyPairType::RoochKeyPairType,
+                Some(password),
+            )
             .await?;
         result = context.assert_execute_success(result)?;
 

--- a/crates/rooch/src/commands/account/commands/switch.rs
+++ b/crates/rooch/src/commands/account/commands/switch.rs
@@ -39,7 +39,6 @@ impl CommandAction<()> for SwitchCommand {
             // Prompt for a password if required
             rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
         };
-        println!("Your password is {}", password);
 
         if !context
             .keystore

--- a/crates/rooch/src/commands/account/commands/switch.rs
+++ b/crates/rooch/src/commands/account/commands/switch.rs
@@ -20,7 +20,7 @@ pub struct SwitchCommand {
     #[clap(short = 'a', long = "address")]
     address: String,
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
 }
 

--- a/crates/rooch/src/commands/account/commands/switch.rs
+++ b/crates/rooch/src/commands/account/commands/switch.rs
@@ -42,7 +42,7 @@ impl CommandAction<()> for SwitchCommand {
 
         if !context
             .keystore
-            .addresses(Some(password))
+            .addresses(Some(password))?
             .contains(&rooch_address)
         {
             return Err(RoochError::SwitchAccountError(format!(

--- a/crates/rooch/src/commands/account/commands/switch.rs
+++ b/crates/rooch/src/commands/account/commands/switch.rs
@@ -19,9 +19,6 @@ pub struct SwitchCommand {
     /// The address of the Rooch account to be set as active
     #[clap(short = 'a', long = "address")]
     address: String,
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
 }
 
 #[async_trait]
@@ -32,19 +29,7 @@ impl CommandAction<()> for SwitchCommand {
             RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))
         })?;
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        };
-
-        if !context
-            .keystore
-            .addresses(Some(password))?
-            .contains(&rooch_address)
-        {
+        if !context.keystore.addresses().contains(&rooch_address) {
             return Err(RoochError::SwitchAccountError(format!(
                 "Address `{}` does not in the Rooch keystore",
                 self.address

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -42,7 +42,6 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
             // Prompt for a password if required
             rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
         };
-        println!("Your password is {}", password);
 
         let mut context = self.context_options.build().await?;
 

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -25,7 +25,7 @@ pub struct UpdateCommand {
     #[clap(short = 'm', long = "mnemonic-phrase")]
     mnemonic_phrase: String,
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -51,10 +51,10 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
             )
             .map_err(|e| RoochError::UpdateAccountError(e.to_string()))?;
 
-        context.config.password = Some(password_hash);
-        context.config.nonce = Some(nonce.encode_hex());
-        context.config.ciphertext = Some(ciphertext.encode_hex());
-        context.config.tag = Some(tag.encode_hex());
+        context.config.password = Some(result.encryption.hashed_password);
+        context.config.nonce = Some(result.encryption.nonce.encode_hex());
+        context.config.ciphertext = Some(result.encryption.ciphertext.encode_hex());
+        context.config.tag = Some(result.encryption.tag.encode_hex());
         context.config.save()?;
 
         println!(
@@ -68,7 +68,7 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
         );
 
         // Get public key
-        let public_key = kp.public();
+        let public_key = result.key_pair.public();
 
         // Get public key reference
         let public_key = public_key.as_ref().to_vec();

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -23,9 +23,9 @@ pub struct UpdateCommand {
     address: String,
     #[clap(short = 'm', long = "mnemonic-phrase")]
     mnemonic_phrase: String,
-    /// Whether a password should be provided.
+    /// Whether a password should be provided
     #[clap(short = 'p', long = "password")]
-    password_required: bool,
+    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -34,12 +34,12 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
     async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
         println!("{:?}", self.mnemonic_phrase);
 
-        let password = if self.password_required {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        } else {
+        let password = if self.password_required == Some(false) {
             // Use an empty password if not required
             String::new()
+        } else {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
         };
         println!("Your password is {}", password);
 

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -23,9 +23,6 @@ pub struct UpdateCommand {
     address: String,
     #[clap(short = 'm', long = "mnemonic-phrase")]
     mnemonic_phrase: String,
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -34,13 +31,12 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
     async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
         println!("{:?}", self.mnemonic_phrase);
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        };
+        // Use an empty password by default
+        let password = String::new();
+
+        // TODO design a password mechanism
+        // // Prompt for a password if required
+        // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
         let mut context = self.context_options.build().await?;
 

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hex::ToHex;
 use move_core_types::account_address::AccountAddress;
 use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
@@ -49,9 +48,6 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
             RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))
         })?;
 
-        let password = rpassword::prompt_password("Enter a password to encrypt the keys in rooch keystore. Empty password leaves an unencrypted key: ").unwrap();
-        println!("Your password is {}", password);
-
         let result = context
             .keystore
             .update_address_with_key_pair_from_key_pair_type(
@@ -62,12 +58,6 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
                 Some(password.clone()),
             )
             .map_err(|e| RoochError::UpdateAccountError(e.to_string()))?;
-
-        context.config.password = Some(result.encryption.hashed_password);
-        context.config.nonce = Some(result.encryption.nonce.encode_hex());
-        context.config.ciphertext = Some(result.encryption.ciphertext.encode_hex());
-        context.config.tag = Some(result.encryption.tag.encode_hex());
-        context.config.save()?;
 
         println!(
             "{}",

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -4,12 +4,13 @@
 use clap::Parser;
 use hex::ToHex;
 use move_core_types::account_address::AccountAddress;
-use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
+use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
 use rooch_types::{
     address::RoochAddress,
     error::{RoochError, RoochResult},
     framework::native_validator::NativeValidatorModule,
+    keypair_type::KeyPairType,
 };
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
@@ -59,7 +60,7 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
                 self.mnemonic_phrase,
                 KeyPairType::RoochKeyPairType,
                 None,
-                Some(password),
+                Some(password.clone()),
             )
             .map_err(|e| RoochError::UpdateAccountError(e.to_string()))?;
 
@@ -90,7 +91,12 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
 
         // Execute the Move call as a transaction
         let result = context
-            .sign_and_execute(existing_address, action, KeyPairType::RoochKeyPairType)
+            .sign_and_execute(
+                existing_address,
+                action,
+                KeyPairType::RoochKeyPairType,
+                Some(password),
+            )
             .await?;
         context.assert_execute_success(result)
     }

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -151,28 +151,28 @@ impl CommandAction<()> for Init {
                 let password = rpassword::prompt_password("Enter a password to encrypt the keys in rooch keystore. Empty password leaves an unencrypted key: ").unwrap();
                 println!("Your password is {}", password);
 
-                let (new_address, phrase, key_pair_type, hashed_password, nonce, ciphertext, tag) =
-                    keystore.generate_and_add_new_key(
-                        KeyPairType::RoochKeyPairType,
-                        None,
-                        None,
-                        Some(password),
-                    )?;
+                let result = keystore.generate_and_add_new_key(
+                    KeyPairType::RoochKeyPairType,
+                    None,
+                    None,
+                    Some(password),
+                )?;
                 println!(
-                    "Generated new keypair for address with type {:?} [{new_address}]",
-                    key_pair_type.type_of()
+                    "Generated new keypair for address with type {:?} [{}]",
+                    result.result.key_pair_type.type_of(),
+                    result.address
                 );
-                println!("Secret Recovery Phrase : [{phrase}]");
+                println!("Secret Recovery Phrase : [{}]", result.result.mnemonic);
                 let dev_env = Env::new_dev_env();
                 let active_env_alias = dev_env.alias.clone();
                 ClientConfig {
                     keystore_path,
                     envs: vec![env, dev_env],
-                    password: Some(hashed_password),
-                    nonce: Some(nonce.encode_hex()),
-                    ciphertext: Some(ciphertext.encode_hex()),
-                    tag: Some(tag.encode_hex()),
-                    active_address: Some(new_address),
+                    password: Some(result.result.encryption.hashed_password),
+                    nonce: Some(result.result.encryption.nonce.encode_hex()),
+                    ciphertext: Some(result.result.encryption.ciphertext.encode_hex()),
+                    tag: Some(result.result.encryption.tag.encode_hex()),
+                    active_address: Some(result.address),
                     // make dev env as default env
                     active_env: Some(active_env_alias),
                 }

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -5,14 +5,12 @@ use crate::cli_types::{CommandAction, WalletContextOptions};
 use crate::utils::read_line;
 use async_trait::async_trait;
 use clap::Parser;
-use hex::ToHex;
 use regex::Regex;
 use rooch_config::config::Config;
 use rooch_config::server_config::ServerConfig;
 use rooch_config::{
     rooch_config_dir, ROOCH_CLIENT_CONFIG, ROOCH_KEYSTORE_FILENAME, ROOCH_SERVER_CONFIG,
 };
-use rooch_key::keypair::KeyPairType;
 use rooch_key::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use rooch_rpc_client::client_config::{ClientConfig, Env};
 use rooch_types::address::RoochAddress;
@@ -48,6 +46,7 @@ impl CommandAction<()> for Init {
             None => rooch_config_dir()?,
         };
 
+        // Rooch client config init
         let client_config_path = config_path.join(ROOCH_CLIENT_CONFIG);
 
         let keystore_path = client_config_path
@@ -81,7 +80,6 @@ impl CommandAction<()> for Init {
             );
         }
 
-        // Rooch client config init
         // Prompt user for connect to devnet fullnode if config does not exist.
         if !client_config_path.exists() {
             let env = match std::env::var_os("ROOCH_CONFIG_WITH_RPC_URL") {
@@ -140,18 +138,6 @@ impl CommandAction<()> for Init {
             };
 
             if let Some(env) = env {
-                let keystore_path = client_config_path
-                    .parent()
-                    .unwrap_or(&rooch_config_dir()?)
-                    .join(ROOCH_KEYSTORE_FILENAME);
-
-                let keystore_result =
-                    FileBasedKeystore::<RoochAddress, RoochKeyPair>::new(&keystore_path);
-                let mut keystore = match keystore_result {
-                    Ok(file_keystore) => Keystore::File(file_keystore),
-                    Err(error) => return Err(RoochError::GenerateKeyError(error.to_string())),
-                };
-
                 let password = if self.password_required == Some(false) {
                     // Use an empty password if not required
                     String::new()

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -3,12 +3,9 @@
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use crate::utils::read_line;
-use argon2::{
-    password_hash::{rand_core::OsRng, PasswordHasher, SaltString},
-    Argon2,
-};
 use async_trait::async_trait;
 use clap::Parser;
+use hex::ToHex;
 use regex::Regex;
 use rooch_config::config::Config;
 use rooch_config::server_config::ServerConfig;
@@ -154,8 +151,13 @@ impl CommandAction<()> for Init {
                 let password = rpassword::prompt_password("Enter a password to encrypt the keys in rooch keystore. Empty password leaves an unencrypted key: ").unwrap();
                 println!("Your password is {}", password);
 
-                let (new_address, phrase, key_pair_type) =
-                    keystore.generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None)?;
+                let (new_address, phrase, key_pair_type, hashed_password, nonce, ciphertext, tag) =
+                    keystore.generate_and_add_new_key(
+                        KeyPairType::RoochKeyPairType,
+                        None,
+                        None,
+                        Some(password),
+                    )?;
                 println!(
                     "Generated new keypair for address with type {:?} [{new_address}]",
                     key_pair_type.type_of()
@@ -166,7 +168,10 @@ impl CommandAction<()> for Init {
                 ClientConfig {
                     keystore_path,
                     envs: vec![env, dev_env],
-                    password: Some(password_hash),
+                    password: Some(hashed_password),
+                    nonce: Some(nonce.encode_hex()),
+                    ciphertext: Some(ciphertext.encode_hex()),
+                    tag: Some(tag.encode_hex()),
                     active_address: Some(new_address),
                     // make dev env as default env
                     active_env: Some(active_env_alias),

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -14,7 +14,6 @@ use rooch_config::{
 use rooch_key::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use rooch_rpc_client::client_config::{ClientConfig, Env};
 use rooch_types::address::RoochAddress;
-use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::RoochError;
 use rooch_types::error::RoochResult;
 use rooch_types::keypair_type::KeyPairType;
@@ -54,7 +53,7 @@ impl CommandAction<()> for Init {
             .unwrap_or(&rooch_config_dir()?)
             .join(ROOCH_KEYSTORE_FILENAME);
 
-        let keystore_result = FileBasedKeystore::<RoochAddress, RoochKeyPair>::new(&keystore_path);
+        let keystore_result = FileBasedKeystore::<RoochAddress>::new(&keystore_path);
         let mut keystore = match keystore_result {
             Ok(file_keystore) => Keystore::File(file_keystore),
             Err(error) => return Err(RoochError::GenerateKeyError(error.to_string())),

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -19,6 +19,7 @@ use rooch_types::address::RoochAddress;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::RoochError;
 use rooch_types::error::RoochResult;
+use rooch_types::keypair_type::KeyPairType;
 use std::fs;
 
 /// Tool for init with rooch
@@ -177,10 +178,6 @@ impl CommandAction<()> for Init {
                 ClientConfig {
                     keystore_path,
                     envs: vec![env, dev_env],
-                    password: Some(result.result.encryption.hashed_password),
-                    nonce: Some(result.result.encryption.nonce.encode_hex()),
-                    ciphertext: Some(result.result.encryption.ciphertext.encode_hex()),
-                    tag: Some(result.result.encryption.tag.encode_hex()),
                     active_address: Some(result.address),
                     // make dev env as default env
                     active_env: Some(active_env_alias),

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -29,7 +29,7 @@ pub struct Init {
     #[clap(short = 's', long = "server-url")]
     pub server_url: Option<String>,
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -26,7 +26,7 @@ pub struct Init {
     /// Command line input of custom server URL
     #[clap(short = 's', long = "server-url")]
     pub server_url: Option<String>,
-    /// Command line input of the optional password to encrypt key store
+    /// Command line input of the optional password for the mnemonic phrase
     #[clap(short = 'p', long = "password")]
     pub password: Option<String>,
     #[clap(flatten)]

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -27,9 +27,9 @@ pub struct Init {
     /// Command line input of custom server URL
     #[clap(short = 's', long = "server-url")]
     pub server_url: Option<String>,
-    /// Whether a password should be provided.
+    /// Whether a password should be provided
     #[clap(short = 'p', long = "password")]
-    password_required: bool,
+    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -151,12 +151,12 @@ impl CommandAction<()> for Init {
                     Err(error) => return Err(RoochError::GenerateKeyError(error.to_string())),
                 };
 
-                let password = if self.password_required {
-                    // Prompt for a password if required
-                    rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-                } else {
+                let password = if self.password_required == Some(false) {
                     // Use an empty password if not required
                     String::new()
+                } else {
+                    // Prompt for a password if required
+                    rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
                 };
                 println!("Your password is {}", password);
 

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -25,9 +25,6 @@ pub struct Init {
     /// Command line input of custom server URL
     #[clap(short = 's', long = "server-url")]
     pub server_url: Option<String>,
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -137,14 +134,12 @@ impl CommandAction<()> for Init {
             };
 
             if let Some(env) = env {
-                let password = if self.password_required == Some(false) {
-                    // Use an empty password if not required
-                    String::new()
-                } else {
-                    // Prompt for a password if required
-                    rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-                };
-                println!("Your password is {}", password);
+                // Use an empty password by default
+                let password = String::new();
+
+                // TODO design a password mechanism
+                // // Prompt for a password if required
+                // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
                 let result = keystore.generate_and_add_new_key(
                     KeyPairType::RoochKeyPairType,

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -27,6 +27,9 @@ pub struct Init {
     /// Command line input of custom server URL
     #[clap(short = 's', long = "server-url")]
     pub server_url: Option<String>,
+    /// Whether a password should be provided.
+    #[clap(short = 'p', long = "password")]
+    password_required: bool,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -148,7 +151,13 @@ impl CommandAction<()> for Init {
                     Err(error) => return Err(RoochError::GenerateKeyError(error.to_string())),
                 };
 
-                let password = rpassword::prompt_password("Enter a password to encrypt the keys in rooch keystore. Empty password leaves an unencrypted key: ").unwrap();
+                let password = if self.password_required {
+                    // Prompt for a password if required
+                    rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
+                } else {
+                    // Use an empty password if not required
+                    String::new()
+                };
                 println!("Your password is {}", password);
 
                 let result = keystore.generate_and_add_new_key(

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -77,7 +77,6 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
             // Prompt for a password if required
             rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
         };
-        println!("Your password is {}", password);
 
         let package_path = self.move_args.package_path;
         let config = self.move_args.build_config;

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -9,8 +9,8 @@ use move_bytecode_utils::dependency_graph::DependencyGraph;
 use move_bytecode_utils::Modules;
 use move_cli::Move;
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
-use rooch_key::keypair::KeyPairType;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
+use rooch_types::keypair_type::KeyPairType;
 use rooch_types::transaction::rooch::RoochTransaction;
 
 use crate::cli_types::{CommandAction, TransactionOptions, WalletContextOptions};
@@ -48,6 +48,10 @@ pub struct Publish {
     /// `moveos_std::account_storage::publish_modules_entry`
     #[clap(long, parse(from_flag))]
     pub by_move_action: bool,
+
+    /// Whether a password should be provided
+    #[clap(short = 'p', long = "password")]
+    password_required: Option<bool>,
 }
 
 impl Publish {
@@ -65,6 +69,15 @@ impl Publish {
 impl CommandAction<ExecuteTransactionResponseView> for Publish {
     async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
         let context = self.context_options.build().await?;
+
+        let password = if self.password_required == Some(false) {
+            // Use an empty password if not required
+            String::new()
+        } else {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
+        };
+        println!("Your password is {}", password);
 
         let package_path = self.move_args.package_path;
         let config = self.move_args.build_config;
@@ -144,14 +157,24 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
                 }
                 None => {
                     context
-                        .sign_and_execute(sender, action, KeyPairType::RoochKeyPairType)
+                        .sign_and_execute(
+                            sender,
+                            action,
+                            KeyPairType::RoochKeyPairType,
+                            Some(password),
+                        )
                         .await?
                 }
             }
         } else {
             let action = MoveAction::ModuleBundle(bundles);
             context
-                .sign_and_execute(sender, action, KeyPairType::RoochKeyPairType)
+                .sign_and_execute(
+                    sender,
+                    action,
+                    KeyPairType::RoochKeyPairType,
+                    Some(password),
+                )
                 .await?
         };
         context.assert_execute_success(tx_result)

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -48,10 +48,6 @@ pub struct Publish {
     /// `moveos_std::account_storage::publish_modules_entry`
     #[clap(long, parse(from_flag))]
     pub by_move_action: bool,
-
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
 }
 
 impl Publish {
@@ -70,13 +66,12 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
     async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
         let context = self.context_options.build().await?;
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        };
+        // Use an empty password by default
+        let password = String::new();
+
+        // TODO design a password mechanism
+        // // Prompt for a password if required
+        // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
         let package_path = self.move_args.package_path;
         let config = self.move_args.build_config;

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -50,7 +50,7 @@ pub struct Publish {
     pub by_move_action: bool,
 
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
 }
 

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -81,7 +81,6 @@ impl CommandAction<ExecuteTransactionResponseView> for RunFunction {
             // Prompt for a password if required
             rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
         };
-        println!("Your password is {}", password);
 
         let context = self.context.build().await?;
         let sender: RoochAddress = context

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -104,7 +104,12 @@ impl CommandAction<ExecuteTransactionResponseView> for RunFunction {
                 let tx_data = context.build_rooch_tx_data(sender, action).await?;
                 let tx = context
                     .keystore
-                    .sign_transaction_via_session_key(&sender, tx_data, &session_key)
+                    .sign_transaction_via_session_key(
+                        &sender,
+                        tx_data,
+                        &session_key,
+                        Some(password.clone()),
+                    )
                     .map_err(|e| RoochError::SignMessageError(e.to_string()))?;
                 context.execute(tx).await
             }

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -55,7 +55,7 @@ pub struct RunFunction {
     tx_options: TransactionOptions,
 
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
 }
 

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -53,10 +53,6 @@ pub struct RunFunction {
 
     #[clap(flatten)]
     tx_options: TransactionOptions,
-
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
 }
 
 #[async_trait]
@@ -74,13 +70,12 @@ impl CommandAction<ExecuteTransactionResponseView> for RunFunction {
             ));
         }
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        };
+        // Use an empty password by default
+        let password = String::new();
+
+        // TODO design a password mechanism
+        // // Prompt for a password if required
+        // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
         let context = self.context.build().await?;
         let sender: RoochAddress = context

--- a/crates/rooch/src/commands/server/commands/start.rs
+++ b/crates/rooch/src/commands/server/commands/start.rs
@@ -5,12 +5,12 @@ use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
 use rooch_config::{RoochOpt, ServerOpt};
-use rooch_key::keypair::KeyPairType;
 use rooch_key::keystore::AccountKeystore;
 use rooch_rpc_server::Service;
 use rooch_types::address::RoochAddress;
 use rooch_types::chain_id::RoochChainID;
 use rooch_types::error::{RoochError, RoochResult};
+use rooch_types::keypair_type::KeyPairType;
 use std::str::FromStr;
 use tokio::signal::ctrl_c;
 #[cfg(unix)]
@@ -25,12 +25,25 @@ pub struct StartCommand {
 
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
+
+    /// Whether a password should be provided
+    #[clap(long = "password")]
+    password_required: Option<bool>,
 }
 
 #[async_trait]
 impl CommandAction<()> for StartCommand {
     async fn execute(mut self) -> RoochResult<()> {
         let mut context = self.context_options.build().await?;
+
+        let password = if self.password_required == Some(false) {
+            // Use an empty password if not required
+            String::new()
+        } else {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to decrypt the keys in the rooch keystore. Press return to have a default password: ").unwrap()
+        };
+
         //Parse key pair from Rooch opt
         let sequencer_account = if self.opt.sequencer_account.is_none() {
             let active_address_opt = context.client_config.active_address;
@@ -50,7 +63,11 @@ impl CommandAction<()> for StartCommand {
         };
         let sequencer_keypair = context
             .keystore
-            .get_key_pair_by_key_pair_type(&sequencer_account, KeyPairType::RoochKeyPairType)
+            .get_key_pair_by_type_password(
+                &sequencer_account,
+                KeyPairType::RoochKeyPairType,
+                Some(password.clone()),
+            )
             .map_err(|e| RoochError::SequencerKeyPairDoesNotExistError(e.to_string()))?;
 
         let proposer_account = if self.opt.proposer_account.is_none() {
@@ -71,7 +88,11 @@ impl CommandAction<()> for StartCommand {
         };
         let proposer_keypair = context
             .keystore
-            .get_key_pair_by_key_pair_type(&proposer_account, KeyPairType::RoochKeyPairType)
+            .get_key_pair_by_type_password(
+                &proposer_account,
+                KeyPairType::RoochKeyPairType,
+                Some(password.clone()),
+            )
             .map_err(|e| RoochError::ProposerKeyPairDoesNotExistError(e.to_string()))?;
 
         let relayer_account = if self.opt.relayer_account.is_none() {
@@ -92,7 +113,11 @@ impl CommandAction<()> for StartCommand {
         };
         let relayer_keypair = context
             .keystore
-            .get_key_pair_by_key_pair_type(&relayer_account, KeyPairType::RoochKeyPairType)
+            .get_key_pair_by_type_password(
+                &relayer_account,
+                KeyPairType::RoochKeyPairType,
+                Some(password),
+            )
             .map_err(|e| RoochError::RelayerKeyPairDoesNotExistError(e.to_string()))?;
 
         // Construct sequencer, proposer and relayer keypair

--- a/crates/rooch/src/commands/server/commands/start.rs
+++ b/crates/rooch/src/commands/server/commands/start.rs
@@ -25,10 +25,6 @@ pub struct StartCommand {
 
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
-
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
 }
 
 #[async_trait]
@@ -36,13 +32,12 @@ impl CommandAction<()> for StartCommand {
     async fn execute(mut self) -> RoochResult<()> {
         let mut context = self.context_options.build().await?;
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to decrypt the keys in the rooch keystore. Press return to have a default password: ").unwrap()
-        };
+        // Use an empty password by default
+        let password = String::new();
+
+        // TODO design a password mechanism
+        // // Prompt for a password if required
+        // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
         //Parse key pair from Rooch opt
         let sequencer_account = if self.opt.sequencer_account.is_none() {

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -4,11 +4,12 @@
 use crate::cli_types::{TransactionOptions, WalletContextOptions};
 use clap::Parser;
 use moveos_types::module_binding::MoveFunctionCaller;
-use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
+use rooch_key::keystore::AccountKeystore;
 use rooch_types::{
     address::RoochAddress,
     error::{RoochError, RoochResult},
     framework::session_key::{SessionKey, SessionKeyModule, SessionScope},
+    keypair_type::KeyPairType,
 };
 
 /// Create a new session key on-chain
@@ -25,6 +26,10 @@ pub struct CreateCommand {
     #[clap(long, default_value = "3600")]
     pub max_inactive_interval: u64,
 
+    /// Whether a password should be provided
+    #[clap(short = 'p', long = "password")]
+    password_required: Option<bool>,
+
     #[clap(flatten)]
     pub tx_options: TransactionOptions,
 
@@ -35,6 +40,15 @@ pub struct CreateCommand {
 impl CreateCommand {
     pub async fn execute(self) -> RoochResult<SessionKey> {
         let mut context = self.context_options.build().await?;
+
+        let password = if self.password_required == Some(false) {
+            // Use an empty password if not required
+            String::new()
+        } else {
+            // Prompt for a password if required
+            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
+        };
+        println!("Your password is {}", password);
 
         if self.tx_options.sender_account.is_none() {
             return Err(RoochError::CommandArgumentError(
@@ -59,7 +73,12 @@ impl CreateCommand {
         println!("Generated new session key {session_auth_key} for address [{sender}]",);
 
         let result = context
-            .sign_and_execute(sender, action, KeyPairType::RoochKeyPairType)
+            .sign_and_execute(
+                sender,
+                action,
+                KeyPairType::RoochKeyPairType,
+                Some(password),
+            )
             .await?;
         context.assert_execute_success(result)?;
         let client = context.get_client().await?;

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -59,7 +59,9 @@ impl CreateCommand {
             .parse_account_arg(self.tx_options.sender_account.unwrap())?
             .into();
 
-        let session_auth_key = context.keystore.generate_session_key(&sender)?;
+        let session_auth_key = context
+            .keystore
+            .generate_session_key(&sender, Some(password.clone()))?;
 
         let session_scope = self.scope;
 

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -27,7 +27,7 @@ pub struct CreateCommand {
     pub max_inactive_interval: u64,
 
     /// Whether a password should be provided
-    #[clap(short = 'p', long = "password")]
+    #[clap(long = "password")]
     password_required: Option<bool>,
 
     #[clap(flatten)]

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -26,10 +26,6 @@ pub struct CreateCommand {
     #[clap(long, default_value = "3600")]
     pub max_inactive_interval: u64,
 
-    /// Whether a password should be provided
-    #[clap(long = "password")]
-    password_required: Option<bool>,
-
     #[clap(flatten)]
     pub tx_options: TransactionOptions,
 
@@ -41,14 +37,12 @@ impl CreateCommand {
     pub async fn execute(self) -> RoochResult<SessionKey> {
         let mut context = self.context_options.build().await?;
 
-        let password = if self.password_required == Some(false) {
-            // Use an empty password if not required
-            String::new()
-        } else {
-            // Prompt for a password if required
-            rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
-        };
-        println!("Your password is {}", password);
+        // Use an empty password by default
+        let password = String::new();
+
+        // TODO design a password mechanism
+        // // Prompt for a password if required
+        // rpassword::prompt_password("Enter a password to encrypt the keys in the rooch keystore. Press return to have an empty value: ").unwrap()
 
         if self.tx_options.sender_account.is_none() {
             return Err(RoochError::CommandArgumentError(

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -1,7 +1,7 @@
 Feature: Rooch CLI integration tests
     @serial
     Scenario: Init
-      Then cmd: "init --password false"
+      Then cmd: "init"
       Then cmd: "env switch --alias local"
 
 
@@ -10,28 +10,28 @@ Feature: Rooch CLI integration tests
       Given a server for account
 
       Then cmd: "object --id {default}"
-      Then cmd: "account create --password false"
-      Then cmd: "account list --password false"
-      Then cmd: "account import --mnemonic-phrase "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit" --password false"
-      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young" --password false"
-      Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --password false"
+      Then cmd: "account create"
+      Then cmd: "account list"
+      Then cmd: "account import --mnemonic-phrase "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit""
+      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
+      Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce"
 
       # session key
-      Then cmd: "session-key create --sender-account {default} --scope 0x3::empty::empty --password false"
-      Then cmd: "move run --function 0x3::empty::empty --sender-account {default} --session-key {{$.session-key[-1].authentication_key}} --password false"
+      Then cmd: "session-key create --sender-account {default} --scope 0x3::empty::empty"
+      Then cmd: "move run --function 0x3::empty::empty --sender-account {default} --session-key {{$.session-key[-1].authentication_key}}"
 
       # transaction
       Then cmd: "transaction get-transactions-by-order --cursor 0 --limit 1"
       Then cmd: "transaction get-transactions-by-hashes --hashes {{$.transaction[-1].data[0].execution_info.tx_hash}}"
 
       # event example
-      Then cmd: "move publish -p ../../examples/event --sender-account {default} --named-addresses rooch_examples={default} --password false"
-      Then cmd: "move run --function {default}::event_test::emit_event --sender-account {default} --args 10u64 --password false"
+      Then cmd: "move publish -p ../../examples/event --sender-account {default} --named-addresses rooch_examples={default}"
+      Then cmd: "move run --function {default}::event_test::emit_event --sender-account {default} --args 10u64"
       Then cmd: "event get-events-by-event-handle --event_handle_type {default}::event_test::WithdrawEvent --cursor 0 --limit 1"
 
       # account balance
-      Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default} --password false"
-      Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default} --password false"
+      Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default}"
+      Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default}"
       Then cmd: "account balance"
       Then cmd: "account balance --coin-type {default}::fixed_supply_coin::FSC"
 
@@ -40,7 +40,7 @@ Feature: Rooch CLI integration tests
     @serial
     Scenario: kv store example
       Given a server for kv_store
-      Then cmd: "move publish -p ../../examples/kv_store --sender-account {default} --named-addresses rooch_examples={default} --password false"
+      Then cmd: "move publish -p ../../examples/kv_store --sender-account {default} --named-addresses rooch_examples={default}"
       #FIXME how to pass args at here.
       #Then cmd: "move run --function {default}::kv_store::add_value --args 'b\"key1\"' 'b\"value1\"' --sender-account default"
       #Then cmd: "move view --function {default}::kv_store::get_value --args 'b\"key1\"' "
@@ -56,26 +56,26 @@ Feature: Rooch CLI integration tests
     Scenario: entry function example
       Given a server for entry_function
 
-      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default} --password false"
-      Then cmd: "move run --function {default}::entry_function::emit_bool --args bool:true --sender-account {default} --password false"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default}"
+      Then cmd: "move run --function {default}::entry_function::emit_bool --args bool:true --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_u8 --args u8:3 --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_u8 --args u8:3 --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_u8 --args 4u8 --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_u8 --args 4u8 --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_address --args address:0x3242 --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_address --args address:0x3242 --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_address --args @0x3242 --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_address --args @0x3242 --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_object_id --args object_id:0x3134 --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_object_id --args object_id:0x3134 --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_string --args string:world --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_string --args string:world --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_vec_u8 --args "vector<u8>:2,3,4" --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_vec_u8 --args "vector<u8>:2,3,4" --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_vec_object_id --args "vector<address>:0x1324,0x41234,0x1234" --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_vec_object_id --args "vector<address>:0x1324,0x41234,0x1234" --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
       Then stop the server
@@ -85,24 +85,24 @@ Feature: Rooch CLI integration tests
       Given a server for publish_through_move_action
 
       # The counter example
-      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default} --by-move-action --password false"
+      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default} --by-move-action"
       Then cmd: "move view --function {default}::counter::value"
       Then assert: "{{$.move[-1].return_values[0].move_value}} == 0"
-      Then cmd: "move run --function {default}::counter::increase --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::counter::increase --sender-account {default}"
       Then cmd: "move view --function {default}::counter::value"
       Then assert: "{{$.move[-1].return_values[0].move_value}} == 1"
       Then cmd: "resource --address {default} --resource {default}::counter::Counter"
       Then assert: "{{$.resource[-1].move_value.value.value}} == 1"
 
       # The entry_function_arguments example
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action --password false"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
       Then assert: ""{{$.move[-1]}}" contains FUNCTION_RESOLUTION_FAILURE"
-      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action --password false"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
       Then assert: "{{$.move[-1].output.status.type}} == executed"
       # check compatibility
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action --password false"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action"
       Then assert: ""{{$.move[-1]}}" contains MiscellaneousError"
 
       Then stop the server
@@ -112,25 +112,25 @@ Feature: Rooch CLI integration tests
       Given a server for publish_through_entry_function
 
       # The counter example
-      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default} --password false"
+      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default}"
       Then cmd: "move view --function {default}::counter::value"
       Then assert: "{{$.move[-1].return_values[0].move_value}} == 0"
-      Then cmd: "move run --function {default}::counter::increase --sender-account {default} --password false"
+      Then cmd: "move run --function {default}::counter::increase --sender-account {default}"
       Then cmd: "move view --function {default}::counter::value"
       Then assert: "{{$.move[-1].return_values[0].move_value}} == 1"
       Then cmd: "resource --address {default} --resource {default}::counter::Counter"
       Then assert: "{{$.resource[-1].move_value.value.value}} == 1"
 
       # The entry_function_arguments example
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --password false"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default}"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
       Then assert: ""{{$.move[-1]}}" contains FUNCTION_RESOLUTION_FAILURE"
-      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default} --password false"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default}"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
       Then assert: "{{$.move[-1].output.status.type}} == executed"
 
       # check compatibility
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --password false"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default}"
       Then assert: ""{{$.move[-1]}}" contains MiscellaneousError"
 
       Then stop the server
@@ -138,11 +138,11 @@ Feature: Rooch CLI integration tests
  @serial
     Scenario: coins example
       Given a server for coins
-      Then cmd: "account create --password false"
-      Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default} --password false"
-      Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default} --password false"
+      Then cmd: "account create"
+      Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default}"
+      Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default}"
       #TODO change the argument `0x3` address to a user account
-      Then cmd: "move run --function 0x3::coin::transfer_entry --type-args {default}::fixed_supply_coin::FSC --args address:0x3  --args 1u256 --sender-account {default} --password false"
+      Then cmd: "move run --function 0x3::coin::transfer_entry --type-args {default}::fixed_supply_coin::FSC --args address:0x3  --args 1u256 --sender-account {default}"
 
       Then stop the server
 

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -11,29 +11,27 @@ Feature: Rooch CLI integration tests
 
       Then cmd: "object --id {default}"
       Then cmd: "account create --password false"
-      Then cmd: "account list"
+      Then cmd: "account list --password false"
       Then cmd: "account import --mnemonic-phrase "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit" --password false"
       Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young" --password false"
-      #Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young" --password false"
-      Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce"
-      #Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce"
+      Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --password false"
 
       # session key
-      Then cmd: "session-key create --sender-account {default} --scope 0x3::empty::empty"
-      Then cmd: "move run --function 0x3::empty::empty --sender-account {default} --session-key {{$.session-key[-1].authentication_key}}"
+      Then cmd: "session-key create --sender-account {default} --scope 0x3::empty::empty --password false"
+      Then cmd: "move run --function 0x3::empty::empty --sender-account {default} --session-key {{$.session-key[-1].authentication_key}} --password false"
 
       # transaction
       Then cmd: "transaction get-transactions-by-order --cursor 0 --limit 1"
       Then cmd: "transaction get-transactions-by-hashes --hashes {{$.transaction[-1].data[0].execution_info.tx_hash}}"
 
       # event example
-      Then cmd: "move publish -p ../../examples/event --sender-account {default} --named-addresses rooch_examples={default}"
-      Then cmd: "move run --function {default}::event_test::emit_event --sender-account {default} --args 10u64"
+      Then cmd: "move publish -p ../../examples/event --sender-account {default} --named-addresses rooch_examples={default} --password false"
+      Then cmd: "move run --function {default}::event_test::emit_event --sender-account {default} --args 10u64 --password false"
       Then cmd: "event get-events-by-event-handle --event_handle_type {default}::event_test::WithdrawEvent --cursor 0 --limit 1"
 
       # account balance
-      Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default}"
-      Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default}"
+      Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default} --password false"
+      Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default} --password false"
       Then cmd: "account balance"
       Then cmd: "account balance --coin-type {default}::fixed_supply_coin::FSC"
 
@@ -42,7 +40,7 @@ Feature: Rooch CLI integration tests
     @serial
     Scenario: kv store example
       Given a server for kv_store
-      Then cmd: "move publish -p ../../examples/kv_store --sender-account {default} --named-addresses rooch_examples={default}"
+      Then cmd: "move publish -p ../../examples/kv_store --sender-account {default} --named-addresses rooch_examples={default} --password false"
       #FIXME how to pass args at here.
       #Then cmd: "move run --function {default}::kv_store::add_value --args 'b\"key1\"' 'b\"value1\"' --sender-account default"
       #Then cmd: "move view --function {default}::kv_store::get_value --args 'b\"key1\"' "
@@ -58,26 +56,26 @@ Feature: Rooch CLI integration tests
     Scenario: entry function example
       Given a server for entry_function
 
-      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default}"
-      Then cmd: "move run --function {default}::entry_function::emit_bool --args bool:true --sender-account {default}"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_bool --args bool:true --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_u8 --args u8:3 --sender-account {default}"
+      Then cmd: "move run --function {default}::entry_function::emit_u8 --args u8:3 --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_u8 --args 4u8 --sender-account {default}"
+      Then cmd: "move run --function {default}::entry_function::emit_u8 --args 4u8 --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_address --args address:0x3242 --sender-account {default}"
+      Then cmd: "move run --function {default}::entry_function::emit_address --args address:0x3242 --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_address --args @0x3242 --sender-account {default}"
+      Then cmd: "move run --function {default}::entry_function::emit_address --args @0x3242 --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_object_id --args object_id:0x3134 --sender-account {default}"
+      Then cmd: "move run --function {default}::entry_function::emit_object_id --args object_id:0x3134 --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_string --args string:world --sender-account {default}"
+      Then cmd: "move run --function {default}::entry_function::emit_string --args string:world --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_vec_u8 --args "vector<u8>:2,3,4" --sender-account {default}"
+      Then cmd: "move run --function {default}::entry_function::emit_vec_u8 --args "vector<u8>:2,3,4" --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_vec_object_id --args "vector<address>:0x1324,0x41234,0x1234" --sender-account {default}"
+      Then cmd: "move run --function {default}::entry_function::emit_vec_object_id --args "vector<address>:0x1324,0x41234,0x1234" --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
       Then stop the server
@@ -87,24 +85,24 @@ Feature: Rooch CLI integration tests
       Given a server for publish_through_move_action
 
       # The counter example
-      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default} --by-move-action"
+      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default} --by-move-action --password false"
       Then cmd: "move view --function {default}::counter::value"
       Then assert: "{{$.move[-1].return_values[0].move_value}} == 0"
-      Then cmd: "move run --function {default}::counter::increase --sender-account {default}"
+      Then cmd: "move run --function {default}::counter::increase --sender-account {default} --password false"
       Then cmd: "move view --function {default}::counter::value"
       Then assert: "{{$.move[-1].return_values[0].move_value}} == 1"
       Then cmd: "resource --address {default} --resource {default}::counter::Counter"
       Then assert: "{{$.resource[-1].move_value.value.value}} == 1"
 
       # The entry_function_arguments example
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
       Then assert: ""{{$.move[-1]}}" contains FUNCTION_RESOLUTION_FAILURE"
-      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
       Then assert: "{{$.move[-1].output.status.type}} == executed"
       # check compatibility
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --by-move-action --password false"
       Then assert: ""{{$.move[-1]}}" contains MiscellaneousError"
 
       Then stop the server
@@ -114,25 +112,25 @@ Feature: Rooch CLI integration tests
       Given a server for publish_through_entry_function
 
       # The counter example
-      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default}"
+      Then cmd: "move publish -p ../../examples/counter --sender-account {default} --named-addresses rooch_examples={default} --password false"
       Then cmd: "move view --function {default}::counter::value"
       Then assert: "{{$.move[-1].return_values[0].move_value}} == 0"
-      Then cmd: "move run --function {default}::counter::increase --sender-account {default}"
+      Then cmd: "move run --function {default}::counter::increase --sender-account {default} --password false"
       Then cmd: "move view --function {default}::counter::value"
       Then assert: "{{$.move[-1].return_values[0].move_value}} == 1"
       Then cmd: "resource --address {default} --resource {default}::counter::Counter"
       Then assert: "{{$.resource[-1].move_value.value.value}} == 1"
 
       # The entry_function_arguments example
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default}"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
       Then assert: ""{{$.move[-1]}}" contains FUNCTION_RESOLUTION_FAILURE"
-      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default}"
-      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default}"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments/ --sender-account {default} --named-addresses rooch_examples={default} --password false"
+      Then cmd: "move run --function {default}::entry_function::emit_mix --args 3u8 "vector<object_id>:0x2342,0x3132" --sender-account {default} --password false"
       Then assert: "{{$.move[-1].output.status.type}} == executed"
 
       # check compatibility
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default}"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/ --sender-account {default} --named-addresses rooch_examples={default} --password false"
       Then assert: ""{{$.move[-1]}}" contains MiscellaneousError"
 
       Then stop the server
@@ -141,10 +139,10 @@ Feature: Rooch CLI integration tests
     Scenario: coins example
       Given a server for coins
       Then cmd: "account create --password false"
-      Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default}"
-      Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default}"
+      Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default} --password false"
+      Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default} --password false"
       #TODO change the argument `0x3` address to a user account
-      Then cmd: "move run --function 0x3::coin::transfer_entry --type-args {default}::fixed_supply_coin::FSC --args address:0x3  --args 1u256 --sender-account {default}"
+      Then cmd: "move run --function 0x3::coin::transfer_entry --type-args {default}::fixed_supply_coin::FSC --args address:0x3  --args 1u256 --sender-account {default} --password false"
 
       Then stop the server
 

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -1,7 +1,7 @@
 Feature: Rooch CLI integration tests
     @serial
     Scenario: Init
-      Then cmd: "init -p false"
+      Then cmd: "init --password false"
       Then cmd: "env switch --alias local"
 
 
@@ -10,11 +10,11 @@ Feature: Rooch CLI integration tests
       Given a server for account
 
       Then cmd: "object --id {default}"
-      Then cmd: "account create -p false"
+      Then cmd: "account create --password false"
       Then cmd: "account list"
-      Then cmd: "account import --mnemonic-phrase "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit" -p false"
-      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young" -p false"
-      #Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young" -p false"
+      Then cmd: "account import --mnemonic-phrase "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit" --password false"
+      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young" --password false"
+      #Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young" --password false"
       Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce"
       #Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce"
 
@@ -140,7 +140,7 @@ Feature: Rooch CLI integration tests
  @serial
     Scenario: coins example
       Given a server for coins
-      Then cmd: "account create"
+      Then cmd: "account create --password false"
       Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default}"
       Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default}"
       #TODO change the argument `0x3` address to a user account

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -1,7 +1,7 @@
 Feature: Rooch CLI integration tests
     @serial
     Scenario: Init
-      Then cmd: "init"
+      Then cmd: "init -p false"
       Then cmd: "env switch --alias local"
 
 
@@ -10,11 +10,11 @@ Feature: Rooch CLI integration tests
       Given a server for account
 
       Then cmd: "object --id {default}"
-      Then cmd: "account create"
+      Then cmd: "account create -p false"
       Then cmd: "account list"
-      Then cmd: "account import --mnemonic-phrase "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit""
-      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
-      #Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young""
+      Then cmd: "account import --mnemonic-phrase "fiber tube acid imitate frost coffee choose crowd grass topple donkey submit" -p false"
+      Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young" -p false"
+      #Then cmd: "account update --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce --mnemonic-phrase "spike air embody solid upper grow mule slender shrimp suggest pride young" -p false"
       Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce"
       #Then cmd: "account nullify --address 0xebf29d2aed4da3d2e13a32d71266a302fbfd5ceb3ff1f465c006fa207f1789ce"
 


### PR DESCRIPTION
## Summary

1. Add encryption algorithm `ChaCha20Poly1305` to encrypt the key pair.
2. Add password encryption algorithm `Argon2id` to encrypt password in plaintext and use input password compared with cipher password.
3. Decryption takes `nonce`, `ciphertext`, `tag`, `password` from key store to compare with input password and if successful, retrieve the private key and form a key pair to sign transactions.

ChaCha20Poly1305 is a standardized encryption algorithm (AEAD) widely used by network softwares:

1. https://en.wikipedia.org/wiki/ChaCha20-Poly1305
2. https://datatracker.ietf.org/doc/html/rfc7539

Argon2id is a password encryption algorithm recommended by OWASP in their recent document:

https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html

- Closes #854 and closes #855