### PR TITLE
[rpc] Implement `eth_getBalance`

### DIFF
--- a/crates/rooch-framework/doc/gas_coin.md
+++ b/crates/rooch-framework/doc/gas_coin.md
@@ -29,7 +29,7 @@ This module defines Rooch Gas Coin.
 
 
 
-<pre><code><b>struct</b> <a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a> <b>has</b> key
+<pre><code><b>struct</b> <a href="gas_coin.md#0x3_gas_coin_GasCoin">GasCoin</a> <b>has</b> store, key
 </code></pre>
 
 

--- a/crates/rooch-framework/sources/gas_coin.move
+++ b/crates/rooch-framework/sources/gas_coin.move
@@ -8,7 +8,9 @@ module rooch_framework::gas_coin {
     friend rooch_framework::genesis;
     friend rooch_framework::transaction_validator;
 
-    struct GasCoin has key {}
+    //TODO should we allow user to transfer gas coin?
+    //If not, we can remove `store` ability from GasCoin.
+    struct GasCoin has key, store {}
 
     public fun balance(ctx: &StorageContext, addr: address): u256 {
         coin::balance<GasCoin>(ctx, addr)

--- a/crates/rooch-rpc-client/src/lib.rs
+++ b/crates/rooch-rpc-client/src/lib.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::{
+    core::client::ClientT,
+    http_client::{HttpClient, HttpClientBuilder},
+};
 use moveos_types::{
     access_path::AccessPath,
     function_return_value::FunctionResult,
@@ -205,6 +208,14 @@ impl Client {
             .http
             .get_balances(account_addr, coin_type, cursor, limit)
             .await?)
+    }
+
+    pub async fn request(
+        &self,
+        method: &str,
+        params: Vec<serde_json::Value>,
+    ) -> Result<serde_json::Value> {
+        Ok(self.rpc.http.request(method, params).await?)
     }
 }
 

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -269,8 +269,11 @@ pub async fn run_start_server(opt: &RoochOpt) -> Result<ServerHandle> {
     ))?;
     rpc_module_builder.register_module(WalletServer::new(rpc_service.clone()))?;
 
-    rpc_module_builder
-        .register_module(EthServer::new(chain_id_opt.chain_id(), rpc_service.clone()))?;
+    rpc_module_builder.register_module(EthServer::new(
+        chain_id_opt.chain_id(),
+        rpc_service.clone(),
+        aggregate_service.clone(),
+    ))?;
 
     // let rpc_api = build_rpc_api(rpc_api);
     let methods_names = rpc_module_builder.module.method_names().collect::<Vec<_>>();

--- a/crates/rooch-rpc-server/src/service/aggregate_service.rs
+++ b/crates/rooch-rpc-server/src/service/aggregate_service.rs
@@ -127,6 +127,9 @@ impl AggregateService {
                     result.push(Some(v))
                 }
             };
