### PR TITLE
feat: fixbug for session key list create_time not show correct

### DIFF
--- a/dashboard/src/views/feature/SessionKeyList.tsx
+++ b/dashboard/src/views/feature/SessionKeyList.tsx
@@ -72,7 +72,7 @@ export default function SessionKeyList() {
       headerName: 'Last Active Time',
       width: 200,
       valueGetter: (params: GridValueGetterParams) => {
-        return formatDate(params.row.last_active_time)
+        return formatDate(params.row.last_active_time * 1000)
       },
     },
     {
@@ -80,7 +80,7 @@ export default function SessionKeyList() {
       headerName: 'Create Time',
       width: 200,
       valueGetter: (params: GridValueGetterParams) => {
-        return formatDate(params.row.create_time)
+        return formatDate(params.row.create_time * 1000)
       },
     },
     {

--- a/sdk/typescript/test/e2e/sdk.test.ts
+++ b/sdk/typescript/test/e2e/sdk.test.ts
@@ -391,6 +391,9 @@ describe('SDK', () => {
       const account = new Account(provider, roochAddress, authorizer)
       expect(account).toBeDefined()
 
+      // wait timestamp sync
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+
       // create session account
       const sessionAccount = await account.createSessionAccount(
         ['0x3::empty::empty', '0x1::*::*'],
@@ -406,6 +409,8 @@ describe('SDK', () => {
       expect(page.data).toHaveLength(1)
       expect(page.data[0].authentication_key).toBeDefined()
       expect(page.data[0].max_inactive_interval).toBe(100)
+      expect(page.data[0].create_time).greaterThan(1696225092)
+      expect(page.data[0].last_active_time).greaterThan(1696225092)
 
       // query next page
       const nextPage = await account.querySessionKeys(page.nextCursor, 10)

--- a/sdk/typescript/test/e2e/servers/rooch-server.ts
+++ b/sdk/typescript/test/e2e/servers/rooch-server.ts
@@ -18,6 +18,8 @@ export class RoochServer {
       'local',
       '-d',
       'TMP',
+      '--eth-rpc-url',
+      'https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
     ])
 
     if (this.child) {


### PR DESCRIPTION
## Summary

Fixed the issue where the session key list was created and the last active time was displayed incorrectly

![image](https://github.com/rooch-network/rooch/assets/1449069/2ed2ba24-c17e-492b-aa30-0a7690c9cf55)


- Closes #issue

https://github.com/rooch-network/rooch/issues/896