### PR TITLE
[ETH&GasCoin] Fix some MetaMask compatibility issue

### DIFF
--- a/crates/rooch-framework/doc/gas_coin.md
+++ b/crates/rooch-framework/doc/gas_coin.md
@@ -166,7 +166,8 @@ TODO find a way to protect this function from DOS attack.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="gas_coin.md#0x3_gas_coin_faucet_entry">faucet_entry</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
-    <b>let</b> amount = 1_0000_0000u256;
+    //100 RGC
+    <b>let</b> amount = 100_000_000_000_000_000_000u256;
     <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     <a href="gas_coin.md#0x3_gas_coin_faucet">faucet</a>(ctx, addr, amount);
 }
@@ -197,7 +198,7 @@ Can only called during genesis to initialize the Rooch coin.
         ctx,
         <a href="_utf8">string::utf8</a>(b"Rooch Gas Coin"),
         <a href="_utf8">string::utf8</a>(b"RGC"),
-        9, // decimals
+        18, // decimals
     );
 }
 </code></pre>

--- a/crates/rooch-framework/sources/gas_coin.move
+++ b/crates/rooch-framework/sources/gas_coin.move
@@ -47,7 +47,8 @@ module rooch_framework::gas_coin {
 
     /// TODO find a way to protect this function from DOS attack.
     public entry fun faucet_entry(ctx: &mut StorageContext, account: &signer) {
-        let amount = 1_0000_0000u256;
+        //100 RGC
+        let amount = 100_000_000_000_000_000_000u256;
         let addr = signer::address_of(account);
         faucet(ctx, addr, amount);
     }
@@ -58,7 +59,7 @@ module rooch_framework::gas_coin {
             ctx,
             string::utf8(b"Rooch Gas Coin"),
             string::utf8(b"RGC"),
-            9, // decimals
+            18, // decimals
         );
     }
 

--- a/crates/rooch-framework/sources/transaction_validator.move
+++ b/crates/rooch-framework/sources/transaction_validator.move
@@ -122,7 +122,8 @@ module rooch_framework::transaction_validator {
             // Auto get gas coin from faucet if not enough
             // TODO remove this after we provide the gas faucet
             let max_gas_amount = storage_context::max_gas_amount(ctx);
-            let init_gas = (max_gas_amount as u256) * 100u256;
+            //100 RGC
+            let init_gas = 100_000_000_000_000_000_000u256;
             gas_coin::faucet(ctx, sender, init_gas); 
         };
         //the transaction validator will put the multi chain address into the context

--- a/crates/rooch-framework/sources/transaction_validator.move
+++ b/crates/rooch-framework/sources/transaction_validator.move
@@ -121,7 +121,6 @@ module rooch_framework::transaction_validator {
             account::create_account(ctx, sender);
             // Auto get gas coin from faucet if not enough
             // TODO remove this after we provide the gas faucet
-            let max_gas_amount = storage_context::max_gas_amount(ctx);
             //100 RGC
             let init_gas = 100_000_000_000_000_000_000u256;
             gas_coin::faucet(ctx, sender, init_gas); 

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -92,6 +92,13 @@ impl RpcService {
         self.executor.get_states(access_path).await
     }
 
+    pub async fn exists_account(&self, address: AccountAddress) -> Result<bool> {
+        let mut resp = self
+            .get_states(AccessPath::resource(address, Account::struct_tag()))
+            .await?;
+        Ok(resp.pop().flatten().is_some())
+    }
+
     pub async fn get_annotated_states(
         &self,
         access_path: AccessPath,

--- a/crates/rooch-types/src/framework/gas_coin.rs
+++ b/crates/rooch-types/src/framework/gas_coin.rs
@@ -1,10 +1,11 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{ident_str, identifier::IdentStr};
+use move_core_types::{ident_str, identifier::IdentStr, u256::U256};
 use moveos_types::state::MoveStructType;
 
 pub const MODULE_NAME: &IdentStr = ident_str!("gas_coin");
+pub const DECIMALS: u8 = 18;
 
 #[derive(Debug, Clone)]
 pub struct GasCoin;
@@ -12,4 +13,10 @@ pub struct GasCoin;
 impl MoveStructType for GasCoin {
     const MODULE_NAME: &'static IdentStr = MODULE_NAME;
     const STRUCT_NAME: &'static IdentStr = ident_str!("GasCoin");
+}
+
+impl GasCoin {
+    pub fn scaling<I: Into<U256>>(value: I) -> U256 {
+        U256::from(10u64.pow(DECIMALS as u32)) * value.into()
+    }
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -148,6 +148,6 @@ Feature: Rooch CLI integration tests
     Scenario: rpc test
       Given a server for rpc
       Then cmd: "rpc request --method eth_getBalance --params \"0x1111111111111111111111111111111111111111\"" 
-      Then assert: "{{$.rpc[-1]}} == 0x0"
+      Then assert: "{{$.rpc[-1]}} == 0x56bc75e2d63100000"
 
       Then stop the server


### PR DESCRIPTION
## Summary

1. GasCoin decimals to 18.
2. If an account does not exist, return a default balance.

- Closes #issue