### PR TITLE
Optimize moveos_stdlib::table 

### DIFF
--- a/crates/rooch-framework-tests/tests/cases/table/test_destroy.exp
+++ b/crates/rooch-framework-tests/tests/cases/table/test_destroy.exp
@@ -1,13 +1,19 @@
-processed 5 tasks
+processed 7 tasks
 
-task 1 'publish'. lines 3-73:
+task 1 'publish'. lines 3-85:
 status EXECUTED
 
-task 2 'run'. lines 75-88:
+task 2 'run'. lines 87-101:
 status EXECUTED
 
-task 3 'run'. lines 89-104:
+task 3 'run'. lines 102-117:
 status EXECUTED
 
-task 4 'run'. lines 105-115:
+task 4 'run'. lines 118-133:
+status EXECUTED
+
+task 5 'run'. lines 134-146:
+status ABORTED with code 3 in 0000000000000000000000000000000000000000000000000000000000000002::raw_table
+
+task 6 'run'. lines 147-160:
 status EXECUTED

--- a/crates/rooch-framework/src/natives/gas_parameter/table_extension.rs
+++ b/crates/rooch-framework/src/natives/gas_parameter/table_extension.rs
@@ -16,6 +16,7 @@ crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasPar
     [.contains_box.per_byte_serialized, "contains_box.per_byte_serialized", (5 + 1) * MUL],
     [.remove_box.base, "remove_box.base", (5 + 1) * MUL],
     [.remove_box.per_byte_serialized, "remove_box.per_byte_serialized", (5 + 1) * MUL],
-    [.destroy_empty_box.base, "destroy_empty_box.base", (5 + 1) * MUL],
+    [.destroy_empty_box_unchecked.base, "destroy_empty_box_unchecked.base", (5 + 1) * MUL],
     [.drop_unchecked_box.base, "drop_unchecked_box.base", (5 + 1) * MUL],
+    [.box_length.base, "box_length.base", (5 + 1) * MUL],
 ]);

--- a/crates/rooch-framework/src/natives/gas_parameter/table_extension.rs
+++ b/crates/rooch-framework/src/natives/gas_parameter/table_extension.rs
@@ -16,7 +16,6 @@ crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasPar
     [.contains_box.per_byte_serialized, "contains_box.per_byte_serialized", (5 + 1) * MUL],
     [.remove_box.base, "remove_box.base", (5 + 1) * MUL],
     [.remove_box.per_byte_serialized, "remove_box.per_byte_serialized", (5 + 1) * MUL],
