### PR TITLE
Support reverse search tx order by tx hash and refactor tx RPC to improve query performance

### DIFF
--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -217,14 +217,14 @@
         }
       ],
       "result": {
-        "name": "Vec<Option<TransactionView>>",
+        "name": "Vec<Option<TransactionResultView>>",
         "required": true,
         "schema": {
           "type": "array",
           "items": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/TransactionView"
+                "$ref": "#/components/schemas/TransactionResultView"
               },
               {
                 "type": "null"

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -1,11 +1,12 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::jsonrpc_types::transaction_view::TransactionResultView;
 use crate::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedFunctionResultView, AnnotatedStateView,
     EventPageView, ExecuteTransactionResponseView, FunctionCallView, H256View,
     ListAnnotatedStatesPageView, ListBalanceInfoPageView, ListStatesPageView, StateView, StrView,
-    StructTagView, TransactionResultPageView, TransactionView,
+    StructTagView, TransactionResultPageView,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -78,23 +79,11 @@ pub trait RoochAPI {
         limit: Option<u64>,
     ) -> RpcResult<EventPageView>;
 
-    // The current scenario of querying events can be satisfied by getEventsByEventHandle. GetEvents by EventFilter will be enabled after Indexer is supported.
-    // /// Get the events by event filter
-    // #[method(name = "getEvents")]
-    // async fn get_events(
-    //     &self,
-    //     filter: EventFilterView,
-    // ) -> RpcResult<Vec<Option<AnnotatedEventView>>>;
-
-    // TODO:
-    // #[method(name = "getTransactionByHash")]
-    // async fn get_transaction_by_hash(&self, hash: H256View) -> RpcResult<Option<TransactionView>>;
-
     #[method(name = "getTransactionsByHash")]
     async fn get_transactions_by_hash(
         &self,
         tx_hashes: Vec<H256View>,
-    ) -> RpcResult<Vec<Option<TransactionView>>>;
+    ) -> RpcResult<Vec<Option<TransactionResultView>>>;
 
     #[method(name = "getTransactionsByOrder")]
     async fn get_transactions_by_order(

--- a/crates/rooch-rpc-client/src/lib.rs
+++ b/crates/rooch-rpc-client/src/lib.rs
@@ -14,6 +14,7 @@ use moveos_types::{
     transaction::FunctionCall,
     tx_context::TxContext,
 };
+use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionResultView;
 use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedFunctionResultView, EventPageView,
     ListAnnotatedStatesPageView, ListBalanceInfoPageView, ListStatesPageView, StrView,
@@ -23,7 +24,6 @@ use rooch_rpc_api::{
     api::rooch_api::RoochAPIClient,
     jsonrpc_types::{
         AnnotatedStateView, ExecuteTransactionResponseView, StateView, TransactionResultPageView,
-        TransactionView,
     },
 };
 use rooch_types::{
@@ -158,7 +158,7 @@ impl Client {
     pub async fn get_transactions_by_hash(
         &self,
         tx_hashes: Vec<H256>,
-    ) -> Result<Vec<Option<TransactionView>>> {
+    ) -> Result<Vec<Option<TransactionResultView>>> {
         Ok(self
             .rpc
             .http

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -300,15 +300,22 @@ impl RoochAPIServer for RoochServer {
         let mut transaction_results: Vec<TransactionResult> = vec![];
         for (index, _tx_hash) in tx_hashes.iter().enumerate() {
             let transaction_result = TransactionResult {
-                transaction: transactions[index]
-                    .clone()
-                    .expect("Transaction should have value when construct TransactionResult"),
-                sequence_info: sequence_infos[index].clone().expect(
-                    "TransactionSequenceInfo should have value when construct TransactionResult",
-                ),
-                execution_info: execution_infos[index].clone().expect(
-                    "TransactionExecutionInfo should have value when construct TransactionResult",
-                ),
+                transaction: transactions[index].clone().ok_or(anyhow::anyhow!(
+                    "Transaction should have value when construct TransactionResult"
+                ))?,
+                // .expect("Transaction should have value when construct TransactionResult"),
+                sequence_info: sequence_infos[index].clone().ok_or(anyhow::anyhow!(
+                    "TransactionSequenceInfo should have value when construct TransactionResult"
+                ))?,
+                //     expect(
+                //     "TransactionSequenceInfo should have value when construct TransactionResult",
+                // ),
+                execution_info: execution_infos[index].clone().ok_or(anyhow::anyhow!(
+                    "TransactionExecutionInfo should have value when construct TransactionResult"
+                ))?,
+                //     .expect(
+                //     "TransactionExecutionInfo should have value when construct TransactionResult",
+                // ),
             };
             transaction_results.push(transaction_result)
         }

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -171,14 +171,14 @@ impl RpcService {
         Ok(resp)
     }
 
-    pub async fn get_tx_sequence_mapping_by_order(
+    pub async fn get_tx_sequence_info_mapping_by_order(
         &self,
         cursor: Option<u128>,
         limit: u64,
-    ) -> Result<Vec<TransactionSequenceInfoMapping>> {
+    ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
         let resp = self
             .sequencer
-            .get_transaction_sequence_mapping_by_order(cursor, limit)
+            .get_transaction_sequence_info_mapping_by_order(cursor, limit)
             .await?;
         Ok(resp)
     }

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -17,6 +17,7 @@ use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponse, ExecuteTransactio
 use rooch_sequencer::proxy::SequencerProxy;
 use rooch_types::account::Account;
 use rooch_types::address::{MultiChainAddress, RoochAddress};
+use rooch_types::sequencer::SequencerOrder;
 use rooch_types::transaction::rooch::RoochTransaction;
 use rooch_types::transaction::{TransactionSequenceInfo, TransactionSequenceInfoMapping};
 use rooch_types::{transaction::TypedTransaction, H256};
@@ -173,12 +174,22 @@ impl RpcService {
 
     pub async fn get_tx_sequence_info_mapping_by_order(
         &self,
-        cursor: Option<u128>,
-        limit: u64,
+        tx_orders: Vec<u128>,
     ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
         let resp = self
             .sequencer
-            .get_transaction_sequence_info_mapping_by_order(cursor, limit)
+            .get_transaction_sequence_info_mapping_by_order(tx_orders)
+            .await?;
+        Ok(resp)
+    }
+
+    pub async fn get_tx_sequence_info_mapping_by_hash(
+        &self,
+        tx_hashes: Vec<H256>,
+    ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
+        let resp = self
+            .sequencer
+            .get_transaction_sequence_info_mapping_by_hash(tx_hashes)
             .await?;
         Ok(resp)
     }
@@ -191,6 +202,11 @@ impl RpcService {
             .executor
             .get_transaction_execution_infos_by_hash(tx_hashes)
             .await?;
+        Ok(resp)
+    }
+
+    pub async fn get_sequencer_order(&self) -> Result<Option<SequencerOrder>> {
+        let resp = self.sequencer.get_sequencer_order().await?;
         Ok(resp)
     }
 }

--- a/crates/rooch-sequencer/src/actor/sequencer.rs
+++ b/crates/rooch-sequencer/src/actor/sequencer.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::messages::{
-    GetTransactionByHashMessage, GetTransactionsByHashMessage, GetTxSequenceInfosMessage,
-    GetTxSequenceMappingByOrderMessage, TransactionSequenceMessage,
+    GetTransactionByHashMessage, GetTransactionsByHashMessage,
+    GetTxSequenceInfoMappingByOrderMessage, GetTxSequenceInfosMessage, TransactionSequenceMessage,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -112,16 +112,16 @@ impl Handler<GetTransactionsByHashMessage> for SequencerActor {
 }
 
 #[async_trait]
-impl Handler<GetTxSequenceMappingByOrderMessage> for SequencerActor {
+impl Handler<GetTxSequenceInfoMappingByOrderMessage> for SequencerActor {
     async fn handle(
         &mut self,
-        msg: GetTxSequenceMappingByOrderMessage,
+        msg: GetTxSequenceInfoMappingByOrderMessage,
         _ctx: &mut ActorContext,
-    ) -> Result<Vec<TransactionSequenceInfoMapping>> {
-        let GetTxSequenceMappingByOrderMessage { cursor, limit } = msg;
+    ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
+        let GetTxSequenceInfoMappingByOrderMessage { cursor, limit } = msg;
         self.rooch_store
             .get_transaction_store()
-            .get_tx_sequence_mapping_by_order(cursor, limit)
+            .get_tx_sequence_info_mapping_by_order(cursor, limit)
     }
 }
 

--- a/crates/rooch-sequencer/src/actor/sequencer.rs
+++ b/crates/rooch-sequencer/src/actor/sequencer.rs
@@ -71,6 +71,8 @@ impl Handler<TransactionSequenceMessage> for SequencerActor {
         self.rooch_store.save_transaction(tx)?;
         self.rooch_store
             .save_tx_sequence_info_mapping(tx_order, hash)?;
+        self.rooch_store
+            .save_tx_sequence_info_reverse_mapping(hash, tx_order)?;
 
         self.rooch_store
             .save_sequencer_order(SequencerOrder::new(self.last_order))?;

--- a/crates/rooch-sequencer/src/messages.rs
+++ b/crates/rooch-sequencer/src/messages.rs
@@ -41,13 +41,13 @@ impl Message for GetTransactionsByHashMessage {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct GetTxSequenceMappingByOrderMessage {
+pub struct GetTxSequenceInfoMappingByOrderMessage {
     pub cursor: Option<u128>,
     pub limit: u64,
 }
 
-impl Message for GetTxSequenceMappingByOrderMessage {
-    type Result = Result<Vec<TransactionSequenceInfoMapping>>;
+impl Message for GetTxSequenceInfoMappingByOrderMessage {
+    type Result = Result<Vec<Option<TransactionSequenceInfoMapping>>>;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rooch-sequencer/src/messages.rs
+++ b/crates/rooch-sequencer/src/messages.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use coerce::actor::message::Message;
+use rooch_types::sequencer::SequencerOrder;
 use rooch_types::transaction::TransactionSequenceInfoMapping;
 use rooch_types::{
     transaction::{TransactionSequenceInfo, TypedTransaction},
@@ -42,11 +43,19 @@ impl Message for GetTransactionsByHashMessage {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetTxSequenceInfoMappingByOrderMessage {
-    pub cursor: Option<u128>,
-    pub limit: u64,
+    pub tx_orders: Vec<u128>,
 }
 
 impl Message for GetTxSequenceInfoMappingByOrderMessage {
+    type Result = Result<Vec<Option<TransactionSequenceInfoMapping>>>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetTxSequenceInfoMappingByHashMessage {
+    pub tx_hashes: Vec<H256>,
+}
+
+impl Message for GetTxSequenceInfoMappingByHashMessage {
     type Result = Result<Vec<Option<TransactionSequenceInfoMapping>>>;
 }
 
@@ -57,4 +66,11 @@ pub struct GetTxSequenceInfosMessage {
 
 impl Message for GetTxSequenceInfosMessage {
     type Result = Result<Vec<Option<TransactionSequenceInfo>>>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetSequencerOrderMessage {}
+
+impl Message for GetSequencerOrderMessage {
+    type Result = Result<Option<SequencerOrder>>;
 }

--- a/crates/rooch-sequencer/src/proxy/mod.rs
+++ b/crates/rooch-sequencer/src/proxy/mod.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::messages::{
-    GetTransactionByHashMessage, GetTransactionsByHashMessage,
-    GetTxSequenceInfoMappingByOrderMessage, GetTxSequenceInfosMessage,
+    GetSequencerOrderMessage, GetTransactionByHashMessage, GetTransactionsByHashMessage,
+    GetTxSequenceInfoMappingByHashMessage, GetTxSequenceInfoMappingByOrderMessage,
+    GetTxSequenceInfosMessage,
 };
 use crate::{actor::sequencer::SequencerActor, messages::TransactionSequenceMessage};
 use anyhow::Result;
 use coerce::actor::ActorRef;
+use rooch_types::sequencer::SequencerOrder;
 use rooch_types::transaction::{TransactionSequenceInfoMapping, TypedTransaction};
 use rooch_types::{transaction::TransactionSequenceInfo, H256};
 
@@ -45,11 +47,19 @@ impl SequencerProxy {
 
     pub async fn get_transaction_sequence_info_mapping_by_order(
         &self,
-        cursor: Option<u128>,
-        limit: u64,
+        tx_orders: Vec<u128>,
     ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
         self.actor
-            .send(GetTxSequenceInfoMappingByOrderMessage { cursor, limit })
+            .send(GetTxSequenceInfoMappingByOrderMessage { tx_orders })
+            .await?
+    }
+
+    pub async fn get_transaction_sequence_info_mapping_by_hash(
+        &self,
+        tx_hashes: Vec<H256>,
+    ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
+        self.actor
+            .send(GetTxSequenceInfoMappingByHashMessage { tx_hashes })
             .await?
     }
 
@@ -60,5 +70,9 @@ impl SequencerProxy {
         self.actor
             .send(GetTxSequenceInfosMessage { orders })
             .await?
+    }
+
+    pub async fn get_sequencer_order(&self) -> Result<Option<SequencerOrder>> {
+        self.actor.send(GetSequencerOrderMessage {}).await?
     }
 }

--- a/crates/rooch-sequencer/src/proxy/mod.rs
+++ b/crates/rooch-sequencer/src/proxy/mod.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::messages::{
-    GetTransactionByHashMessage, GetTransactionsByHashMessage, GetTxSequenceInfosMessage,
-    GetTxSequenceMappingByOrderMessage,
+    GetTransactionByHashMessage, GetTransactionsByHashMessage,
+    GetTxSequenceInfoMappingByOrderMessage, GetTxSequenceInfosMessage,
 };
 use crate::{actor::sequencer::SequencerActor, messages::TransactionSequenceMessage};
 use anyhow::Result;
@@ -43,13 +43,13 @@ impl SequencerProxy {
             .await?
     }
 
-    pub async fn get_transaction_sequence_mapping_by_order(
+    pub async fn get_transaction_sequence_info_mapping_by_order(
         &self,
         cursor: Option<u128>,
         limit: u64,
-    ) -> Result<Vec<TransactionSequenceInfoMapping>> {
+    ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
         self.actor
-            .send(GetTxSequenceMappingByOrderMessage { cursor, limit })
+            .send(GetTxSequenceInfoMappingByOrderMessage { cursor, limit })
             .await?
     }
 

--- a/crates/rooch-store/src/lib.rs
+++ b/crates/rooch-store/src/lib.rs
@@ -36,6 +36,7 @@ static VEC_PREFIX_NAME: Lazy<Vec<ColumnFamilyName>> = Lazy::new(|| {
         TX_SEQUENCE_INFO_PREFIX_NAME,
         TX_SEQUENCE_INFO_MAPPING_PREFIX_NAME,
         META_SEQUENCER_ORDER_PREFIX_NAME,
+        TX_SEQUENCE_INFO_REVERSE_MAPPING_PREFIX_NAME,
     ]
 });
 
@@ -130,11 +131,10 @@ impl TransactionStore for RoochStore {
 
     fn get_tx_sequence_info_mapping_by_order(
         &self,
-        cursor: Option<u128>,
-        limit: u64,
+        tx_orders: Vec<u128>,
     ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
         self.transaction_store
-            .get_tx_sequence_info_mapping_by_order(cursor, limit)
+            .get_tx_sequence_info_mapping_by_order(tx_orders)
     }
 
     fn save_tx_sequence_info_reverse_mapping(&self, tx_hash: H256, tx_order: u128) -> Result<()> {

--- a/crates/rooch-store/src/lib.rs
+++ b/crates/rooch-store/src/lib.rs
@@ -23,6 +23,8 @@ pub mod transaction_store;
 pub const TYPED_TRANSACTION_PREFIX_NAME: ColumnFamilyName = "typed_transaction";
 pub const TX_SEQUENCE_INFO_PREFIX_NAME: ColumnFamilyName = "tx_sequence_info";
 pub const TX_SEQUENCE_INFO_MAPPING_PREFIX_NAME: ColumnFamilyName = "tx_sequence_info_mapping";
+pub const TX_SEQUENCE_INFO_REVERSE_MAPPING_PREFIX_NAME: ColumnFamilyName =
+    "tx_sequence_info_reverse_mapping";
 
 pub const META_SEQUENCER_ORDER_PREFIX_NAME: ColumnFamilyName = "meta_sequencer_order";
 
@@ -133,6 +135,18 @@ impl TransactionStore for RoochStore {
     ) -> Result<Vec<TransactionSequenceInfoMapping>> {
         self.transaction_store
             .get_tx_sequence_mapping_by_order(cursor, limit)
+    }
+
+    fn save_tx_sequence_info_reverse_mapping(&self, tx_hash: H256, tx_order: u128) -> Result<()> {
+        self.transaction_store
+            .save_tx_sequence_info_reverse_mapping(tx_hash, tx_order)
+    }
+    fn multi_get_tx_sequence_info_mapping_by_hash(
+        &self,
+        tx_hashes: Vec<H256>,
+    ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
+        self.transaction_store
+            .multi_get_tx_sequence_info_mapping_by_hash(tx_hashes)
     }
 }
 

--- a/crates/rooch-store/src/lib.rs
+++ b/crates/rooch-store/src/lib.rs
@@ -118,7 +118,7 @@ impl TransactionStore for RoochStore {
         &self,
         cursor: Option<u128>,
         limit: u64,
-    ) -> Result<Vec<TransactionSequenceInfo>> {
+    ) -> Result<Vec<Option<TransactionSequenceInfo>>> {
         self.transaction_store
             .get_tx_sequence_infos_by_order(cursor, limit)
     }
@@ -132,9 +132,9 @@ impl TransactionStore for RoochStore {
         &self,
         cursor: Option<u128>,
         limit: u64,
-    ) -> Result<Vec<TransactionSequenceInfoMapping>> {
+    ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
         self.transaction_store
-            .get_tx_sequence_mapping_by_order(cursor, limit)
+            .get_tx_sequence_info_mapping_by_order(cursor, limit)
     }
 
     fn save_tx_sequence_info_reverse_mapping(&self, tx_hash: H256, tx_order: u128) -> Result<()> {

--- a/crates/rooch-store/src/transaction_store/mod.rs
+++ b/crates/rooch-store/src/transaction_store/mod.rs
@@ -10,7 +10,7 @@ use rooch_types::H256;
 
 use crate::{
     TX_SEQUENCE_INFO_MAPPING_PREFIX_NAME, TX_SEQUENCE_INFO_PREFIX_NAME,
-    TYPED_TRANSACTION_PREFIX_NAME,
+    TX_SEQUENCE_INFO_REVERSE_MAPPING_PREFIX_NAME, TYPED_TRANSACTION_PREFIX_NAME,
 };
 use raw_store::{derive_store, StoreInstance};
 
@@ -35,6 +35,13 @@ derive_store!(
     TX_SEQUENCE_INFO_MAPPING_PREFIX_NAME
 );
 
+derive_store!(
+    TxSequenceInfoReverseMappingStore,
+    H256,
+    u128,
+    TX_SEQUENCE_INFO_REVERSE_MAPPING_PREFIX_NAME
+);
+
 pub trait TransactionStore {
     fn save_transaction(&mut self, transaction: TypedTransaction) -> Result<()>;
     fn get_transaction_by_hash(&self, hash: H256) -> Result<Option<TypedTransaction>>;
@@ -55,6 +62,12 @@ pub trait TransactionStore {
         cursor: Option<u128>,
         limit: u64,
     ) -> Result<Vec<TransactionSequenceInfoMapping>>;
+
+    fn save_tx_sequence_info_reverse_mapping(&self, tx_hash: H256, tx_order: u128) -> Result<()>;
+    fn multi_get_tx_sequence_info_mapping_by_hash(
+        &self,
+        tx_hashes: Vec<H256>,
+    ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>>;
 }
 
 #[derive(Clone)]
@@ -62,6 +75,7 @@ pub struct TransactionDBStore {
     tx_store: TypedTransactionStore,
     tx_sequence_info_store: TxSequenceInfoStore,
     tx_sequence_info_mapping_store: TxSequenceInfoMappingStore,
+    tx_sequence_info_reverse_mapping_store: TxSequenceInfoReverseMappingStore,
 }
 
 impl TransactionDBStore {
@@ -69,7 +83,10 @@ impl TransactionDBStore {
         TransactionDBStore {
             tx_store: TypedTransactionStore::new(instance.clone()),
             tx_sequence_info_store: TxSequenceInfoStore::new(instance.clone()),
-            tx_sequence_info_mapping_store: TxSequenceInfoMappingStore::new(instance),
+            tx_sequence_info_mapping_store: TxSequenceInfoMappingStore::new(instance.clone()),
+            tx_sequence_info_reverse_mapping_store: TxSequenceInfoReverseMappingStore::new(
+                instance,
+            ),
         }
     }
 
@@ -166,5 +183,52 @@ impl TransactionDBStore {
         orders: Vec<u128>,
     ) -> Result<Vec<Option<TransactionSequenceInfo>>> {
         self.tx_sequence_info_store.multiple_get(orders)
+    }
+
+    pub fn save_tx_sequence_info_reverse_mapping(
+        &self,
+        tx_hash: H256,
+        tx_order: u128,
+    ) -> Result<()> {
+        self.tx_sequence_info_reverse_mapping_store
+            .kv_put(tx_hash, tx_order)
+    }
+
+    pub fn multi_get_tx_sequence_info_mapping_by_hash(
+        &self,
+        tx_hashes: Vec<H256>,
+    ) -> Result<Vec<Option<TransactionSequenceInfoMapping>>> {
+        let mappings = self
+            .tx_sequence_info_reverse_mapping_store
+            .multiple_get(tx_hashes.clone())?;
+
+        mappings
+            .into_iter()
+            .enumerate()
+            .map(|(index, value)| match value {
+                Some(tx_order) => {
+                    let tx_hash = tx_hashes[index];
+                    let tx_sequence_info_mapping =
+                        TransactionSequenceInfoMapping { tx_order, tx_hash };
+                    Ok(Some(tx_sequence_info_mapping))
+                }
+                None => Ok(None),
+            })
+            .collect()
+
+        // let mut result: Vec<Option<TransactionSequenceInfoMapping>> = vec![];
+        // for (index, tx_hash) in tx_hashes.iter().enumerate() {
+        //     let tx_order = mappings[index].ok_or(anyhow::anyhow!("Invalid transaction sequence info mapping"))?;
+        //     let tx_sequence_info_mapping = TransactionSequenceInfoMapping {
+        //         // pub tx_order: u128,
+        //         // /// The tx hash.
+        //         // pub tx_hash: H256,
+        //         tx_order,
+        //         *tx_hash,
+        //     };
+        //     result.push(tx_sequence_info_mapping);
+        // }
+
+        // Ok(result)
     }
 }

--- a/crates/rooch/src/commands/transaction/commands/get_transactions_by_hash.rs
+++ b/crates/rooch/src/commands/transaction/commands/get_transactions_by_hash.rs
@@ -3,12 +3,12 @@
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
-use rooch_rpc_api::jsonrpc_types::TransactionView;
+use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionResultView;
 use rooch_types::{error::RoochResult, H256};
 
 /// Get transactions by hashes
 #[derive(Debug, clap::Parser)]
-pub struct GetTransactionsByHashesCommand {
+pub struct GetTransactionsByHashCommand {
     /// Transaction's hashes
     #[clap(long, value_delimiter = ',')]
     pub hashes: Vec<H256>,
@@ -18,8 +18,8 @@ pub struct GetTransactionsByHashesCommand {
 }
 
 #[async_trait]
-impl CommandAction<Vec<Option<TransactionView>>> for GetTransactionsByHashesCommand {
-    async fn execute(self) -> RoochResult<Vec<Option<TransactionView>>> {
+impl CommandAction<Vec<Option<TransactionResultView>>> for GetTransactionsByHashCommand {
+    async fn execute(self) -> RoochResult<Vec<Option<TransactionResultView>>> {
         let client = self.context_options.build().await?.get_client().await?;
 
         let resp = client.get_transactions_by_hash(self.hashes).await?;

--- a/crates/rooch/src/commands/transaction/mod.rs
+++ b/crates/rooch/src/commands/transaction/mod.rs
@@ -23,7 +23,7 @@ impl CommandAction<String> for Transaction {
     async fn execute(self) -> RoochResult<String> {
         match self.cmd {
             TransactionCommand::GetTransactionsByOrder(cmd) => cmd.execute_serialized().await,
-            TransactionCommand::GetTransactionsByHashes(cmd) => cmd.execute_serialized().await,
+            TransactionCommand::GetTransactionsByHash(cmd) => cmd.execute_serialized().await,
         }
     }
 }
@@ -31,5 +31,5 @@ impl CommandAction<String> for Transaction {
 #[derive(clap::Subcommand)]
 pub enum TransactionCommand {
     GetTransactionsByOrder(GetTransactionsByOrderCommand),
-    GetTransactionsByHashes(GetTransactionsByHashCommand),
+    GetTransactionsByHash(GetTransactionsByHashCommand),
 }

--- a/crates/rooch/src/commands/transaction/mod.rs
+++ b/crates/rooch/src/commands/transaction/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::cli_types::CommandAction;
 use crate::commands::transaction::commands::{
-    get_transactions_by_hash::GetTransactionsByHashesCommand,
+    get_transactions_by_hash::GetTransactionsByHashCommand,
     get_transactions_by_order::GetTransactionsByOrderCommand,
 };
 use async_trait::async_trait;
@@ -31,5 +31,5 @@ impl CommandAction<String> for Transaction {
 #[derive(clap::Subcommand)]
 pub enum TransactionCommand {
     GetTransactionsByOrder(GetTransactionsByOrderCommand),
-    GetTransactionsByHashes(GetTransactionsByHashesCommand),
+    GetTransactionsByHashes(GetTransactionsByHashCommand),
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -22,7 +22,7 @@ Feature: Rooch CLI integration tests
 
       # transaction
       Then cmd: "transaction get-transactions-by-order --cursor 0 --limit 1"
-      Then cmd: "transaction get-transactions-by-hashes --hashes {{$.transaction[-1].data[0].execution_info.tx_hash}}"
+      Then cmd: "transaction get-transactions-by-hash --hashes {{$.transaction[-1].data[0].execution_info.tx_hash}}"
 
       # event example
       Then cmd: "move publish -p ../../examples/event --sender-account {default} --named-addresses rooch_examples={default}"

--- a/sdk/typescript/src/provider/json-rpc-provider.ts
+++ b/sdk/typescript/src/provider/json-rpc-provider.ts
@@ -10,14 +10,15 @@ import {
   TypeTag,
   Arg,
   Bytes,
-  TransactionView,
+  // TransactionView,
   AnnotatedFunctionResultView,
   AnnotatedStateView,
   TransactionResultPageView,
   AnnotatedEventResultPageView,
   ListAnnotatedStateResultPageView,
   StateView,
-  StateResultPageView, TransactionResultView,
+  StateResultPageView,
+  TransactionResultView,
 } from '../types'
 import { functionIdToStirng, typeTagToString, encodeArg, toHexString } from '../utils'
 import { IProvider } from './interface'

--- a/sdk/typescript/src/provider/json-rpc-provider.ts
+++ b/sdk/typescript/src/provider/json-rpc-provider.ts
@@ -17,7 +17,7 @@ import {
   AnnotatedEventResultPageView,
   ListAnnotatedStateResultPageView,
   StateView,
-  StateResultPageView,
+  StateResultPageView, TransactionResultView,
 } from '../types'
 import { functionIdToStirng, typeTagToString, encodeArg, toHexString } from '../utils'
 import { IProvider } from './interface'
@@ -128,7 +128,7 @@ export class JsonRpcProvider implements IProvider {
     return this.client.rooch_sendRawTransaction(playload)
   }
 
-  async getTransactionsByHash(tx_hashes: string[]): Promise<TransactionView | null[]> {
+  async getTransactionsByHash(tx_hashes: string[]): Promise<TransactionResultView | null[]> {
     return await this.client.rooch_getTransactionsByHash(tx_hashes)
   }
 

--- a/sdk/typescript/test/e2e/sdk.test.ts
+++ b/sdk/typescript/test/e2e/sdk.test.ts
@@ -409,8 +409,8 @@ describe('SDK', () => {
       expect(page.data).toHaveLength(1)
       expect(page.data[0].authentication_key).toBeDefined()
       expect(page.data[0].max_inactive_interval).toBe(100)
-      expect(page.data[0].create_time).greaterThan(1696225092)
-      expect(page.data[0].last_active_time).greaterThan(1696225092)
+      // expect(page.data[0].create_time).greaterThan(1696225092)
+      // expect(page.data[0].last_active_time).greaterThan(1696225092)
 
       // query next page
       const nextPage = await account.querySessionKeys(page.nextCursor, 10)

--- a/sdk/typescript/test/e2e/sdk.test.ts
+++ b/sdk/typescript/test/e2e/sdk.test.ts
@@ -409,8 +409,8 @@ describe('SDK', () => {
       expect(page.data).toHaveLength(1)
       expect(page.data[0].authentication_key).toBeDefined()
       expect(page.data[0].max_inactive_interval).toBe(100)
-      // expect(page.data[0].create_time).greaterThan(1696225092)
-      // expect(page.data[0].last_active_time).greaterThan(1696225092)
+      expect(page.data[0].create_time).greaterThan(1696225092)
+      expect(page.data[0].last_active_time).greaterThan(1696225092)
 
       // query next page
       const nextPage = await account.querySessionKeys(page.nextCursor, 10)


### PR DESCRIPTION
resolve https://github.com/rooch-network/rooch/issues/844

Summary
1. Support reverse search tx order by tx hash
2. Make the output of get_transactions_by_hash and get_transactions_by_order are consistent, contains transaction, sequence info and execution info at the same time
3. Refactor tx rpc for traversing the SMT Tree be optimized into a multi get query to improve query performance
4. Make `Sequencer Order` start with 0, which is semantically consistent with the contract’s `sequence_number`, RPC’s cursor and other parameters.
