### PR TITLE
[MoveosStd] wrap object::new with context::new_object

### DIFF
--- a/crates/rooch-framework-tests/tests/cases/object/basic.exp
+++ b/crates/rooch-framework-tests/tests/cases/object/basic.exp
@@ -1,32 +1,32 @@
 processed 10 tasks
 
-task 1 'publish'. lines 3-51:
+task 1 'publish'. lines 3-47:
 status EXECUTED
 
-task 2 'run'. lines 53-53:
+task 2 'run'. lines 49-49:
 status EXECUTED
 
-task 3 'view_object'. lines 55-57:
+task 3 'view_object'. lines 51-53:
 Object { id: ObjectID(ae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647), owner: 0000000000000000000000000000000000000000000000000000000000000043, value: AnnotatedMoveStruct { abilities: [Store, Key, ], type_: StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("S"), type_params: [] }, value: [(Identifier("v"), U8(1))] } }
 
-task 4 'run'. lines 59-59:
+task 4 'run'. lines 55-55:
 status EXECUTED
 
-task 5 'view_object'. lines 61-64:
+task 5 'view_object'. lines 57-60:
 Object { id: ObjectID(0bbaf311ae6768a532b1f9dee65b1758a7bb1114fd57df8fa94cb2d1cb5f6896), owner: 0000000000000000000000000000000000000000000000000000000000000043, value: AnnotatedMoveStruct { abilities: [Store, Key, ], type_: StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("Cup"), type_params: [Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("S"), type_params: [] })] }, value: [(Identifier("v"), U8(2))] } }
 
-task 6 'run'. lines 66-66:
+task 6 'run'. lines 62-62:
 status EXECUTED
 
-task 7 'view'. lines 68-70:
+task 7 'view'. lines 64-66:
 store key 0x42::m::S {
     v: 1u8
 }
 
-task 8 'run'. lines 72-72:
+task 8 'run'. lines 68-68:
 status EXECUTED
 
-task 9 'view'. lines 74-74:
+task 9 'view'. lines 70-70:
 store key 0x42::m::Cup<0x42::m::S> {
     v: 2u8
 }