-    [.destroy_empty_box_unchecked.base, "destroy_empty_box_unchecked.base", (5 + 1) * MUL],
     [.drop_unchecked_box.base, "drop_unchecked_box.base", (5 + 1) * MUL],
     [.box_length.base, "box_length.base", (5 + 1) * MUL],
 ]);

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
@@ -19,6 +19,9 @@ This type table if for design internal global storage, so all functions are frie
 -  [Function `upsert`](#0x2_raw_table_upsert)
 -  [Function `remove`](#0x2_raw_table_remove)
 -  [Function `contains`](#0x2_raw_table_contains)
+-  [Function `length`](#0x2_raw_table_length)
+-  [Function `is_empty`](#0x2_raw_table_is_empty)
+-  [Function `drop_unchecked`](#0x2_raw_table_drop_unchecked)
 -  [Function `destroy_empty`](#0x2_raw_table_destroy_empty)
 -  [Function `new_table_handle`](#0x2_raw_table_new_table_handle)
 
@@ -347,11 +350,86 @@ Returns true if <code><a href="table.md#0x2_table">table</a></code> contains an 
 
 </details>
 
+<a name="0x2_raw_table_length"></a>
+
+## Function `length`
+
+Returns the size of the table, the number of key-value pairs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="raw_table.md#0x2_raw_table_length">length</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="raw_table.md#0x2_raw_table_length">length</a>(table_handle: &ObjectID): u64 {
+    <a href="raw_table.md#0x2_raw_table_box_length">box_length</a>(table_handle)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_raw_table_is_empty"></a>
+
+## Function `is_empty`
+
+Returns true iff the table is empty (if <code>length</code> returns <code>0</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="raw_table.md#0x2_raw_table_is_empty">is_empty</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="raw_table.md#0x2_raw_table_is_empty">is_empty</a>(table_handle: &ObjectID): bool {
+    <a href="raw_table.md#0x2_raw_table_length">length</a>(table_handle) == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_raw_table_drop_unchecked"></a>
+
+## Function `drop_unchecked`
+
+Testing only: allows to drop a table even if it is not empty.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_drop_unchecked">drop_unchecked</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_drop_unchecked">drop_unchecked</a>(table_handle: &ObjectID) {
+    <a href="raw_table.md#0x2_raw_table_destroy_empty_box_unchecked">destroy_empty_box_unchecked</a>(table_handle)
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_raw_table_destroy_empty"></a>
 
 ## Function `destroy_empty`
 
-Destroy a table. The table must be empty to succeed.
+Destroy a table. Aborts if the table is not empty
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_destroy_empty">destroy_empty</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>)
@@ -364,7 +442,8 @@ Destroy a table. The table must be empty to succeed.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_destroy_empty">destroy_empty</a>(table_handle: &ObjectID) {
-    <a href="raw_table.md#0x2_raw_table_destroy_empty_box">destroy_empty_box</a>(table_handle)
+    <b>assert</b>!(<a href="raw_table.md#0x2_raw_table_is_empty">is_empty</a>(table_handle), <a href="raw_table.md#0x2_raw_table_ErrorNotEmpty">ErrorNotEmpty</a>);
+    <a href="raw_table.md#0x2_raw_table_destroy_empty_box_unchecked">destroy_empty_box_unchecked</a>(table_handle)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
@@ -51,6 +51,12 @@ This type table if for design internal global storage, so all functions are frie
 <dd>
 
 </dd>
+<dt>
+<code>size: u64</code>
+</dt>
+<dd>
+
+</dd>
 </dl>
 
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
@@ -357,7 +357,7 @@ Returns true if <code><a href="table.md#0x2_table">table</a></code> contains an 
 Returns the size of the table, the number of key-value pairs
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="raw_table.md#0x2_raw_table_length">length</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_length">length</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): u64
 </code></pre>
 
 
@@ -366,7 +366,7 @@ Returns the size of the table, the number of key-value pairs
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="raw_table.md#0x2_raw_table_length">length</a>(table_handle: &ObjectID): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_length">length</a>(table_handle: &ObjectID): u64 {
     <a href="raw_table.md#0x2_raw_table_box_length">box_length</a>(table_handle)
 }
 </code></pre>
@@ -382,7 +382,7 @@ Returns the size of the table, the number of key-value pairs
 Returns true iff the table is empty (if <code>length</code> returns <code>0</code>)
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="raw_table.md#0x2_raw_table_is_empty">is_empty</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): bool
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_is_empty">is_empty</a>(table_handle: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): bool
 </code></pre>
 
 
@@ -391,7 +391,7 @@ Returns true iff the table is empty (if <code>length</code> returns <code>0</cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="raw_table.md#0x2_raw_table_is_empty">is_empty</a>(table_handle: &ObjectID): bool {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_is_empty">is_empty</a>(table_handle: &ObjectID): bool {
     <a href="raw_table.md#0x2_raw_table_length">length</a>(table_handle) == 0
 }
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
@@ -417,7 +417,7 @@ Testing only: allows to drop a table even if it is not empty.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_drop_unchecked">drop_unchecked</a>(table_handle: &ObjectID) {
-    <a href="raw_table.md#0x2_raw_table_destroy_empty_box_unchecked">destroy_empty_box_unchecked</a>(table_handle)
+    <a href="raw_table.md#0x2_raw_table_drop_unchecked_box">drop_unchecked_box</a>(table_handle)
 }
 </code></pre>
 
@@ -443,7 +443,7 @@ Destroy a table. Aborts if the table is not empty
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_destroy_empty">destroy_empty</a>(table_handle: &ObjectID) {
     <b>assert</b>!(<a href="raw_table.md#0x2_raw_table_is_empty">is_empty</a>(table_handle), <a href="raw_table.md#0x2_raw_table_ErrorNotEmpty">ErrorNotEmpty</a>);
-    <a href="raw_table.md#0x2_raw_table_destroy_empty_box_unchecked">destroy_empty_box_unchecked</a>(table_handle)
+    <a href="raw_table.md#0x2_raw_table_drop_unchecked_box">drop_unchecked_box</a>(table_handle)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
@@ -23,6 +23,9 @@ struct itself, while the operations are implemented as native functions. No trav
 -  [Function `remove`](#0x2_table_remove)
 -  [Function `contains`](#0x2_table_contains)
 -  [Function `destroy_empty`](#0x2_table_destroy_empty)
+-  [Function `length`](#0x2_table_length)
+-  [Function `is_empty`](#0x2_table_is_empty)
+-  [Function `drop`](#0x2_table_drop)
 
 
 <pre><code><b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
@@ -341,6 +344,83 @@ Destroy a table. The table must be empty to succeed.
 <pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;) {
     <b>let</b> <a href="table.md#0x2_table_Table">Table</a> { handle } = <a href="table.md#0x2_table">table</a>;
     <a href="raw_table.md#0x2_raw_table_destroy_empty">raw_table::destroy_empty</a>(&handle)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_length"></a>
+
+## Function `length`
+
+Returns the size of the table, the number of key-value pairs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_length">length</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_length">length</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;): u64 {
+    <a href="raw_table.md#0x2_raw_table_length">raw_table::length</a>(&<a href="table.md#0x2_table">table</a>.handle)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_is_empty"></a>
+
+## Function `is_empty`
+
+Returns true iff the table is empty (if <code>length</code> returns <code>0</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;): bool {
+    <a href="raw_table.md#0x2_raw_table_length">raw_table::length</a>(&<a href="table.md#0x2_table">table</a>.handle) == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_drop"></a>
+
+## Function `drop`
+
+Drop a possibly non-empty table.
+Usable only if the value type <code>V</code> has the <code>drop</code> ability
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_drop">drop</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_drop">drop</a>&lt;K: <b>copy</b> + drop , V: drop&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="table.md#0x2_table_Table">Table</a> { handle } = <a href="table.md#0x2_table">table</a>;
+    <a href="raw_table.md#0x2_raw_table_drop_unchecked">raw_table::drop_unchecked</a>(&handle)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
@@ -87,12 +87,12 @@ module moveos_std::raw_table {
     }
 
     /// Returns the size of the table, the number of key-value pairs
-    public fun length(table_handle: &ObjectID): u64 {
+    public(friend) fun length(table_handle: &ObjectID): u64 {
         box_length(table_handle)
     }
 
     /// Returns true iff the table is empty (if `length` returns `0`)
-    public fun is_empty(table_handle: &ObjectID): bool {
+    public(friend) fun is_empty(table_handle: &ObjectID): bool {
         length(table_handle) == 0
     }
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
@@ -98,13 +98,13 @@ module moveos_std::raw_table {
 
     /// Testing only: allows to drop a table even if it is not empty.
     public(friend) fun drop_unchecked(table_handle: &ObjectID) {
-        destroy_empty_box_unchecked(table_handle)
+        drop_unchecked_box(table_handle)
     }
     
     /// Destroy a table. Aborts if the table is not empty
     public(friend) fun destroy_empty(table_handle: &ObjectID) {
         assert!(is_empty(table_handle), ErrorNotEmpty);
-        destroy_empty_box_unchecked(table_handle)
+        drop_unchecked_box(table_handle)
     }
 
     // ======================================================================================================
@@ -129,8 +129,6 @@ module moveos_std::raw_table {
     native fun contains_box<K: copy + drop>(table_handle: &ObjectID, key: K): bool;
 
     native fun remove_box<K: copy + drop, V, B>(table_handle: &ObjectID, key: K): Box<V>;
-
-    native fun destroy_empty_box_unchecked(table_handle: &ObjectID);
 
     native fun drop_unchecked_box(table_handle: &ObjectID);
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
@@ -21,6 +21,8 @@ module moveos_std::raw_table {
     struct TableInfo has key {
         // Table SMT root
         state_root: address,
+        // Table size, number of items
+        size: u64,
     }
     
     /// Add a new entry to the table. Aborts if an entry for this

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/raw_table.move
@@ -86,15 +86,25 @@ module moveos_std::raw_table {
         contains_box<K>(table_handle, key)
     }
 
-    #[test_only]
+    /// Returns the size of the table, the number of key-value pairs
+    public fun length(table_handle: &ObjectID): u64 {
+        box_length(table_handle)
+    }
+
+    /// Returns true iff the table is empty (if `length` returns `0`)
+    public fun is_empty(table_handle: &ObjectID): bool {
+        length(table_handle) == 0
+    }
+
     /// Testing only: allows to drop a table even if it is not empty.
     public(friend) fun drop_unchecked(table_handle: &ObjectID) {
-        drop_unchecked_box(table_handle)
+        destroy_empty_box_unchecked(table_handle)
     }
     
-    /// Destroy a table. The table must be empty to succeed.
+    /// Destroy a table. Aborts if the table is not empty
     public(friend) fun destroy_empty(table_handle: &ObjectID) {
-        destroy_empty_box(table_handle)
+        assert!(is_empty(table_handle), ErrorNotEmpty);
+        destroy_empty_box_unchecked(table_handle)
     }
 
     // ======================================================================================================
@@ -120,7 +130,9 @@ module moveos_std::raw_table {
 
     native fun remove_box<K: copy + drop, V, B>(table_handle: &ObjectID, key: K): Box<V>;
 
-    native fun destroy_empty_box(table_handle: &ObjectID);
+    native fun destroy_empty_box_unchecked(table_handle: &ObjectID);
 
     native fun drop_unchecked_box(table_handle: &ObjectID);
+
+    native fun box_length(table_handle: &ObjectID): u64;
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -92,6 +92,22 @@ module moveos_std::table {
         raw_table::destroy_empty(&handle)
     }
 
+    /// Returns the size of the table, the number of key-value pairs
+    public fun length<K: copy + drop, V>(table: &Table<K, V>): u64 {
+        raw_table::length(&table.handle)
+    }
+
+    /// Returns true iff the table is empty (if `length` returns `0`)
+    public fun is_empty<K: copy + drop, V>(table: &Table<K, V>): bool {
+        raw_table::length(&table.handle) == 0
+    }
+
+    /// Drop a possibly non-empty table.
+    /// Usable only if the value type `V` has the `drop` ability
+    public fun drop<K: copy + drop , V: drop>(table: Table<K, V>) {
+        let Table { handle } = table;
+        raw_table::drop_unchecked(&handle)
+    }
 
     #[test_only]
     struct TableHolder<phantom K: copy + drop, phantom V: drop> has key {

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -230,15 +230,15 @@ module moveos_std::table {
 
         let t2 = new_with_id<u8, u32>(copy t2_id);
         assert!(contains(&t2, t2_key), 2);
-        drop_unchecked(t2);
+        let Table { handle: _ } = t2;
 
         let borrowed_mut_t2 = borrow_mut(&mut t1, t1_key);
         remove(borrowed_mut_t2, t2_key);
 
-        let t2 = new_with_id<u8, u32>(t2_id);
-        assert!(!contains(&t2, t2_key), 2);
-        drop_unchecked(t2);
-
+        let t3 = new_with_id<u8, u32>(t2_id);
+        assert!(!contains(&t3, t2_key), 2);
+        
+        drop_unchecked(t3); // No need to drop t2 as t2 shares same handle with t3
         drop_unchecked(t1);
     }
 

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
@@ -178,6 +178,7 @@ pub struct Table {
     handle: ObjectID,
     key_layout: MoveTypeLayout,
     content: BTreeMap<Vec<u8>, TableRuntimeValue>,
+    size_increment: i64,
 }
 
 // =========================================================================================
@@ -210,6 +211,7 @@ impl TableData {
                     handle,
                     key_layout,
                     content: Default::default(),
+                    size_increment: 0,
                 };
                 if log::log_enabled!(log::Level::Trace) {
                     let key_type = type_to_type_tag(context, key_ty)?;
@@ -232,6 +234,7 @@ impl TableData {
                     handle,
                     key_layout,
                     content: Default::default(),
+                    size_increment: 0,
                 };
                 e.insert(table)
             }
@@ -354,13 +357,15 @@ impl Table {
         ObjectID,
         MoveTypeLayout,
         BTreeMap<Vec<u8>, TableRuntimeValue>,
+        i64,
     ) {
         let Table {
             handle,
             key_layout,
             content,
+            size_increment,
         } = self;
-        (handle, key_layout, content)
+        (handle, key_layout, content, size_increment)
     }
 
     pub fn key_layout(&self) -> &MoveTypeLayout {
@@ -470,7 +475,10 @@ fn native_add_box(
     let value_layout = type_to_type_layout(context, &ty_args[1])?;
     let value_type = type_to_type_tag(context, &ty_args[1])?;
     match tv.move_to(val, value_layout, value_type) {
-        Ok(_) => Ok(NativeResult::ok(cost, smallvec![])),
+        Ok(_) => {
+            table.size_increment += 1;
+            Ok(NativeResult::ok(cost, smallvec![]))
+        }
         Err(_) => Ok(NativeResult::err(
             cost,
             moveos_types::move_std::error::already_exists(E_ALREADY_EXISTS),
@@ -629,7 +637,10 @@ fn native_remove_box(
     cost += common_gas_params.calculate_load_cost(loaded);
     let value_type = type_to_type_tag(context, &ty_args[1])?;
     match tv.move_from(value_type) {
-        Ok(val) => Ok(NativeResult::ok(cost, smallvec![val])),
+        Ok(val) => {
+            table.size_increment -= 1;
+            Ok(NativeResult::ok(cost, smallvec![val]))
+        }
         Err(_) => Ok(NativeResult::err(
             cost,
             moveos_types::move_std::error::not_found(E_NOT_FOUND),
@@ -665,9 +676,21 @@ fn native_destroy_empty_box(
     let mut table_data = table_context.table_data.write();
 
     let handle = get_table_handle(pop_arg!(args, StructRef))?;
-    if table_data.tables.contains_key(&handle)
-        && !table_data.tables.get(&handle).unwrap().content.is_empty()
-    {
+
+    let remote_table_size = table_context
+        .resolver
+        .resolve_size(&handle)
+        .map_err(|err| {
+            partial_extension_error(format!("remote table resolver failure: {}", err))
+        })?;
+    let size_increment = if table_data.exist_table(&handle) {
+        table_data.borrow_table(&handle).unwrap().size_increment
+    } else {
+        0i64
+    };
+    let updated_table_size = (remote_table_size as i64) + size_increment;
+    debug_assert!(updated_table_size >= 0);
+    if updated_table_size > 0 {
         return Ok(NativeResult::err(
             gas_params.base,
             moveos_types::move_std::error::invalid_state(E_NOT_EMPTY),

--- a/moveos/moveos-store/src/lib.rs
+++ b/moveos/moveos-store/src/lib.rs
@@ -303,4 +303,8 @@ impl StateResolver for MoveOSStore {
     ) -> std::result::Result<Vec<Option<(Vec<u8>, State)>>, Error> {
         self.statedb.resolve_list_state(handle, cursor, limit)
     }
+
+    fn resolve_size(&self, handle: &ObjectID) -> Result<u64, anyhow::Error> {
+        self.statedb.resolve_size(handle)
+    }
 }

--- a/moveos/moveos-types/src/object.rs
+++ b/moveos/moveos-types/src/object.rs
@@ -248,11 +248,15 @@ pub struct TableInfo {
     //TODO use u256?
     pub state_root: AccountAddress,
     //TODO keep Table Key TypeTag at here
+    pub size: u64,
 }
 
 impl TableInfo {
     pub fn new(state_root: AccountAddress) -> Self {
-        TableInfo { state_root }
+        TableInfo {
+            state_root,
+            size: 0u64,
+        }
     }
 }
 

--- a/moveos/moveos-types/src/state.rs
+++ b/moveos/moveos-types/src/state.rs
@@ -425,6 +425,8 @@ impl StateChangeSet {
 pub struct TableChange {
     //TODO should we keep the key's type here?
     pub entries: BTreeMap<Vec<u8>, Op<State>>,
+    /// The size increment of the table, may be negtive which means more deleting than inserting.
+    pub size_increment: i64,
 }
 
 /// StateSet is represent state dump result. Not include events and other stores

--- a/moveos/moveos-types/src/state_resolver.rs
+++ b/moveos/moveos-types/src/state_resolver.rs
@@ -34,6 +34,9 @@ pub trait StateResolver {
         cursor: Option<Vec<u8>>,
         limit: usize,
     ) -> Result<Vec<Option<ListState>>, anyhow::Error>;
+
+    /// Resolve the table size if the handle is a table.
+    fn resolve_size(&self, handle: &ObjectID) -> Result<u64, anyhow::Error>;
 }
 
 /// A proxy type for proxy the StateResolver to MoveResolver
@@ -102,6 +105,10 @@ where
         limit: usize,
     ) -> Result<Vec<Option<ListState>>, anyhow::Error> {
         self.0.resolve_list_state(handle, cursor, limit)
+    }
+
+    fn resolve_size(&self, handle: &ObjectID) -> Result<u64, anyhow::Error> {
+        self.0.resolve_size(handle)
     }
 }
 

--- a/moveos/moveos/src/gas/parameter.rs
+++ b/moveos/moveos/src/gas/parameter.rs
@@ -496,6 +496,7 @@ static G_NATIVE_STRS: Lazy<Vec<&str>> = Lazy::new(|| {
         "table.contains_box.per_byte_serialized",
         "table.destroy_empty_box.base",
         "table.drop_unchecked_box.base",
+        "table.box_length.base",
         "move_stdlib.string.check_utf8.per_byte",
         "move_stdlib.string.sub_string.per_byte",
         "move_stdlib.string.is_char_boundary.base",

--- a/moveos/moveos/src/vm/data_cache.rs
+++ b/moveos/moveos/src/vm/data_cache.rs
@@ -270,7 +270,7 @@ pub fn into_change_set(table_data: Arc<RwLock<TableData>>) -> PartialVMResult<St
     let (new_tables, removed_tables, tables) = data.into_inner();
     let mut changes = BTreeMap::new();
     for (handle, table) in tables {
-        let (_, _, content) = table.into_inner();
+        let (_, _, content, size_increment) = table.into_inner();
         let mut entries = BTreeMap::new();
         for (key, table_value) in content {
             let (value_layout, value_type, op) = match table_value.into_effect() {
@@ -304,7 +304,15 @@ pub fn into_change_set(table_data: Arc<RwLock<TableData>>) -> PartialVMResult<St
             }
         }
         if !entries.is_empty() {
-            changes.insert(handle, TableChange { entries });
+            changes.insert(
+                handle,
+                TableChange {
+                    entries,
+                    size_increment,
+                },
+            );
+        } else {
+            debug_assert!(size_increment == 0);
         }
     }
     Ok(StateChangeSet {

--- a/moveos/moveos/src/vm/unit_tests/vm_arguments_tests.rs
+++ b/moveos/moveos/src/vm/unit_tests/vm_arguments_tests.rs
@@ -297,7 +297,7 @@ impl StateResolver for RemoteStore {
         todo!()
     }
 
-    fn resolve_size(&self, handle: &ObjectID) -> anyhow::Result<u64, anyhow::Error> {
+    fn resolve_size(&self, _handle: &ObjectID) -> anyhow::Result<u64, anyhow::Error> {
         todo!()
     }
 }

--- a/moveos/moveos/src/vm/unit_tests/vm_arguments_tests.rs
+++ b/moveos/moveos/src/vm/unit_tests/vm_arguments_tests.rs
@@ -296,6 +296,10 @@ impl StateResolver for RemoteStore {
     ) -> anyhow::Result<Vec<Option<ListState>>, anyhow::Error> {
         todo!()
     }
+
+    fn resolve_size(&self, handle: &ObjectID) -> anyhow::Result<u64, anyhow::Error> {
+        todo!()
+    }
 }
 
 fn combine_signers_and_args(


### PR DESCRIPTION
## Summary

1. Destroy the table if the value of table has the drop ability. Close #899 
2. Add interface of table::length and table::is_empty, support destroy empty table. Close #342
3. Fix bug when table::destroy non-empty tables. Close #320