### PR TITLE
Refactor the keypair management of sequencer, proposer, and relayer

### DIFF
--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -11,11 +11,11 @@ use clap::Parser;
 use moveos_config::{temp_dir, DataDirPath};
 use once_cell::sync::Lazy;
 use rooch_types::chain_id::RoochChainID;
+use rooch_types::crypto::RoochKeyPair;
 use serde::{Deserialize, Serialize};
 use std::fs::create_dir_all;
 use std::sync::Arc;
 use std::{fmt::Debug, path::Path, path::PathBuf};
-use rooch_types::address::RoochAddress;
 
 pub const ROOCH_DIR: &str = ".rooch";
 pub const ROOCH_CONFIR_DIR: &str = "rooch_config";
@@ -85,9 +85,10 @@ pub struct RoochOpt {
     pub eth_rpc_url: Option<String>,
 
     /// The address of the Rooch account to be use as key address
-    // #[clap(short = 'k', long = "key-address")]
-    // pub key_address: Option<String>,
+    #[clap(short = 'k', long = "key-address")]
     pub key_address: Option<String>,
+    // /// Sequencer, proposer and relayer keypair
+    // pub key_keypairs: Vec<RoochKeyPair>,
 }
 
 impl std::fmt::Display for RoochOpt {
@@ -109,6 +110,7 @@ impl RoochOpt {
             port: None,
             eth_rpc_url: None,
             key_address: None,
+            // key_keypairs: vec![],
         }
     }
 }
@@ -156,5 +158,29 @@ pub trait ConfigModule: Sized {
     /// Init the skip field or overwrite config by global command line option.
     fn merge_with_opt(&mut self, _opt: &RoochOpt, _base: Arc<BaseConfig>) -> Result<()> {
         Ok(())
+    }
+}
+
+#[derive(Debug, Parser, Default, Serialize, Deserialize)]
+pub struct ServerOpt {
+    /// Sequencer, proposer and relayer keypair
+    pub key_keypairs: Vec<RoochKeyPair>,
+}
+
+impl std::fmt::Display for ServerOpt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).map_err(|_e| std::fmt::Error)?
+        )
+    }
+}
+
+impl ServerOpt {
+    pub fn new() -> Self {
+        ServerOpt {
+            key_keypairs: vec![],
+        }
     }
 }

--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -161,7 +161,9 @@ pub trait ConfigModule: Sized {
 #[derive(Debug, Parser, Default, Serialize, Deserialize)]
 pub struct ServerOpt {
     /// Sequencer, proposer and relayer keypair
-    pub key_keypairs: Vec<RoochKeyPair>,
+    pub sequencer_keypair: Option<RoochKeyPair>,
+    pub proposer_keypair: Option<RoochKeyPair>,
+    pub relayer_keypair: Option<RoochKeyPair>,
 }
 
 impl std::fmt::Display for ServerOpt {
@@ -177,7 +179,9 @@ impl std::fmt::Display for ServerOpt {
 impl ServerOpt {
     pub fn new() -> Self {
         ServerOpt {
-            key_keypairs: vec![],
+            sequencer_keypair: None,
+            proposer_keypair: None,
+            relayer_keypair: None,
         }
     }
 }

--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::fs::create_dir_all;
 use std::sync::Arc;
 use std::{fmt::Debug, path::Path, path::PathBuf};
+use rooch_types::address::RoochAddress;
 
 pub const ROOCH_DIR: &str = ".rooch";
 pub const ROOCH_CONFIR_DIR: &str = "rooch_config";
@@ -82,6 +83,11 @@ pub struct RoochOpt {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[clap(long)]
     pub eth_rpc_url: Option<String>,
+
+    /// The address of the Rooch account to be use as key address
+    // #[clap(short = 'k', long = "key-address")]
+    // pub key_address: Option<String>,
+    pub key_address: Option<String>,
 }
 
 impl std::fmt::Display for RoochOpt {
@@ -102,6 +108,7 @@ impl RoochOpt {
             store: StoreConfig::default(),
             port: None,
             eth_rpc_url: None,
+            key_address: None,
         }
     }
 }

--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -84,9 +84,15 @@ pub struct RoochOpt {
     #[clap(long)]
     pub eth_rpc_url: Option<String>,
 
-    /// The address of the Rooch account to be use as key address
-    #[clap(short = 'k', long = "key-address")]
-    pub key_address: Option<String>,
+    /// The address of the sequencer account
+    #[clap(long)]
+    pub sequencer_account: Option<String>,
+    /// The address of the proposer account
+    #[clap(long)]
+    pub proposer_account: Option<String>,
+    /// The address of the relayer account
+    #[clap(long)]
+    pub relayer_account: Option<String>,
 }
 
 impl std::fmt::Display for RoochOpt {
@@ -107,7 +113,9 @@ impl RoochOpt {
             store: StoreConfig::default(),
             port: None,
             eth_rpc_url: None,
-            key_address: None,
+            sequencer_account: None,
+            proposer_account: None,
+            relayer_account: None,
         }
     }
 }

--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -87,8 +87,6 @@ pub struct RoochOpt {
     /// The address of the Rooch account to be use as key address
     #[clap(short = 'k', long = "key-address")]
     pub key_address: Option<String>,
-    // /// Sequencer, proposer and relayer keypair
-    // pub key_keypairs: Vec<RoochKeyPair>,
 }
 
 impl std::fmt::Display for RoochOpt {
@@ -110,7 +108,6 @@ impl RoochOpt {
             port: None,
             eth_rpc_url: None,
             key_address: None,
-            // key_keypairs: vec![],
         }
     }
 }