+        } else {
+            // If the account do not exist, return None
+            result.push(None)
         }
 
         for (_key, balance_info) in result.iter_mut().flatten() {

--- a/crates/rooch-types/src/framework/gas_coin.rs
+++ b/crates/rooch-types/src/framework/gas_coin.rs
@@ -1,0 +1,15 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::{ident_str, identifier::IdentStr};
+use moveos_types::state::MoveStructType;
+
+pub const MODULE_NAME: &IdentStr = ident_str!("gas_coin");
+
+#[derive(Debug, Clone)]
+pub struct GasCoin;
+
+impl MoveStructType for GasCoin {
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("GasCoin");
+}

--- a/crates/rooch-types/src/framework/mod.rs
+++ b/crates/rooch-types/src/framework/mod.rs
@@ -15,6 +15,7 @@ pub mod empty;
 pub mod ethereum_address;
 pub mod ethereum_light_client;
 pub mod ethereum_validator;
+pub mod gas_coin;
 pub mod genesis;
 pub mod native_validator;
 pub mod session_key;

--- a/crates/rooch/src/commands/mod.rs
+++ b/crates/rooch/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod init;
 pub mod move_cli;
 pub mod object;
 pub mod resource;
+pub mod rpc;
 pub mod server;
 pub mod session_key;
 pub mod state;

--- a/crates/rooch/src/commands/rpc/commands/mod.rs
+++ b/crates/rooch/src/commands/rpc/commands/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod request;

--- a/crates/rooch/src/commands/rpc/commands/request.rs
+++ b/crates/rooch/src/commands/rpc/commands/request.rs
@@ -1,0 +1,41 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::{CommandAction, WalletContextOptions};
+use async_trait::async_trait;
+use clap::Parser;
+use rooch_types::error::RoochResult;
+
+/// Send a RPC request
+#[derive(Debug, Parser)]
+pub struct RequestCommand {
+    /// The RPC method name
+    /// --method rooch_getAnnotatedStates
+    #[clap(long)]
+    pub method: String,
+
+    /// The RPC method params, json value.
+    /// --params '"/resource/0x3/0x3::timestamp::CurrentTimeMicroseconds"'
+    /// or
+    /// --params '["/resource/0x3/0x3::timestamp::CurrentTimeMicroseconds"]'
+    #[clap(long)]
+    pub params: Option<serde_json::Value>,
+
+    #[clap(flatten)]
+    pub(crate) context_options: WalletContextOptions,
+}
+
+#[async_trait]
+impl CommandAction<serde_json::Value> for RequestCommand {
+    async fn execute(self) -> RoochResult<serde_json::Value> {
+        let client = self.context_options.build().await?.get_client().await?;
+        let params = match self.params {
+            Some(serde_json::Value::Array(array)) => array,
+            Some(value) => {
+                vec![value]
+            }
+            None => vec![],
+        };
+        Ok(client.request(self.method.as_str(), params).await?)
+    }
+}

--- a/crates/rooch/src/commands/rpc/mod.rs
+++ b/crates/rooch/src/commands/rpc/mod.rs
@@ -1,0 +1,31 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use async_trait::async_trait;
+use clap::Parser;
+use commands::request::RequestCommand;
+use rooch_types::error::RoochResult;
+
+pub mod commands;
+
+#[derive(Parser)]
+pub struct Rpc {
+    #[clap(subcommand)]
+    cmd: RpcCommand,
+}
+
+#[async_trait]
+impl CommandAction<String> for Rpc {
+    async fn execute(self) -> RoochResult<String> {
+        match self.cmd {
+            RpcCommand::Request(request) => request.execute_serialized().await,
+        }
+    }
+}
+
+#[derive(clap::Subcommand)]
+#[clap(name = "server")]
+pub enum RpcCommand {
+    Request(RequestCommand),
+}

--- a/crates/rooch/src/lib.rs
+++ b/crates/rooch/src/lib.rs
@@ -5,8 +5,8 @@ use crate::commands::event::EventCommand;
 use cli_types::CommandAction;
 use commands::{
     abi::ABI, account::Account, dashboard::Dashboard, env::Env, init::Init, move_cli::MoveCli,
-    object::ObjectCommand, resource::ResourceCommand, server::Server, session_key::SessionKey,
-    state::StateCommand, transaction::Transaction,
+    object::ObjectCommand, resource::ResourceCommand, rpc::Rpc, server::Server,
+    session_key::SessionKey, state::StateCommand, transaction::Transaction,
 };
 use rooch_types::error::RoochResult;
 
@@ -39,6 +39,7 @@ pub enum Command {
     ABI(ABI),
     Env(Env),
     SessionKey(SessionKey),
+    Rpc(Rpc),
 }
 
 pub async fn run_cli(opt: RoochCli) -> RoochResult<String> {
@@ -56,5 +57,6 @@ pub async fn run_cli(opt: RoochCli) -> RoochResult<String> {
         Command::ABI(abi) => abi.execute().await,
         Command::Env(env) => env.execute().await,
         Command::SessionKey(session_key) => session_key.execute().await,
+        Command::Rpc(rpc) => rpc.execute().await,
     }
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -143,3 +143,11 @@ Feature: Rooch CLI integration tests
       Then cmd: "move run --function 0x3::coin::transfer_entry --type-args {default}::fixed_supply_coin::FSC --args address:0x3  --args 1u256 --sender-account {default}"
     
       Then stop the server
+
+  @serial
+    Scenario: rpc test
+      Given a server for rpc
+      Then cmd: "rpc request --method eth_getBalance --params \"0x1111111111111111111111111111111111111111\"" 
+      Then assert: "{{$.rpc[-1]}} == 0x0"
+
+      Then stop the server

--- a/crates/testsuite/tests/integration.rs
+++ b/crates/testsuite/tests/integration.rs
@@ -155,7 +155,7 @@ fn split_string_with_quotes(s: &str) -> Result<Vec<String>> {
                 if in_escape {
                     current.push(c);
                     in_escape = false;
-                }else{
+                } else {
                     // Skip the quote
                     in_quotes = !in_quotes;
                 }

--- a/crates/testsuite/tests/integration.rs
+++ b/crates/testsuite/tests/integration.rs
@@ -100,7 +100,7 @@ async fn assert_output(world: &mut World, args: String) {
     assert!(world.tpl_ctx.is_some(), "tpl_ctx is none");
     let args = eval_command_args(world.tpl_ctx.as_ref().unwrap(), args);
     let parameters = split_string_with_quotes(&args).expect("Invalid commands");
-
+    info!("parameters: {:?}", parameters);
     for chunk in parameters.chunks(3) {
         let first = chunk.get(0).cloned();
         let op = chunk.get(1).cloned();
@@ -130,10 +130,10 @@ async fn assert_output(world: &mut World, args: String) {
 }
 
 fn eval_command_args(ctx: &TemplateContext, args: String) -> String {
-    // info!("args: {}", args);
-    let args = args.replace("\\\"", "\"");
+    //info!("args: {}", args);
+    //let args = args.replace("\\\"", "\"");
     let eval_args = jpst::format_str!(&args, ctx);
-    // info!("eval args:{}", eval_args);
+    //info!("eval args:{}", eval_args);
     eval_args
 }
 
@@ -144,12 +144,21 @@ fn split_string_with_quotes(s: &str) -> Result<Vec<String>> {
     let mut chars = s.chars().peekable();
     let mut current = String::new();
     let mut in_quotes = false;
+    let mut in_escape = false;
 
     while let Some(c) = chars.next() {
         match c {
+            '\\' => {
+                in_escape = true;
+            }
             '"' => {
-                in_quotes = !in_quotes;
-                // Skip the quote
+                if in_escape {
+                    current.push(c);
+                    in_escape = false;
+                }else{
+                    // Skip the quote
+                    in_quotes = !in_quotes;
+                }
             }
             ' ' if !in_quotes => {
                 if !current.is_empty() {


### PR DESCRIPTION
## Summary

1. Implement `eth_getBalance` API, and return GasCoin as balance. If the account does not exist, return zero("0x0").
2. Add `store` to GasCoin, allow public transfer GasCoin.
3. Add `rooch rpc request` command for rpc test.
4. Improve integration test for supporting escape string in the arguments.


- Closes #765 