### PR TITLE
Refactor ObjectStorage and StorageContext

### DIFF
--- a/crates/rooch-framework-tests/tests/cases/event/basic.exp
+++ b/crates/rooch-framework-tests/tests/cases/event/basic.exp
@@ -3,5 +3,5 @@ processed 3 tasks
 task 1 'publish'. lines 3-18:
 status EXECUTED
 
-task 2 'run'. lines 19-29:
+task 2 'run'. lines 19-28:
 status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/event/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/event/basic.move
@@ -19,11 +19,10 @@ module test::m {
 //# run --signers test
 script {
     use moveos_std::storage_context::{Self, StorageContext};
-    use moveos_std::tx_context;
     use test::m;
 
     fun main(ctx: &mut StorageContext) {
-        let sender_addr = tx_context::sender(storage_context::tx_context(ctx));
+        let sender_addr = storage_context::sender(ctx);
         m::emit_withdraw_event(ctx, sender_addr, 100);
     }
 }

--- a/crates/rooch-framework-tests/tests/cases/object/basic.exp
+++ b/crates/rooch-framework-tests/tests/cases/object/basic.exp
@@ -1,32 +1,32 @@
 processed 10 tasks
 
-task 1 'publish'. lines 3-57:
+task 1 'publish'. lines 3-51:
 status EXECUTED
 
-task 2 'run'. lines 59-59:
+task 2 'run'. lines 53-53:
 status EXECUTED
 
-task 3 'view_object'. lines 61-63:
+task 3 'view_object'. lines 55-57:
 Object { id: ObjectID(ae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647), owner: 0000000000000000000000000000000000000000000000000000000000000043, value: AnnotatedMoveStruct { abilities: [Store, Key, ], type_: StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("S"), type_params: [] }, value: [(Identifier("v"), U8(1))] } }
 
-task 4 'run'. lines 65-65:
+task 4 'run'. lines 59-59:
 status EXECUTED
 
-task 5 'view_object'. lines 67-70:
+task 5 'view_object'. lines 61-64:
 Object { id: ObjectID(0bbaf311ae6768a532b1f9dee65b1758a7bb1114fd57df8fa94cb2d1cb5f6896), owner: 0000000000000000000000000000000000000000000000000000000000000043, value: AnnotatedMoveStruct { abilities: [Store, Key, ], type_: StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("Cup"), type_params: [Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("S"), type_params: [] })] }, value: [(Identifier("v"), U8(2))] } }
 
-task 6 'run'. lines 72-72:
+task 6 'run'. lines 66-66:
 status EXECUTED
 
-task 7 'view'. lines 74-76:
+task 7 'view'. lines 68-70:
 store key 0x42::m::S {
     v: 1u8
 }
 
-task 8 'run'. lines 78-78:
+task 8 'run'. lines 72-72:
 status EXECUTED
 
-task 9 'view'. lines 80-80:
+task 9 'view'. lines 74-74:
 store key 0x42::m::Cup<0x42::m::S> {
     v: 2u8
 }