--- a/crates/rooch-config/src/server_config.rs
+++ b/crates/rooch-config/src/server_config.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config::Config;
 use rooch_types::address::RoochAddress;
 use serde::Deserialize;
 use serde::Serialize;
@@ -10,8 +11,10 @@ use std::fmt::{Display, Formatter, Result, Write};
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
-    pub proposer_address: Option<RoochAddress>,
-    pub sequencer_address: Option<RoochAddress>,
+    // pub proposer_address: Option<RoochAddress>,
+    // pub sequencer_address: Option<RoochAddress>,
+    // pub relayer_address: Option<RoochAddress>,
+    pub key_address: Option<RoochAddress>,
     pub block_propose_duration_in_seconds: u16,
 }
 
@@ -30,6 +33,8 @@ impl ServerConfig {
     }
 }
 
+impl Config for ServerConfig {}
+
 impl Display for ServerConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let mut writer = String::new();
@@ -46,8 +51,9 @@ impl Default for ServerConfig {
         Self {
             host: "0.0.0.0".to_string(),
             port: 50051,
-            proposer_address: None,
-            sequencer_address: None,
+            // proposer_address: None,
+            // sequencer_address: None,
+            key_address: None,
             block_propose_duration_in_seconds: 5,
         }
     }

--- a/crates/rooch-config/src/server_config.rs
+++ b/crates/rooch-config/src/server_config.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;
-use rooch_types::address::RoochAddress;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt::{Display, Formatter, Result, Write};
@@ -11,7 +10,6 @@ use std::fmt::{Display, Formatter, Result, Write};
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
-    pub key_address: Option<RoochAddress>,
     pub block_propose_duration_in_seconds: u16,
 }
 
@@ -48,7 +46,6 @@ impl Default for ServerConfig {
         Self {
             host: "0.0.0.0".to_string(),
             port: 50051,
-            key_address: None,
             block_propose_duration_in_seconds: 5,
         }
     }

--- a/crates/rooch-config/src/server_config.rs
+++ b/crates/rooch-config/src/server_config.rs
@@ -11,9 +11,6 @@ use std::fmt::{Display, Formatter, Result, Write};
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
-    // pub proposer_address: Option<RoochAddress>,
-    // pub sequencer_address: Option<RoochAddress>,
-    // pub relayer_address: Option<RoochAddress>,
     pub key_address: Option<RoochAddress>,
     pub block_propose_duration_in_seconds: u16,
 }
