### PR TITLE
[Framework] Support transfer coin to multichain address

### DIFF
--- a/crates/rooch-framework/doc/README.md
+++ b/crates/rooch-framework/doc/README.md
@@ -34,6 +34,7 @@ This is the reference documentation of the Rooch Framework.
 -  [`0x3::gas_coin`](gas_coin.md#0x3_gas_coin)
 -  [`0x3::genesis`](genesis.md#0x3_genesis)
 -  [`0x3::hash`](hash.md#0x3_hash)
+-  [`0x3::multichain_address`](multichain_address.md#0x3_multichain_address)
 -  [`0x3::native_validator`](native_validator.md#0x3_native_validator)
 -  [`0x3::schnorr`](schnorr.md#0x3_schnorr)
 -  [`0x3::session_key`](session_key.md#0x3_session_key)

--- a/crates/rooch-framework/doc/address_mapping.md
+++ b/crates/rooch-framework/doc/address_mapping.md
@@ -5,10 +5,8 @@
 
 
 
--  [Struct `MultiChainAddress`](#0x3_address_mapping_MultiChainAddress)
 -  [Resource `AddressMapping`](#0x3_address_mapping_AddressMapping)
--  [Constants](#@Constants_0)
--  [Function `is_rooch_address`](#0x3_address_mapping_is_rooch_address)
+-  [Function `genesis_init`](#0x3_address_mapping_genesis_init)
 -  [Function `resolve`](#0x3_address_mapping_resolve)
 -  [Function `resolve_or_generate`](#0x3_address_mapping_resolve_or_generate)
 -  [Function `exists_mapping`](#0x3_address_mapping_exists_mapping)
@@ -20,48 +18,14 @@
 <b>use</b> <a href="">0x1::signer</a>;
 <b>use</b> <a href="">0x2::account_storage</a>;
 <b>use</b> <a href="">0x2::bcs</a>;
-<b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="">0x2::table</a>;
 <b>use</b> <a href="">0x2::tx_context</a>;
-<b>use</b> <a href="core_addresses.md#0x3_core_addresses">0x3::core_addresses</a>;
 <b>use</b> <a href="hash.md#0x3_hash">0x3::hash</a>;
+<b>use</b> <a href="multichain_address.md#0x3_multichain_address">0x3::multichain_address</a>;
 </code></pre>
 
 
-
-<a name="0x3_address_mapping_MultiChainAddress"></a>
-
-## Struct `MultiChainAddress`
-
-
-
-<pre><code><b>struct</b> <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a> <b>has</b> <b>copy</b>, drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>multichain_id: u64</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>raw_address: <a href="">vector</a>&lt;u8&gt;</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
 
 <a name="0x3_address_mapping_AddressMapping"></a>
 
@@ -80,7 +44,7 @@
 
 <dl>
 <dt>
-<code>mapping: <a href="_Table">table::Table</a>&lt;<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>, <b>address</b>&gt;</code>
+<code>mapping: <a href="_Table">table::Table</a>&lt;<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>, <b>address</b>&gt;</code>
 </dt>
 <dd>
 
@@ -90,54 +54,13 @@
 
 </details>
 
-<a name="@Constants_0"></a>
+<a name="0x3_address_mapping_genesis_init"></a>
 
-## Constants
-
-
-<a name="0x3_address_mapping_MULTICHAIN_ID_BITCOIN"></a>
+## Function `genesis_init`
 
 
 
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_BITCOIN">MULTICHAIN_ID_BITCOIN</a>: u64 = 0;
-</code></pre>
-
-
-
-<a name="0x3_address_mapping_MULTICHAIN_ID_ETHER"></a>
-
-
-
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ETHER">MULTICHAIN_ID_ETHER</a>: u64 = 60;
-</code></pre>
-
-
-
-<a name="0x3_address_mapping_MULTICHAIN_ID_NOSTR"></a>
-
-
-
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_NOSTR">MULTICHAIN_ID_NOSTR</a>: u64 = 1237;
-</code></pre>
-
-
-
-<a name="0x3_address_mapping_MULTICHAIN_ID_ROOCH"></a>
-
-
-
-<pre><code><b>const</b> <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>: u64 = 20230101;
-</code></pre>
-
-
-
-<a name="0x3_address_mapping_is_rooch_address"></a>
-
-## Function `is_rooch_address`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(maddress: &<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): bool
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, genesis_account: &<a href="">signer</a>)
 </code></pre>
 
 
@@ -146,8 +69,12 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(maddress: &<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) : bool{
-    maddress.multichain_id == <a href="address_mapping.md#0x3_address_mapping_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, genesis_account: &<a href="">signer</a>) {
+    <b>let</b> tx_ctx = <a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
+    <b>let</b> mapping = <a href="_new">table::new</a>&lt;MultiChainAddress, <b>address</b>&gt;(tx_ctx);
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, <a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>{
+        mapping,
+    });
 }
 </code></pre>
 
@@ -162,7 +89,7 @@
 Resolve a multi-chain address to a rooch address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve">resolve</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): <a href="_Option">option::Option</a>&lt;<b>address</b>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve">resolve</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): <a href="_Option">option::Option</a>&lt;<b>address</b>&gt;
 </code></pre>
 
 
@@ -171,9 +98,9 @@ Resolve a multi-chain address to a rooch address
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve">resolve</a>(ctx: &StorageContext, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>): Option&lt;<b>address</b>&gt; {
-    <b>if</b> (<a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(&maddress)) {
-        <b>return</b> <a href="_some">option::some</a>(moveos_std::bcs::to_address(maddress.raw_address))
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve">resolve</a>(ctx: &StorageContext, maddress: MultiChainAddress): Option&lt;<b>address</b>&gt; {
+    <b>if</b> (<a href="multichain_address.md#0x3_multichain_address_is_rooch_address">multichain_address::is_rooch_address</a>(&maddress)) {
+        <b>return</b> <a href="_some">option::some</a>(<a href="multichain_address.md#0x3_multichain_address_into_rooch_address">multichain_address::into_rooch_address</a>(maddress))
     };
     <b>let</b> am = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
     <b>if</b>(<a href="_contains">table::contains</a>(&am.mapping, maddress)){
@@ -196,7 +123,7 @@ Resolve a multi-chain address to a rooch address
 Resolve a multi-chain address to a rooch address, if not exists, generate a new rooch address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve_or_generate">resolve_or_generate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve_or_generate">resolve_or_generate</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): <b>address</b>
 </code></pre>
 
 
@@ -205,10 +132,10 @@ Resolve a multi-chain address to a rooch address, if not exists, generate a new 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve_or_generate">resolve_or_generate</a>(ctx: &StorageContext, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>): <b>address</b> {
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_resolve_or_generate">resolve_or_generate</a>(ctx: &StorageContext, maddress: MultiChainAddress): <b>address</b> {
     <b>let</b> addr = <a href="address_mapping.md#0x3_address_mapping_resolve">resolve</a>(ctx, maddress);
     <b>if</b>(<a href="_is_none">option::is_none</a>(&addr)){
-        <a href="address_mapping.md#0x3_address_mapping_generate_rooch_address">generate_rooch_address</a>(maddress)
+        <a href="address_mapping.md#0x3_address_mapping_generate_rooch_address">generate_rooch_address</a>(&maddress)
     }<b>else</b>{
         <a href="_extract">option::extract</a>(&<b>mut</b> addr)
     }
@@ -226,7 +153,7 @@ Resolve a multi-chain address to a rooch address, if not exists, generate a new 
 Check if a multi-chain address is bound to a rooch address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_exists_mapping">exists_mapping</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_exists_mapping">exists_mapping</a>(ctx: &<a href="_StorageContext">storage_context::StorageContext</a>, maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): bool
 </code></pre>
 
 
@@ -235,8 +162,8 @@ Check if a multi-chain address is bound to a rooch address
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_exists_mapping">exists_mapping</a>(ctx: &StorageContext, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>): bool {
-    <b>if</b> (<a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(&maddress)) {
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_exists_mapping">exists_mapping</a>(ctx: &StorageContext, maddress: MultiChainAddress): bool {
+    <b>if</b> (<a href="multichain_address.md#0x3_multichain_address_is_rooch_address">multichain_address::is_rooch_address</a>(&maddress)) {
         <b>return</b> <b>true</b>
     };
     <b>let</b> am = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
@@ -256,7 +183,7 @@ Bind a multi-chain address to the sender's rooch address
 The caller need to ensure the relationship between the multi-chain address and the rooch address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, sender: &<a href="">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, sender: &<a href="">signer</a>, maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>)
 </code></pre>
 
 
@@ -265,7 +192,7 @@ The caller need to ensure the relationship between the multi-chain address and t
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="">signer</a>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind">bind</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="">signer</a>, maddress: MultiChainAddress) {
     <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx, <a href="_address_of">signer::address_of</a>(sender), maddress);
 }
 </code></pre>
@@ -281,7 +208,7 @@ The caller need to ensure the relationship between the multi-chain address and t
 Bind a rooch address to a multi-chain address
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, rooch_address: <b>address</b>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">address_mapping::MultiChainAddress</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, rooch_address: <b>address</b>, maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>)
 </code></pre>
 
 
@@ -290,14 +217,14 @@ Bind a rooch address to a multi-chain address
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx: &<b>mut</b> StorageContext, rooch_address: <b>address</b>, maddress: <a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>) {
-    <b>if</b>(<a href="address_mapping.md#0x3_address_mapping_is_rooch_address">is_rooch_address</a>(&maddress)){
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_bind_no_check">bind_no_check</a>(ctx: &<b>mut</b> StorageContext, rooch_address: <b>address</b>, maddress: MultiChainAddress) {
+    <b>if</b>(<a href="multichain_address.md#0x3_multichain_address_is_rooch_address">multichain_address::is_rooch_address</a>(&maddress)){
         //Do nothing <b>if</b> the multi-chain <b>address</b> is a rooch <b>address</b>
         <b>return</b>
     };
     <b>let</b> am = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>&gt;(ctx, @rooch_framework);
     <a href="_add">table::add</a>(&<b>mut</b> am.mapping, maddress, rooch_address);
-    //TODO matienance the reverse mapping rooch_address -&gt; <a href="">vector</a>&lt;<a href="address_mapping.md#0x3_address_mapping_MultiChainAddress">MultiChainAddress</a>&gt;
+    //TODO matienance the reverse mapping rooch_address -&gt; <a href="">vector</a>&lt;MultiChainAddress&gt;
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/bitcoin_address.md
+++ b/crates/rooch-framework/doc/bitcoin_address.md
@@ -9,6 +9,7 @@
 -  [Constants](#@Constants_0)
 -  [Function `new_legacy`](#0x3_bitcoin_address_new_legacy)
 -  [Function `new_bech32`](#0x3_bitcoin_address_new_bech32)
+-  [Function `from_bytes`](#0x3_bitcoin_address_from_bytes)
 -  [Function `as_bytes`](#0x3_bitcoin_address_as_bytes)
 -  [Function `into_bytes`](#0x3_bitcoin_address_into_bytes)
 -  [Function `create_p2pkh_address`](#0x3_bitcoin_address_create_p2pkh_address)
@@ -239,6 +240,33 @@ error code
     <b>let</b> <a href="bitcoin_address.md#0x3_bitcoin_address">bitcoin_address</a> = <a href="bitcoin_address.md#0x3_bitcoin_address_create_bech32_address">create_bech32_address</a>(pub_key, version);
 
     <a href="bitcoin_address.md#0x3_bitcoin_address">bitcoin_address</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_bitcoin_address_from_bytes"></a>
+
+## Function `from_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_from_bytes">from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_from_bytes">from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
+    //TODO check the <b>address</b> bytes.
+    <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">BTCAddress</a> {
+        bytes: bytes,
+    }
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/ethereum_address.md
+++ b/crates/rooch-framework/doc/ethereum_address.md
@@ -8,6 +8,7 @@
 -  [Struct `ETHAddress`](#0x3_ethereum_address_ETHAddress)
 -  [Constants](#@Constants_0)
 -  [Function `new`](#0x3_ethereum_address_new)
+-  [Function `from_bytes`](#0x3_ethereum_address_from_bytes)
 -  [Function `as_bytes`](#0x3_ethereum_address_as_bytes)
 -  [Function `into_bytes`](#0x3_ethereum_address_into_bytes)
 
@@ -69,6 +70,15 @@
 
 
 
+<a name="0x3_ethereum_address_ErrorInvaidAddresBytes"></a>
+
+
+
+<pre><code><b>const</b> <a href="ethereum_address.md#0x3_ethereum_address_ErrorInvaidAddresBytes">ErrorInvaidAddresBytes</a>: u64 = 2;
+</code></pre>
+
+
+
 <a name="0x3_ethereum_address_ErrorMalformedPublicKey"></a>
 
 error code
@@ -126,6 +136,36 @@ error code
     // Return the 20 bytes <b>address</b> <b>as</b> the Ethereum <b>address</b>
     <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a> {
         bytes: address_bytes,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_ethereum_address_from_bytes"></a>
+
+## Function `from_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_from_bytes">from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ethereum_address.md#0x3_ethereum_address_from_bytes">from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a> {
+    <b>assert</b>!(
+        <a href="_length">vector::length</a>(&bytes) == <a href="ethereum_address.md#0x3_ethereum_address_ETHEREUM_ADDR_LENGTH">ETHEREUM_ADDR_LENGTH</a>,
+        <a href="_invalid_argument">error::invalid_argument</a>(<a href="ethereum_address.md#0x3_ethereum_address_ErrorInvaidAddresBytes">ErrorInvaidAddresBytes</a>)
+    );
+    <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ETHAddress</a> {
+        bytes: bytes,
     }
 }
 </code></pre>

--- a/crates/rooch-framework/doc/genesis.md
+++ b/crates/rooch-framework/doc/genesis.md
@@ -13,6 +13,7 @@
 <b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account.md#0x3_account">0x3::account</a>;
+<b>use</b> <a href="address_mapping.md#0x3_address_mapping">0x3::address_mapping</a>;
 <b>use</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry">0x3::auth_validator_registry</a>;
 <b>use</b> <a href="builtin_validators.md#0x3_builtin_validators">0x3::builtin_validators</a>;
 <b>use</b> <a href="chain_id.md#0x3_chain_id">0x3::chain_id</a>;

--- a/crates/rooch-framework/doc/multichain_address.md
+++ b/crates/rooch-framework/doc/multichain_address.md
@@ -1,0 +1,480 @@
+
+<a name="0x3_multichain_address"></a>
+
+# Module `0x3::multichain_address`
+
+
+
+-  [Struct `MultiChainAddress`](#0x3_multichain_address_MultiChainAddress)
+-  [Constants](#@Constants_0)
+-  [Function `multichain_id_bitcoin`](#0x3_multichain_address_multichain_id_bitcoin)
+-  [Function `multichain_id_ether`](#0x3_multichain_address_multichain_id_ether)
+-  [Function `multichain_id_nostr`](#0x3_multichain_address_multichain_id_nostr)
+-  [Function `multichain_id_rooch`](#0x3_multichain_address_multichain_id_rooch)
+-  [Function `new`](#0x3_multichain_address_new)
+-  [Function `from_eth`](#0x3_multichain_address_from_eth)
+-  [Function `from_bitcoin`](#0x3_multichain_address_from_bitcoin)
+-  [Function `multichain_id`](#0x3_multichain_address_multichain_id)
+-  [Function `raw_address`](#0x3_multichain_address_raw_address)
+-  [Function `is_rooch_address`](#0x3_multichain_address_is_rooch_address)
+-  [Function `is_eth_address`](#0x3_multichain_address_is_eth_address)
+-  [Function `is_bitcoin_address`](#0x3_multichain_address_is_bitcoin_address)
+-  [Function `into_rooch_address`](#0x3_multichain_address_into_rooch_address)
+-  [Function `into_eth_address`](#0x3_multichain_address_into_eth_address)
+-  [Function `into_bitcoin_address`](#0x3_multichain_address_into_bitcoin_address)
+
+
+<pre><code><b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x2::bcs</a>;
+<b>use</b> <a href="bitcoin_address.md#0x3_bitcoin_address">0x3::bitcoin_address</a>;
+<b>use</b> <a href="ethereum_address.md#0x3_ethereum_address">0x3::ethereum_address</a>;
+</code></pre>
+
+
+
+<a name="0x3_multichain_address_MultiChainAddress"></a>
+
+## Struct `MultiChainAddress`
+
+
+
+<pre><code><b>struct</b> <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>multichain_id: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>raw_address: <a href="">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x3_multichain_address_ErrorMultiChainIDMismatch"></a>
+
+
+
+<pre><code><b>const</b> <a href="multichain_address.md#0x3_multichain_address_ErrorMultiChainIDMismatch">ErrorMultiChainIDMismatch</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x3_multichain_address_MULTICHAIN_ID_BITCOIN"></a>
+
+
+
+<pre><code><b>const</b> <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_BITCOIN">MULTICHAIN_ID_BITCOIN</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x3_multichain_address_MULTICHAIN_ID_ETHER"></a>
+
+
+
+<pre><code><b>const</b> <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_ETHER">MULTICHAIN_ID_ETHER</a>: u64 = 60;
+</code></pre>
+
+
+
+<a name="0x3_multichain_address_MULTICHAIN_ID_NOSTR"></a>
+
+
+
+<pre><code><b>const</b> <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_NOSTR">MULTICHAIN_ID_NOSTR</a>: u64 = 1237;
+</code></pre>
+
+
+
+<a name="0x3_multichain_address_MULTICHAIN_ID_ROOCH"></a>
+
+
+
+<pre><code><b>const</b> <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>: u64 = 20230101;
+</code></pre>
+
+
+
+<a name="0x3_multichain_address_multichain_id_bitcoin"></a>
+
+## Function `multichain_id_bitcoin`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id_bitcoin">multichain_id_bitcoin</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id_bitcoin">multichain_id_bitcoin</a>(): u64 { <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_BITCOIN">MULTICHAIN_ID_BITCOIN</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_multichain_id_ether"></a>
+
+## Function `multichain_id_ether`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id_ether">multichain_id_ether</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id_ether">multichain_id_ether</a>(): u64 { <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_ETHER">MULTICHAIN_ID_ETHER</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_multichain_id_nostr"></a>
+
+## Function `multichain_id_nostr`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id_nostr">multichain_id_nostr</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id_nostr">multichain_id_nostr</a>(): u64 { <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_NOSTR">MULTICHAIN_ID_NOSTR</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_multichain_id_rooch"></a>
+
+## Function `multichain_id_rooch`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id_rooch">multichain_id_rooch</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id_rooch">multichain_id_rooch</a>(): u64 { <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_new"></a>
+
+## Function `new`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_new">new</a>(multichain_id: u64, raw_address: <a href="">vector</a>&lt;u8&gt;): <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_new">new</a>(multichain_id: u64, raw_address: <a href="">vector</a>&lt;u8&gt;): <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a> {
+    <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a> {
+        multichain_id: multichain_id,
+        raw_address: raw_address,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_from_eth"></a>
+
+## Function `from_eth`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_from_eth">from_eth</a>(eth_address: <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>): <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_from_eth">from_eth</a>(eth_address: ETHAddress): <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a> {
+    <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a> {
+        multichain_id: <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_ETHER">MULTICHAIN_ID_ETHER</a>,
+        raw_address: <a href="ethereum_address.md#0x3_ethereum_address_into_bytes">ethereum_address::into_bytes</a>(eth_address),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_from_bitcoin"></a>
+
+## Function `from_bitcoin`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_from_bitcoin">from_bitcoin</a>(<a href="bitcoin_address.md#0x3_bitcoin_address">bitcoin_address</a>: <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>): <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_from_bitcoin">from_bitcoin</a>(<a href="bitcoin_address.md#0x3_bitcoin_address">bitcoin_address</a>: BTCAddress): <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a> {
+    <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a> {
+        multichain_id: <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_BITCOIN">MULTICHAIN_ID_BITCOIN</a>,
+        raw_address: <a href="bitcoin_address.md#0x3_bitcoin_address_into_bytes">bitcoin_address::into_bytes</a>(<a href="bitcoin_address.md#0x3_bitcoin_address">bitcoin_address</a>),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_multichain_id"></a>
+
+## Function `multichain_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id">multichain_id</a>(self: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_multichain_id">multichain_id</a>(self: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a>): u64 {
+    self.multichain_id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_raw_address"></a>
+
+## Function `raw_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_raw_address">raw_address</a>(self: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_raw_address">raw_address</a>(self: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a>): &<a href="">vector</a>&lt;u8&gt; {
+    &self.raw_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_is_rooch_address"></a>
+
+## Function `is_rooch_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_is_rooch_address">is_rooch_address</a>(maddress: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_is_rooch_address">is_rooch_address</a>(maddress: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a>) : bool{
+    maddress.multichain_id == <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_is_eth_address"></a>
+
+## Function `is_eth_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_is_eth_address">is_eth_address</a>(maddress: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_is_eth_address">is_eth_address</a>(maddress: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a>) : bool{
+    maddress.multichain_id == <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_ETHER">MULTICHAIN_ID_ETHER</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_is_bitcoin_address"></a>
+
+## Function `is_bitcoin_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_is_bitcoin_address">is_bitcoin_address</a>(maddress: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_is_bitcoin_address">is_bitcoin_address</a>(maddress: &<a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a>) : bool{
+    maddress.multichain_id == <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_BITCOIN">MULTICHAIN_ID_BITCOIN</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_into_rooch_address"></a>
+
+## Function `into_rooch_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_into_rooch_address">into_rooch_address</a>(maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_into_rooch_address">into_rooch_address</a>(maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a>) : <b>address</b> {
+    <b>assert</b>!(maddress.multichain_id == <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_ROOCH">MULTICHAIN_ID_ROOCH</a>, <a href="_invalid_argument">error::invalid_argument</a>(<a href="multichain_address.md#0x3_multichain_address_ErrorMultiChainIDMismatch">ErrorMultiChainIDMismatch</a>));
+    moveos_std::bcs::to_address(maddress.raw_address)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_into_eth_address"></a>
+
+## Function `into_eth_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_into_eth_address">into_eth_address</a>(maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): <a href="ethereum_address.md#0x3_ethereum_address_ETHAddress">ethereum_address::ETHAddress</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_into_eth_address">into_eth_address</a>(maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a>) : ETHAddress {
+    <b>assert</b>!(maddress.multichain_id == <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_ETHER">MULTICHAIN_ID_ETHER</a>, <a href="_invalid_argument">error::invalid_argument</a>(<a href="multichain_address.md#0x3_multichain_address_ErrorMultiChainIDMismatch">ErrorMultiChainIDMismatch</a>));
+    <a href="ethereum_address.md#0x3_ethereum_address_from_bytes">ethereum_address::from_bytes</a>(maddress.raw_address)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_multichain_address_into_bitcoin_address"></a>
+
+## Function `into_bitcoin_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_into_bitcoin_address">into_bitcoin_address</a>(maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">multichain_address::MultiChainAddress</a>): <a href="bitcoin_address.md#0x3_bitcoin_address_BTCAddress">bitcoin_address::BTCAddress</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multichain_address.md#0x3_multichain_address_into_bitcoin_address">into_bitcoin_address</a>(maddress: <a href="multichain_address.md#0x3_multichain_address_MultiChainAddress">MultiChainAddress</a>) : BTCAddress {
+    <b>assert</b>!(maddress.multichain_id == <a href="multichain_address.md#0x3_multichain_address_MULTICHAIN_ID_BITCOIN">MULTICHAIN_ID_BITCOIN</a>, <a href="_invalid_argument">error::invalid_argument</a>(<a href="multichain_address.md#0x3_multichain_address_ErrorMultiChainIDMismatch">ErrorMultiChainIDMismatch</a>));
+    <a href="bitcoin_address.md#0x3_bitcoin_address_from_bytes">bitcoin_address::from_bytes</a>(maddress.raw_address)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/rooch-framework/doc/transaction_validator.md
+++ b/crates/rooch-framework/doc/transaction_validator.md
@@ -22,6 +22,7 @@
 <b>use</b> <a href="chain_id.md#0x3_chain_id">0x3::chain_id</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
 <b>use</b> <a href="gas_coin.md#0x3_gas_coin">0x3::gas_coin</a>;
+<b>use</b> <a href="multichain_address.md#0x3_multichain_address">0x3::multichain_address</a>;
 <b>use</b> <a href="session_key.md#0x3_session_key">0x3::session_key</a>;
 <b>use</b> <a href="transaction_fee.md#0x3_transaction_fee">0x3::transaction_fee</a>;
 </code></pre>

--- a/crates/rooch-framework/doc/transfer.md
+++ b/crates/rooch-framework/doc/transfer.md
@@ -6,11 +6,14 @@
 
 
 -  [Function `transfer_coin`](#0x3_transfer_transfer_coin)
+-  [Function `transfer_coin_to_multichain_address`](#0x3_transfer_transfer_coin_to_multichain_address)
 
 
 <pre><code><b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="account.md#0x3_account">0x3::account</a>;
+<b>use</b> <a href="address_mapping.md#0x3_address_mapping">0x3::address_mapping</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
+<b>use</b> <a href="multichain_address.md#0x3_multichain_address">0x3::multichain_address</a>;
 </code></pre>
 
 
@@ -42,6 +45,45 @@ This public entry function requires the <code>CoinType</code> to have <code>key<
         <a href="account.md#0x3_account_create_account">account::create_account</a>(ctx, <b>to</b>);
     };
 
+    <a href="coin.md#0x3_coin_transfer">coin::transfer</a>&lt;CoinType&gt;(ctx, from, <b>to</b>, amount)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_transfer_transfer_coin_to_multichain_address"></a>
+
+## Function `transfer_coin_to_multichain_address`
+
+Transfer <code>amount</code> of coins <code>CoinType</code> from <code>from</code> to a MultiChainAddress.
+The MultiChainAddress is represented by <code>multichain_id</code> and <code>raw_address</code>.
+This public entry function requires the <code>CoinType</code> to have <code>key</code> and <code>store</code> abilities.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="transfer.md#0x3_transfer_transfer_coin_to_multichain_address">transfer_coin_to_multichain_address</a>&lt;CoinType: store, key&gt;(ctx: &<b>mut</b> <a href="_StorageContext">storage_context::StorageContext</a>, from: &<a href="">signer</a>, multichain_id: u64, raw_address: <a href="">vector</a>&lt;u8&gt;, amount: u256)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="transfer.md#0x3_transfer_transfer_coin_to_multichain_address">transfer_coin_to_multichain_address</a>&lt;CoinType: key + store&gt;(
+    ctx: &<b>mut</b> StorageContext,
+    from: &<a href="">signer</a>,
+    multichain_id: u64,
+    raw_address: <a href="">vector</a>&lt;u8&gt;,
+    amount: u256,
+) {
+    <b>let</b> maddress = <a href="multichain_address.md#0x3_multichain_address_new">multichain_address::new</a>(multichain_id, raw_address);
+    <b>let</b> <b>to</b> = <a href="address_mapping.md#0x3_address_mapping_resolve_or_generate">address_mapping::resolve_or_generate</a>(ctx, maddress);
+    <b>if</b>(!<a href="account.md#0x3_account_exists_at">account::exists_at</a>(ctx, <b>to</b>)) {
+        <a href="account.md#0x3_account_create_account">account::create_account</a>(ctx, <b>to</b>);
+        <a href="address_mapping.md#0x3_address_mapping_bind_no_check">address_mapping::bind_no_check</a>(ctx, <b>to</b>, maddress);
+    };
     <a href="coin.md#0x3_coin_transfer">coin::transfer</a>&lt;CoinType&gt;(ctx, from, <b>to</b>, amount)
 }
 </code></pre>

--- a/crates/rooch-framework/sources/address_mapping.move
+++ b/crates/rooch-framework/sources/address_mapping.move
@@ -5,45 +5,29 @@ module rooch_framework::address_mapping{
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::table::{Self, Table};
     use moveos_std::account_storage;
-    use moveos_std::signer as moveos_signer;
     use rooch_framework::hash::{blake2b256};
+    use rooch_framework::multichain_address::{Self, MultiChainAddress};
 
+    friend rooch_framework::genesis;
     friend rooch_framework::transaction_validator;
-
-    //The multichain id standard is defined in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
-    //Please keep consistent with rust Symbol
-    const MULTICHAIN_ID_BITCOIN: u64 = 0;
-    const MULTICHAIN_ID_ETHER: u64 = 60;
-    const MULTICHAIN_ID_NOSTR: u64 = 1237;
-    const MULTICHAIN_ID_ROOCH: u64 = 20230101; // placeholder for MULTICHAIN_ID_ROOCH pending for actual id from slip-0044
-
-    struct MultiChainAddress has copy, store, drop {
-        multichain_id: u64,
-        raw_address: vector<u8>,
-    }
+    friend rooch_framework::transfer;
     
     struct AddressMapping has key{
         mapping: Table<MultiChainAddress, address>,
     }
 
-    fun init(ctx: &mut StorageContext) {
-        let sender = &moveos_signer::module_signer<AddressMapping>();
-        rooch_framework::core_addresses::assert_rooch_framework(sender);
+    public(friend) fun genesis_init(ctx: &mut StorageContext, genesis_account: &signer) {
         let tx_ctx = storage_context::tx_context_mut(ctx);
         let mapping = table::new<MultiChainAddress, address>(tx_ctx);
-        account_storage::global_move_to(ctx, sender, AddressMapping{
+        account_storage::global_move_to(ctx, genesis_account, AddressMapping{
             mapping,
         });
     }
 
-    public fun is_rooch_address(maddress: &MultiChainAddress) : bool{
-        maddress.multichain_id == MULTICHAIN_ID_ROOCH
-    }
-
     /// Resolve a multi-chain address to a rooch address
     public fun resolve(ctx: &StorageContext, maddress: MultiChainAddress): Option<address> {
-        if (is_rooch_address(&maddress)) {
-            return option::some(moveos_std::bcs::to_address(maddress.raw_address))
+        if (multichain_address::is_rooch_address(&maddress)) {
+            return option::some(multichain_address::into_rooch_address(maddress))
         };
         let am = account_storage::global_borrow<AddressMapping>(ctx, @rooch_framework);
         if(table::contains(&am.mapping, maddress)){
@@ -58,20 +42,20 @@ module rooch_framework::address_mapping{
     public fun resolve_or_generate(ctx: &StorageContext, maddress: MultiChainAddress): address {
         let addr = resolve(ctx, maddress);
         if(option::is_none(&addr)){
-            generate_rooch_address(maddress)
+            generate_rooch_address(&maddress)
         }else{
             option::extract(&mut addr)
         }
     }
     
-    fun generate_rooch_address(maddress: MultiChainAddress): address {
-        let hash = blake2b256(&maddress.raw_address);
+    fun generate_rooch_address(maddress: &MultiChainAddress): address {
+        let hash = blake2b256(multichain_address::raw_address(maddress));
         moveos_std::bcs::to_address(hash)
     }
 
     /// Check if a multi-chain address is bound to a rooch address
     public fun exists_mapping(ctx: &StorageContext, maddress: MultiChainAddress): bool {
-        if (is_rooch_address(&maddress)) {
+        if (multichain_address::is_rooch_address(&maddress)) {
             return true
         };
         let am = account_storage::global_borrow<AddressMapping>(ctx, @rooch_framework);
@@ -86,7 +70,7 @@ module rooch_framework::address_mapping{
 
     /// Bind a rooch address to a multi-chain address
     public(friend) fun bind_no_check(ctx: &mut StorageContext, rooch_address: address, maddress: MultiChainAddress) {
-        if(is_rooch_address(&maddress)){
+        if(multichain_address::is_rooch_address(&maddress)){
             //Do nothing if the multi-chain address is a rooch address
             return
         };
@@ -94,20 +78,5 @@ module rooch_framework::address_mapping{
         table::add(&mut am.mapping, maddress, rooch_address);
         //TODO matienance the reverse mapping rooch_address -> vector<MultiChainAddress>
     }
-
-    #[test(sender=@rooch_framework)]
-    fun test_address_mapping(sender: signer){
-        let sender_addr = signer::address_of(&sender);
-        let ctx = storage_context::new_test_context(sender_addr);
-        account_storage::create_account_storage(&mut ctx, @rooch_framework);
-        init(&mut ctx);
-        let multi_chain_address = MultiChainAddress{
-            multichain_id: MULTICHAIN_ID_BITCOIN,
-            raw_address: x"1234567890abcdef",
-        };
-        bind(&mut ctx, &sender, multi_chain_address);
-        let addr = option::extract(&mut resolve(&ctx, multi_chain_address));
-        assert!(addr == @rooch_framework, 1000);
-        storage_context::drop_test_context(ctx);
-    }
+   
 }

--- a/crates/rooch-framework/sources/address_type/bitcoin_address.move
+++ b/crates/rooch-framework/sources/address_type/bitcoin_address.move
@@ -80,6 +80,13 @@ module rooch_framework::bitcoin_address{
         bitcoin_address
     }
 
+    public fun from_bytes(bytes: vector<u8>): BTCAddress {
+        //TODO check the address bytes.
+        BTCAddress {
+            bytes: bytes,
+        }
+    }
+
     public fun as_bytes(addr: &BTCAddress): &vector<u8> {
         &addr.bytes
     }

--- a/crates/rooch-framework/sources/address_type/ethereum_address.move
+++ b/crates/rooch-framework/sources/address_type/ethereum_address.move
@@ -10,6 +10,7 @@ module rooch_framework::ethereum_address {
     /// error code
     const ErrorMalformedPublicKey: u64 = 0;
     const ErrorDecompressPublicKey: u64 = 1;
+    const ErrorInvaidAddresBytes: u64 = 2;
 
     struct ETHAddress has store,copy,drop {
         bytes: vector<u8>,
@@ -47,6 +48,16 @@ module rooch_framework::ethereum_address {
         // Return the 20 bytes address as the Ethereum address
         ETHAddress {
             bytes: address_bytes,
+        }
+    }
+
+    public fun from_bytes(bytes: vector<u8>): ETHAddress {
+        assert!(
+            vector::length(&bytes) == ETHEREUM_ADDR_LENGTH,
+            error::invalid_argument(ErrorInvaidAddresBytes)
+        );
+        ETHAddress {
+            bytes: bytes,
         }
     }
 

--- a/crates/rooch-framework/sources/address_type/multichain_address.move
+++ b/crates/rooch-framework/sources/address_type/multichain_address.move
@@ -1,0 +1,84 @@
+module rooch_framework::multichain_address{
+    
+    use std::error;
+    use rooch_framework::ethereum_address::{Self, ETHAddress};
+    use rooch_framework::bitcoin_address::{Self, BTCAddress};
+
+    const ErrorMultiChainIDMismatch: u64 = 1;
+
+    //The multichain id standard is defined in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+    //Please keep consistent with rust Symbol
+    const MULTICHAIN_ID_BITCOIN: u64 = 0;
+    const MULTICHAIN_ID_ETHER: u64 = 60;
+    const MULTICHAIN_ID_NOSTR: u64 = 1237;
+    const MULTICHAIN_ID_ROOCH: u64 = 20230101; // placeholder for MULTICHAIN_ID_ROOCH pending for actual id from slip-0044
+
+    public fun multichain_id_bitcoin(): u64 { MULTICHAIN_ID_BITCOIN }
+
+    public fun multichain_id_ether(): u64 { MULTICHAIN_ID_ETHER }
+
+    public fun multichain_id_nostr(): u64 { MULTICHAIN_ID_NOSTR }
+
+    public fun multichain_id_rooch(): u64 { MULTICHAIN_ID_ROOCH }
+
+    struct MultiChainAddress has copy, store, drop {
+        multichain_id: u64,
+        raw_address: vector<u8>,
+    }
+
+    public fun new(multichain_id: u64, raw_address: vector<u8>): MultiChainAddress {
+        MultiChainAddress {
+            multichain_id: multichain_id,
+            raw_address: raw_address,
+        }
+    }
+
+    public fun from_eth(eth_address: ETHAddress): MultiChainAddress {
+        MultiChainAddress {
+            multichain_id: MULTICHAIN_ID_ETHER,
+            raw_address: ethereum_address::into_bytes(eth_address),
+        }
+    }
+
+    public fun from_bitcoin(bitcoin_address: BTCAddress): MultiChainAddress {
+        MultiChainAddress {
+            multichain_id: MULTICHAIN_ID_BITCOIN,
+            raw_address: bitcoin_address::into_bytes(bitcoin_address),
+        }
+    }
+
+    public fun multichain_id(self: &MultiChainAddress): u64 {
+        self.multichain_id
+    }
+
+    public fun raw_address(self: &MultiChainAddress): &vector<u8> {
+        &self.raw_address
+    }
+
+    public fun is_rooch_address(maddress: &MultiChainAddress) : bool{
+        maddress.multichain_id == MULTICHAIN_ID_ROOCH
+    }
+
+    public fun is_eth_address(maddress: &MultiChainAddress) : bool{
+        maddress.multichain_id == MULTICHAIN_ID_ETHER
+    }
+
+    public fun is_bitcoin_address(maddress: &MultiChainAddress) : bool{
+        maddress.multichain_id == MULTICHAIN_ID_BITCOIN
+    }
+
+    public fun into_rooch_address(maddress: MultiChainAddress) : address {
+        assert!(maddress.multichain_id == MULTICHAIN_ID_ROOCH, error::invalid_argument(ErrorMultiChainIDMismatch));
+        moveos_std::bcs::to_address(maddress.raw_address)
+    }
+
+    public fun into_eth_address(maddress: MultiChainAddress) : ETHAddress {
+        assert!(maddress.multichain_id == MULTICHAIN_ID_ETHER, error::invalid_argument(ErrorMultiChainIDMismatch));
+        ethereum_address::from_bytes(maddress.raw_address)
+    }
+
+    public fun into_bitcoin_address(maddress: MultiChainAddress) : BTCAddress {
+        assert!(maddress.multichain_id == MULTICHAIN_ID_BITCOIN, error::invalid_argument(ErrorMultiChainIDMismatch));
+        bitcoin_address::from_bytes(maddress.raw_address)
+    }
+}

--- a/crates/rooch-framework/sources/genesis.move
+++ b/crates/rooch-framework/sources/genesis.move
@@ -11,6 +11,7 @@ module rooch_framework::genesis {
     use rooch_framework::gas_coin;
     use rooch_framework::transaction_fee;
     use rooch_framework::timestamp;
+    use rooch_framework::address_mapping;
     use rooch_framework::ethereum_light_client;
 
     const ErrorGenesisInit: u64 = 1;
@@ -24,7 +25,7 @@ module rooch_framework::genesis {
 
     fun init(ctx: &mut StorageContext){
         //TODO genesis account should be a resource account?
-        let genesis_account = &account::create_account(ctx, @rooch_framework);//&moveos_signer::module_signer<GenesisContext>();
+        let genesis_account = &account::create_account(ctx, @rooch_framework);
         let genesis_context_option = storage_context::get<GenesisContext>(ctx);
         assert!(option::is_some(&genesis_context_option), error::invalid_argument(ErrorGenesisInit));
         let genesis_context = option::extract(&mut genesis_context_option);
@@ -35,6 +36,7 @@ module rooch_framework::genesis {
         gas_coin::genesis_init(ctx, genesis_account);
         transaction_fee::genesis_init(ctx, genesis_account);
         timestamp::genesis_init(ctx, genesis_account, genesis_context.timestamp);
+        address_mapping::genesis_init(ctx, genesis_account);
         ethereum_light_client::genesis_init(ctx, genesis_account);
     }
 

--- a/crates/rooch-framework/sources/tests/address_maping_test.move
+++ b/crates/rooch-framework/sources/tests/address_maping_test.move
@@ -1,0 +1,25 @@
+#[test_only]
+/// This test module is used to test the address_mapping
+module rooch_framework::address_mapping_test{
+
+    use std::option;
+    use moveos_std::signer;
+    use rooch_framework::multichain_address;
+    use rooch_framework::address_mapping;
+
+    #[test(sender=@0x42)]
+    fun test_address_mapping(sender: signer){
+        let genesis_ctx = rooch_framework::genesis::init_for_test();
+        let sender_addr = signer::address_of(&sender);
+
+        let multi_chain_address = multichain_address::new(
+            multichain_address::multichain_id_bitcoin(),
+            x"1234567890abcdef",
+        );
+        address_mapping::bind(&mut genesis_ctx, &sender, multi_chain_address);
+        let addr = option::extract(&mut address_mapping::resolve(&genesis_ctx, multi_chain_address));
+        assert!(addr == sender_addr, 1000);
+        moveos_std::storage_context::drop_test_context(genesis_ctx);
+    }
+   
+}

--- a/crates/rooch-framework/sources/tests/transfer_test.move
+++ b/crates/rooch-framework/sources/tests/transfer_test.move
@@ -1,0 +1,61 @@
+#[test_only]
+/// This test module is used to test the trasfer entry functions
+module rooch_framework::transfer_test{
+
+    use std::option;
+    use rooch_framework::account;
+    use rooch_framework::transfer;
+    use rooch_framework::gas_coin::{Self, GasCoin};
+    use rooch_framework::multichain_address::{Self, MultiChainAddress};
+    use rooch_framework::ethereum_address;
+    use rooch_framework::address_mapping;
+
+
+    #[test(from = @0x42, to = @0x43)]
+    fun test_transfer_coin(from: address, to: address){
+        let genesis_ctx = rooch_framework::genesis::init_for_test();
+        let from_signer = account::create_account_for_test(&mut genesis_ctx, from);
+        let init_gas = 9999u256;
+        gas_coin::faucet_for_test(&mut genesis_ctx, from, init_gas); 
+        assert!(gas_coin::balance(&genesis_ctx, from) == init_gas, 1000);
+
+        let amount = 11u256;
+        transfer::transfer_coin<GasCoin>(&mut genesis_ctx, &from_signer, to, amount);
+
+        assert!(gas_coin::balance(&genesis_ctx, from) == init_gas - amount, 1001);
+        assert!(gas_coin::balance(&genesis_ctx, to) == amount, 1002);
+        moveos_std::storage_context::drop_test_context(genesis_ctx);
+    }
+
+    #[test_only]
+    fun test_transfer_coin_to_multichain_address(from: address, to: MultiChainAddress){
+        let genesis_ctx = rooch_framework::genesis::init_for_test();
+        let from_signer = account::create_account_for_test(&mut genesis_ctx, from);
+        let init_gas = 9999u256;
+        gas_coin::faucet_for_test(&mut genesis_ctx, from, init_gas); 
+        assert!(gas_coin::balance(&genesis_ctx, from) == init_gas, 1000);
+
+        let amount = 11u256;
+        transfer::transfer_coin_to_multichain_address<GasCoin>(&mut genesis_ctx, &from_signer, multichain_address::multichain_id(&to), *multichain_address::raw_address(&to), amount);
+
+        let to_address_opt = address_mapping::resolve(&genesis_ctx, to);
+        assert!(option::is_some(&to_address_opt), 1001);
+        let to_address = option::extract(&mut to_address_opt);
+
+        assert!(gas_coin::balance(&genesis_ctx, from) == init_gas - amount, 1002);
+        assert!(gas_coin::balance(&genesis_ctx, to_address) == amount, 1003);
+
+        //transfer again
+        transfer::transfer_coin_to_multichain_address<GasCoin>(&mut genesis_ctx, &from_signer, multichain_address::multichain_id(&to), *multichain_address::raw_address(&to), amount);
+        assert!(gas_coin::balance(&genesis_ctx, to_address) == amount*2, 1004);
+        
+        moveos_std::storage_context::drop_test_context(genesis_ctx);
+    }
+
+     #[test(from = @0x42)]
+    fun test_transfer_coin_to_eth_address(from: address){
+        let eth_address = ethereum_address::from_bytes(x"1111111111111111111111111111111111111111");
+        let multichain_address = multichain_address::from_eth(eth_address);
+        test_transfer_coin_to_multichain_address(from, multichain_address);
+    }
+}

--- a/crates/rooch-framework/sources/transaction_validator.move
+++ b/crates/rooch-framework/sources/transaction_validator.move
@@ -4,7 +4,8 @@ module rooch_framework::transaction_validator {
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::tx_result;
     use rooch_framework::account;
-    use rooch_framework::address_mapping::{Self, MultiChainAddress};
+    use rooch_framework::multichain_address::MultiChainAddress;
+    use rooch_framework::address_mapping;
     use rooch_framework::account_authentication;
     use rooch_framework::auth_validator::{Self, TxValidateResult};
     use rooch_framework::auth_validator_registry;

--- a/crates/rooch-framework/sources/transfer.move
+++ b/crates/rooch-framework/sources/transfer.move
@@ -2,6 +2,8 @@ module rooch_framework::transfer {
     use rooch_framework::account;
     use moveos_std::storage_context::StorageContext;
     use rooch_framework::coin;
+    use rooch_framework::multichain_address;
+    use rooch_framework::address_mapping;
 
     /// Transfer `amount` of coins `CoinType` from `from` to `to`.
     /// This public entry function requires the `CoinType` to have `key` and `store` abilities.
@@ -15,6 +17,25 @@ module rooch_framework::transfer {
             account::create_account(ctx, to);
         };
 
+        coin::transfer<CoinType>(ctx, from, to, amount)
+    }
+
+    /// Transfer `amount` of coins `CoinType` from `from` to a MultiChainAddress.
+    /// The MultiChainAddress is represented by `multichain_id` and `raw_address`.
+    /// This public entry function requires the `CoinType` to have `key` and `store` abilities.
+    public entry fun transfer_coin_to_multichain_address<CoinType: key + store>(
+        ctx: &mut StorageContext,
+        from: &signer,
+        multichain_id: u64,
+        raw_address: vector<u8>,
+        amount: u256,
+    ) {
+        let maddress = multichain_address::new(multichain_id, raw_address);
+        let to = address_mapping::resolve_or_generate(ctx, maddress);
+        if(!account::exists_at(ctx, to)) {
+            account::create_account(ctx, to);
+            address_mapping::bind_no_check(ctx, to, maddress);
+        };
         coin::transfer<CoinType>(ctx, from, to, amount)
     }
 }

--- a/crates/rooch-types/src/framework/ethereum_light_client.rs
+++ b/crates/rooch-types/src/framework/ethereum_light_client.rs
@@ -73,14 +73,14 @@ impl<T> TryFrom<&Block<T>> for BlockHeader {
             transactions_root: value.transactions_root.as_bytes().to_vec(),
             receipts_root: value.receipts_root.as_bytes().to_vec(),
             logs_bloom: value.logs_bloom.map(|b| b.0.to_vec()).unwrap_or(vec![]),
-            difficulty: eth_u256_to_move_u256(value.difficulty),
+            difficulty: eth_u256_to_move_u256(&value.difficulty),
             number: value
                 .number
                 .ok_or_else(|| anyhow::format_err!("Unexpected pending block"))?
                 .as_u64(),
-            gas_limit: eth_u256_to_move_u256(value.gas_limit),
-            gas_used: eth_u256_to_move_u256(value.gas_used),
-            timestamp: eth_u256_to_move_u256(value.timestamp),
+            gas_limit: eth_u256_to_move_u256(&value.gas_limit),
+            gas_used: eth_u256_to_move_u256(&value.gas_used),
+            timestamp: eth_u256_to_move_u256(&value.timestamp),
             extra_data: value.extra_data.to_vec(),
         };
         Ok(block_header)
@@ -140,7 +140,7 @@ impl<'a> ModuleBinding<'a> for EthereumLightClientModule<'a> {
 }
 
 //TODO implement From<PrimitiveU256> for U256 in move side
-fn eth_u256_to_move_u256(value: ethers::types::U256) -> U256 {
+pub fn eth_u256_to_move_u256(value: &ethers::types::U256) -> U256 {
     let mut bytes = [0u8; U256_NUM_BYTES];
     value.to_little_endian(&mut bytes);
     U256::from_le_bytes(&bytes)

--- a/crates/rooch-types/src/framework/gas_coin.rs
+++ b/crates/rooch-types/src/framework/gas_coin.rs
@@ -1,7 +1,10 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{ident_str, identifier::IdentStr, u256::U256};
+use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, u256::U256,
+};
 use moveos_types::state::MoveStructType;
 
 pub const MODULE_NAME: &IdentStr = ident_str!("gas_coin");
@@ -11,6 +14,7 @@ pub const DECIMALS: u8 = 18;
 pub struct GasCoin;
 
 impl MoveStructType for GasCoin {
+    const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
     const MODULE_NAME: &'static IdentStr = MODULE_NAME;
     const STRUCT_NAME: &'static IdentStr = ident_str!("GasCoin");
 }

--- a/crates/rooch-types/src/framework/mod.rs
+++ b/crates/rooch-types/src/framework/mod.rs
@@ -21,6 +21,7 @@ pub mod native_validator;
 pub mod session_key;
 pub mod timestamp;
 pub mod transaction_validator;
+pub mod transfer;
 
 /// MoveOS system pre_execute functions registry.
 /// The registry is used to filter out system pre_execute functions.

--- a/crates/rooch-types/src/framework/transfer.rs
+++ b/crates/rooch-types/src/framework/transfer.rs
@@ -1,0 +1,67 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{address::MultiChainAddress, addresses::ROOCH_FRAMEWORK_ADDRESS};
+use move_core_types::{
+    account_address::AccountAddress,
+    ident_str,
+    identifier::IdentStr,
+    language_storage::{StructTag, TypeTag},
+    u256::U256,
+    value::MoveValue,
+};
+use moveos_types::{
+    module_binding::{ModuleBinding, MoveFunctionCaller},
+    transaction::MoveAction,
+};
+
+pub const MODULE_NAME: &IdentStr = ident_str!("transfer");
+
+/// Rust bindings for RoochFramework transfer module
+pub struct TransferModule;
+
+impl TransferModule {
+    pub const TRANSFER_COIN_FUNCTION_NAME: &'static IdentStr = ident_str!("transfer_coin");
+    pub const TRANSFER_COIN_TO_MULTICHAIN_ADDRESS_FUNCTION_NAME: &'static IdentStr =
+        ident_str!("transfer_coin_to_multichain_address");
+
+    pub fn create_transfer_coin_action(
+        coin_type: StructTag,
+        to: AccountAddress,
+        amount: U256,
+    ) -> MoveAction {
+        Self::create_move_action(
+            Self::TRANSFER_COIN_FUNCTION_NAME,
+            vec![TypeTag::Struct(Box::new(coin_type))],
+            vec![MoveValue::Address(to), MoveValue::U256(amount)],
+        )
+    }
+
+    pub fn create_transfer_coin_to_multichain_address_action(
+        coin_type: StructTag,
+        to: MultiChainAddress,
+        amount: U256,
+    ) -> MoveAction {
+        Self::create_move_action(
+            Self::TRANSFER_COIN_TO_MULTICHAIN_ADDRESS_FUNCTION_NAME,
+            vec![TypeTag::Struct(Box::new(coin_type))],
+            vec![
+                MoveValue::U64(to.multichain_id as u64),
+                MoveValue::vector_u8(to.raw_address),
+                MoveValue::U256(amount),
+            ],
+        )
+    }
+}
+
+impl<'a> ModuleBinding<'a> for TransferModule {
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const MODULE_ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+
+    fn new(_caller: &'a impl MoveFunctionCaller) -> Self
+    where
+        Self: Sized,
+    {
+        Self
+    }
+}


### PR DESCRIPTION
## Summary

1. Migrate `MultiChainAddress` to `multichain_address.move`
2. Implement `transfer::transfer_coin_to_multichain_address`
3. Auto convert ETH transfer transaction to GasCoin transfer, support transfer GasCoin in MetaMask.

- Closes #879 