--- a/crates/rooch-framework-tests/tests/cases/object/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/object/basic.move
@@ -13,13 +13,11 @@ module test::m {
     struct Cup<phantom T: store> has store, key { v: u8 }
 
     public entry fun mint_s(ctx: &mut Context) {
-        let sender = context::sender(ctx);
-        let tx_hash = context::tx_hash(ctx);        
-        let tx_ctx = context::tx_context_mut(ctx);
+        let tx_hash = context::tx_hash(ctx);
         debug::print(&tx_hash);
         // if the tx hash change, need to figure out why.
         assert!(x"7852c5dcbd87e82102dba0db36d44b5a9fb0006b3e828c0b5f0832f70a8ff6ee" == tx_hash, 1000);
-        let obj = object::new(tx_ctx, sender , S { v: 1});
+        let obj = context::new_object(ctx, S { v: 1});
         debug::print(&obj);
         context::add_object(ctx, obj);
     }
@@ -33,9 +31,7 @@ module test::m {
     }
 
     public entry fun mint_cup<T: store>(ctx: &mut Context) {
-        let sender = context::sender(ctx);
-        let tx_ctx = context::tx_context_mut(ctx);
-        let obj = object::new(tx_ctx, sender, Cup<T> { v: 2 });
+        let obj = context::new_object(ctx, Cup<T> { v: 2 });
         debug::print(&obj);
         context::add_object(ctx, obj);
     }

--- a/crates/rooch-framework-tests/tests/cases/object/object_cap.exp
+++ b/crates/rooch-framework-tests/tests/cases/object/object_cap.exp
@@ -3,23 +3,23 @@ processed 3 tasks
 task 1 'publish'. lines 3-21:
 status EXECUTED
 
-task 2 'run'. lines 22-37:
-Error: error: resource type "TestObject" in function "0x2::object::new" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:30:19
+task 2 'run'. lines 22-36:
+Error: error: resource type "TestObject" in function "0x2::context::new_object" not defined in current module or not allowed
+   ┌─ /tmp/tempfile:29:19
    │
-30 │         let obj = object::new<TestObject>(context::tx_context_mut(ctx), sender_addr, object);
-   │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+29 │         let obj = context::new_object<TestObject>(ctx, object);
+   │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: resource type "TestObject" in function "0x2::object::borrow" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:31:30
+   ┌─ /tmp/tempfile:30:30
    │
-31 │         let _borrow_object = object::borrow(&obj);
+30 │         let _borrow_object = object::borrow(&obj);
    │                              ^^^^^^^^^^^^^^^^^^^^
 
 error: resource type "TestObject" in function "0x2::object::unpack" not defined in current module or not allowed
-   ┌─ /tmp/tempfile:32:42
+   ┌─ /tmp/tempfile:31:42
    │
-32 │         let (_id, _owner, test_object) = object::unpack(obj);
+31 │         let (_id, _owner, test_object) = object::unpack(obj);
    │                                          ^^^^^^^^^^^^^^^^^^^
 
 

--- a/crates/rooch-framework-tests/tests/cases/object/object_cap.move
+++ b/crates/rooch-framework-tests/tests/cases/object/object_cap.move
@@ -26,9 +26,8 @@ script {
     use test::m::{Self, TestObject};
 
     fun main(ctx: &mut Context) {
-        let sender_addr = context::sender(ctx);
         let object = m::new_test_object(12);
-        let obj = object::new<TestObject>(context::tx_context_mut(ctx), sender_addr, object);
+        let obj = context::new_object<TestObject>(ctx, object);
 
         let _borrow_object = object::borrow(&obj);
         let (_id, _owner, test_object) = object::unpack(obj);

--- a/crates/rooch-framework-tests/tests/cases/table/basic.exp
+++ b/crates/rooch-framework-tests/tests/cases/table/basic.exp
@@ -1,10 +1,10 @@
 processed 4 tasks
 
-task 1 'publish'. lines 3-46:
+task 1 'publish'. lines 3-44:
 status EXECUTED
 
-task 2 'run'. lines 48-60:
+task 2 'run'. lines 46-58:
 status EXECUTED
 
-task 3 'run'. lines 62-75:
+task 3 'run'. lines 60-73:
 status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/table/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/table/basic.move
@@ -31,9 +31,7 @@ module test::m {
     }
 
     public fun save_to_object_storage(ctx: &mut Context, kv: KVStore) : ObjectID {
-        let sender = context::sender(ctx);        
-        let tx_ctx = context::tx_context_mut(ctx);
-        let object = object::new(tx_ctx, sender, kv);
+        let object = context::new_object(ctx, kv);
         let object_id = object::id(&object);
         context::add_object(ctx, object);
         object_id

--- a/crates/rooch-framework-tests/tests/cases/table/test_destroy.exp
+++ b/crates/rooch-framework-tests/tests/cases/table/test_destroy.exp
@@ -1,19 +1,19 @@
 processed 7 tasks
 
-task 1 'publish'. lines 3-80:
+task 1 'publish'. lines 3-78:
 status EXECUTED
 
-task 2 'run'. lines 82-96:
+task 2 'run'. lines 80-94:
 status EXECUTED
 
-task 3 'run'. lines 97-112:
+task 3 'run'. lines 95-110:
 status EXECUTED
 
-task 4 'run'. lines 113-128:
+task 4 'run'. lines 111-126:
 status EXECUTED
 
-task 5 'run'. lines 129-141:
+task 5 'run'. lines 127-139:
 status ABORTED with code 3 in 0000000000000000000000000000000000000000000000000000000000000002::raw_table
 
-task 6 'run'. lines 142-155:
+task 6 'run'. lines 140-153:
 status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
+++ b/crates/rooch-framework-tests/tests/cases/table/test_destroy.move
@@ -36,9 +36,7 @@ module test::m {
     }
 
     public fun save_to_object_storage(ctx: &mut Context, kv: KVStore) : ObjectID {        
-        let sender = context::sender(ctx);
-        let tx_ctx = context::tx_context_mut(ctx);
-        let object = object::new(tx_ctx, sender, kv);
+        let object = context::new_object(ctx, kv);
         let object_id = object::id(&object);
         context::add_object(ctx, object);
         object_id

--- a/examples/basic_object/sources/something.move
+++ b/examples/basic_object/sources/something.move
@@ -51,24 +51,25 @@ module rooch_examples::something {
         value: V,
     }
 
-    struct BarTableItemAdded has key {
+    struct BarTableItemAdded {
         item: KeyValuePair<u8, u128>
     }
 
+    struct FooTableItemAdded {
+        item: KeyValuePair<String, String>
+    }
+
     public(friend) fun create_something(
-        storage_ctx: &mut Context,
+        ctx: &mut Context,
         i: u32,
         j: u128,
     ): Object<SomethingProperties> {
-        let value = new_something_properties(storage_ctx, i, j);
-        let owner = context::sender(storage_ctx);
-        let tx_ctx = context::tx_context_mut(storage_ctx);
-        let obj = object::new(
-            tx_ctx,
-            owner,
+        let value = new_something_properties(ctx, i, j);
+        let obj = context::new_object(
+            ctx,
             value,
         );
-        event::emit(storage_ctx, SomethingCreated {
+        event::emit(ctx, SomethingCreated {
             obj_id: object::id(&obj),
             i,
             j,
@@ -77,29 +78,29 @@ module rooch_examples::something {
     }
 
     fun new_something_properties(
-        storage_ctx: &mut Context,
+        ctx: &mut Context,
         i: u32,
         j: u128,
     ): SomethingProperties {
         let ps = SomethingProperties {
             i,
             j,
-            fooTable: table::new(storage_ctx),
-            barTable: table::new(storage_ctx),
+            fooTable: table::new(ctx),
+            barTable: table::new(ctx),
         };
-        add_bar_table_item(storage_ctx, &mut ps.barTable, 0, 0);
-        add_bar_table_item(storage_ctx, &mut ps.barTable, 1, 1);
-        add_bar_table_item(storage_ctx, &mut ps.barTable, 2, 2);
+        add_bar_table_item(ctx, &mut ps.barTable, 0, 0);
+        add_bar_table_item(ctx, &mut ps.barTable, 1, 1);
+        add_bar_table_item(ctx, &mut ps.barTable, 2, 2);
         ps
     }
 
-    fun add_bar_table_item(storage_ctx: &mut Context,
+    fun add_bar_table_item(ctx: &mut Context,
                            table: &mut Table<u8, u128>,
                            key: u8,
                            val: u128
     ) {
         table::add(table, key, val);
-        event::emit(storage_ctx, BarTableItemAdded {
+        event::emit(ctx, BarTableItemAdded {
             item: KeyValuePair {
                 key,
                 value: val,
@@ -108,26 +109,28 @@ module rooch_examples::something {
     }
 
     public(friend) fun add_foo_table_item(
-        storage_ctx: &mut Context,
+        ctx: &mut Context,
         obj: &mut Object<SomethingProperties>,
         key: String,
         val: String
     ) {
         table::add(&mut object::borrow_mut(obj).fooTable, key, val);
-        // event::emit(storage_ctx, FooTableItemAdded {
-        //     key
-        // });
-        let _ = storage_ctx;
+        event::emit(ctx, FooTableItemAdded {
+            item: KeyValuePair {
+                key,
+                value: val,
+            }
+        });
     }
 
-    public(friend) fun add_something(storage_ctx: &mut Context, obj: Object<SomethingProperties>) {
-        context::add_object(storage_ctx, obj);
+    public(friend) fun add_something(ctx: &mut Context, obj: Object<SomethingProperties>) {
+        context::add_object(ctx, obj);
     }
 
     public(friend) fun remove_something(
-        storage_ctx: &mut Context,
+        ctx: &mut Context,
         obj_id: ObjectID
     ): Object<SomethingProperties> {
-        context::remove_object<SomethingProperties>(storage_ctx, obj_id)
+        context::remove_object<SomethingProperties>(ctx, obj_id)
     }
 }

--- a/examples/blog/sources/article.move
+++ b/examples/blog/sources/article.move
@@ -33,9 +33,9 @@ module rooch_examples::article {
         comment_seq_id: u64,
     }
 
-    public fun initialize(storage_ctx: &mut Context, account: &signer) {
+    public fun initialize(ctx: &mut Context, account: &signer) {
         assert!(signer::address_of(account) == @rooch_examples, error::invalid_argument(ErrorNotGenesisAccount));
-        let _ = storage_ctx;
+        let _ = ctx;
         let _ = account;
     }
 
@@ -87,11 +87,11 @@ module rooch_examples::article {
         object::borrow_mut(article_obj).body = body;
     }
 
-    public(friend) fun add_comment(storage_ctx: &mut Context, article_obj: &mut Object<Article>, comment: Comment) {
+    public(friend) fun add_comment(ctx: &mut Context, article_obj: &mut Object<Article>, comment: Comment) {
         let comment_seq_id = comment::comment_seq_id(&comment);
         assert!(!table::contains(&object::borrow_mut(article_obj).comments, comment_seq_id), ErrorIdAlreadyExists);
         table::add(&mut object::borrow_mut(article_obj).comments, comment_seq_id, comment);
-        event::emit(storage_ctx, CommentTableItemAdded {
+        event::emit(ctx, CommentTableItemAdded {
             article_id: id(article_obj),
             comment_seq_id,
         });
@@ -333,53 +333,50 @@ module rooch_examples::article {
 
 
     public(friend) fun create_article(
-        storage_ctx: &mut Context,
+        ctx: &mut Context,
         title: String,
         body: String,
     ): Object<Article> {
         let article = new_article(
-            storage_ctx,
+            ctx,
             title,
             body,
         );
         
-        let obj_owner = context::sender(storage_ctx);
-        let tx_ctx = context::tx_context_mut(storage_ctx);
-        let article_obj = object::new(
-            tx_ctx,
-            obj_owner,
+        let article_obj = context::new_object(
+            ctx,
             article,
         );
         article_obj
     }
 
-    public(friend) fun update_version_and_add(storage_ctx: &mut Context, article_obj: Object<Article>) {
+    public(friend) fun update_version_and_add(ctx: &mut Context, article_obj: Object<Article>) {
         object::borrow_mut(&mut article_obj).version = object::borrow( &mut article_obj).version + 1;
         //assert!(object::borrow(&article_obj).version != 0, ErrorInappropriateVersion);
-        private_add_article(storage_ctx, article_obj);
+        private_add_article(ctx, article_obj);
     }
 
-    public(friend) fun remove_article(storage_ctx: &mut Context, obj_id: ObjectID): Object<Article> {
-        context::remove_object<Article>(storage_ctx, obj_id)
+    public(friend) fun remove_article(ctx: &mut Context, obj_id: ObjectID): Object<Article> {
+        context::remove_object<Article>(ctx, obj_id)
     }
 
-    public(friend) fun add_article(storage_ctx: &mut Context, article_obj: Object<Article>) {
+    public(friend) fun add_article(ctx: &mut Context, article_obj: Object<Article>) {
         assert!(object::borrow(&article_obj).version == 0, ErrorInappropriateVersion);
-        private_add_article(storage_ctx, article_obj);
+        private_add_article(ctx, article_obj);
     }
 
-    fun private_add_article(storage_ctx: &mut Context, article_obj: Object<Article>) {
+    fun private_add_article(ctx: &mut Context, article_obj: Object<Article>) {
         assert!(std::string::length(&object::borrow(&article_obj).title) <= 200, ErrorDataTooLong);
         assert!(std::string::length(&object::borrow(&article_obj).body) <= 2000, ErrorDataTooLong);
-        context::add_object<Article>(storage_ctx, article_obj);
+        context::add_object<Article>(ctx, article_obj);
     }
 
-    public fun get_article(storage_ctx: &mut Context, obj_id: ObjectID): Object<Article> {
-        remove_article(storage_ctx, obj_id)
+    public fun get_article(ctx: &mut Context, obj_id: ObjectID): Object<Article> {
+        remove_article(ctx, obj_id)
     }
 
-    public fun return_article(storage_ctx: &mut Context, article_obj: Object<Article>) {
-        private_add_article(storage_ctx, article_obj);
+    public fun return_article(ctx: &mut Context, article_obj: Object<Article>) {
+        private_add_article(ctx, article_obj);
     }
 
     public(friend) fun drop_article(article_obj: Object<Article>) {
@@ -397,28 +394,28 @@ module rooch_examples::article {
         table::destroy_empty(comments);
     }
 
-    public(friend) fun emit_comment_updated(storage_ctx: &mut Context, comment_updated: CommentUpdated) {
-        event::emit(storage_ctx, comment_updated);
+    public(friend) fun emit_comment_updated(ctx: &mut Context, comment_updated: CommentUpdated) {
+        event::emit(ctx, comment_updated);
     }
 
-    public(friend) fun emit_comment_removed(storage_ctx: &mut Context, comment_removed: CommentRemoved) {
-        event::emit(storage_ctx, comment_removed);
+    public(friend) fun emit_comment_removed(ctx: &mut Context, comment_removed: CommentRemoved) {
+        event::emit(ctx, comment_removed);
     }
 
-    public(friend) fun emit_comment_added(storage_ctx: &mut Context, comment_added: CommentAdded) {
-        event::emit(storage_ctx, comment_added);
+    public(friend) fun emit_comment_added(ctx: &mut Context, comment_added: CommentAdded) {
+        event::emit(ctx, comment_added);
     }
 
-    public(friend) fun emit_article_created(storage_ctx: &mut Context, article_created: ArticleCreated) {
-        event::emit(storage_ctx, article_created);
+    public(friend) fun emit_article_created(ctx: &mut Context, article_created: ArticleCreated) {
+        event::emit(ctx, article_created);
     }
 
-    public(friend) fun emit_article_updated(storage_ctx: &mut Context, article_updated: ArticleUpdated) {
-        event::emit(storage_ctx, article_updated);
+    public(friend) fun emit_article_updated(ctx: &mut Context, article_updated: ArticleUpdated) {
+        event::emit(ctx, article_updated);
     }
 
-    public(friend) fun emit_article_deleted(storage_ctx: &mut Context, article_deleted: ArticleDeleted) {
-        event::emit(storage_ctx, article_deleted);
+    public(friend) fun emit_article_deleted(ctx: &mut Context, article_deleted: ArticleDeleted) {
+        event::emit(ctx, article_deleted);
     }
 
 }

--- a/examples/complex_struct/sources/complex_struct.move
+++ b/examples/complex_struct/sources/complex_struct.move
@@ -6,7 +6,6 @@ module rooch_examples::complex_struct {
    use moveos_std::object;
    use moveos_std::bcs;
    use std::vector;
-   use std::signer;
 
    struct SimpleStruct has store, copy, drop {
       value: u64,
@@ -104,12 +103,10 @@ module rooch_examples::complex_struct {
    //init when module publish
    fun init(ctx: &mut Context, sender: signer) {
       
-      let addr = signer::address_of(&sender);
       let object_id = context::fresh_object_id(ctx);
       let s = new_complex_struct(object_id);
       let complex_object = {
-         let tx_ctx = context::tx_context_mut(ctx);
-         object::new(tx_ctx, addr, s)
+         context::new_object(ctx, s)
       };
       let complex_object_id = object::id(&complex_object);
       context::add_object(ctx, complex_object);

--- a/examples/module_init/sources/box.move
+++ b/examples/module_init/sources/box.move
@@ -36,15 +36,12 @@ module rooch_examples::box {
     }
 
     public(friend) fun create_box(
-        storage_ctx: &mut Context,
+        ctx: &mut Context,
         name: String,
         count: u128,
     ): Object<Box> {
-        let owner = context::sender(storage_ctx);
-        let tx_ctx = context::tx_context_mut(storage_ctx);
-        let obj = object::new(
-            tx_ctx,
-            owner,
+        let obj = context::new_object(
+            ctx,
             new_box(name, count),
         );
         obj
@@ -60,14 +57,14 @@ module rooch_examples::box {
         }
     }
 
-    public(friend) fun add_box(storage_ctx: &mut Context, obj: Object<Box>) {
-        context::add_object(storage_ctx, obj);
+    public(friend) fun add_box(ctx: &mut Context, obj: Object<Box>) {
+        context::add_object(ctx, obj);
     }
 
     public(friend) fun remove_box(
-        storage_ctx: &mut Context,
+        ctx: &mut Context,
         obj_id: ObjectID
     ): Object<Box> {
-        context::remove_object<Box>(storage_ctx, obj_id)
+        context::remove_object<Box>(ctx, obj_id)
     }
 }

--- a/examples/simple_blog/sources/article.move
+++ b/examples/simple_blog/sources/article.move
@@ -42,16 +42,15 @@ module simple_blog::article {
         assert!(std::string::length(&title) <= 200, error::invalid_argument(ErrorDataTooLong));
         assert!(std::string::length(&body) <= 2000, error::invalid_argument(ErrorDataTooLong));
 
-        let tx_ctx = context::tx_context_mut(ctx);
         let article = Article {
             version: 0,
             title,
             body,
         };
-        let owner_address = signer::address_of(owner);
-        let article_obj = object::new(
-            tx_ctx,
-            owner_address,
+        let owner_addr = signer::address_of(owner);
+        let article_obj = context::new_object_with_owner(
+            ctx,
+            owner_addr,
             article,
         );
         let id = object::id(&article_obj);

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/context.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/context.md
@@ -86,7 +86,7 @@ The Context can not be <code>drop</code> or <code>store</code>, so developers ne
 Get an immutable reference to the transaction context from the storage context
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context">tx_context</a>(self: &<a href="context.md#0x2_context_Context">context::Context</a>): &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context">tx_context</a>(self: &<a href="context.md#0x2_context_Context">context::Context</a>): &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>
 </code></pre>
 
 
@@ -95,7 +95,7 @@ Get an immutable reference to the transaction context from the storage context
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context">tx_context</a>(self: &<a href="context.md#0x2_context_Context">Context</a>): &TxContext {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context">tx_context</a>(self: &<a href="context.md#0x2_context_Context">Context</a>): &TxContext {
     &self.<a href="tx_context.md#0x2_tx_context">tx_context</a>
 }
 </code></pre>
@@ -111,7 +111,7 @@ Get an immutable reference to the transaction context from the storage context
 Get a mutable reference to the transaction context from the storage context
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_tx_context_mut">tx_context_mut</a>(self: &<b>mut</b> <a href="context.md#0x2_context_Context">context::Context</a>): &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="context.md#0x2_context_tx_context_mut">tx_context_mut</a>(self: &<b>mut</b> <a href="context.md#0x2_context_Context">context::Context</a>): &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>
 </code></pre>
 
 
@@ -120,7 +120,7 @@ Get a mutable reference to the transaction context from the storage context
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_tx_context_mut">tx_context_mut</a>(self: &<b>mut</b> <a href="context.md#0x2_context_Context">Context</a>): &<b>mut</b> TxContext {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="context.md#0x2_context_tx_context_mut">tx_context_mut</a>(self: &<b>mut</b> <a href="context.md#0x2_context_Context">Context</a>): &<b>mut</b> TxContext {
     &<b>mut</b> self.<a href="tx_context.md#0x2_tx_context">tx_context</a>
 }
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/context.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/context.md
@@ -26,6 +26,8 @@ and let developers can customize the storage
 -  [Function `remove_object`](#0x2_context_remove_object)
 -  [Function `add_object`](#0x2_context_add_object)
 -  [Function `contains_object`](#0x2_context_contains_object)
+-  [Function `new_object`](#0x2_context_new_object)
+-  [Function `new_object_with_owner`](#0x2_context_new_object_with_owner)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -492,6 +494,57 @@ Add object to object store
 
 <pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_contains_object">contains_object</a>(self: &<a href="context.md#0x2_context_Context">Context</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): bool {
     <a href="storage_context.md#0x2_storage_context_contains">storage_context::contains</a>(&self.<a href="storage_context.md#0x2_storage_context">storage_context</a>, <a href="object_id.md#0x2_object_id">object_id</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_context_new_object"></a>
+
+## Function `new_object`
+
+Create a new Object, the owner is the <code>sender</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_new_object">new_object</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="context.md#0x2_context_Context">context::Context</a>, value: T): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_new_object">new_object</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="context.md#0x2_context_Context">Context</a>, value: T): Object&lt;T&gt; {
+    <b>let</b> owner = <a href="context.md#0x2_context_sender">sender</a>(self);
+    <a href="object.md#0x2_object_new">object::new</a>&lt;T&gt;(&<b>mut</b> self.<a href="tx_context.md#0x2_tx_context">tx_context</a>, owner, value)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_context_new_object_with_owner"></a>
+
+## Function `new_object_with_owner`
+
+Create a new Object with owner
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_new_object_with_owner">new_object_with_owner</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="context.md#0x2_context_Context">context::Context</a>, owner: <b>address</b>, value: T): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_new_object_with_owner">new_object_with_owner</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="context.md#0x2_context_Context">Context</a>, owner: <b>address</b>, value: T): Object&lt;T&gt; {
+    <a href="object.md#0x2_object_new">object::new</a>(&<b>mut</b> self.<a href="tx_context.md#0x2_tx_context">tx_context</a>, owner, value)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
@@ -21,8 +21,7 @@ The differents with the Object in [Sui](https://github.com/MystenLabs/sui/blob/5
 -  [Function `unpack`](#0x2_object_unpack)
 
 
-<pre><code><b>use</b> <a href="">0x1::debug</a>;
-<b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
+<pre><code><b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
@@ -74,10 +73,9 @@ The object can not be copied, droped, only can be consumed by StorageContext API
 ## Function `new`
 
 Create a new object, the object is owned by <code>owner</code>
-The private generic is indicate the T should be defined in the same module as the caller. This is ensured by the verifier.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_new">new</a>&lt;T: key&gt;(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>, owner: <b>address</b>, value: T): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_new">new</a>&lt;T: key&gt;(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>, owner: <b>address</b>, value: T): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
 </code></pre>
 
 
@@ -86,11 +84,9 @@ The private generic is indicate the T should be defined in the same module as th
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_new">new</a>&lt;T: key&gt;(ctx: &<b>mut</b> TxContext, owner: <b>address</b>, value: T): <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_new">new</a>&lt;T: key&gt;(ctx: &<b>mut</b> TxContext, owner: <b>address</b>, value: T): <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt; {
     <b>let</b> id = <a href="tx_context.md#0x2_tx_context_fresh_object_id">tx_context::fresh_object_id</a>(ctx);
     <b>let</b> obj = <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;{id, value, owner};
-    //TODO after add <a href="event.md#0x2_event">event</a>, then remove the <a href="">debug</a> info
-    <a href="_print">debug::print</a>(&obj);
     obj
 }
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/context.move
@@ -8,12 +8,9 @@ module moveos_std::context {
     use moveos_std::storage_context::{Self, StorageContext};
     use moveos_std::tx_context::{Self, TxContext};
     use moveos_std::object_id::ObjectID;
-    use moveos_std::object::Object;
+    use moveos_std::object::{Self, Object};
     use moveos_std::tx_meta::{TxMeta};
     use moveos_std::tx_result::{TxResult};
-
-    #[test_only]
-    use moveos_std::test_helper;
 
     /// Information about the global context include TxContext and StorageContext
     /// We can not put the StorageContext to TxContext, because object module depends on tx_context module,
@@ -117,6 +114,21 @@ module moveos_std::context {
         storage_context::contains(&self.storage_context, object_id)
     }
 
+    // Wrap functions for Object
+
+    #[private_generics(T)]
+    /// Create a new Object, the owner is the `sender`
+    public fun new_object<T: key>(self: &mut Context, value: T): Object<T> {
+        let owner = sender(self);
+        object::new<T>(&mut self.tx_context, owner, value)
+    }
+
+    #[private_generics(T)]
+    /// Create a new Object with owner
+    public fun new_object_with_owner<T: key>(self: &mut Context, owner: address, value: T): Object<T> {
+        object::new(&mut self.tx_context, owner, value)
+    }
+
     #[test_only]
     /// Create a Context for unit test
     public fun new_test_context(sender: address): Context {
@@ -142,6 +154,6 @@ module moveos_std::context {
     #[test_only]
     /// Testing only: allow to drop Context
     public fun drop_test_context(self: Context) {
-        test_helper::destroy<Context>(self);
+        moveos_std::test_helper::destroy<Context>(self);
     }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/context.move
@@ -12,6 +12,10 @@ module moveos_std::context {
     use moveos_std::tx_meta::{TxMeta};
     use moveos_std::tx_result::{TxResult};
 
+    friend moveos_std::table;
+    friend moveos_std::type_table;
+    friend moveos_std::account_storage;
+
     /// Information about the global context include TxContext and StorageContext
     /// We can not put the StorageContext to TxContext, because object module depends on tx_context module,
     /// and storage_context module depends on object module.
@@ -24,12 +28,12 @@ module moveos_std::context {
     }
 
     /// Get an immutable reference to the transaction context from the storage context
-    public fun tx_context(self: &Context): &TxContext {
+    public(friend) fun tx_context(self: &Context): &TxContext {
         &self.tx_context
     }
 
     /// Get a mutable reference to the transaction context from the storage context
-    public fun tx_context_mut(self: &mut Context): &mut TxContext {
+    public(friend) fun tx_context_mut(self: &mut Context): &mut TxContext {
         &mut self.tx_context
     }
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
@@ -5,10 +5,11 @@
 /// 2. The Object is a use case for the Hot Potato pattern in Move. Objects do not have any ability, so they cannot be drop, copy, or store, and can only be handled by StorageContext API after creation.
 module moveos_std::object {
     use moveos_std::tx_context::{Self, TxContext};
-    use std::debug;
     use moveos_std::object_id::ObjectID;
 
+    friend moveos_std::context;
     friend moveos_std::account_storage;
+    friend moveos_std::storage_context;
     friend moveos_std::event;
    
     /// Box style object
@@ -22,14 +23,10 @@ module moveos_std::object {
         value: T,
     }
 
-    #[private_generics(T)]
     /// Create a new object, the object is owned by `owner`
-    /// The private generic is indicate the T should be defined in the same module as the caller. This is ensured by the verifier.
-    public fun new<T: key>(ctx: &mut TxContext, owner: address, value: T): Object<T> {
+    public(friend) fun new<T: key>(ctx: &mut TxContext, owner: address, value: T): Object<T> {
         let id = tx_context::fresh_object_id(ctx);
         let obj = Object<T>{id, value, owner};
-        //TODO after add event, then remove the debug info
-        debug::print(&obj);
         obj
     }
 


### PR DESCRIPTION
## Summary

Follow refactor of #918 

1. Make `object::new` to friend.
2. Provide `context::new_object` and `context::new_object_with_owner`.