@@ -51,8 +48,6 @@ impl Default for ServerConfig {
         Self {
             host: "0.0.0.0".to_string(),
             port: 50051,
-            // proposer_address: None,
-            // sequencer_address: None,
             key_address: None,
             block_propose_duration_in_seconds: 5,
         }

--- a/crates/rooch-key/Cargo.toml
+++ b/crates/rooch-key/Cargo.toml
@@ -18,7 +18,7 @@ bip32 = { workspace = true }
 enum_dispatch = {workspace = true }
 derive_more = { workspace = true }
 eyre = { workspace = true }
-fastcrypto = { workspace = true }
+fastcrypto = { workspace = true, features = ["copy_key"] }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }

--- a/crates/rooch-key/src/keystore.rs
+++ b/crates/rooch-key/src/keystore.rs
@@ -39,7 +39,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[enum_dispatch(AccountKeystore)]
 pub enum Keystore<K: Ord, V> {
     File(FileBasedKeystore<K, V>),
@@ -1016,7 +1016,7 @@ impl
     }
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize, Debug)]
 pub struct FileBasedKeystore<K: Ord, V> {
     keystore: BaseKeyStore<K, V>,
     path: Option<PathBuf>,

--- a/crates/rooch-rpc-server/Cargo.toml
+++ b/crates/rooch-rpc-server/Cargo.toml
@@ -37,7 +37,8 @@ tracing-subscriber = { workspace = true }
 schemars = { workspace = true }
 serde_with = { workspace = true }
 rand = { workspace = true }
-fastcrypto = { workspace = true }
+#fastcrypto = { workspace = true }
+fastcrypto = { workspace = true, features = ["copy_key"] }
 hyper = { workspace = true }
 log = { workspace = true }
 lazy_static = { workspace = true }

--- a/crates/rooch-rpc-server/Cargo.toml
+++ b/crates/rooch-rpc-server/Cargo.toml
@@ -37,7 +37,6 @@ tracing-subscriber = { workspace = true }
 schemars = { workspace = true }
 serde_with = { workspace = true }
 rand = { workspace = true }
-#fastcrypto = { workspace = true }
 fastcrypto = { workspace = true, features = ["copy_key"] }
 hyper = { workspace = true }
 log = { workspace = true }

--- a/crates/rooch-types/Cargo.toml
+++ b/crates/rooch-types/Cargo.toml
@@ -31,7 +31,8 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 derive_more = { workspace = true }
 eyre = { workspace = true }
-fastcrypto = { workspace = true }
+#fastcrypto = { workspace = true }
+fastcrypto = { workspace = true, features = ["copy_key"] }
 schemars = {workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }

--- a/crates/rooch-types/Cargo.toml
+++ b/crates/rooch-types/Cargo.toml
@@ -31,7 +31,6 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 derive_more = { workspace = true }
 eyre = { workspace = true }
-#fastcrypto = { workspace = true }
 fastcrypto = { workspace = true, features = ["copy_key"] }
 schemars = {workspace = true }
 strum = { workspace = true }

--- a/crates/rooch-types/src/crypto.rs
+++ b/crates/rooch-types/src/crypto.rs
@@ -52,6 +52,12 @@ impl RoochKeyPair {
     pub fn authentication_key(&self) -> AuthenticationKey {
         self.public().authentication_key()
     }
+
+    pub fn copy(&self) -> Self {
+        match self {
+            RoochKeyPair::Ed25519(kp) => RoochKeyPair::Ed25519(kp.copy()),
+        }
+    }
 }
 
 impl Signer<Signature> for RoochKeyPair {

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -103,6 +103,9 @@ pub enum RoochError {
 
     #[error("Use of disabled feature: {:?}", error)]
     UnsupportedFeatureError { error: String },
+
+    #[error("Rooch key address does not exist error:")]
+    KeyAddressDoesNotExistError(),
 }
 
 impl From<anyhow::Error> for RoochError {

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -104,8 +104,11 @@ pub enum RoochError {
     #[error("Use of disabled feature: {:?}", error)]
     UnsupportedFeatureError { error: String },
 
-    #[error("Rooch key address does not exist error:")]
-    KeyAddressDoesNotExistError(),
+    #[error("Rooch key address does not exist error")]
+    KeyAddressDoesNotExistError,
+
+    #[error("Rooch key address key pair does not exist error: {0}")]
+    KeyAddressKeyPairDoesNotExistError(String),
 }
 
 impl From<anyhow::Error> for RoochError {

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -104,11 +104,20 @@ pub enum RoochError {
     #[error("Use of disabled feature: {:?}", error)]
     UnsupportedFeatureError { error: String },
 
-    #[error("Rooch key address does not exist error")]
-    KeyAddressDoesNotExistError,
+    #[error("Active address does not exist error")]
+    ActiveAddressDoesNotExistError,
 
-    #[error("Rooch key address key pair does not exist error: {0}")]
-    KeyAddressKeyPairDoesNotExistError(String),
+    #[error("Sequencer key pair does not exist error: {0}")]
+    SequencerKeyPairDoesNotExistError(String),
+
+    #[error("Proposer key pair does not exist error: {0}")]
+    ProposerKeyPairDoesNotExistError(String),
+
+    #[error("Relayer key pair does not exist error: {0}")]
+    RelayerKeyPairDoesNotExistError(String),
+
+    #[error("Invalid sequencer or proposer or relayer key pair")]
+    InvalidSequencerOrProposerOrRelayerKeyPair,
 }
 
 impl From<anyhow::Error> for RoochError {

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -32,7 +32,7 @@ impl CommandAction<()> for BalanceCommand {
             .address
             .map_or(
                 context
-                    .config
+                    .client_config
                     .active_address
                     .map(|active_address| AccountAddress::from(active_address).into()),
                 Some,

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -24,7 +24,7 @@ impl CreateCommand {
         let mut context = self.context_options.build().await?;
 
         let (new_address, phrase, multichain_id) = context
-            .config
+            .client_config
             .keystore
             .generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None)?;
 

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -27,7 +27,7 @@ impl CommandAction<()> for ImportCommand {
         let mut context = self.context_options.build().await?;
 
         let address = context
-            .config
+            .client_config
             .keystore
             .import_from_mnemonic(&self.mnemonic_phrase, KeyPairType::RoochKeyPairType, None)
             .map_err(|e| RoochError::ImportAccountError(e.to_string()))?;

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -19,14 +19,14 @@ pub struct ListCommand {
 impl CommandAction<()> for ListCommand {
     async fn execute(self) -> RoochResult<()> {
         let context = self.context_options.build().await?;
-        let active_address = context.config.active_address;
+        let active_address = context.client_config.active_address;
 
         println!(
             "{0: ^66} | {1: ^48} | {2: ^16} | {3: ^12}",
             "Rooch Address (Ed25519)", "Public Key (Base64)", "Auth Validator ID", "Active Address"
         );
         println!("{}", ["-"; 153].join(""));
-        for (address, public_key) in context.config.keystore.get_address_public_keys() {
+        for (address, public_key) in context.client_config.keystore.get_address_public_keys() {
             let auth_validator_id = public_key.auth_validator().flag();
             let mut active = "";
             if active_address == Some(address) {

--- a/crates/rooch/src/commands/account/commands/nullify.rs
+++ b/crates/rooch/src/commands/account/commands/nullify.rs
@@ -52,7 +52,7 @@ impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
 
         // Remove keypair by coin id from Rooch key store after successfully executing transaction
         context
-            .config
+            .client_config
             .keystore
             .nullify_address_with_key_pair_from_key_pair_type(
                 &existing_address,

--- a/crates/rooch/src/commands/account/commands/switch.rs
+++ b/crates/rooch/src/commands/account/commands/switch.rs
@@ -29,15 +29,20 @@ impl CommandAction<()> for SwitchCommand {
             RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))
         })?;
 
-        if !context.config.keystore.addresses().contains(&rooch_address) {
+        if !context
+            .client_config
+            .keystore
+            .addresses()
+            .contains(&rooch_address)
+        {
             return Err(RoochError::SwitchAccountError(format!(
                 "Address `{}` does not in the Rooch keystore",
                 self.address
             )));
         }
 
-        context.config.active_address = Some(rooch_address);
-        context.config.save()?;
+        context.client_config.active_address = Some(rooch_address);
+        context.client_config.save()?;
 
         println!(
             "The active account was successfully switched to `{}`",

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -37,7 +37,7 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
         })?;
 
         let kp = context
-            .config
+            .client_config
             .keystore
             .update_address_with_key_pair_from_key_pair_type(
                 &existing_address,

--- a/crates/rooch/src/commands/env/commands/add.rs
+++ b/crates/rooch/src/commands/env/commands/add.rs
@@ -32,8 +32,8 @@ impl AddCommand {
 
         // TODO: is this request timeout okay?
         env.create_rpc_client(Duration::from_secs(5), None).await?;
-        context.config.add_env(env);
-        context.config.save()?;
+        context.client_config.add_env(env);
+        context.client_config.save()?;
 
         println!("Environment `{} was successfully added", alias);
 

--- a/crates/rooch/src/commands/env/commands/list.rs
+++ b/crates/rooch/src/commands/env/commands/list.rs
@@ -22,9 +22,9 @@ impl ListCommand {
         );
         println!("{}", ["-"; 153].join(""));
 
-        for env in context.config.envs.iter() {
+        for env in context.client_config.envs.iter() {
             let mut active = "";
-            if context.config.active_env == Some(env.alias.clone()) {
+            if context.client_config.active_env == Some(env.alias.clone()) {
                 active = "True"
             }
 

--- a/crates/rooch/src/commands/env/commands/remove.rs
+++ b/crates/rooch/src/commands/env/commands/remove.rs
@@ -17,7 +17,7 @@ pub struct RemoveCommand {
 impl RemoveCommand {
     pub async fn execute(self) -> RoochResult<()> {
         let mut context = self.context_options.build().await?;
-        if let Some(active_env) = &context.config.active_env {
+        if let Some(active_env) = &context.client_config.active_env {
             if active_env == &self.env {
                 return Err(RoochError::RemoveEnvError(
                     "Cannot remove the currently active environment. Please switch to another environment and try again".to_owned()
@@ -25,8 +25,11 @@ impl RemoveCommand {
             }
         }
 
-        context.config.envs.retain(|env| env.alias != self.env);
-        context.config.save()?;
+        context
+            .client_config
+            .envs
+            .retain(|env| env.alias != self.env);
+        context.client_config.save()?;
 
         println!("Environment `{}` was successfully removed", self.env);
 

--- a/crates/rooch/src/commands/env/commands/switch.rs
+++ b/crates/rooch/src/commands/env/commands/switch.rs
@@ -19,15 +19,15 @@ impl SwitchCommand {
         let mut context = self.context_options.build().await?;
         let env = Some(self.alias.clone());
 
-        if context.config.get_env(&env).is_none() {
+        if context.client_config.get_env(&env).is_none() {
             return Err(RoochError::SwitchEnvError(format!(
                 "The environment config for `{}` does not exist",
                 self.alias
             )));
         }
 
-        context.config.active_env = env;
-        context.config.save()?;
+        context.client_config.active_env = env;
+        context.client_config.save()?;
 
         println!(
             "The active environment was successfully switched to `{}`",

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -19,7 +19,6 @@ use rooch_types::crypto::RoochKeyPair;
 use rooch_types::error::RoochError;
 use rooch_types::error::RoochResult;
 use std::fs;
-use std::str::FromStr;
 
 /// Tool for init with rooch
 #[derive(Parser)]
@@ -27,9 +26,6 @@ pub struct Init {
     /// Command line input of custom server URL
     #[clap(short = 's', long = "server-url")]
     pub server_url: Option<String>,
-    /// The address of the Rooch account to be set as key address
-    #[clap(short = 'k', long = "key-address")]
-    key_address: Option<String>,
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 }
@@ -63,25 +59,7 @@ impl CommandAction<()> for Init {
         // Rooch server config init
         let server_config_path = config_path.join(ROOCH_SERVER_CONFIG);
         if !server_config_path.exists() {
-            let key_address = if self.key_address.is_none() {
-                let (new_address, phrase, key_pair_type) =
-                    keystore.generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None)?;
-                println!(
-                    "Generated key keypair for address with type {:?} [{new_address}]",
-                    key_pair_type.type_of()
-                );
-                println!("Secret Recovery Phrase : [{phrase}]");
-                new_address
-            } else {
-                RoochAddress::from_str(self.key_address.unwrap().as_str()).map_err(|e| {
-                    RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))
-                })?
-            };
-
-            let server_config = ServerConfig {
-                key_address: Some(key_address),
-                ..Default::default()
-            };
+            let server_config = ServerConfig::default();
 
             server_config
                 .persisted(server_config_path.as_path())

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -35,7 +35,7 @@ pub struct Init {
 }
 
 #[async_trait]
-impl CommandAction<String> for Init {
+impl CommandAction<()> for Init {
     async fn execute(self) -> RoochResult<()> {
         let config_path = match self.context_options.config_dir {
             Some(v) => {
@@ -139,15 +139,15 @@ impl CommandAction<String> for Init {
                 .save()?;
             }
 
-            println!(format!(
+            println!(
                 "Rooch client config file generated at {}",
                 client_config_path.display()
-            ));
+            );
         } else {
-            println!(format!(
+            println!(
                 "Rooch client config file already exists at {}",
                 client_config_path.display()
-            ));
+            );
         }
 
         // Rooch server config init
@@ -173,11 +173,12 @@ impl CommandAction<String> for Init {
                     "Generated key keypair for address with type {:?} [{new_address}]",
                     key_pair_type.type_of()
                 );
+                println!("Secret Recovery Phrase : [{phrase}]");
                 new_address
             } else {
                 RoochAddress::from_str(self.key_address.unwrap().as_str()).map_err(|e| {
                     RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))
-                })?;
+                })?
             };
 
             let mut server_config = ServerConfig::default();
@@ -186,15 +187,15 @@ impl CommandAction<String> for Init {
                 .persisted(server_config_path.as_path())
                 .save()?;
 
-            println!(format!(
+            println!(
                 "Rooch server config file generated at {}",
                 server_config_path.display()
-            ));
+            );
         } else {
-            println!(format!(
+            println!(
                 "Rooch server config file already exists at {}",
                 server_config_path.display()
-            ));
+            );
         }
 
         Ok(())

--- a/crates/rooch/src/commands/move_cli/commands/new.rs
+++ b/crates/rooch/src/commands/move_cli/commands/new.rs
@@ -42,7 +42,7 @@ impl New {
         // build wallet context options
         let context = self.wallet_context_options.build().await?;
         // get active account address value
-        match context.config.active_address {
+        match context.client_config.active_address {
             Some(address) => Ok(AccountAddress::from(address).to_hex_literal()),
             None => Err(RoochError::ConfigLoadError(
                 ROOCH_CLIENT_CONFIG.to_string(),

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -90,7 +90,7 @@ impl CommandAction<ExecuteTransactionResponseView> for RunFunction {
             (_, Some(session_key)) => {
                 let tx_data = context.build_rooch_tx_data(sender, action).await?;
                 let tx = context
-                    .config
+                    .client_config
                     .keystore
                     .sign_transaction_via_session_key(&sender, tx_data, &session_key)
                     .map_err(|e| RoochError::SignMessageError(e.to_string()))?;

--- a/crates/rooch/src/commands/server/commands/start.rs
+++ b/crates/rooch/src/commands/server/commands/start.rs
@@ -50,11 +50,11 @@ impl CommandAction<()> for StartCommand {
             .get_key_pair_by_key_pair_type(&key_address, KeyPairType::RoochKeyPairType)
             .map_err(|e| RoochError::KeyAddressKeyPairDoesNotExistError(e.to_string()))?;
 
-        // Add sequencer, proposer and relayer keypair
-        let key_keypairs = vec![key_keypair.copy(), key_keypair.copy(), key_keypair.copy()];
-
+        // Construct sequencer, proposer and relayer keypair
         let mut server_opt = ServerOpt::new();
-        server_opt.key_keypairs = key_keypairs;
+        server_opt.sequencer_keypair = Some(key_keypair.copy());
+        server_opt.proposer_keypair = Some(key_keypair.copy());
+        server_opt.relayer_keypair = Some(key_keypair.copy());
 
         let mut service = Service::new();
         service

--- a/crates/rooch/src/commands/server/commands/start.rs
+++ b/crates/rooch/src/commands/server/commands/start.rs
@@ -44,31 +44,14 @@ impl CommandAction<()> for StartCommand {
             })?
         };
 
-        println!("Debug key_address {:?}", key_address);
-
-        let aa = "0xa9c2f2b534b403e1f58e787f8a2e6ac3a0aad63fa62a1199f44803cf362aa847";
-        let aa_address = RoochAddress::from_str(aa)?;
-        let aa_key_keypair = context
-            .client_config
-            .keystore
-            .get_key_pair_by_key_pair_type(&aa_address, KeyPairType::RoochKeyPairType)
-            .map_err(|e| RoochError::KeyAddressKeyPairDoesNotExistError(e.to_string()))?;
-        println!("Debug aa_key_keypair {:?}", aa_key_keypair);
-
         let key_keypair = context
             .client_config
             .keystore
             .get_key_pair_by_key_pair_type(&key_address, KeyPairType::RoochKeyPairType)
             .map_err(|e| RoochError::KeyAddressKeyPairDoesNotExistError(e.to_string()))?;
-        // .ok()
-        // .ok_or_else(|| RoochError::KeyAddressKeyPairDoesNotExistError)?;
-        println!("Debug key_keypair {:?}", key_keypair);
 
-        let mut key_keypairs = vec![];
         // Add sequencer, proposer and relayer keypair
-        key_keypairs.push(key_keypair.copy());
-        key_keypairs.push(key_keypair.copy());
-        key_keypairs.push(key_keypair.copy());
+        let key_keypairs = vec![key_keypair.copy(), key_keypair.copy(), key_keypair.copy()];
 
         let mut server_opt = ServerOpt::new();
         server_opt.key_keypairs = key_keypairs;

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -45,7 +45,10 @@ impl CreateCommand {
             .parse_account_arg(self.tx_options.sender_account.unwrap())?
             .into();
 
-        let session_auth_key = context.config.keystore.generate_session_key(&sender)?;
+        let session_auth_key = context
+            .client_config
+            .keystore
+            .generate_session_key(&sender)?;
 
         let session_scope = self.scope;
 

--- a/crates/testsuite/tests/integration.rs
+++ b/crates/testsuite/tests/integration.rs
@@ -7,7 +7,7 @@ use cucumber::{given, then, World as _};
 use jpst::TemplateContext;
 use move_core_types::account_address::AccountAddress;
 use rooch::RoochCli;
-use rooch_config::{rooch_config_dir, RoochOpt};
+use rooch_config::{rooch_config_dir, RoochOpt, ServerOpt};
 use rooch_rpc_client::wallet_context::WalletContext;
 use rooch_rpc_server::Service;
 use serde_json::Value;
@@ -23,7 +23,8 @@ struct World {
 async fn start_server(w: &mut World, _scenario: String) {
     let mut service = Service::new();
     let opt = RoochOpt::new_with_temp_store();
-    service.start(&opt).await.unwrap();
+    let server_opt = ServerOpt::new();
+    service.start(&opt, server_opt).await.unwrap();
 
     w.service = Some(service);
 }

--- a/crates/testsuite/tests/integration.rs
+++ b/crates/testsuite/tests/integration.rs
@@ -54,7 +54,7 @@ async fn run_cmd(world: &mut World, args: String) {
     let default = if config_dir.exists() {
         let context = WalletContext::new(Some(config_dir.clone())).await.unwrap();
 
-        match context.config.active_address {
+        match context.client_config.active_address {
             Some(addr) => AccountAddress::from(addr).to_hex_literal(),
             None => "".to_owned(),
         }


### PR DESCRIPTION
resolve https://github.com/rooch-network/rooch/issues/800

Summary
1. Init server config when `Rooch init`, and generate rooch key pair in keystore, both for sequencer, proposer, and relayer

Notice
Due to dependencies (Keystore is in WalletContext), the server loads key pairs from the command line by default and then passes them to the RPC Server. KeyPair does not have a clone attribute. The ServerOpt attribute is newly added to encapsulate and extend KeyPairs and other configurations.
There will be an impact on the SDK.

Todo
Wait the password option to decrypt private key for commands