### PR TITLE
refactor wallet context and fixup account cli

### DIFF
--- a/crates/rooch-key/src/keystore.rs
+++ b/crates/rooch-key/src/keystore.rs
@@ -1302,6 +1302,31 @@ impl FileBasedKeystore<RoochAddress, RoochKeyPair> {
         })
     }
 
+    pub fn load(path: &PathBuf) -> Result<Self, anyhow::Error> {
+        if path.exists() {
+            let reader = BufReader::new(File::open(path).map_err(|e| {
+                anyhow!(
+                    "Can't open FileBasedKeystore from Rooch path {:?}: {}",
+                    path,
+                    e
+                )
+            })?);
+            let keystore = serde_json::from_reader(reader).map_err(|e| {
+                anyhow!(
+                    "Can't deserialize FileBasedKeystore from Rooch path {:?}: {}",
+                    path,
+                    e
+                )
+            })?;
+            Ok(Self {
+                keystore,
+                path: Some(path.to_path_buf()),
+            })
+        } else {
+            Err(anyhow!("Key store path {:?} does not exist", path))
+        }
+    }
+
     pub fn set_path(&mut self, path: &Path) {
         self.path = Some(path.to_path_buf());
     }

--- a/crates/rooch/src/cli_types.rs
+++ b/crates/rooch/src/cli_types.rs
@@ -15,6 +15,8 @@ use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::path::PathBuf;
 
+use rooch_types::address::RoochAddress;
+use rooch_types::crypto::RoochKeyPair;
 use std::str::FromStr;
 
 #[async_trait]