--- a/crates/rooch-framework-tests/tests/cases/object/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/object/basic.move
@@ -8,7 +8,6 @@ module test::m {
     use moveos_std::object;
     use moveos_std::object_id::ObjectID;
     use moveos_std::account_storage;
-    use moveos_std::object_storage;
     use std::debug;
 
     struct S has store, key { v: u8 }
@@ -23,14 +22,12 @@ module test::m {
         assert!(x"7852c5dcbd87e82102dba0db36d44b5a9fb0006b3e828c0b5f0832f70a8ff6ee" == tx_hash, 1000);
         let obj = object::new(tx_ctx, sender , S { v: 1});
         debug::print(&obj);
-        let object_storage = storage_context::object_storage_mut(ctx);
-        object_storage::add(object_storage, obj);
+        storage_context::add_object(ctx, obj);
     }
 
     public entry fun move_s_to_global(ctx: &mut StorageContext, sender: signer, object_id: ObjectID) {
-        let object_storage = storage_context::object_storage_mut(ctx);
         debug::print(&object_id);
-        let obj = object_storage::remove<S>(object_storage, object_id);
+        let obj = storage_context::remove_object(ctx, object_id);
         debug::print(&obj);
         let (_id, _owner, value) = object::unpack(obj);
         account_storage::global_move_to(ctx, &sender, value);
@@ -41,13 +38,11 @@ module test::m {
         let sender = tx_context::sender(tx_ctx);
         let obj = object::new(tx_ctx, sender, Cup<T> { v: 2 });
         debug::print(&obj);
-        let object_storage = storage_context::object_storage_mut(ctx);
-        object_storage::add(object_storage, obj);
+        storage_context::add_object(ctx, obj);
     }
 
     public entry fun move_cup_to_global<T:store>(ctx: &mut StorageContext, sender: signer, object_id: ObjectID) {
-        let object_storage = storage_context::object_storage_mut(ctx);
-        let obj = object_storage::remove<Cup<S>>(object_storage, object_id);
+        let obj = storage_context::remove_object(ctx, object_id);
         debug::print(&obj);
         let (_id,_owner,value) = object::unpack(obj);
         account_storage::global_move_to(ctx, &sender, value);

--- a/crates/rooch-framework-tests/tests/cases/object/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/object/basic.move
@@ -3,7 +3,6 @@
 //# publish
 
 module test::m {
-    use moveos_std::tx_context;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::object;
     use moveos_std::object_id::ObjectID;
@@ -15,8 +14,8 @@ module test::m {
 
     public entry fun mint_s(ctx: &mut StorageContext) {
         let tx_ctx = storage_context::tx_context_mut(ctx);
-        let sender = tx_context::sender(tx_ctx);
-        let tx_hash = tx_context::tx_hash(tx_ctx);
+        let sender = storage_context::sender(ctx);
+        let tx_hash = storage_context::tx_hash(ctx);
         debug::print(&tx_hash);
         // if the tx hash change, need to figure out why.
         assert!(x"7852c5dcbd87e82102dba0db36d44b5a9fb0006b3e828c0b5f0832f70a8ff6ee" == tx_hash, 1000);

--- a/crates/rooch-framework-tests/tests/cases/object/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/object/basic.move
@@ -13,9 +13,9 @@ module test::m {
     struct Cup<phantom T: store> has store, key { v: u8 }
 
     public entry fun mint_s(ctx: &mut StorageContext) {
-        let tx_ctx = storage_context::tx_context_mut(ctx);
         let sender = storage_context::sender(ctx);
-        let tx_hash = storage_context::tx_hash(ctx);
+        let tx_hash = storage_context::tx_hash(ctx);        
+        let tx_ctx = storage_context::tx_context_mut(ctx);
         debug::print(&tx_hash);
         // if the tx hash change, need to figure out why.
         assert!(x"7852c5dcbd87e82102dba0db36d44b5a9fb0006b3e828c0b5f0832f70a8ff6ee" == tx_hash, 1000);

--- a/crates/rooch-framework-tests/tests/cases/object/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/object/basic.move
@@ -26,22 +26,22 @@ module test::m {
 
     public entry fun move_s_to_global(ctx: &mut StorageContext, sender: signer, object_id: ObjectID) {
         debug::print(&object_id);
-        let obj = storage_context::remove_object(ctx, object_id);
+        let obj = storage_context::remove_object<S>(ctx, object_id);
         debug::print(&obj);
         let (_id, _owner, value) = object::unpack(obj);
         account_storage::global_move_to(ctx, &sender, value);
     }
 
     public entry fun mint_cup<T: store>(ctx: &mut StorageContext) {
+        let sender = storage_context::sender(ctx);
         let tx_ctx = storage_context::tx_context_mut(ctx);
-        let sender = tx_context::sender(tx_ctx);
         let obj = object::new(tx_ctx, sender, Cup<T> { v: 2 });
         debug::print(&obj);
         storage_context::add_object(ctx, obj);
     }
 
     public entry fun move_cup_to_global<T:store>(ctx: &mut StorageContext, sender: signer, object_id: ObjectID) {
-        let obj = storage_context::remove_object(ctx, object_id);
+        let obj = storage_context::remove_object<Cup<S>>(ctx, object_id);
         debug::print(&obj);
         let (_id,_owner,value) = object::unpack(obj);
         account_storage::global_move_to(ctx, &sender, value);

--- a/crates/rooch-framework-tests/tests/cases/object/object_cap.exp
+++ b/crates/rooch-framework-tests/tests/cases/object/object_cap.exp
@@ -3,23 +3,23 @@ processed 3 tasks
 task 1 'publish'. lines 3-21:
 status EXECUTED
 
-task 2 'run'. lines 22-38:
+task 2 'run'. lines 22-37:
 Error: error: resource type "TestObject" in function "0x2::object::new" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:31:19
+   ┌─ /tmp/tempfile:30:19
    │
-31 │         let obj = object::new<TestObject>(storage_context::tx_context_mut(ctx), sender_addr, object);
+30 │         let obj = object::new<TestObject>(storage_context::tx_context_mut(ctx), sender_addr, object);
    │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: resource type "TestObject" in function "0x2::object::borrow" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:32:30
+   ┌─ /tmp/tempfile:31:30
    │
-32 │         let _borrow_object = object::borrow(&obj);
+31 │         let _borrow_object = object::borrow(&obj);
    │                              ^^^^^^^^^^^^^^^^^^^^
 
 error: resource type "TestObject" in function "0x2::object::unpack" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:33:42
+   ┌─ /tmp/tempfile:32:42
    │
-33 │         let (_id, _owner, test_object) = object::unpack(obj);
+32 │         let (_id, _owner, test_object) = object::unpack(obj);
    │                                          ^^^^^^^^^^^^^^^^^^^
 
 

--- a/crates/rooch-framework-tests/tests/cases/object/object_cap.move
+++ b/crates/rooch-framework-tests/tests/cases/object/object_cap.move
@@ -22,12 +22,11 @@ module test::m {
 //# run --signers A
 script {
     use moveos_std::storage_context::{Self, StorageContext};
-    use moveos_std::tx_context;
     use moveos_std::object;
     use test::m::{Self, TestObject};
 
     fun main(ctx: &mut StorageContext) {
-        let sender_addr = tx_context::sender(storage_context::tx_context(ctx));
+        let sender_addr = storage_context::sender(ctx);
         let object = m::new_test_object(12);
         let obj = object::new<TestObject>(storage_context::tx_context_mut(ctx), sender_addr, object);
 

--- a/crates/rooch-framework-tests/tests/cases/table/basic.exp
+++ b/crates/rooch-framework-tests/tests/cases/table/basic.exp
@@ -1,10 +1,10 @@
 processed 4 tasks
 
-task 1 'publish'. lines 3-51:
+task 1 'publish'. lines 3-46:
 status EXECUTED
 
-task 2 'run'. lines 53-65:
+task 2 'run'. lines 48-60:
 status EXECUTED
 
-task 3 'run'. lines 67-80:
+task 3 'run'. lines 62-75:
 status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/table/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/table/basic.move
@@ -7,7 +7,6 @@ module test::m {
     use moveos_std::tx_context;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::object;
-    use moveos_std::object_storage;
     use moveos_std::object_id::{ObjectID};
 
     struct KVStore has store, key {
@@ -38,14 +37,12 @@ module test::m {
         let sender = tx_context::sender(tx_ctx);
         let object = object::new(tx_ctx, sender, kv);
         let object_id = object::id(&object);
-        let object_storage = storage_context::object_storage_mut(ctx);
-        object_storage::add(object_storage, object);
+        storage_context::add_object(ctx, object);
         object_id
     }
 
     public fun borrow_from_object_storage(ctx: &mut StorageContext, object_id: ObjectID): &KVStore {
-        let object_storage = storage_context::object_storage(ctx);
-        let object = object_storage::borrow(object_storage, object_id);
+        let object = storage_context::borrow_object(ctx, object_id);
         object::borrow<KVStore>(object)
     }
 }

--- a/crates/rooch-framework-tests/tests/cases/table/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/table/basic.move
@@ -31,8 +31,8 @@ module test::m {
     }
 
     public fun save_to_object_storage(ctx: &mut StorageContext, kv: KVStore) : ObjectID {
+        let sender = storage_context::sender(ctx);        
         let tx_ctx = storage_context::tx_context_mut(ctx);
-        let sender = storage_context::sender(ctx);
         let object = object::new(tx_ctx, sender, kv);
         let object_id = object::id(&object);
         storage_context::add_object(ctx, object);

--- a/crates/rooch-framework-tests/tests/cases/table/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/table/basic.move
@@ -4,7 +4,6 @@
 module test::m {
     use std::string::String;
     use moveos_std::table::{Self, Table};
-    use moveos_std::tx_context;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::object;
     use moveos_std::object_id::{ObjectID};
@@ -14,9 +13,8 @@ module test::m {
     }
 
     public fun make_kv_store(ctx: &mut StorageContext): KVStore {
-        let tx_ctx = storage_context::tx_context_mut(ctx);
         KVStore{
-            table: table::new(tx_ctx),
+            table: table::new(ctx),
         }
     }
 
@@ -34,7 +32,7 @@ module test::m {
 
     public fun save_to_object_storage(ctx: &mut StorageContext, kv: KVStore) : ObjectID {
         let tx_ctx = storage_context::tx_context_mut(ctx);
-        let sender = tx_context::sender(tx_ctx);
+        let sender = storage_context::sender(ctx);
         let object = object::new(tx_ctx, sender, kv);
         let object_id = object::id(&object);
         storage_context::add_object(ctx, object);

--- a/crates/rooch-framework-tests/tests/cases/table/test_destroy.exp
+++ b/crates/rooch-framework-tests/tests/cases/table/test_destroy.exp
@@ -1,19 +1,19 @@
 processed 7 tasks
 
-task 1 'publish'. lines 3-85:
+task 1 'publish'. lines 3-80:
 status EXECUTED
 
-task 2 'run'. lines 87-101:
+task 2 'run'. lines 82-96:
 status EXECUTED
 
-task 3 'run'. lines 102-117:
+task 3 'run'. lines 97-112:
 status EXECUTED
 
-task 4 'run'. lines 118-133:
+task 4 'run'. lines 113-128:
 status EXECUTED
 
-task 5 'run'. lines 134-146:
+task 5 'run'. lines 129-141:
 status ABORTED with code 3 in 0000000000000000000000000000000000000000000000000000000000000002::raw_table
 
-task 6 'run'. lines 147-160:
+task 6 'run'. lines 142-155:
 status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
+++ b/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
@@ -4,7 +4,6 @@
 module test::m {
     use std::string::String;
     use moveos_std::table::{Self, Table};
-    use moveos_std::tx_context;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::object;
     use moveos_std::object_id::{ObjectID};
@@ -15,9 +14,8 @@ module test::m {
     }
 
     public fun make_kv_store(ctx: &mut StorageContext): KVStore{
-        let tx_ctx = storage_context::tx_context_mut(ctx);
         KVStore{
-            table: table::new(tx_ctx),
+            table: table::new(ctx),
         }
     }
 
@@ -39,7 +37,7 @@ module test::m {
 
     public fun save_to_object_storage(ctx: &mut StorageContext, kv: KVStore) : ObjectID {
         let tx_ctx = storage_context::tx_context_mut(ctx);
-        let sender = tx_context::sender(tx_ctx);
+        let sender = storage_context::sender(ctx);
         let object = object::new(tx_ctx, sender, kv);
         let object_id = object::id(&object);
         storage_context::add_object(ctx, object);

--- a/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
+++ b/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
@@ -35,9 +35,9 @@ module test::m {
         table::borrow(&store.table, key)
     }
 
-    public fun save_to_object_storage(ctx: &mut StorageContext, kv: KVStore) : ObjectID {
-        let tx_ctx = storage_context::tx_context_mut(ctx);
+    public fun save_to_object_storage(ctx: &mut StorageContext, kv: KVStore) : ObjectID {        
         let sender = storage_context::sender(ctx);
+        let tx_ctx = storage_context::tx_context_mut(ctx);
         let object = object::new(tx_ctx, sender, kv);
         let object_id = object::id(&object);
         storage_context::add_object(ctx, object);

--- a/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
+++ b/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
@@ -7,7 +7,6 @@ module test::m {
     use moveos_std::tx_context;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::object;
-    use moveos_std::object_storage;
     use moveos_std::object_id::{ObjectID};
     use moveos_std::account_storage;
 
@@ -43,14 +42,12 @@ module test::m {
         let sender = tx_context::sender(tx_ctx);
         let object = object::new(tx_ctx, sender, kv);
         let object_id = object::id(&object);
-        let object_storage = storage_context::object_storage_mut(ctx);
-        object_storage::add(object_storage, object);
+        storage_context::add_object(ctx, object);
         object_id
     }
 
     public fun borrow_from_object_storage(ctx: &mut StorageContext, object_id: ObjectID): &KVStore {
-        let object_storage = storage_context::object_storage(ctx);
-        let object = object_storage::borrow(object_storage, object_id);
+        let object = storage_context::borrow_object(ctx, object_id);
         object::borrow<KVStore>(object)
     }
 

--- a/crates/rooch-framework/doc/account_authentication.md
+++ b/crates/rooch-framework/doc/account_authentication.md
@@ -26,7 +26,6 @@ Migrate their from the account module for simplyfying the account module.
 <b>use</b> <a href="">0x1::vector</a>;
 <b>use</b> <a href="">0x2::account_storage</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
-<b>use</b> <a href="">0x2::tx_context</a>;
 <b>use</b> <a href="">0x2::type_table</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
 <b>use</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry">0x3::auth_validator_registry</a>;
@@ -201,7 +200,7 @@ max authentication key length
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account_authentication.md#0x3_account_authentication_init_authentication_keys">init_authentication_keys</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>) {
    <b>let</b> authentication_keys = <a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a> {
-      authentication_keys: <a href="_new">type_table::new</a>(<a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx)),
+      authentication_keys: <a href="_new">type_table::new</a>(ctx),
    };
    <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="account_authentication.md#0x3_account_authentication_AuthenticationKeys">AuthenticationKeys</a>&gt;(ctx, <a href="account.md#0x3_account">account</a>, authentication_keys);
 }

--- a/crates/rooch-framework/doc/address_mapping.md
+++ b/crates/rooch-framework/doc/address_mapping.md
@@ -20,7 +20,6 @@
 <b>use</b> <a href="">0x2::bcs</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="">0x2::table</a>;
-<b>use</b> <a href="">0x2::tx_context</a>;
 <b>use</b> <a href="hash.md#0x3_hash">0x3::hash</a>;
 <b>use</b> <a href="multichain_address.md#0x3_multichain_address">0x3::multichain_address</a>;
 </code></pre>
@@ -70,8 +69,7 @@
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="address_mapping.md#0x3_address_mapping_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, genesis_account: &<a href="">signer</a>) {
-    <b>let</b> tx_ctx = <a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
-    <b>let</b> mapping = <a href="_new">table::new</a>&lt;MultiChainAddress, <b>address</b>&gt;(tx_ctx);
+    <b>let</b> mapping = <a href="_new">table::new</a>&lt;MultiChainAddress, <b>address</b>&gt;(ctx);
     <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, <a href="address_mapping.md#0x3_address_mapping_AddressMapping">AddressMapping</a>{
         mapping,
     });

--- a/crates/rooch-framework/doc/auth_validator_registry.md
+++ b/crates/rooch-framework/doc/auth_validator_registry.md
@@ -20,7 +20,6 @@
 <b>use</b> <a href="">0x2::account_storage</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="">0x2::table</a>;
-<b>use</b> <a href="">0x2::tx_context</a>;
 <b>use</b> <a href="">0x2::type_info</a>;
 <b>use</b> <a href="">0x2::type_table</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
@@ -136,8 +135,8 @@ Init function called by genesis.
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, sender: &<a href="">signer</a>){
     <b>let</b> registry = <a href="auth_validator_registry.md#0x3_auth_validator_registry_ValidatorRegistry">ValidatorRegistry</a> {
         validator_num: 0,
-        validators: <a href="_new">table::new</a>(<a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx)),
-        validators_with_type: <a href="_new">type_table::new</a>(<a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx)),
+        validators: <a href="_new">table::new</a>(ctx),
+        validators_with_type: <a href="_new">type_table::new</a>(ctx),
     };
     <a href="_global_move_to">account_storage::global_move_to</a>(ctx, sender, registry);
 }

--- a/crates/rooch-framework/doc/coin.md
+++ b/crates/rooch-framework/doc/coin.md
@@ -66,7 +66,6 @@ This module provides the foundation for typesafe Coins.
 <b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="">0x2::table</a>;
-<b>use</b> <a href="">0x2::tx_context</a>;
 <b>use</b> <a href="">0x2::type_info</a>;
 <b>use</b> <a href="">0x2::type_table</a>;
 </code></pre>
@@ -606,14 +605,15 @@ Coin amount cannot be zero
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="coin.md#0x3_coin_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, genesis_account: &<a href="">signer</a>) {
-    <b>let</b> tx_ctx = <a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
-    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, <a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>{
-        coin_infos: <a href="_new">type_table::new</a>(tx_ctx),
-    });
-    <b>let</b> tx_ctx = <a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
-    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, <a href="coin.md#0x3_coin_AutoAcceptCoins">AutoAcceptCoins</a>{
-        auto_accept_coins: <a href="_new">table::new</a>&lt;<b>address</b>, bool&gt;(tx_ctx),
-    });
+    <b>let</b> coin_infos = <a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a> {
+        coin_infos: <a href="_new">type_table::new</a>(ctx),
+    };
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, coin_infos);
+
+    <b>let</b> auto_accepted_coins = <a href="coin.md#0x3_coin_AutoAcceptCoins">AutoAcceptCoins</a> {
+        auto_accept_coins: <a href="_new">table::new</a>&lt;<b>address</b>, bool&gt;(ctx),
+    };
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, auto_accepted_coins);
 }
 </code></pre>
 
@@ -637,10 +637,10 @@ Coin amount cannot be zero
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="coin.md#0x3_coin_init_account_coin_store">init_account_coin_store</a>(ctx: &<b>mut</b> StorageContext, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>){
-    <b>let</b> tx_ctx = <a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
-    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, <a href="account.md#0x3_account">account</a>, <a href="coin.md#0x3_coin_CoinStores">CoinStores</a>{
-        coin_stores: <a href="_new">type_table::new</a>(tx_ctx),
-    });
+    <b>let</b> coin_stores = <a href="coin.md#0x3_coin_CoinStores">CoinStores</a> {
+        coin_stores: <a href="_new">type_table::new</a>(ctx),
+    };
+    <a href="_global_move_to">account_storage::global_move_to</a>(ctx, <a href="account.md#0x3_account">account</a>, coin_stores);
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/ethereum_light_client.md
+++ b/crates/rooch-framework/doc/ethereum_light_client.md
@@ -18,7 +18,6 @@
 <b>use</b> <a href="">0x2::bcs</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="">0x2::table</a>;
-<b>use</b> <a href="">0x2::tx_context</a>;
 <b>use</b> <a href="ethereum_address.md#0x3_ethereum_address">0x3::ethereum_address</a>;
 <b>use</b> <a href="timestamp.md#0x3_timestamp">0x3::timestamp</a>;
 </code></pre>
@@ -187,9 +186,8 @@
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ethereum_light_client.md#0x3_ethereum_light_client_genesis_init">genesis_init</a>(ctx: &<b>mut</b> StorageContext, genesis_account: &<a href="">signer</a>){
-    <b>let</b> tx_ctx = <a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
     <b>let</b> block_store = <a href="ethereum_light_client.md#0x3_ethereum_light_client_BlockStore">BlockStore</a>{
-        blocks: <a href="_new">table::new</a>(tx_ctx),
+        blocks: <a href="_new">table::new</a>(ctx),
     };
     <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, block_store);
 }

--- a/crates/rooch-framework/doc/session_key.md
+++ b/crates/rooch-framework/doc/session_key.md
@@ -30,7 +30,6 @@
 <b>use</b> <a href="">0x2::account_storage</a>;
 <b>use</b> <a href="">0x2::storage_context</a>;
 <b>use</b> <a href="">0x2::table</a>;
-<b>use</b> <a href="">0x2::tx_context</a>;
 <b>use</b> <a href="">0x2::tx_meta</a>;
 <b>use</b> <a href="auth_validator.md#0x3_auth_validator">0x3::auth_validator</a>;
 <b>use</b> <a href="native_validator.md#0x3_native_validator">0x3::native_validator</a>;
@@ -368,7 +367,7 @@ Get the session key of the account_address by the authentication key
         max_inactive_interval: max_inactive_interval,
     };
     <b>if</b> (!<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender_addr)){
-        <b>let</b> keys = <a href="_new">table::new</a>&lt;<a href="">vector</a>&lt;u8&gt;, <a href="session_key.md#0x3_session_key_SessionKey">SessionKey</a>&gt;(<a href="_tx_context_mut">storage_context::tx_context_mut</a>(ctx));
+        <b>let</b> keys = <a href="_new">table::new</a>&lt;<a href="">vector</a>&lt;u8&gt;, <a href="session_key.md#0x3_session_key_SessionKey">SessionKey</a>&gt;(ctx);
         <a href="_global_move_to">account_storage::global_move_to</a>&lt;<a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>&gt;(ctx, sender, <a href="session_key.md#0x3_session_key_SessionKeys">SessionKeys</a>{keys});
     };
 

--- a/crates/rooch-framework/sources/account_authentication.move
+++ b/crates/rooch-framework/sources/account_authentication.move
@@ -7,7 +7,7 @@ module rooch_framework::account_authentication{
    use std::signer;
    use std::vector;
    use moveos_std::account_storage;
-   use moveos_std::storage_context::{Self, StorageContext};
+   use moveos_std::storage_context::StorageContext;
    use moveos_std::type_table::{Self, TypeTable};
    use rooch_framework::auth_validator_registry;
    use rooch_framework::auth_validator;
@@ -47,7 +47,7 @@ module rooch_framework::account_authentication{
 
    public(friend) fun init_authentication_keys(ctx: &mut StorageContext, account: &signer) {
       let authentication_keys = AuthenticationKeys {
-         authentication_keys: type_table::new(storage_context::tx_context_mut(ctx)),
+         authentication_keys: type_table::new(ctx),
       };
       account_storage::global_move_to<AuthenticationKeys>(ctx, account, authentication_keys);
    }

--- a/crates/rooch-framework/sources/address_mapping.move
+++ b/crates/rooch-framework/sources/address_mapping.move
@@ -2,7 +2,7 @@ module rooch_framework::address_mapping{
     
     use std::option::{Self, Option};
     use std::signer;
-    use moveos_std::storage_context::{Self, StorageContext};
+    use moveos_std::storage_context::StorageContext;
     use moveos_std::table::{Self, Table};
     use moveos_std::account_storage;
     use rooch_framework::hash::{blake2b256};
@@ -17,8 +17,7 @@ module rooch_framework::address_mapping{
     }
 
     public(friend) fun genesis_init(ctx: &mut StorageContext, genesis_account: &signer) {
-        let tx_ctx = storage_context::tx_context_mut(ctx);
-        let mapping = table::new<MultiChainAddress, address>(tx_ctx);
+        let mapping = table::new<MultiChainAddress, address>(ctx);
         account_storage::global_move_to(ctx, genesis_account, AddressMapping{
             mapping,
         });

--- a/crates/rooch-framework/sources/auth_validator/auth_validator_registry.move
+++ b/crates/rooch-framework/sources/auth_validator/auth_validator_registry.move
@@ -5,9 +5,12 @@ module rooch_framework::auth_validator_registry{
     use moveos_std::table::{Self, Table};
     use moveos_std::type_table::{Self, TypeTable};
     use moveos_std::account_storage;
-    use moveos_std::storage_context::{Self, StorageContext};
+    use moveos_std::storage_context::StorageContext;
     use rooch_framework::auth_validator::{Self, AuthValidator};
 
+    #[test_only]
+    use moveos_std::storage_context;
+    
     friend rooch_framework::genesis;
     friend rooch_framework::builtin_validators;
 
@@ -29,8 +32,8 @@ module rooch_framework::auth_validator_registry{
     public(friend) fun genesis_init(ctx: &mut StorageContext, sender: &signer){
         let registry = ValidatorRegistry {
             validator_num: 0,
-            validators: table::new(storage_context::tx_context_mut(ctx)),
-            validators_with_type: type_table::new(storage_context::tx_context_mut(ctx)),
+            validators: table::new(ctx),
+            validators_with_type: type_table::new(ctx),
         };
         account_storage::global_move_to(ctx, sender, registry);
     }

--- a/crates/rooch-framework/sources/coin.move
+++ b/crates/rooch-framework/sources/coin.move
@@ -7,11 +7,10 @@ module rooch_framework::coin {
     use moveos_std::object_id::ObjectID;
     use moveos_std::table;
     use moveos_std::table::Table;
-    use moveos_std::type_table::{TypeTable};
-    use moveos_std::storage_context;
+    use moveos_std::type_table::TypeTable;
     use moveos_std::type_table;
     use moveos_std::account_storage;
-    use moveos_std::storage_context::{StorageContext};
+    use moveos_std::storage_context::StorageContext;
     use moveos_std::event;
     use moveos_std::type_info::{Self, TypeInfo, type_of};
     use moveos_std::signer;
@@ -156,21 +155,22 @@ module rooch_framework::coin {
     }
 
     public(friend) fun genesis_init(ctx: &mut StorageContext, genesis_account: &signer) {
-        let tx_ctx = storage_context::tx_context_mut(ctx);
-        account_storage::global_move_to(ctx, genesis_account, CoinInfos{
-            coin_infos: type_table::new(tx_ctx),
-        });
-        let tx_ctx = storage_context::tx_context_mut(ctx);
-        account_storage::global_move_to(ctx, genesis_account, AutoAcceptCoins{
-            auto_accept_coins: table::new<address, bool>(tx_ctx),
-        });
+        let coin_infos = CoinInfos {
+            coin_infos: type_table::new(ctx),
+        };
+        account_storage::global_move_to(ctx, genesis_account, coin_infos);
+
+        let auto_accepted_coins = AutoAcceptCoins {
+            auto_accept_coins: table::new<address, bool>(ctx),
+        };
+        account_storage::global_move_to(ctx, genesis_account, auto_accepted_coins);
     }
 
     public(friend) fun init_account_coin_store(ctx: &mut StorageContext, account: &signer){
-        let tx_ctx = storage_context::tx_context_mut(ctx);
-        account_storage::global_move_to(ctx, account, CoinStores{
-            coin_stores: type_table::new(tx_ctx),
-        });
+        let coin_stores = CoinStores {
+            coin_stores: type_table::new(ctx),
+        };
+        account_storage::global_move_to(ctx, account, coin_stores);
     }
 
     //

--- a/crates/rooch-framework/sources/ethereum_light_client.move
+++ b/crates/rooch-framework/sources/ethereum_light_client.move
@@ -2,7 +2,7 @@ module rooch_framework::ethereum_light_client{
 
     use std::error;
     use moveos_std::bcs;
-    use moveos_std::storage_context::{Self, StorageContext};
+    use moveos_std::storage_context::StorageContext;
     use moveos_std::account_storage;
     use moveos_std::table::{Self, Table};
     use rooch_framework::ethereum_address::ETHAddress;
@@ -48,9 +48,8 @@ module rooch_framework::ethereum_light_client{
     }
 
     public(friend) fun genesis_init(ctx: &mut StorageContext, genesis_account: &signer){
-        let tx_ctx = storage_context::tx_context_mut(ctx);
         let block_store = BlockStore{
-            blocks: table::new(tx_ctx),
+            blocks: table::new(ctx),
         };
         account_storage::global_move_to(ctx, genesis_account, block_store);
     }

--- a/crates/rooch-framework/sources/session_key.move
+++ b/crates/rooch-framework/sources/session_key.move
@@ -112,7 +112,7 @@ module rooch_framework::session_key {
             max_inactive_interval: max_inactive_interval,
         };
         if (!account_storage::global_exists<SessionKeys>(ctx, sender_addr)){
-            let keys = table::new<vector<u8>, SessionKey>(storage_context::tx_context_mut(ctx));
+            let keys = table::new<vector<u8>, SessionKey>(ctx);
             account_storage::global_move_to<SessionKeys>(ctx, sender, SessionKeys{keys});
         };
 

--- a/crates/rooch-integration-test-runner/src/lib.rs
+++ b/crates/rooch-integration-test-runner/src/lib.rs
@@ -292,7 +292,11 @@ impl<'a> MoveOSTestAdapter<'a> for MoveOSTestRunner<'a> {
         );
         let verified_tx = self.moveos.verify(tx)?;
         let (_state_root, output) = self.moveos.execute_and_apply(verified_tx)?;
-        debug_assert!(output.status == move_core_types::vm_status::KeptVMStatus::Executed);
+        debug_assert!(
+            output.status == move_core_types::vm_status::KeptVMStatus::Executed,
+            "{:?}",
+            output
+        );
         //TODO return values
         let value = SerializedReturnValues {
             mutable_reference_outputs: vec![],

--- a/crates/rooch-integration-test-runner/tests/cases/private_generics_direct_call.exp
+++ b/crates/rooch-integration-test-runner/tests/cases/private_generics_direct_call.exp
@@ -1,12 +1,12 @@
 processed 4 tasks
 
-task 1 'publish'. lines 3-35:
+task 1 'publish'. lines 3-33:
 status EXECUTED
 
-task 2 'run'. lines 37-45:
+task 2 'run'. lines 35-43:
 status EXECUTED
 
-task 3 'view'. lines 47-49:
+task 3 'view'. lines 45-47:
 store key 0x42::test::Foo {
     x: 500
 }

--- a/crates/rooch-integration-test-runner/tests/cases/private_generics_direct_call.move
+++ b/crates/rooch-integration-test-runner/tests/cases/private_generics_direct_call.move
@@ -7,7 +7,6 @@ module creator::test {
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::object;
     use moveos_std::object_id::ObjectID;
-    use moveos_std::object_storage;
     use std::debug;
 
     struct Foo has key, store {
@@ -25,9 +24,8 @@ module creator::test {
     }
 
     public fun call_moveos_std<T: store>(ctx: &mut StorageContext, sender: &signer, object_id: ObjectID) {
-        let object_storage = storage_context::object_storage_mut(ctx);
         debug::print(&object_id);
-        let obj = object_storage::remove<Foo>(object_storage, object_id);
+        let obj = storage_context::remove_object<Foo>(ctx, object_id);
         debug::print(&obj);
         let (_id,_owner,value) = object::unpack(obj);
         account_storage::global_move_to<Foo>(ctx, sender, value);

--- a/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.exp
+++ b/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.exp
@@ -3,29 +3,29 @@ processed 3 tasks
 task 1 'publish'. lines 3-8:
 status EXECUTED
 
-task 2 'publish'. lines 10-43:
-Error: error: resource type "KeyStruct" in function "0x2::object_storage::remove" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:34:19
+task 2 'publish'. lines 10-41:
+Error: error: resource type "KeyStruct" in function "0x2::storage_context::remove_object" not defined in current module or not allowed
+   ┌─ /tmp/tempfile:32:19
    │
-34 │         let obj = object_storage::remove<KeyStruct>(object_storage, object_id);
-   │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+32 │         let obj = storage_context::remove_object<KeyStruct>(ctx, object_id);
+   │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: resource type "KeyStruct" in function "0x2::object::unpack" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:36:34
+   ┌─ /tmp/tempfile:34:34
    │
-36 │         let (_id,_owner,value) = object::unpack(obj);
+34 │         let (_id,_owner,value) = object::unpack(obj);
    │                                  ^^^^^^^^^^^^^^^^^^^
 
 error: resource type "KeyStruct" in function "0x2::account_storage::global_move_to" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:37:9
+   ┌─ /tmp/tempfile:35:9
    │
-37 │         account_storage::global_move_to(ctx, sender, value);
+35 │         account_storage::global_move_to(ctx, sender, value);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: resource type "KeyStruct" in function "0x42::test::publish_foo" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:29:9
+   ┌─ /tmp/tempfile:28:9
    │
-29 │         publish_foo<KeyStruct>(ctx, s)
+28 │         publish_foo<KeyStruct>(ctx, s)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 

--- a/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.move
+++ b/crates/rooch-integration-test-runner/tests/cases/private_generics_indirect_call.move
@@ -16,7 +16,6 @@ module creator::test {
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::object;
     use moveos_std::object_id::ObjectID;
-    use moveos_std::object_storage;
 
     struct Foo has key {
         x: u64,
@@ -33,9 +32,8 @@ module creator::test {
     }
 
     public fun call_moveos_std<T:store>(ctx: &mut StorageContext, sender: &signer, object_id: ObjectID) {
-        let object_storage = storage_context::object_storage_mut(ctx);
         debug::print(&object_id);
-        let obj = object_storage::remove<KeyStruct>(object_storage, object_id);
+        let obj = storage_context::remove_object<KeyStruct>(ctx, object_id);
         debug::print(&obj);
         let (_id,_owner,value) = object::unpack(obj);
         account_storage::global_move_to(ctx, sender, value);

--- a/examples/basic_object/sources/something.move
+++ b/examples/basic_object/sources/something.move
@@ -82,12 +82,11 @@ module rooch_examples::something {
         i: u32,
         j: u128,
     ): SomethingProperties {
-        let tx_ctx = storage_context::tx_context_mut(storage_ctx);
         let ps = SomethingProperties {
             i,
             j,
-            fooTable: table::new(tx_ctx),
-            barTable: table::new(tx_ctx),
+            fooTable: table::new(storage_ctx),
+            barTable: table::new(storage_ctx),
         };
         add_bar_table_item(storage_ctx, &mut ps.barTable, 0, 0);
         add_bar_table_item(storage_ctx, &mut ps.barTable, 1, 1);

--- a/examples/basic_object/sources/something.move
+++ b/examples/basic_object/sources/something.move
@@ -6,7 +6,6 @@ module rooch_examples::something {
     use moveos_std::object_id::ObjectID;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::table::{Self, Table};
-    use moveos_std::tx_context;
 
     friend rooch_examples::something_aggregate;
     friend rooch_examples::something_do_logic;
@@ -62,8 +61,8 @@ module rooch_examples::something {
         j: u128,
     ): Object<SomethingProperties> {
         let value = new_something_properties(storage_ctx, i, j);
+        let owner = storage_context::sender(storage_ctx);
         let tx_ctx = storage_context::tx_context_mut(storage_ctx);
-        let owner = tx_context::sender(tx_ctx);
         let obj = object::new(
             tx_ctx,
             owner,

--- a/examples/basic_object/sources/something.move
+++ b/examples/basic_object/sources/something.move
@@ -4,7 +4,6 @@ module rooch_examples::something {
     use moveos_std::event;
     use moveos_std::object::{Self, Object};
     use moveos_std::object_id::ObjectID;
-    use moveos_std::object_storage;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::table::{Self, Table};
     use moveos_std::tx_context;
@@ -124,15 +123,13 @@ module rooch_examples::something {
     }
 
     public(friend) fun add_something(storage_ctx: &mut StorageContext, obj: Object<SomethingProperties>) {
-        let obj_store = storage_context::object_storage_mut(storage_ctx);
-        object_storage::add(obj_store, obj);
+        storage_context::add_object(storage_ctx, obj);
     }
 
     public(friend) fun remove_something(
         storage_ctx: &mut StorageContext,
         obj_id: ObjectID
     ): Object<SomethingProperties> {
-        let obj_store = storage_context::object_storage_mut(storage_ctx);
-        object_storage::remove<SomethingProperties>(obj_store, obj_id)
+        storage_context::remove_object<SomethingProperties>(storage_ctx, obj_id)
     }
 }

--- a/examples/blog/sources/article.move
+++ b/examples/blog/sources/article.move
@@ -7,7 +7,6 @@ module rooch_examples::article {
     use moveos_std::event;
     use moveos_std::object::{Self, Object};
     use moveos_std::object_id::ObjectID;
-    use moveos_std::object_storage;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::table::{Self, Table};
     use moveos_std::tx_context;
@@ -361,8 +360,7 @@ module rooch_examples::article {
     }
 
     public(friend) fun remove_article(storage_ctx: &mut StorageContext, obj_id: ObjectID): Object<Article> {
-        let obj_store = storage_context::object_storage_mut(storage_ctx);
-        object_storage::remove<Article>(obj_store, obj_id)
+        storage_context::remove_object<Article>(storage_ctx, obj_id)
     }
 
     public(friend) fun add_article(storage_ctx: &mut StorageContext, article_obj: Object<Article>) {
@@ -373,8 +371,7 @@ module rooch_examples::article {
     fun private_add_article(storage_ctx: &mut StorageContext, article_obj: Object<Article>) {
         assert!(std::string::length(&object::borrow(&article_obj).title) <= 200, ErrorDataTooLong);
         assert!(std::string::length(&object::borrow(&article_obj).body) <= 2000, ErrorDataTooLong);
-        let obj_store = storage_context::object_storage_mut(storage_ctx);
-        object_storage::add(obj_store, article_obj);
+        storage_context::add_object<Article>(storage_ctx, article_obj);
     }
 
     public fun get_article(storage_ctx: &mut StorageContext, obj_id: ObjectID): Object<Article> {

--- a/examples/blog/sources/article.move
+++ b/examples/blog/sources/article.move
@@ -9,7 +9,6 @@ module rooch_examples::article {
     use moveos_std::object_id::ObjectID;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::table::{Self, Table};
-    use moveos_std::tx_context;
     use rooch_examples::comment::{Self, Comment};
     use std::error;
     use std::option;
@@ -117,7 +116,7 @@ module rooch_examples::article {
     }
 
     fun new_article(
-        tx_ctx: &mut tx_context::TxContext,
+        ctx: &mut StorageContext,
         title: String,
         body: String,
     ): Article {
@@ -127,7 +126,7 @@ module rooch_examples::article {
             version: 0,
             title,
             body,
-            comments: table::new<u64, Comment>(tx_ctx),
+            comments: table::new<u64, Comment>(ctx),
             comment_seq_id_generator: CommentSeqIdGenerator { sequence: 0, },
         }
     }
@@ -338,13 +337,14 @@ module rooch_examples::article {
         title: String,
         body: String,
     ): Object<Article> {
-        let tx_ctx = storage_context::tx_context_mut(storage_ctx);
         let article = new_article(
-            tx_ctx,
+            storage_ctx,
             title,
             body,
         );
-        let obj_owner = tx_context::sender(tx_ctx);
+        
+        let obj_owner = storage_context::sender(storage_ctx);
+        let tx_ctx = storage_context::tx_context_mut(storage_ctx);
         let article_obj = object::new(
             tx_ctx,
             obj_owner,

--- a/examples/borrow_reference/sources/borrowd.move
+++ b/examples/borrow_reference/sources/borrowd.move
@@ -1,7 +1,6 @@
 module rooch_examples::borrowd {
     use moveos_std::account_storage;
     use moveos_std::storage_context::{Self, StorageContext};
-    use moveos_std::tx_context;
 
     struct BorrowCapability has key, copy, store {}
 
@@ -23,7 +22,7 @@ module rooch_examples::borrowd {
         ctx: &StorageContext,
         _borrow_cap: &BorrowCapability,
     ) {
-        let addr = tx_context::sender(storage_context::tx_context(ctx));
+        let addr = storage_context::sender(ctx);
         account_storage::global_exists<BorrowCapability>(ctx, addr);
     }
 

--- a/examples/complex_struct/sources/complex_struct.move
+++ b/examples/complex_struct/sources/complex_struct.move
@@ -1,7 +1,6 @@
 module rooch_examples::complex_struct {
 
    use moveos_std::storage_context::{Self, StorageContext};
-   use moveos_std::tx_context;
    use moveos_std::account_storage;
    use moveos_std::object_id::{ObjectID};
    use moveos_std::object;
@@ -106,10 +105,7 @@ module rooch_examples::complex_struct {
    fun init(ctx: &mut StorageContext, sender: signer) {
       
       let addr = signer::address_of(&sender);
-      let object_id = {
-         let tx_ctx = storage_context::tx_context_mut(ctx);
-         tx_context::fresh_object_id(tx_ctx) 
-      };
+      let object_id = storage_context::fresh_object_id(ctx);
       let s = new_complex_struct(object_id);
       let complex_object = {
          let tx_ctx = storage_context::tx_context_mut(ctx);

--- a/examples/complex_struct/sources/complex_struct.move
+++ b/examples/complex_struct/sources/complex_struct.move
@@ -5,7 +5,6 @@ module rooch_examples::complex_struct {
    use moveos_std::account_storage;
    use moveos_std::object_id::{ObjectID};
    use moveos_std::object;
-   use moveos_std::object_storage;
    use moveos_std::bcs;
    use std::vector;
    use std::signer;
@@ -117,8 +116,7 @@ module rooch_examples::complex_struct {
          object::new(tx_ctx, addr, s)
       };
       let complex_object_id = object::id(&complex_object);
-      let object_storage = storage_context::object_storage_mut(ctx);
-      object_storage::add(object_storage, complex_object);
+      storage_context::add_object(ctx, complex_object);
 
       let s2 = new_complex_struct(complex_object_id);
       account_storage::global_move_to(ctx, &sender, s2);

--- a/examples/event/sources/event_test.move
+++ b/examples/event/sources/event_test.move
@@ -1,7 +1,6 @@
 module rooch_examples::event_test {
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::event;
-    use moveos_std::tx_context;
 
     #[test_only]
     use std::debug;
@@ -17,7 +16,7 @@ module rooch_examples::event_test {
         // addr: address,
         amount: u64,
     ) {
-        let addr = tx_context::sender(storage_context::tx_context(ctx));
+        let addr = storage_context::sender(ctx);
         event::emit<WithdrawEvent>(ctx, WithdrawEvent {
             addr,
             amount,

--- a/examples/kv_store/sources/kv_store.move
+++ b/examples/kv_store/sources/kv_store.move
@@ -1,6 +1,6 @@
 module rooch_examples::kv_store {
 
-   use moveos_std::storage_context::{Self, StorageContext};
+   use moveos_std::storage_context::StorageContext;
    use moveos_std::account_storage;
    use moveos_std::table::{Self, Table};
    use std::string::{String};
@@ -35,9 +35,8 @@ module rooch_examples::kv_store {
 
    //init when module publish
    fun init(ctx: &mut StorageContext, sender: signer) {
-      let tx_ctx = storage_context::tx_context_mut(ctx);
       let kv = KVStore{
-         table: table::new(tx_ctx),
+         table: table::new(ctx),
       };
       account_storage::global_move_to(ctx, &sender, kv);
    }

--- a/examples/module_init/sources/box.move
+++ b/examples/module_init/sources/box.move
@@ -3,7 +3,6 @@ module rooch_examples::box {
     use moveos_std::object::{Self, Object};
     use moveos_std::object_id::ObjectID;
     use moveos_std::storage_context::{Self, StorageContext};
-    use moveos_std::tx_context;
 
     friend rooch_examples::box_fun;
     friend rooch_examples::box_friend;
@@ -41,8 +40,8 @@ module rooch_examples::box {
         name: String,
         count: u128,
     ): Object<Box> {
+        let owner = storage_context::sender(storage_ctx);
         let tx_ctx = storage_context::tx_context_mut(storage_ctx);
-        let owner = tx_context::sender(tx_ctx);
         let obj = object::new(
             tx_ctx,
             owner,

--- a/examples/module_init/sources/box.move
+++ b/examples/module_init/sources/box.move
@@ -2,7 +2,6 @@ module rooch_examples::box {
     use std::string::{String};
     use moveos_std::object::{Self, Object};
     use moveos_std::object_id::ObjectID;
-    use moveos_std::object_storage;
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::tx_context;
 
@@ -63,15 +62,13 @@ module rooch_examples::box {
     }
 
     public(friend) fun add_box(storage_ctx: &mut StorageContext, obj: Object<Box>) {
-        let obj_store = storage_context::object_storage_mut(storage_ctx);
-        object_storage::add(obj_store, obj);
+        storage_context::add_object(storage_ctx, obj);
     }
 
     public(friend) fun remove_box(
         storage_ctx: &mut StorageContext,
         obj_id: ObjectID
     ): Object<Box> {
-        let obj_store = storage_context::object_storage_mut(storage_ctx);
-        object_storage::remove<Box>(obj_store, obj_id)
+        storage_context::remove_object<Box>(storage_ctx, obj_id)
     }
 }

--- a/examples/simple_blog/sources/article.move
+++ b/examples/simple_blog/sources/article.move
@@ -6,7 +6,6 @@ module simple_blog::article {
     use moveos_std::event;
     use moveos_std::object::{Self, Object};
     use moveos_std::object_id::ObjectID;
-    use moveos_std::object_storage;
     use moveos_std::storage_context::{Self, StorageContext};
 
     const ErrorDataTooLong: u64 = 1;
@@ -56,8 +55,7 @@ module simple_blog::article {
             article,
         );
         let id = object::id(&article_obj);
-        let object_storage = storage_context::object_storage_mut(ctx);
-        object_storage::add(object_storage, article_obj);
+        storage_context::add_object(ctx, article_obj);
 
         let article_created_event = ArticleCreatedEvent {
             id,
@@ -77,8 +75,7 @@ module simple_blog::article {
         assert!(std::string::length(&new_title) <= 200, error::invalid_argument(ErrorDataTooLong));
         assert!(std::string::length(&new_body) <= 2000, error::invalid_argument(ErrorDataTooLong));
 
-        let object_storage = storage_context::object_storage_mut(ctx);
-        let article_obj = object_storage::borrow_mut<Article>(object_storage, id);
+        let article_obj = storage_context::borrow_object_mut<Article>(ctx, id);
         let owner_address = signer::address_of(owner);
         
         // only article owner can update the article 
@@ -102,8 +99,7 @@ module simple_blog::article {
         owner: &signer,
         id: ObjectID,
     ) {
-        let object_storage = storage_context::object_storage_mut(ctx);
-        let article_obj = object_storage::remove<Article>(object_storage, id);
+        let article_obj = storage_context::remove_object<Article>(ctx, id);
         let owner_address = signer::address_of(owner);
         
         // only article owner can delete the article 
@@ -130,8 +126,7 @@ module simple_blog::article {
 
     /// get article object by id
     public fun get_article(ctx: &StorageContext, article_id: ObjectID): &Object<Article> {
-        let obj_store = storage_context::object_storage(ctx);
-        object_storage::borrow(obj_store, article_id)
+        storage_context::borrow_object<Article>(ctx, article_id)
     }
 
     /// get article id

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/account_storage.md
@@ -31,7 +31,6 @@ It is used to store the account's resources and modules
 <b>use</b> <a href="move_module.md#0x2_move_module">0x2::move_module</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
-<b>use</b> <a href="object_storage.md#0x2_object_storage">0x2::object_storage</a>;
 <b>use</b> <a href="storage_context.md#0x2_storage_context">0x2::storage_context</a>;
 <b>use</b> <a href="table.md#0x2_table">0x2::table</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
@@ -199,10 +198,9 @@ Create a new account storage space
         resources: <a href="type_table.md#0x2_type_table_new_with_id">type_table::new_with_id</a>(<a href="account_storage.md#0x2_account_storage_named_table_id">named_table_id</a>(account, <a href="account_storage.md#0x2_account_storage_NamedTableResource">NamedTableResource</a>)),
         modules: <a href="table.md#0x2_table_new_with_id">table::new_with_id</a>(<a href="account_storage.md#0x2_account_storage_named_table_id">named_table_id</a>(account, <a href="account_storage.md#0x2_account_storage_NamedTableModule">NamedTableModule</a>)),
     };
-    <b>let</b> <a href="object_storage.md#0x2_object_storage">object_storage</a> = <a href="storage_context.md#0x2_storage_context_object_storage_mut">storage_context::object_storage_mut</a>(ctx);
-    <b>assert</b>!(!<a href="object_storage.md#0x2_object_storage_contains">object_storage::contains</a>(<a href="object_storage.md#0x2_object_storage">object_storage</a>, <a href="object_id.md#0x2_object_id">object_id</a>), <a href="account_storage.md#0x2_account_storage_ErrorAccountAlreadyExists">ErrorAccountAlreadyExists</a>);
+    <b>assert</b>!(!<a href="storage_context.md#0x2_storage_context_contains_object">storage_context::contains_object</a>(ctx, <a href="object_id.md#0x2_object_id">object_id</a>), <a href="account_storage.md#0x2_account_storage_ErrorAccountAlreadyExists">ErrorAccountAlreadyExists</a>);
     <b>let</b> <a href="object.md#0x2_object">object</a> = <a href="object.md#0x2_object_new_with_id">object::new_with_id</a>(<a href="object_id.md#0x2_object_id">object_id</a>, account, <a href="account_storage.md#0x2_account_storage">account_storage</a>);
-    <a href="object_storage.md#0x2_object_storage_add">object_storage::add</a>(<a href="object_storage.md#0x2_object_storage">object_storage</a>, <a href="object.md#0x2_object">object</a>);
+    <a href="storage_context.md#0x2_storage_context_add_object">storage_context::add_object</a>(ctx, <a href="object.md#0x2_object">object</a>);
 }
 </code></pre>
 
@@ -228,8 +226,7 @@ check if account storage eixst
 
 <pre><code><b>public</b> <b>fun</b> <a href="account_storage.md#0x2_account_storage_exist_account_storage">exist_account_storage</a>(ctx: &StorageContext, account: <b>address</b>): bool {
     <b>let</b> <a href="object_id.md#0x2_object_id">object_id</a> = <a href="object_id.md#0x2_object_id_address_to_object_id">object_id::address_to_object_id</a>(account);
-    <b>let</b> <a href="object_storage.md#0x2_object_storage">object_storage</a> = <a href="storage_context.md#0x2_storage_context_object_storage">storage_context::object_storage</a>(ctx);
-    <a href="object_storage.md#0x2_object_storage_contains">object_storage::contains</a>(<a href="object_storage.md#0x2_object_storage">object_storage</a>, <a href="object_id.md#0x2_object_id">object_id</a>)
+    <a href="storage_context.md#0x2_storage_context_contains_object">storage_context::contains_object</a>(ctx, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
 
@@ -281,8 +278,7 @@ This function equates to <code><b>borrow_global</b>&lt;T&gt;(<b>address</b>)</co
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account_storage.md#0x2_account_storage_global_borrow">global_borrow</a>&lt;T: key&gt;(ctx: &StorageContext, account: <b>address</b>): &T {
-    <b>let</b> <a href="object_storage.md#0x2_object_storage">object_storage</a> = <a href="storage_context.md#0x2_storage_context_object_storage">storage_context::object_storage</a>(ctx);
-    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage">borrow_account_storage</a>(<a href="object_storage.md#0x2_object_storage">object_storage</a>, account);
+    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage">borrow_account_storage</a>(ctx, account);
     <a href="account_storage.md#0x2_account_storage_borrow_resource_from_account_storage">borrow_resource_from_account_storage</a>&lt;T&gt;(<a href="account_storage.md#0x2_account_storage">account_storage</a>)
 }
 </code></pre>
@@ -309,8 +305,7 @@ This function equates to <code><b>borrow_global_mut</b>&lt;T&gt;(<b>address</b>)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account_storage.md#0x2_account_storage_global_borrow_mut">global_borrow_mut</a>&lt;T: key&gt;(ctx: &<b>mut</b> StorageContext, account: <b>address</b>): &<b>mut</b> T {
-    <b>let</b> <a href="object_storage.md#0x2_object_storage">object_storage</a> = <a href="storage_context.md#0x2_storage_context_object_storage_mut">storage_context::object_storage_mut</a>(ctx);
-    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage_mut">borrow_account_storage_mut</a>(<a href="object_storage.md#0x2_object_storage">object_storage</a>, account);
+    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage_mut">borrow_account_storage_mut</a>(ctx, account);
     <a href="account_storage.md#0x2_account_storage_borrow_mut_resource_from_account_storage">borrow_mut_resource_from_account_storage</a>&lt;T&gt;(<a href="account_storage.md#0x2_account_storage">account_storage</a>)
 }
 </code></pre>
@@ -340,7 +335,7 @@ This function equates to <code><b>move_to</b>&lt;T&gt;(&<a href="">signer</a>, r
     <b>let</b> account_address = <a href="_address_of">signer::address_of</a>(account);
     //Auto create the account storage when <b>move</b> resource <b>to</b> the account
     <a href="account_storage.md#0x2_account_storage_ensure_account_storage">ensure_account_storage</a>(ctx, account_address);
-    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage_mut">borrow_account_storage_mut</a>(<a href="storage_context.md#0x2_storage_context_object_storage_mut">storage_context::object_storage_mut</a>(ctx), account_address);
+    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage_mut">borrow_account_storage_mut</a>(ctx, account_address);
     <a href="account_storage.md#0x2_account_storage_add_resource_to_account_storage">add_resource_to_account_storage</a>(<a href="account_storage.md#0x2_account_storage">account_storage</a>, resource);
 }
 </code></pre>
@@ -367,7 +362,7 @@ This function equates to <code><b>move_from</b>&lt;T&gt;(<b>address</b>)</code> 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account_storage.md#0x2_account_storage_global_move_from">global_move_from</a>&lt;T: key&gt;(ctx: &<b>mut</b> StorageContext, account: <b>address</b>): T {
-    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage_mut">borrow_account_storage_mut</a>(<a href="storage_context.md#0x2_storage_context_object_storage_mut">storage_context::object_storage_mut</a>(ctx), account);
+    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage_mut">borrow_account_storage_mut</a>(ctx, account);
     <a href="account_storage.md#0x2_account_storage_remove_resource_from_account_storage">remove_resource_from_account_storage</a>&lt;T&gt;(<a href="account_storage.md#0x2_account_storage">account_storage</a>)
 }
 </code></pre>
@@ -395,7 +390,7 @@ This function equates to <code><b>exists</b>&lt;T&gt;(<b>address</b>)</code> ins
 
 <pre><code><b>public</b> <b>fun</b> <a href="account_storage.md#0x2_account_storage_global_exists">global_exists</a>&lt;T: key&gt;(ctx: &StorageContext, account: <b>address</b>) : bool {
     <b>if</b> (<a href="account_storage.md#0x2_account_storage_exist_account_storage">exist_account_storage</a>(ctx, account)) {
-        <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage">borrow_account_storage</a>(<a href="storage_context.md#0x2_storage_context_object_storage">storage_context::object_storage</a>(ctx), account);
+        <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage">borrow_account_storage</a>(ctx, account);
         <a href="account_storage.md#0x2_account_storage_exists_resource_at_account_storage">exists_resource_at_account_storage</a>&lt;T&gt;(<a href="account_storage.md#0x2_account_storage">account_storage</a>)
     }<b>else</b>{
         <b>false</b>
@@ -424,7 +419,7 @@ Check if the account has a module with the given name
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account_storage.md#0x2_account_storage_exists_module">exists_module</a>(ctx: &StorageContext, account: <b>address</b>, name: String): bool {
-    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage">borrow_account_storage</a>(<a href="storage_context.md#0x2_storage_context_object_storage">storage_context::object_storage</a>(ctx), account);
+    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage">borrow_account_storage</a>(ctx, account);
     <a href="account_storage.md#0x2_account_storage_exists_module_at_account_storage">exists_module_at_account_storage</a>(<a href="account_storage.md#0x2_account_storage">account_storage</a>, name)
 }
 </code></pre>
@@ -451,7 +446,7 @@ Publish modules to the account's storage
 
 <pre><code><b>public</b> <b>fun</b> <a href="account_storage.md#0x2_account_storage_publish_modules">publish_modules</a>(ctx: &<b>mut</b> StorageContext, account: &<a href="">signer</a>, modules: <a href="">vector</a>&lt;MoveModule&gt;) {
     <b>let</b> account_address = <a href="_address_of">signer::address_of</a>(account);
-    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage_mut">borrow_account_storage_mut</a>(<a href="storage_context.md#0x2_storage_context_object_storage_mut">storage_context::object_storage_mut</a>(ctx), account_address);
+    <b>let</b> <a href="account_storage.md#0x2_account_storage">account_storage</a> = <a href="account_storage.md#0x2_account_storage_borrow_account_storage_mut">borrow_account_storage_mut</a>(ctx, account_address);
     <b>let</b> i = 0;
     <b>let</b> len = <a href="_length">vector::length</a>(&modules);
     <b>let</b> (module_names, module_names_with_init_fn) = <a href="move_module.md#0x2_move_module_verify_modules">move_module::verify_modules</a>(&modules, account_address);

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/event.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/event.md
@@ -20,7 +20,6 @@ events emitted to a handle and emit events to the event store.
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
 <b>use</b> <a href="storage_context.md#0x2_storage_context">0x2::storage_context</a>;
-<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="type_info.md#0x2_type_info">0x2::type_info</a>;
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/event.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/event.md
@@ -19,7 +19,6 @@ events emitted to a handle and emit events to the event store.
 <b>use</b> <a href="bcs.md#0x2_bcs">0x2::bcs</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
-<b>use</b> <a href="object_storage.md#0x2_object_storage">0x2::object_storage</a>;
 <b>use</b> <a href="storage_context.md#0x2_storage_context">0x2::storage_context</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="type_info.md#0x2_type_info">0x2::type_info</a>;
@@ -105,12 +104,10 @@ is event_handle_id doesn't exist, sender will default 0x0
     <b>let</b> event_handle_id = <a href="event.md#0x2_event_derive_event_handle_id">derive_event_handle_id</a>&lt;T&gt;();
     <b>let</b> sender = @0x0;
     <b>let</b> event_seq = 0;
-    <b>if</b> (<a href="event.md#0x2_event_exists_event_handle">exists_event_handle</a>&lt;T&gt;(<a href="storage_context.md#0x2_storage_context_object_storage">storage_context::object_storage</a>(ctx))) {
-        <b>let</b> event_handle = <a href="event.md#0x2_event_borrow_event_handle">borrow_event_handle</a>&lt;T&gt;(
-            <a href="storage_context.md#0x2_storage_context_object_storage">storage_context::object_storage</a>(ctx)
-        );
+    <b>if</b> (<a href="event.md#0x2_event_exists_event_handle">exists_event_handle</a>&lt;T&gt;(ctx)) {
+        <b>let</b> event_handle = <a href="event.md#0x2_event_borrow_event_handle">borrow_event_handle</a>&lt;T&gt;(ctx);
         event_seq = event_handle.counter;
-        sender = <a href="event.md#0x2_event_get_event_handle_owner">get_event_handle_owner</a>&lt;T&gt;(<a href="storage_context.md#0x2_storage_context_object_storage">storage_context::object_storage</a>(ctx));
+        sender = <a href="event.md#0x2_event_get_event_handle_owner">get_event_handle_owner</a>&lt;T&gt;(ctx);
     };
     (event_handle_id, sender, event_seq)
 }
@@ -136,7 +133,7 @@ is event_handle_id doesn't exist, sender will default 0x0
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_ensure_event_handle">ensure_event_handle</a>&lt;T&gt;(ctx: &<b>mut</b> StorageContext) {
-    <b>if</b> (!<a href="event.md#0x2_event_exists_event_handle">exists_event_handle</a>&lt;T&gt;(<a href="storage_context.md#0x2_storage_context_object_storage">storage_context::object_storage</a>(ctx))) {
+    <b>if</b> (!<a href="event.md#0x2_event_exists_event_handle">exists_event_handle</a>&lt;T&gt;(ctx)) {
         <a href="event.md#0x2_event_new_event_handle">new_event_handle</a>&lt;T&gt;(ctx);
     }
 }
@@ -171,9 +168,7 @@ phantom parameters, eg emit(MyEvent<phantom T>).
 <pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_emit">emit</a>&lt;T&gt;(ctx: &<b>mut</b> StorageContext, <a href="event.md#0x2_event">event</a>: T) {
     <a href="event.md#0x2_event_ensure_event_handle">ensure_event_handle</a>&lt;T&gt;(ctx);
     <b>let</b> event_handle_id = <a href="event.md#0x2_event_derive_event_handle_id">derive_event_handle_id</a>&lt;T&gt;();
-    <b>let</b> event_handle_ref = <a href="event.md#0x2_event_borrow_event_handle_mut">borrow_event_handle_mut</a>&lt;T&gt;(
-        <a href="storage_context.md#0x2_storage_context_object_storage_mut">storage_context::object_storage_mut</a>(ctx)
-    );
+    <b>let</b> event_handle_ref = <a href="event.md#0x2_event_borrow_event_handle_mut">borrow_event_handle_mut</a>&lt;T&gt;(ctx);
     <a href="event.md#0x2_event_native_emit">native_emit</a>&lt;T&gt;(&event_handle_id, event_handle_ref.counter, <a href="event.md#0x2_event">event</a>);
     event_handle_ref.counter = event_handle_ref.counter + 1;
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object_storage.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object_storage.md
@@ -9,7 +9,6 @@ It is used to store the objects
 
 -  [Struct `ObjectStorage`](#0x2_object_storage_ObjectStorage)
 -  [Constants](#@Constants_0)
--  [Function `new`](#0x2_object_storage_new)
 -  [Function `new_with_id`](#0x2_object_storage_new_with_id)
 -  [Function `global_object_storage_handle`](#0x2_object_storage_global_object_storage_handle)
 -  [Function `borrow`](#0x2_object_storage_borrow)
@@ -17,13 +16,11 @@ It is used to store the objects
 -  [Function `remove`](#0x2_object_storage_remove)
 -  [Function `add`](#0x2_object_storage_add)
 -  [Function `contains`](#0x2_object_storage_contains)
--  [Function `destroy_empty`](#0x2_object_storage_destroy_empty)
 
 
 <pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
 <b>use</b> <a href="raw_table.md#0x2_raw_table">0x2::raw_table</a>;
-<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
 
@@ -68,32 +65,6 @@ It is used to store the objects
 </code></pre>
 
 
-
-<a name="0x2_object_storage_new"></a>
-
-## Function `new`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_new">new</a>(ctx: &<b>mut</b> TxContext): <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a> {
-    <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a> {
-        handle: <a href="raw_table.md#0x2_raw_table_new_table_handle">raw_table::new_table_handle</a>(ctx),
-    }
-}
-</code></pre>
-
-
-
-</details>
 
 <a name="0x2_object_storage_new_with_id"></a>
 
@@ -154,7 +125,7 @@ The global object storage's table handle should be 0x0
 Borrow Object from object store with object_id
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow">borrow</a>&lt;T: key&gt;(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow">borrow</a>&lt;T: key&gt;(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
 </code></pre>
 
 
@@ -163,7 +134,7 @@ Borrow Object from object store with object_id
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow">borrow</a>&lt;T: key&gt;(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &Object&lt;T&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow">borrow</a>&lt;T: key&gt;(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &Object&lt;T&gt; {
     <a href="raw_table.md#0x2_raw_table_borrow">raw_table::borrow</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
@@ -179,7 +150,7 @@ Borrow Object from object store with object_id
 Borrow mut Object from object store with object_id
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut">borrow_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut">borrow_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
 </code></pre>
 
 
@@ -188,7 +159,7 @@ Borrow mut Object from object store with object_id
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut">borrow_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &<b>mut</b> Object&lt;T&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_borrow_mut">borrow_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &<b>mut</b> Object&lt;T&gt; {
     <a href="raw_table.md#0x2_raw_table_borrow_mut">raw_table::borrow_mut</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
@@ -204,7 +175,7 @@ Borrow mut Object from object store with object_id
 Remove object from object store
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
 </code></pre>
 
 
@@ -213,7 +184,7 @@ Remove object from object store
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): Object&lt;T&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): Object&lt;T&gt; {
     <a href="raw_table.md#0x2_raw_table_remove">raw_table::remove</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
@@ -229,7 +200,7 @@ Remove object from object store
 Add object to object store
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -238,7 +209,7 @@ Add object to object store
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, obj: Object&lt;T&gt;) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, obj: Object&lt;T&gt;) {
     <a href="raw_table.md#0x2_raw_table_add">raw_table::add</a>&lt;ObjectID, Object&lt;T&gt;&gt;(&self.handle, <a href="object.md#0x2_object_id">object::id</a>(&obj), obj);
 }
 </code></pre>
@@ -253,7 +224,7 @@ Add object to object store
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_contains">contains</a>(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): bool
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_contains">contains</a>(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): bool
 </code></pre>
 
 
@@ -262,34 +233,8 @@ Add object to object store
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_contains">contains</a>(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): bool {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_storage.md#0x2_object_storage_contains">contains</a>(self: &<a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): bool {
     <a href="raw_table.md#0x2_raw_table_contains">raw_table::contains</a>&lt;ObjectID&gt;(&self.handle, <a href="object_id.md#0x2_object_id">object_id</a>)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_object_storage_destroy_empty"></a>
-
-## Function `destroy_empty`
-
-Destroy a ObjectStroage. The ObjectStorage must be empty to succeed.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_destroy_empty">destroy_empty</a>(self: <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage_destroy_empty">destroy_empty</a>(self: <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a>) {
-    <b>let</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">ObjectStorage</a> { handle } = self;
-    <a href="raw_table.md#0x2_raw_table_destroy_empty">raw_table::destroy_empty</a>(&handle)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/storage_context.md
@@ -11,8 +11,6 @@ and let developers can customize the storage
 -  [Struct `StorageContext`](#0x2_storage_context_StorageContext)
 -  [Function `tx_context`](#0x2_storage_context_tx_context)
 -  [Function `tx_context_mut`](#0x2_storage_context_tx_context_mut)
--  [Function `object_storage`](#0x2_storage_context_object_storage)
--  [Function `object_storage_mut`](#0x2_storage_context_object_storage_mut)
 -  [Function `sender`](#0x2_storage_context_sender)
 -  [Function `sequence_number`](#0x2_storage_context_sequence_number)
 -  [Function `max_gas_amount`](#0x2_storage_context_max_gas_amount)
@@ -23,9 +21,15 @@ and let developers can customize the storage
 -  [Function `get`](#0x2_storage_context_get)
 -  [Function `tx_meta`](#0x2_storage_context_tx_meta)
 -  [Function `tx_result`](#0x2_storage_context_tx_result)
+-  [Function `borrow_object`](#0x2_storage_context_borrow_object)
+-  [Function `borrow_object_mut`](#0x2_storage_context_borrow_object_mut)
+-  [Function `remove_object`](#0x2_storage_context_remove_object)
+-  [Function `add_object`](#0x2_storage_context_add_object)
+-  [Function `contains_object`](#0x2_storage_context_contains_object)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
 <b>use</b> <a href="object_storage.md#0x2_object_storage">0x2::object_storage</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
@@ -123,61 +127,10 @@ Get a mutable reference to the transaction context from the storage context
 
 </details>
 
-<a name="0x2_storage_context_object_storage"></a>
-
-## Function `object_storage`
-
-Get an immutable reference to the object storage from the storage context
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage">object_storage</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="object_storage.md#0x2_object_storage">object_storage</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &ObjectStorage {
-    &self.<a href="object_storage.md#0x2_object_storage">object_storage</a>
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_storage_context_object_storage_mut"></a>
-
-## Function `object_storage_mut`
-
-Get a mutable reference to the object storage from the storage context
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_object_storage_mut">object_storage_mut</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): &<b>mut</b> <a href="object_storage.md#0x2_object_storage_ObjectStorage">object_storage::ObjectStorage</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_object_storage_mut">object_storage_mut</a>(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): &<b>mut</b> ObjectStorage {
-    &<b>mut</b> self.<a href="object_storage.md#0x2_object_storage">object_storage</a>
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x2_storage_context_sender"></a>
 
 ## Function `sender`
 
-Wrap functions for TxContext
 Return the address of the user that signed the current transaction
 
 
@@ -415,6 +368,130 @@ Get a value from the context map
 
 <pre><code><b>public</b> <b>fun</b> <a href="tx_result.md#0x2_tx_result">tx_result</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>): TxResult {
     <a href="tx_context.md#0x2_tx_context_tx_result">tx_context::tx_result</a>(&self.<a href="tx_context.md#0x2_tx_context">tx_context</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_storage_context_borrow_object"></a>
+
+## Function `borrow_object`
+
+Borrow Object from object store with object_id
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_borrow_object">borrow_object</a>&lt;T: key&gt;(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_borrow_object">borrow_object</a>&lt;T: key&gt;(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &Object&lt;T&gt; {
+    <a href="object_storage.md#0x2_object_storage_borrow">object_storage::borrow</a>&lt;T&gt;(&self.<a href="object_storage.md#0x2_object_storage">object_storage</a>, <a href="object_id.md#0x2_object_id">object_id</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_storage_context_borrow_object_mut"></a>
+
+## Function `borrow_object_mut`
+
+Borrow mut Object from object store with object_id
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_borrow_object_mut">borrow_object_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_borrow_object_mut">borrow_object_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): &<b>mut</b> Object&lt;T&gt; {
+    <a href="object_storage.md#0x2_object_storage_borrow_mut">object_storage::borrow_mut</a>&lt;T&gt;(&<b>mut</b> self.<a href="object_storage.md#0x2_object_storage">object_storage</a>, <a href="object_id.md#0x2_object_id">object_id</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_storage_context_remove_object"></a>
+
+## Function `remove_object`
+
+Remove object from object store
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_remove_object">remove_object</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_remove_object">remove_object</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): Object&lt;T&gt; {
+    <a href="object_storage.md#0x2_object_storage_remove">object_storage::remove</a>&lt;T&gt;(&<b>mut</b> self.<a href="object_storage.md#0x2_object_storage">object_storage</a>, <a href="object_id.md#0x2_object_id">object_id</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_storage_context_add_object"></a>
+
+## Function `add_object`
+
+Add object to object store
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_add_object">add_object</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_add_object">add_object</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>, obj: Object&lt;T&gt;) {
+    <a href="object_storage.md#0x2_object_storage_add">object_storage::add</a>&lt;T&gt;(&<b>mut</b> self.<a href="object_storage.md#0x2_object_storage">object_storage</a>, obj)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_storage_context_contains_object"></a>
+
+## Function `contains_object`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_contains_object">contains_object</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>, <a href="object_id.md#0x2_object_id">object_id</a>: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_context.md#0x2_storage_context_contains_object">contains_object</a>(self: &<a href="storage_context.md#0x2_storage_context_StorageContext">StorageContext</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): bool {
+    <a href="object_storage.md#0x2_object_storage_contains">object_storage::contains</a>(&self.<a href="object_storage.md#0x2_object_storage">object_storage</a>, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
@@ -30,6 +30,7 @@ struct itself, while the operations are implemented as native functions. No trav
 
 <pre><code><b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
 <b>use</b> <a href="raw_table.md#0x2_raw_table">0x2::raw_table</a>;
+<b>use</b> <a href="storage_context.md#0x2_storage_context">0x2::storage_context</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
@@ -70,7 +71,7 @@ Type of tables
 Create a new Table.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_new">new</a>&lt;K: <b>copy</b>, drop, V: store&gt;(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_new">new</a>&lt;K: <b>copy</b>, drop, V: store&gt;(ctx: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;
 </code></pre>
 
 
@@ -79,9 +80,10 @@ Create a new Table.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_new">new</a>&lt;K: <b>copy</b> + drop, V: store&gt;(ctx: &<b>mut</b> TxContext): <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_new">new</a>&lt;K: <b>copy</b> + drop, V: store&gt;(ctx: &<b>mut</b> StorageContext): <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt; {
+    <b>let</b> tx_ctx = <a href="storage_context.md#0x2_storage_context_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
     <a href="table.md#0x2_table_Table">Table</a> {
-        handle: <a href="raw_table.md#0x2_raw_table_new_table_handle">raw_table::new_table_handle</a>(ctx),
+        handle: <a href="raw_table.md#0x2_raw_table_new_table_handle">raw_table::new_table_handle</a>(tx_ctx),
     }
 }
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/tx_context.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/tx_context.md
@@ -120,7 +120,7 @@ Return the address of the user that signed the current
 transaction
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_sender">sender</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_sender">sender</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
 </code></pre>
 
 
@@ -129,7 +129,7 @@ transaction
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_sender">sender</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <b>address</b> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_sender">sender</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <b>address</b> {
     self.sender
 }
 </code></pre>
@@ -145,7 +145,7 @@ transaction
 Return the sequence number of the current transaction
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_sequence_number">sequence_number</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_sequence_number">sequence_number</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
 </code></pre>
 
 
@@ -154,7 +154,7 @@ Return the sequence number of the current transaction
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_sequence_number">sequence_number</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_sequence_number">sequence_number</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): u64 {
     self.sequence_number
 }
 </code></pre>
@@ -170,7 +170,7 @@ Return the sequence number of the current transaction
 Return the max gas to be used
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_max_gas_amount">max_gas_amount</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_max_gas_amount">max_gas_amount</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
 </code></pre>
 
 
@@ -179,7 +179,7 @@ Return the max gas to be used
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_max_gas_amount">max_gas_amount</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_max_gas_amount">max_gas_amount</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): u64 {
     self.max_gas_amount
 }
 </code></pre>
@@ -195,7 +195,7 @@ Return the max gas to be used
 Generate a new unique address,
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_address">fresh_address</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_address">fresh_address</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
 </code></pre>
 
 
@@ -204,7 +204,7 @@ Generate a new unique address,
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_address">fresh_address</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <b>address</b> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_address">fresh_address</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <b>address</b> {
     <b>let</b> addr = <a href="tx_context.md#0x2_tx_context_derive_id">derive_id</a>(ctx.tx_hash, ctx.ids_created);
     ctx.ids_created = ctx.ids_created + 1;
     addr
@@ -222,7 +222,7 @@ Generate a new unique address,
 Generate a new unique object ID
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_object_id">fresh_object_id</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_object_id">fresh_object_id</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
 </code></pre>
 
 
@@ -231,7 +231,7 @@ Generate a new unique object ID
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_object_id">fresh_object_id</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): ObjectID {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_object_id">fresh_object_id</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): ObjectID {
     <a href="object_id.md#0x2_object_id_address_to_object_id">object_id::address_to_object_id</a>(<a href="tx_context.md#0x2_tx_context_fresh_address">fresh_address</a>(ctx))
 }
 </code></pre>
@@ -275,7 +275,7 @@ Generate a new unique object ID
 Return the hash of the current transaction
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_tx_hash">tx_hash</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="">vector</a>&lt;u8&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_tx_hash">tx_hash</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -284,7 +284,7 @@ Return the hash of the current transaction
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_tx_hash">tx_hash</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <a href="">vector</a>&lt;u8&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_tx_hash">tx_hash</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <a href="">vector</a>&lt;u8&gt; {
     self.tx_hash
 }
 </code></pre>
@@ -300,7 +300,7 @@ Return the hash of the current transaction
 Add a value to the context map
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_add">add</a>&lt;T: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>, value: T)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_add">add</a>&lt;T: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>, value: T)
 </code></pre>
 
 
@@ -309,7 +309,7 @@ Add a value to the context map
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_add">add</a>&lt;T: drop + store + <b>copy</b>&gt;(self: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>, value: T) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_add">add</a>&lt;T: drop + store + <b>copy</b>&gt;(self: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>, value: T) {
     <b>let</b> <a href="any.md#0x2_any">any</a> = <a href="copyable_any.md#0x2_copyable_any_pack">copyable_any::pack</a>(value);
     <b>let</b> <a href="">type_name</a> = *<a href="copyable_any.md#0x2_copyable_any_type_name">copyable_any::type_name</a>(&<a href="any.md#0x2_any">any</a>);
     <a href="simple_map.md#0x2_simple_map_add">simple_map::add</a>(&<b>mut</b> self.map, <a href="">type_name</a>, <a href="any.md#0x2_any">any</a>)
@@ -327,7 +327,7 @@ Add a value to the context map
 Get a value from the context map
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_get">get</a>&lt;T: <b>copy</b>, drop, store&gt;(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="_Option">option::Option</a>&lt;T&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_get">get</a>&lt;T: <b>copy</b>, drop, store&gt;(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="_Option">option::Option</a>&lt;T&gt;
 </code></pre>
 
 
@@ -336,7 +336,7 @@ Get a value from the context map
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_get">get</a>&lt;T: drop + store + <b>copy</b>&gt;(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): Option&lt;T&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_get">get</a>&lt;T: drop + store + <b>copy</b>&gt;(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): Option&lt;T&gt; {
     <b>let</b> <a href="">type_name</a> = <a href="type_info.md#0x2_type_info_type_name">type_info::type_name</a>&lt;T&gt;();
     <b>if</b> (<a href="simple_map.md#0x2_simple_map_contains_key">simple_map::contains_key</a>(&self.map, &<a href="">type_name</a>)) {
         <b>let</b> <a href="any.md#0x2_any">any</a> = <a href="simple_map.md#0x2_simple_map_borrow">simple_map::borrow</a>(&self.map, &<a href="">type_name</a>);
@@ -358,7 +358,7 @@ Get a value from the context map
 Check if the key is in the context map
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_contains">contains</a>&lt;T: <b>copy</b>, drop, store&gt;(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): bool
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_contains">contains</a>&lt;T: <b>copy</b>, drop, store&gt;(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): bool
 </code></pre>
 
 
@@ -367,7 +367,7 @@ Check if the key is in the context map
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_contains">contains</a>&lt;T: drop + store + <b>copy</b>&gt;(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): bool {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_contains">contains</a>&lt;T: drop + store + <b>copy</b>&gt;(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): bool {
     <b>let</b> <a href="">type_name</a> = <a href="type_info.md#0x2_type_info_type_name">type_info::type_name</a>&lt;T&gt;();
     <a href="simple_map.md#0x2_simple_map_contains_key">simple_map::contains_key</a>(&self.map, &<a href="">type_name</a>)
 }
@@ -386,7 +386,7 @@ The TxMeta is writed by the VM before the transaction execution.
 The meta data is only available when executing or validating a transaction, otherwise abort(eg. readonly function call).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_meta.md#0x2_tx_meta">tx_meta</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="tx_meta.md#0x2_tx_meta_TxMeta">tx_meta::TxMeta</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_meta.md#0x2_tx_meta">tx_meta</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="tx_meta.md#0x2_tx_meta_TxMeta">tx_meta::TxMeta</a>
 </code></pre>
 
 
@@ -395,7 +395,7 @@ The meta data is only available when executing or validating a transaction, othe
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_meta.md#0x2_tx_meta">tx_meta</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): TxMeta {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_meta.md#0x2_tx_meta">tx_meta</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): TxMeta {
     <b>let</b> meta = <a href="tx_context.md#0x2_tx_context_get">get</a>&lt;TxMeta&gt;(self);
     <b>assert</b>!(<a href="_is_some">option::is_some</a>(&meta), <a href="_invalid_state">error::invalid_state</a>(<a href="tx_context.md#0x2_tx_context_ErrorInvalidContext">ErrorInvalidContext</a>));
     <a href="_extract">option::extract</a>(&<b>mut</b> meta)
@@ -413,7 +413,7 @@ The meta data is only available when executing or validating a transaction, othe
 The result is only available in the <code>post_execute</code> function.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_result.md#0x2_tx_result">tx_result</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="tx_result.md#0x2_tx_result_TxResult">tx_result::TxResult</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_result.md#0x2_tx_result">tx_result</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="tx_result.md#0x2_tx_result_TxResult">tx_result::TxResult</a>
 </code></pre>
 
 
@@ -422,7 +422,7 @@ The result is only available in the <code>post_execute</code> function.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_result.md#0x2_tx_result">tx_result</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): TxResult {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_result.md#0x2_tx_result">tx_result</a>(self: &<a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): TxResult {
     <b>let</b> result = <a href="tx_context.md#0x2_tx_context_get">get</a>&lt;TxResult&gt;(self);
     <b>assert</b>!(<a href="_is_some">option::is_some</a>(&result), <a href="_invalid_state">error::invalid_state</a>(<a href="tx_context.md#0x2_tx_context_ErrorInvalidContext">ErrorInvalidContext</a>));
     <a href="_extract">option::extract</a>(&<b>mut</b> result)

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/type_table.md
@@ -22,6 +22,7 @@ TypeTable is a table use struct Type as Key, struct as Value
 <b>use</b> <a href="">0x1::type_name</a>;
 <b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
 <b>use</b> <a href="raw_table.md#0x2_raw_table">0x2::raw_table</a>;
+<b>use</b> <a href="storage_context.md#0x2_storage_context">0x2::storage_context</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
@@ -61,7 +62,7 @@ TypeTable is a table use struct Type as Key, struct as Value
 Create a new Table.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a>
+<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_new">new</a>(ctx: &<b>mut</b> <a href="storage_context.md#0x2_storage_context_StorageContext">storage_context::StorageContext</a>): <a href="type_table.md#0x2_type_table_TypeTable">type_table::TypeTable</a>
 </code></pre>
 
 
@@ -70,9 +71,10 @@ Create a new Table.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_new">new</a>(ctx: &<b>mut</b> TxContext): <a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="type_table.md#0x2_type_table_new">new</a>(ctx: &<b>mut</b> StorageContext): <a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a> {
+    <b>let</b> tx_ctx = <a href="storage_context.md#0x2_storage_context_tx_context_mut">storage_context::tx_context_mut</a>(ctx);
     <a href="type_table.md#0x2_type_table_TypeTable">TypeTable</a> {
-        handle: <a href="raw_table.md#0x2_raw_table_new_table_handle">raw_table::new_table_handle</a>(ctx),
+        handle: <a href="raw_table.md#0x2_raw_table_new_table_handle">raw_table::new_table_handle</a>(tx_ctx),
     }
 }
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/account_storage.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/account_storage.move
@@ -11,7 +11,6 @@ module moveos_std::account_storage {
     use moveos_std::table::{Self, Table};
     use moveos_std::object;
     use moveos_std::object_id::{Self, ObjectID};
-    use moveos_std::object_storage::{Self, ObjectStorage};
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::tx_context;
     use moveos_std::move_module::{Self, MoveModule};
@@ -51,17 +50,15 @@ module moveos_std::account_storage {
             resources: type_table::new_with_id(named_table_id(account, NamedTableResource)),
             modules: table::new_with_id(named_table_id(account, NamedTableModule)),
         };
-        let object_storage = storage_context::object_storage_mut(ctx);
-        assert!(!object_storage::contains(object_storage, object_id), ErrorAccountAlreadyExists);
+        assert!(!storage_context::contains_object(ctx, object_id), ErrorAccountAlreadyExists);
         let object = object::new_with_id(object_id, account, account_storage);
-        object_storage::add(object_storage, object);
+        storage_context::add_object(ctx, object);
     }
 
     /// check if account storage eixst
     public fun exist_account_storage(ctx: &StorageContext, account: address): bool {
         let object_id = object_id::address_to_object_id(account);
-        let object_storage = storage_context::object_storage(ctx);
-        object_storage::contains(object_storage, object_id)
+        storage_context::contains_object(ctx, object_id)
     }
 
     public fun ensure_account_storage(ctx: &mut StorageContext, account: address) {
@@ -72,15 +69,15 @@ module moveos_std::account_storage {
 
     //TODO the resource and module table's id is determined by the account address, so we can use the account address to get the table id
     //And don't need to borrow the account storage from the object storage, but if we create the table every time, how to drop the table?
-    fun borrow_account_storage(object_storage: &ObjectStorage, account: address): &AccountStorage{
+    fun borrow_account_storage(ctx: &StorageContext, account: address): &AccountStorage{
         let object_id = object_id::address_to_object_id(account);
-        let object = object_storage::borrow<AccountStorage>(object_storage, object_id);
+        let object = storage_context::borrow_object<AccountStorage>(ctx, object_id);
         object::borrow(object)
     }
 
-    fun borrow_account_storage_mut(object_storage: &mut ObjectStorage, account: address): &mut AccountStorage{
+    fun borrow_account_storage_mut(ctx: &mut StorageContext, account: address): &mut AccountStorage{
         let object_id = object_id::address_to_object_id(account);
-        let object = object_storage::borrow_mut<AccountStorage>(object_storage, object_id);
+        let object = storage_context::borrow_object_mut<AccountStorage>(ctx, object_id);
         object::borrow_mut(object)
     }
 
@@ -121,8 +118,7 @@ module moveos_std::account_storage {
     /// Borrow a resource from the account's storage
     /// This function equates to `borrow_global<T>(address)` instruction in Move
     public fun global_borrow<T: key>(ctx: &StorageContext, account: address): &T {
-        let object_storage = storage_context::object_storage(ctx);
-        let account_storage = borrow_account_storage(object_storage, account);
+        let account_storage = borrow_account_storage(ctx, account);
         borrow_resource_from_account_storage<T>(account_storage)
     }
 
@@ -130,8 +126,7 @@ module moveos_std::account_storage {
     /// Borrow a mut resource from the account's storage
     /// This function equates to `borrow_global_mut<T>(address)` instruction in Move
     public fun global_borrow_mut<T: key>(ctx: &mut StorageContext, account: address): &mut T {
-        let object_storage = storage_context::object_storage_mut(ctx);
-        let account_storage = borrow_account_storage_mut(object_storage, account);
+        let account_storage = borrow_account_storage_mut(ctx, account);
         borrow_mut_resource_from_account_storage<T>(account_storage)
     }
 
@@ -142,7 +137,7 @@ module moveos_std::account_storage {
         let account_address = signer::address_of(account);
         //Auto create the account storage when move resource to the account
         ensure_account_storage(ctx, account_address);
-        let account_storage = borrow_account_storage_mut(storage_context::object_storage_mut(ctx), account_address);
+        let account_storage = borrow_account_storage_mut(ctx, account_address);
         add_resource_to_account_storage(account_storage, resource);
     }
 
@@ -150,7 +145,7 @@ module moveos_std::account_storage {
     /// Move a resource from the account's storage
     /// This function equates to `move_from<T>(address)` instruction in Move
     public fun global_move_from<T: key>(ctx: &mut StorageContext, account: address): T {
-        let account_storage = borrow_account_storage_mut(storage_context::object_storage_mut(ctx), account);
+        let account_storage = borrow_account_storage_mut(ctx, account);
         remove_resource_from_account_storage<T>(account_storage)
     }
 
@@ -159,7 +154,7 @@ module moveos_std::account_storage {
     /// This function equates to `exists<T>(address)` instruction in Move
     public fun global_exists<T: key>(ctx: &StorageContext, account: address) : bool {
         if (exist_account_storage(ctx, account)) {
-            let account_storage = borrow_account_storage(storage_context::object_storage(ctx), account);
+            let account_storage = borrow_account_storage(ctx, account);
             exists_resource_at_account_storage<T>(account_storage)
         }else{
             false
@@ -170,14 +165,14 @@ module moveos_std::account_storage {
 
     /// Check if the account has a module with the given name
     public fun exists_module(ctx: &StorageContext, account: address, name: String): bool {
-        let account_storage = borrow_account_storage(storage_context::object_storage(ctx), account);
+        let account_storage = borrow_account_storage(ctx, account);
         exists_module_at_account_storage(account_storage, name) 
     }
 
     /// Publish modules to the account's storage
     public fun publish_modules(ctx: &mut StorageContext, account: &signer, modules: vector<MoveModule>) {
         let account_address = signer::address_of(account);
-        let account_storage = borrow_account_storage_mut(storage_context::object_storage_mut(ctx), account_address);
+        let account_storage = borrow_account_storage_mut(ctx, account_address);
         let i = 0;
         let len = vector::length(&modules);
         let (module_names, module_names_with_init_fn) = move_module::verify_modules(&modules, account_address);

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/event.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/event.move
@@ -4,7 +4,6 @@
 module moveos_std::event {
     use moveos_std::bcs;
     use moveos_std::storage_context::{Self, StorageContext};
-    use moveos_std::tx_context::{Self};
     use moveos_std::object_id::{Self, ObjectID};
     use moveos_std::object;
     #[test_only]
@@ -72,7 +71,7 @@ module moveos_std::event {
     /// Use EventHandle to generate a unique event handle
     /// user doesn't need to call this method directly
     fun new_event_handle<T>(ctx: &mut StorageContext) {
-        let account_addr = tx_context::sender(storage_context::tx_context(ctx));
+        let account_addr = storage_context::sender(ctx);
         let event_handle_id = derive_event_handle_id<T>();
         let event_handle = EventHandle {
             counter: 0,

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object_storage.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object_storage.move
@@ -8,7 +8,7 @@ module moveos_std::object_storage {
     #[test_only]
     use moveos_std::test_helper;
     #[test_only]
-    use moveos_std::tx_context::{TxContext};
+    use moveos_std::tx_context::TxContext;
 
     friend moveos_std::account_storage;
     friend moveos_std::storage_context;

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object_storage.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object_storage.move
@@ -2,12 +2,13 @@
 /// It is used to store the objects
 
 module moveos_std::object_storage {
-    use moveos_std::tx_context::{TxContext};
     use moveos_std::raw_table;
     use moveos_std::object::{Self, Object};
     use moveos_std::object_id::{Self, ObjectID};
     #[test_only]
     use moveos_std::test_helper;
+    #[test_only]
+    use moveos_std::tx_context::{TxContext};
 
     friend moveos_std::account_storage;
     friend moveos_std::storage_context;
@@ -16,12 +17,6 @@ module moveos_std::object_storage {
 
     struct ObjectStorage has store {
         handle: ObjectID,
-    }
-
-    public fun new(ctx: &mut TxContext): ObjectStorage {
-        ObjectStorage {
-            handle: raw_table::new_table_handle(ctx),
-        }
     }
 
     /// Create a new ObjectStorage with a given handle.
@@ -36,44 +31,51 @@ module moveos_std::object_storage {
         object_id::address_to_object_id(GlobalObjectStorageHandle)
     }
 
-    #[private_generics(T)]
     /// Borrow Object from object store with object_id
-    public fun borrow<T: key>(self: &ObjectStorage, object_id: ObjectID): &Object<T> {
+    public(friend) fun borrow<T: key>(self: &ObjectStorage, object_id: ObjectID): &Object<T> {
         raw_table::borrow<ObjectID, Object<T>>(&self.handle, object_id)
     }
 
-    #[private_generics(T)]
     /// Borrow mut Object from object store with object_id
-    public fun borrow_mut<T: key>(self: &mut ObjectStorage, object_id: ObjectID): &mut Object<T> {
+    public(friend) fun borrow_mut<T: key>(self: &mut ObjectStorage, object_id: ObjectID): &mut Object<T> {
         raw_table::borrow_mut<ObjectID, Object<T>>(&self.handle, object_id)
     }
 
-    #[private_generics(T)]
     /// Remove object from object store
-    public fun remove<T: key>(self: &mut ObjectStorage, object_id: ObjectID): Object<T> {
+    public(friend) fun remove<T: key>(self: &mut ObjectStorage, object_id: ObjectID): Object<T> {
         raw_table::remove<ObjectID, Object<T>>(&self.handle, object_id)
     }
 
-    #[private_generics(T)]
     /// Add object to object store
-    public fun add<T: key>(self: &mut ObjectStorage, obj: Object<T>) {
+    public(friend) fun add<T: key>(self: &mut ObjectStorage, obj: Object<T>) {
         raw_table::add<ObjectID, Object<T>>(&self.handle, object::id(&obj), obj);
     }
 
-    public fun contains(self: &ObjectStorage, object_id: ObjectID): bool {
+    public(friend) fun contains(self: &ObjectStorage, object_id: ObjectID): bool {
         raw_table::contains<ObjectID>(&self.handle, object_id)
     }
 
-    /// Destroy a ObjectStroage. The ObjectStorage must be empty to succeed.
-    public fun destroy_empty(self: ObjectStorage) {
-        let ObjectStorage { handle } = self;
-        raw_table::destroy_empty(&handle)
-    }
 
     #[test_only]
     /// Testing only: allow to drop oject storage
     public fun drop_object_storage(self: ObjectStorage) {
         test_helper::destroy<ObjectStorage>(self);
+    }
+
+    #[test_only]
+    /// There is only one instance: the global object storage.
+    /// This `new` function is only used for testing
+    public fun new(ctx: &mut TxContext): ObjectStorage {
+        ObjectStorage {
+            handle: raw_table::new_table_handle(ctx),
+        }
+    }
+
+    #[test_only]    
+    /// Destroy a ObjectStroage. The ObjectStorage must be empty to succeed.
+    public fun destroy_empty(self: ObjectStorage) {
+        let ObjectStorage { handle } = self;
+        raw_table::destroy_empty(&handle)
     }
 
     #[test_only]

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
@@ -5,14 +5,13 @@
 module moveos_std::storage_context {
 
     use std::option::Option;
-    use moveos_std::object_storage::{ObjectStorage};
+    use moveos_std::object_storage::{Self, ObjectStorage};
     use moveos_std::tx_context::{Self, TxContext};
-    use moveos_std::object_id::{ObjectID};
+    use moveos_std::object_id::ObjectID;
+    use moveos_std::object::Object;
     use moveos_std::tx_meta::{TxMeta};
     use moveos_std::tx_result::{TxResult};
 
-    #[test_only]
-    use moveos_std::object_storage::{Self};
     #[test_only]
     use moveos_std::test_helper;
 
@@ -37,17 +36,7 @@ module moveos_std::storage_context {
         &mut self.tx_context
     }
 
-    /// Get an immutable reference to the object storage from the storage context
-    public fun object_storage(self: &StorageContext): &ObjectStorage {
-        &self.object_storage
-    }
-
-    /// Get a mutable reference to the object storage from the storage context
-    public fun object_storage_mut(self: &mut StorageContext): &mut ObjectStorage {
-        &mut self.object_storage
-    }
-
-    /// Wrap functions for TxContext
+    // Wrap functions for TxContext
 
     /// Return the address of the user that signed the current transaction
     public fun sender(self: &StorageContext): address {
@@ -95,6 +84,37 @@ module moveos_std::storage_context {
 
     public fun tx_result(self: &StorageContext): TxResult {
         tx_context::tx_result(&self.tx_context)
+    }
+
+
+    // Wrap functions for ObjectStorage 
+
+    #[private_generics(T)]
+    /// Borrow Object from object store with object_id
+    public fun borrow_object<T: key>(self: &StorageContext, object_id: ObjectID): &Object<T> {
+        object_storage::borrow<T>(&self.object_storage, object_id)
+    }
+
+    #[private_generics(T)]
+    /// Borrow mut Object from object store with object_id
+    public fun borrow_object_mut<T: key>(self: &mut StorageContext, object_id: ObjectID): &mut Object<T> {
+        object_storage::borrow_mut<T>(&mut self.object_storage, object_id)
+    }
+
+    #[private_generics(T)]
+    /// Remove object from object store
+    public fun remove_object<T: key>(self: &mut StorageContext, object_id: ObjectID): Object<T> {
+        object_storage::remove<T>(&mut self.object_storage, object_id)
+    }
+
+    #[private_generics(T)]
+    /// Add object to object store
+    public fun add_object<T: key>(self: &mut StorageContext, obj: Object<T>) {
+        object_storage::add<T>(&mut self.object_storage, obj)
+    }
+
+    public fun contains_object(self: &StorageContext, object_id: ObjectID): bool {
+        object_storage::contains(&self.object_storage, object_id)
     }
 
     #[test_only]

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/tx_context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/tx_context.move
@@ -19,6 +19,7 @@ module moveos_std::tx_context {
     friend moveos_std::raw_table;
     friend moveos_std::account_storage;
     friend moveos_std::event;
+    friend moveos_std::storage_context;
 
     const ErrorInvalidContext: u64 = 1;
 
@@ -43,29 +44,29 @@ module moveos_std::tx_context {
 
     /// Return the address of the user that signed the current
     /// transaction
-    public fun sender(self: &TxContext): address {
+    public(friend) fun sender(self: &TxContext): address {
         self.sender
     }
 
     /// Return the sequence number of the current transaction
-    public fun sequence_number(self: &TxContext): u64 {
+    public(friend) fun sequence_number(self: &TxContext): u64 {
         self.sequence_number
     }
 
     /// Return the max gas to be used
-    public fun max_gas_amount(self: &TxContext): u64 {
+    public(friend) fun max_gas_amount(self: &TxContext): u64 {
         self.max_gas_amount
     } 
 
     /// Generate a new unique address,
-    public fun fresh_address(ctx: &mut TxContext): address {
+    public(friend) fun fresh_address(ctx: &mut TxContext): address {
         let addr = derive_id(ctx.tx_hash, ctx.ids_created);
         ctx.ids_created = ctx.ids_created + 1;
         addr
     }
 
     /// Generate a new unique object ID
-    public fun fresh_object_id(ctx: &mut TxContext): ObjectID {
+    public(friend) fun fresh_object_id(ctx: &mut TxContext): ObjectID {
         object_id::address_to_object_id(fresh_address(ctx))
     }
 
@@ -78,7 +79,7 @@ module moveos_std::tx_context {
     }
 
     /// Return the hash of the current transaction
-    public fun tx_hash(self: &TxContext): vector<u8> {
+    public(friend) fun tx_hash(self: &TxContext): vector<u8> {
         self.tx_hash
     }
 
@@ -89,14 +90,14 @@ module moveos_std::tx_context {
     }
 
     /// Add a value to the context map
-    public fun add<T: drop + store + copy>(self: &mut TxContext, value: T) {
+    public(friend) fun add<T: drop + store + copy>(self: &mut TxContext, value: T) {
         let any = copyable_any::pack(value);
         let type_name = *copyable_any::type_name(&any);
         simple_map::add(&mut self.map, type_name, any)
     }
 
     /// Get a value from the context map
-    public fun get<T: drop + store + copy>(self: &TxContext): Option<T> {
+    public(friend) fun get<T: drop + store + copy>(self: &TxContext): Option<T> {
         let type_name = type_info::type_name<T>();
         if (simple_map::contains_key(&self.map, &type_name)) {
             let any = simple_map::borrow(&self.map, &type_name);
@@ -107,7 +108,7 @@ module moveos_std::tx_context {
     }
 
     /// Check if the key is in the context map
-    public fun contains<T: drop + store + copy>(self: &TxContext): bool {
+    public(friend) fun contains<T: drop + store + copy>(self: &TxContext): bool {
         let type_name = type_info::type_name<T>();
         simple_map::contains_key(&self.map, &type_name)
     }
@@ -115,14 +116,14 @@ module moveos_std::tx_context {
     /// Get the transaction meta data
     /// The TxMeta is writed by the VM before the transaction execution.
     /// The meta data is only available when executing or validating a transaction, otherwise abort(eg. readonly function call).
-    public fun tx_meta(self: &TxContext): TxMeta {
+    public(friend) fun tx_meta(self: &TxContext): TxMeta {
         let meta = get<TxMeta>(self);
         assert!(option::is_some(&meta), error::invalid_state(ErrorInvalidContext));
         option::extract(&mut meta)
     }
 
     /// The result is only available in the `post_execute` function.
-    public fun tx_result(self: &TxContext): TxResult {
+    public(friend) fun tx_result(self: &TxContext): TxResult {
         let result = get<TxResult>(self);
         assert!(option::is_some(&result), error::invalid_state(ErrorInvalidContext));
         option::extract(&mut result)

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
@@ -4,7 +4,7 @@ module moveos_std::type_table {
 
     use std::ascii::{String};
     use moveos_std::raw_table;
-    use moveos_std::tx_context::TxContext;
+    use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::object_id::ObjectID;
 
     friend moveos_std::account_storage;
@@ -14,9 +14,10 @@ module moveos_std::type_table {
     }
 
     /// Create a new Table.
-    public fun new(ctx: &mut TxContext): TypeTable {
+    public fun new(ctx: &mut StorageContext): TypeTable {
+        let tx_ctx = storage_context::tx_context_mut(ctx);
         TypeTable {
-            handle: raw_table::new_table_handle(ctx),
+            handle: raw_table::new_table_handle(tx_ctx),
         }
     }
 
@@ -91,8 +92,8 @@ module moveos_std::type_table {
     #[test(account = @0x1)]
     fun test_all(account: signer) {
         let sender = std::signer::address_of(&account);
-        let tx_context = moveos_std::tx_context::new_test_context(sender);
-        let table = new(&mut tx_context);
+        let ctx = moveos_std::storage_context::new_test_context(sender);
+        let table = new(&mut ctx);
 
         let t = TestType {
             val: 1,
@@ -110,14 +111,15 @@ module moveos_std::type_table {
         assert!(!contains<TestType>(&table), 5);
 
         drop_unchecked(table);
+        moveos_std::storage_context::drop_test_context(ctx);
     }
 
     #[test(account = @0x1)]
     #[expected_failure]
     fun test_add_key_exist_failure(account: signer) {
         let sender = std::signer::address_of(&account);
-        let tx_context = moveos_std::tx_context::new_test_context(sender);
-        let table = new(&mut tx_context);
+        let ctx = moveos_std::storage_context::new_test_context(sender);
+        let table = new(&mut ctx);
 
         let t = TestType {
             val: 1,
@@ -132,53 +134,58 @@ module moveos_std::type_table {
         add<TestType>(&mut table, t);
 
         drop_unchecked(table);
+        moveos_std::storage_context::drop_test_context(ctx);
     }
 
     #[test(account = @0x1)]
     #[expected_failure]
     fun test_borrow_key_not_exist_failure(account: signer) {
-        let sender = std::signer::address_of(&account);
-        let tx_context = moveos_std::tx_context::new_test_context(sender);
-        let table = new(&mut tx_context);
+        let sender = std::signer::address_of(&account);        
+        let ctx = moveos_std::storage_context::new_test_context(sender);
+        let table = new(&mut ctx);
         let _ = borrow<TestType>(&table).val;
 
         drop_unchecked(table);
+        moveos_std::storage_context::drop_test_context(ctx);
     }
 
     #[test(account = @0x1)]
     #[expected_failure]
     fun test_borrow_mut_key_not_exist_failure(account: signer) {
         let sender = std::signer::address_of(&account);
-        let tx_context = moveos_std::tx_context::new_test_context(sender);
-        let table = new(&mut tx_context);
+        let ctx = moveos_std::storage_context::new_test_context(sender);
+        let table = new(&mut ctx);
         let t = borrow_mut<TestType>(&mut table);
         t.val = 1;
 
         drop_unchecked(table);
+        moveos_std::storage_context::drop_test_context(ctx);
     }
 
     #[test(account = @0x1)]
     #[expected_failure]
     fun test_remove_key_not_exist_failure(account: signer) {
         let sender = std::signer::address_of(&account);
-        let tx_context = moveos_std::tx_context::new_test_context(sender);
-        let table = new(&mut tx_context);
+        let ctx = moveos_std::storage_context::new_test_context(sender);
+        let table = new(&mut ctx);
         let TestType { val: _} = remove<TestType>(&mut table);
 
         drop_unchecked(table);
+        moveos_std::storage_context::drop_test_context(ctx);
     }
 
     #[test(account = @0x1)]
     #[expected_failure]
     fun test_destroy_non_empty_failure(account: signer) {
         let sender = std::signer::address_of(&account);
-        let tx_context = moveos_std::tx_context::new_test_context(sender);
-        let table = new(&mut tx_context);
+        let ctx = moveos_std::storage_context::new_test_context(sender);
+        let table = new(&mut ctx);
         let t = TestType {
             val: 1,
         };
         add<TestType>(&mut table, t);
 
         destroy_empty(table);
+        moveos_std::storage_context::drop_test_context(ctx);
     }
 }


### PR DESCRIPTION
## Summary

1. Merge the ObjectStorage and StorageContext, and provide object_storage functions in the storage_context module.
2. Make the Table and TypeTable dependent on StorageContext, change table::new(TxContext) to table::new(StorageContext).
3. Make all TxContext functions as friend. Developers should call these functions through StorageContext.

partial of  #912