@@ -99,7 +101,7 @@ pub struct WalletContextOptions {
 }
 
 impl WalletContextOptions {
-    pub async fn build(&self) -> RoochResult<WalletContext> {
+    pub async fn build(&self) -> RoochResult<WalletContext<RoochAddress, RoochKeyPair>> {
         WalletContext::new(self.config_dir.clone())
             .await
             .map_err(RoochError::from)

--- a/crates/rooch/src/commands/account/commands/create.rs
+++ b/crates/rooch/src/commands/account/commands/create.rs
@@ -5,10 +5,10 @@ use crate::cli_types::WalletContextOptions;
 use clap::Parser;
 use move_core_types::account_address::AccountAddress;
 use rooch_key::{keypair::KeyPairType, keystore::AccountKeystore};
-use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
-use rooch_types::{account::AccountModule, error::RoochResult};
+use rooch_types::error::RoochResult;
 
-/// Create a new account on-chain
+/// Create a new account off-chain.
+/// If an account not exist on-chain, contract will auto create the account on-chain.
 ///
 /// An account can be created by transferring coins, or by making an explicit
 /// call to create an account.  This will create an account with no coins, and
@@ -20,30 +20,21 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
+    pub async fn execute(self) -> RoochResult<String> {
         let mut context = self.context_options.build().await?;
 
-        let (new_address, phrase, multichain_id) = context
-            .client_config
-            .keystore
-            .generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None)?;
+        let (new_address, phrase, multichain_id) =
+            context
+                .keystore
+                .generate_and_add_new_key(KeyPairType::RoochKeyPairType, None, None)?;
 
-        println!("{}", AccountAddress::from(new_address).to_hex_literal());
+        let address = AccountAddress::from(new_address).to_hex_literal();
         println!(
             "Generated new keypair for address with multichain id {:?} [{new_address}]",
-            KeyPairType::RoochKeyPairType.type_of()
+            multichain_id
         );
         println!("Secret Recovery Phrase : [{phrase}]");
 
-        // Obtain account address
-        let address = AccountAddress::from(new_address);
-
-        // Create account action
-        let action = AccountModule::create_account_action(address);
-
-        let result = context
-            .sign_and_execute(new_address, action, multichain_id)
-            .await?;
-        context.assert_execute_success(result)
+        Ok(address)
     }
 }

--- a/crates/rooch/src/commands/account/commands/import.rs
+++ b/crates/rooch/src/commands/account/commands/import.rs
@@ -27,7 +27,6 @@ impl CommandAction<()> for ImportCommand {
         let mut context = self.context_options.build().await?;
 
         let address = context
-            .client_config
             .keystore
             .import_from_mnemonic(&self.mnemonic_phrase, KeyPairType::RoochKeyPairType, None)
             .map_err(|e| RoochError::ImportAccountError(e.to_string()))?;

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -26,7 +26,8 @@ impl CommandAction<()> for ListCommand {
             "Rooch Address (Ed25519)", "Public Key (Base64)", "Auth Validator ID", "Active Address"
         );
         println!("{}", ["-"; 153].join(""));
-        for (address, public_key) in context.client_config.keystore.get_address_public_keys() {
+
+        for (address, public_key) in context.keystore.get_address_public_keys() {
             let auth_validator_id = public_key.auth_validator().flag();
             let mut active = "";
             if active_address == Some(address) {

--- a/crates/rooch/src/commands/account/commands/nullify.rs
+++ b/crates/rooch/src/commands/account/commands/nullify.rs
@@ -52,7 +52,6 @@ impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
 
         // Remove keypair by coin id from Rooch key store after successfully executing transaction
         context
-            .client_config
             .keystore
             .nullify_address_with_key_pair_from_key_pair_type(
                 &existing_address,

--- a/crates/rooch/src/commands/account/commands/switch.rs
+++ b/crates/rooch/src/commands/account/commands/switch.rs
@@ -29,12 +29,7 @@ impl CommandAction<()> for SwitchCommand {
             RoochError::CommandArgumentError(format!("Invalid Rooch address String: {}", e))
         })?;
 
-        if !context
-            .client_config
-            .keystore
-            .addresses()
-            .contains(&rooch_address)
-        {
+        if !context.keystore.addresses().contains(&rooch_address) {
             return Err(RoochError::SwitchAccountError(format!(
                 "Address `{}` does not in the Rooch keystore",
                 self.address

--- a/crates/rooch/src/commands/account/commands/update.rs
+++ b/crates/rooch/src/commands/account/commands/update.rs
@@ -37,7 +37,6 @@ impl CommandAction<ExecuteTransactionResponseView> for UpdateCommand {
         })?;
 
         let kp = context
-            .client_config
             .keystore
             .update_address_with_key_pair_from_key_pair_type(
                 &existing_address,

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -49,6 +49,8 @@ impl CommandAction<()> for Init {
             .parent()
             .unwrap_or(&rooch_config_dir()?)
             .join(ROOCH_KEYSTORE_FILENAME);
+        println!("Debug client_config_path: {:?}", client_config_path);
+        println!("Debug keystore_path: {:?}", keystore_path);
 
         let keystore_result = FileBasedKeystore::<RoochAddress, RoochKeyPair>::new(&keystore_path);
         let mut keystore = match keystore_result {
@@ -145,7 +147,7 @@ impl CommandAction<()> for Init {
                 let dev_env = Env::new_dev_env();
                 let active_env_alias = dev_env.alias.clone();
                 ClientConfig {
-                    keystore,
+                    keystore_path,
                     envs: vec![env, dev_env],
                     active_address: Some(new_address),
                     // make dev env as default env

--- a/crates/rooch/src/commands/init.rs
+++ b/crates/rooch/src/commands/init.rs
@@ -49,8 +49,6 @@ impl CommandAction<()> for Init {
             .parent()
             .unwrap_or(&rooch_config_dir()?)
             .join(ROOCH_KEYSTORE_FILENAME);
-        println!("Debug client_config_path: {:?}", client_config_path);
-        println!("Debug keystore_path: {:?}", keystore_path);
 
         let keystore_result = FileBasedKeystore::<RoochAddress, RoochKeyPair>::new(&keystore_path);
         let mut keystore = match keystore_result {

--- a/crates/rooch/src/commands/move_cli/commands/run_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_function.rs
@@ -90,7 +90,6 @@ impl CommandAction<ExecuteTransactionResponseView> for RunFunction {
             (_, Some(session_key)) => {
                 let tx_data = context.build_rooch_tx_data(sender, action).await?;
                 let tx = context
-                    .client_config
                     .keystore
                     .sign_transaction_via_session_key(&sender, tx_data, &session_key)
                     .map_err(|e| RoochError::SignMessageError(e.to_string()))?;

--- a/crates/rooch/src/commands/server/commands/start.rs
+++ b/crates/rooch/src/commands/server/commands/start.rs
@@ -49,7 +49,6 @@ impl CommandAction<()> for StartCommand {
             )?
         };
         let sequencer_keypair = context
-            .client_config
             .keystore
             .get_key_pair_by_key_pair_type(&sequencer_account, KeyPairType::RoochKeyPairType)
             .map_err(|e| RoochError::SequencerKeyPairDoesNotExistError(e.to_string()))?;
@@ -71,7 +70,6 @@ impl CommandAction<()> for StartCommand {
             )?
         };
         let proposer_keypair = context
-            .client_config
             .keystore
             .get_key_pair_by_key_pair_type(&proposer_account, KeyPairType::RoochKeyPairType)
             .map_err(|e| RoochError::ProposerKeyPairDoesNotExistError(e.to_string()))?;
@@ -93,7 +91,6 @@ impl CommandAction<()> for StartCommand {
             )?
         };
         let relayer_keypair = context
-            .client_config
             .keystore
             .get_key_pair_by_key_pair_type(&relayer_account, KeyPairType::RoochKeyPairType)
             .map_err(|e| RoochError::RelayerKeyPairDoesNotExistError(e.to_string()))?;

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -45,10 +45,7 @@ impl CreateCommand {
             .parse_account_arg(self.tx_options.sender_account.unwrap())?
             .into();
 
-        let session_auth_key = context
-            .client_config
-            .keystore
-            .generate_session_key(&sender)?;
+        let session_auth_key = context.keystore.generate_session_key(&sender)?;
 
         let session_scope = self.scope;
 


### PR DESCRIPTION
resolve https://github.com/rooch-network/rooch/issues/906

Summary
1. Remove the keystore from the client config, leaving only the keystore path in the client config
2. Load keystore in Wallet Context, keystore is used as an attribute of WalletContext
3. Make the account account create to a local operation; do not execute the transaction