### PR TITLE
[Framework & RPC] Implement ObjectRef, refactor CoinStore and balance RPC

### DIFF
--- a/crates/rooch-framework/doc/coin.md
+++ b/crates/rooch-framework/doc/coin.md
@@ -7,8 +7,9 @@ This module provides the foundation for typesafe Coins.
 
 
 -  [Struct `Coin`](#0x3_coin_Coin)
+-  [Struct `Balance`](#0x3_coin_Balance)
 -  [Resource `CoinStore`](#0x3_coin_CoinStore)
--  [Resource `CoinInfo`](#0x3_coin_CoinInfo)
+-  [Struct `CoinInfo`](#0x3_coin_CoinInfo)
 -  [Resource `CoinInfos`](#0x3_coin_CoinInfos)
 -  [Resource `AutoAcceptCoins`](#0x3_coin_AutoAcceptCoins)
 -  [Resource `CoinStores`](#0x3_coin_CoinStores)
@@ -27,22 +28,28 @@ This module provides the foundation for typesafe Coins.
 -  [Function `decimals`](#0x3_coin_decimals)
 -  [Function `supply`](#0x3_coin_supply)
 -  [Function `is_same_coin`](#0x3_coin_is_same_coin)
--  [Function `coin_store_handle`](#0x3_coin_coin_store_handle)
--  [Function `coin_info_handle`](#0x3_coin_coin_info_handle)
+-  [Function `coin_store_id`](#0x3_coin_coin_store_id)
+-  [Function `coin_stores_handle`](#0x3_coin_coin_stores_handle)
+-  [Function `coin_infos_handle`](#0x3_coin_coin_infos_handle)
+-  [Function `create_coin_store`](#0x3_coin_create_coin_store)
 -  [Function `is_account_accept_coin`](#0x3_coin_is_account_accept_coin)
 -  [Function `can_auto_accept_coin`](#0x3_coin_can_auto_accept_coin)
 -  [Function `do_accept_coin`](#0x3_coin_do_accept_coin)
 -  [Function `set_auto_accept_coin`](#0x3_coin_set_auto_accept_coin)
 -  [Function `withdraw`](#0x3_coin_withdraw)
 -  [Function `deposit`](#0x3_coin_deposit)
+-  [Function `deposit_to_store`](#0x3_coin_deposit_to_store)
 -  [Function `transfer`](#0x3_coin_transfer)
 -  [Function `destroy_zero`](#0x3_coin_destroy_zero)
 -  [Function `extract`](#0x3_coin_extract)
+-  [Function `extract_from_store`](#0x3_coin_extract_from_store)
 -  [Function `extract_all`](#0x3_coin_extract_all)
 -  [Function `merge`](#0x3_coin_merge)
+-  [Function `merge_to_store`](#0x3_coin_merge_to_store)
 -  [Function `value`](#0x3_coin_value)
 -  [Function `zero`](#0x3_coin_zero)
--  [Function `exist_coin_store`](#0x3_coin_exist_coin_store)
+-  [Function `exist_account_coin_store`](#0x3_coin_exist_account_coin_store)
+-  [Function `is_account_coin_store_frozen`](#0x3_coin_is_account_coin_store_frozen)
 -  [Function `is_coin_store_frozen`](#0x3_coin_is_coin_store_frozen)
 -  [Function `register_extend`](#0x3_coin_register_extend)
 -  [Function `mint_extend`](#0x3_coin_mint_extend)
@@ -63,11 +70,12 @@ This module provides the foundation for typesafe Coins.
 <b>use</b> <a href="">0x2::account_storage</a>;
 <b>use</b> <a href="">0x2::context</a>;
 <b>use</b> <a href="">0x2::event</a>;
+<b>use</b> <a href="">0x2::object</a>;
 <b>use</b> <a href="">0x2::object_id</a>;
+<b>use</b> <a href="">0x2::object_ref</a>;
 <b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="">0x2::table</a>;
 <b>use</b> <a href="">0x2::type_info</a>;
-<b>use</b> <a href="">0x2::type_table</a>;
 </code></pre>
 
 
@@ -77,13 +85,14 @@ This module provides the foundation for typesafe Coins.
 ## Struct `Coin`
 
 Core data structures
-Main structure representing a coin/coin in an account's custody.
+Main structure representing a coin.
 Note the <code>CoinType</code> must have <code>key</code> ability.
 if the <code>CoinType</code> has <code>store</code> ability, the <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> is a public coin, the user can operate it directly by coin module's function.
 Otherwise, the <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> is a private coin, the user can only operate it by <code>CoinType</code> module's function.
+The Coin has no ability, it is a hot potato type, only can handle by Coin module.
 
 
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType: key&gt; <b>has</b> store
+<pre><code><b>struct</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType: key&gt;
 </code></pre>
 
 
@@ -105,13 +114,14 @@ Otherwise, the <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> is a privat
 
 </details>
 
-<a name="0x3_coin_CoinStore"></a>
+<a name="0x3_coin_Balance"></a>
 
-## Resource `CoinStore`
+## Struct `Balance`
+
+The Balance resource that stores the balance of a specific coin type.
 
 
-
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&lt;CoinType: key&gt; <b>has</b> key
+<pre><code><b>struct</b> <a href="coin.md#0x3_coin_Balance">Balance</a> <b>has</b> store
 </code></pre>
 
 
@@ -122,7 +132,40 @@ Otherwise, the <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> is a privat
 
 <dl>
 <dt>
-<code><a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;</code>
+<code>value: u256</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x3_coin_CoinStore"></a>
+
+## Resource `CoinStore`
+
+
+
+<pre><code><b>struct</b> <a href="coin.md#0x3_coin_CoinStore">CoinStore</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>coin_type: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>balance: <a href="coin.md#0x3_coin_Balance">coin::Balance</a></code>
 </dt>
 <dd>
 
@@ -140,12 +183,12 @@ Otherwise, the <code><a href="coin.md#0x3_coin_Coin">Coin</a></code> is a privat
 
 <a name="0x3_coin_CoinInfo"></a>
 
-## Resource `CoinInfo`
+## Struct `CoinInfo`
 
-Information about a specific coin type. Stored on the creator of the coin's account.
+Information about a specific coin type. Stored in the global CoinInfos table.
 
 
-<pre><code><b>struct</b> <a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType: key&gt; <b>has</b> key
+<pre><code><b>struct</b> <a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a> <b>has</b> store
 </code></pre>
 
 
@@ -156,10 +199,17 @@ Information about a specific coin type. Stored on the creator of the coin's acco
 
 <dl>
 <dt>
+<code>coin_type: <a href="_String">string::String</a></code>
+</dt>
+<dd>
+ Type of the coin: <code>address::my_module::XCoin</code>, same as <code>moveos_std::type_info::type_name&lt;CoinType&gt;()</code>.
+ The name and symbol can repeat across different coin types, but the coin type must be unique.
+</dd>
+<dt>
 <code>name: <a href="_String">string::String</a></code>
 </dt>
 <dd>
-
+ Name of the coin.
 </dd>
 <dt>
 <code>symbol: <a href="_String">string::String</a></code>
@@ -180,7 +230,7 @@ Information about a specific coin type. Stored on the creator of the coin's acco
 <code>supply: u256</code>
 </dt>
 <dd>
- The total value for the coin represented by <code>CoinType</code>. Mutable.
+ The total value for the coin represented by coin type. Mutable.
 </dd>
 </dl>
 
@@ -205,7 +255,7 @@ A resource that holds the CoinInfo for all accounts.
 
 <dl>
 <dt>
-<code>coin_infos: <a href="_TypeTable">type_table::TypeTable</a></code>
+<code>coin_infos: <a href="_Table">table::Table</a>&lt;<a href="_String">string::String</a>, <a href="coin.md#0x3_coin_CoinInfo">coin::CoinInfo</a>&gt;</code>
 </dt>
 <dd>
 
@@ -248,7 +298,7 @@ The main scenario is that the user can actively turn off the AutoAcceptCoin sett
 
 ## Resource `CoinStores`
 
-A resource that holds all the CoinStore for account.
+A resource that holds all the ObjectRef<CoinStore> for account.
 Default Deposit Coin no longer depends on accept coin
 
 
@@ -263,7 +313,7 @@ Default Deposit Coin no longer depends on accept coin
 
 <dl>
 <dt>
-<code>coin_stores: <a href="_TypeTable">type_table::TypeTable</a></code>
+<code>coin_stores: <a href="_Table">table::Table</a>&lt;<a href="_String">string::String</a>, <a href="_ObjectRef">object_ref::ObjectRef</a>&lt;<a href="coin.md#0x3_coin_CoinStore">coin::CoinStore</a>&gt;&gt;</code>
 </dt>
 <dd>
 
@@ -291,10 +341,10 @@ Event emitted when some amount of a coin is deposited into an account.
 
 <dl>
 <dt>
-<code>coin_type_info: <a href="_TypeInfo">type_info::TypeInfo</a></code>
+<code>coin_type: <a href="_String">string::String</a></code>
 </dt>
 <dd>
- The type info for the coin that was sent
+ The type of the coin that was sent
 </dd>
 <dt>
 <code>amount: u256</code>
@@ -325,10 +375,10 @@ Event emitted when some amount of a coin is withdrawn from an account.
 
 <dl>
 <dt>
-<code>coin_type_info: <a href="_TypeInfo">type_info::TypeInfo</a></code>
+<code>coin_type: <a href="_String">string::String</a></code>
 </dt>
 <dd>
- The type info for the coin that was sent
+ The type of the coin that was sent
 </dd>
 <dt>
 <code>amount: u256</code>
@@ -387,10 +437,10 @@ Event emitted when coin minted.
 
 <dl>
 <dt>
-<code>coin_type_info: <a href="_TypeInfo">type_info::TypeInfo</a></code>
+<code>coin_type: <a href="_String">string::String</a></code>
 </dt>
 <dd>
- full info of coin
+ The type of coin that was minted
 </dd>
 <dt>
 <code>amount: u256</code>
@@ -421,10 +471,10 @@ Event emitted when coin burned.
 
 <dl>
 <dt>
-<code>coin_type_info: <a href="_TypeInfo">type_info::TypeInfo</a></code>
+<code>coin_type: <a href="_String">string::String</a></code>
 </dt>
 <dd>
- full info of coin
+ The type of coin that was burned
 </dd>
 <dt>
 <code>amount: u256</code>
@@ -541,6 +591,16 @@ Symbol of the coin is too long
 
 
 
+<a name="0x3_coin_ErrorCoinTypeAndStoreMismatch"></a>
+
+The CoinType parameter and CoinType in CoinStore do not match
+
+
+<pre><code><b>const</b> <a href="coin.md#0x3_coin_ErrorCoinTypeAndStoreMismatch">ErrorCoinTypeAndStoreMismatch</a>: u64 = 10;
+</code></pre>
+
+
+
 <a name="0x3_coin_ErrorDestroyOfNonZeroCoin"></a>
 
 Cannot destroy non-zero coins
@@ -606,7 +666,7 @@ Coin amount cannot be zero
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="coin.md#0x3_coin_genesis_init">genesis_init</a>(ctx: &<b>mut</b> Context, genesis_account: &<a href="">signer</a>) {
     <b>let</b> coin_infos = <a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a> {
-        coin_infos: <a href="_new">type_table::new</a>(ctx),
+        coin_infos: <a href="_new">table::new</a>(ctx),
     };
     <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, coin_infos);
 
@@ -638,7 +698,7 @@ Coin amount cannot be zero
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="coin.md#0x3_coin_init_account_coin_store">init_account_coin_store</a>(ctx: &<b>mut</b> Context, <a href="account.md#0x3_account">account</a>: &<a href="">signer</a>){
     <b>let</b> coin_stores = <a href="coin.md#0x3_coin_CoinStores">CoinStores</a> {
-        coin_stores: <a href="_new">type_table::new</a>(ctx),
+        coin_stores: <a href="_new">table::new</a>&lt;<a href="_String">string::String</a>, ObjectRef&lt;<a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&gt;&gt;(ctx),
     };
     <a href="_global_move_to">account_storage::global_move_to</a>(ctx, <a href="account.md#0x3_account">account</a>, coin_stores);
 }
@@ -665,8 +725,8 @@ Returns the balance of <code>addr</code> for provided <code>CoinType</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_balance">balance</a>&lt;CoinType: key&gt;(ctx: &Context, addr: <b>address</b>): u256 {
-    <b>if</b> (<a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx, addr)) {
-        <a href="coin.md#0x3_coin_borrow_coin_store">borrow_coin_store</a>&lt;CoinType&gt;(ctx, addr).<a href="coin.md#0x3_coin">coin</a>.value
+    <b>if</b> (<a href="coin.md#0x3_coin_exist_account_coin_store">exist_account_coin_store</a>&lt;CoinType&gt;(ctx, addr)) {
+        <a href="coin.md#0x3_coin_borrow_account_coin_store">borrow_account_coin_store</a>&lt;CoinType&gt;(ctx, addr).balance.value
     } <b>else</b> {
         0u256
     }
@@ -696,7 +756,8 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is an registe
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_registered">is_registered</a>&lt;CoinType: key&gt;(ctx: &Context): bool {
     <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework)) {
         <b>let</b> coin_infos = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
-        <a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(&coin_infos.coin_infos)
+        <b>let</b> coin_type = <a href="_type_name">type_info::type_name</a>&lt;CoinType&gt;();
+        <a href="_contains">table::contains</a>(&coin_infos.coin_infos, coin_type)
     } <b>else</b> {
         <b>false</b>
     }
@@ -834,14 +895,14 @@ Return true if the type <code>CoinType1</code> is same with <code>CoinType2</cod
 
 </details>
 
-<a name="0x3_coin_coin_store_handle"></a>
+<a name="0x3_coin_coin_store_id"></a>
 
-## Function `coin_store_handle`
+## Function `coin_store_id`
 
-Return coin store handle for addr
+Return the account CoinStore object id for addr
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_handle">coin_store_handle</a>(ctx: &<a href="_Context">context::Context</a>, addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="_ObjectID">object_id::ObjectID</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_id">coin_store_id</a>&lt;CoinType: key&gt;(ctx: &<a href="_Context">context::Context</a>, addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="_ObjectID">object_id::ObjectID</a>&gt;
 </code></pre>
 
 
@@ -850,11 +911,12 @@ Return coin store handle for addr
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_handle">coin_store_handle</a>(ctx: &Context, addr: <b>address</b>): Option&lt;ObjectID&gt; {
-    <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr))
-    {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_store_id">coin_store_id</a>&lt;CoinType: key&gt;(ctx: &Context, addr: <b>address</b>): Option&lt;ObjectID&gt; {
+    <b>if</b> (<a href="coin.md#0x3_coin_exist_account_coin_store">exist_account_coin_store</a>&lt;CoinType&gt;(ctx, addr)) {
         <b>let</b> coin_stores = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr);
-        <a href="_some">option::some</a>(*<a href="_handle">type_table::handle</a>(&coin_stores.coin_stores))
+        <b>let</b> coin_type = <a href="_type_name">type_info::type_name</a>&lt;CoinType&gt;();
+        <b>let</b> coin_store_ref = <a href="_borrow">table::borrow</a>(&coin_stores.coin_stores, coin_type);
+        <a href="_some">option::some</a>(<a href="_id">object_ref::id</a>(coin_store_ref))
     } <b>else</b> {
         <a href="_none">option::none</a>&lt;ObjectID&gt;()
     }
@@ -865,14 +927,14 @@ Return coin store handle for addr
 
 </details>
 
-<a name="0x3_coin_coin_info_handle"></a>
+<a name="0x3_coin_coin_stores_handle"></a>
 
-## Function `coin_info_handle`
+## Function `coin_stores_handle`
 
-Return coin info handle
+Return CoinStores table handle for addr
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_info_handle">coin_info_handle</a>(ctx: &<a href="_Context">context::Context</a>): <a href="_ObjectID">object_id::ObjectID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_stores_handle">coin_stores_handle</a>(ctx: &<a href="_Context">context::Context</a>, addr: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="_ObjectID">object_id::ObjectID</a>&gt;
 </code></pre>
 
 
@@ -881,11 +943,75 @@ Return coin info handle
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_info_handle">coin_info_handle</a>(ctx: &Context): ObjectID {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_stores_handle">coin_stores_handle</a>(ctx: &Context, addr: <b>address</b>): Option&lt;ObjectID&gt; {
+    <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr))
+    {
+        <b>let</b> coin_stores = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr);
+        <a href="_some">option::some</a>(*<a href="_handle">table::handle</a>(&coin_stores.coin_stores))
+    } <b>else</b> {
+        <a href="_none">option::none</a>&lt;ObjectID&gt;()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_coin_infos_handle"></a>
+
+## Function `coin_infos_handle`
+
+Return CoinInfos table handle
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_infos_handle">coin_infos_handle</a>(ctx: &<a href="_Context">context::Context</a>): <a href="_ObjectID">object_id::ObjectID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_coin_infos_handle">coin_infos_handle</a>(ctx: &Context): ObjectID {
     // <a href="coin.md#0x3_coin">coin</a> info ensured via the Genesis transaction, so it should always exist
     <b>assert</b>!(<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework), <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinInfosNotFound">ErrorCoinInfosNotFound</a>));
     <b>let</b> coin_infos = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
-    *<a href="_handle">type_table::handle</a>(&coin_infos.coin_infos)
+    *<a href="_handle">table::handle</a>(&coin_infos.coin_infos)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_create_coin_store"></a>
+
+## Function `create_coin_store`
+
+Create a new CoinStore Object for <code>CoinType</code> and return the ObjectRef
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_create_coin_store">create_coin_store</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> <a href="_Context">context::Context</a>): <a href="_ObjectRef">object_ref::ObjectRef</a>&lt;<a href="coin.md#0x3_coin_CoinStore">coin::CoinStore</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_create_coin_store">create_coin_store</a>&lt;CoinType: key&gt;(ctx: &<b>mut</b> Context): ObjectRef&lt;<a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&gt;{
+    //TODO check the CoinType is registered
+    <b>let</b> coin_store_object = <a href="_new_object">context::new_object</a>(ctx, <a href="coin.md#0x3_coin_CoinStore">CoinStore</a>{
+        coin_type: <a href="_type_name">type_info::type_name</a>&lt;CoinType&gt;(),
+        balance: <a href="coin.md#0x3_coin_Balance">Balance</a> { value: 0 },
+        frozen: <b>false</b>,
+    });
+    <b>let</b> ref = <a href="_new">object_ref::new</a>(&coin_store_object);
+    <a href="_add_object">context::add_object</a>(ctx, coin_store_object);
+    ref
 }
 </code></pre>
 
@@ -913,7 +1039,7 @@ Return whether the account at <code>addr</code> accept <code><a href="coin.md#0x
     <b>if</b> (<a href="coin.md#0x3_coin_can_auto_accept_coin">can_auto_accept_coin</a>(ctx, addr)) {
         <b>true</b>
     } <b>else</b> {
-        <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx, addr)
+        <a href="coin.md#0x3_coin_exist_account_coin_store">exist_account_coin_store</a>&lt;CoinType&gt;(ctx, addr)
     }
 }
 </code></pre>
@@ -1038,7 +1164,7 @@ This public entry function requires the <code>CoinType</code> to have <code>key<
 ): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
     <b>let</b> addr = <a href="_address_of">signer::address_of</a>(<a href="account.md#0x3_account">account</a>);
     // the <a href="coin.md#0x3_coin">coin</a> `frozen` only affect user withdraw, does not affect `withdraw_extend`.
-    <a href="coin.md#0x3_coin_check_coin_store_frozen">check_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr);
+    <a href="coin.md#0x3_coin_check_account_coin_store_frozen">check_account_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr);
     <a href="coin.md#0x3_coin_withdraw_internal">withdraw_internal</a>&lt;CoinType&gt;(ctx, addr, amount)
 }
 </code></pre>
@@ -1065,8 +1191,34 @@ This public entry function requires the <code>CoinType</code> to have <code>key<
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit">deposit</a>&lt;CoinType: key + store&gt;(ctx: &<b>mut</b> Context, addr: <b>address</b>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
-    <a href="coin.md#0x3_coin_check_coin_store_frozen">check_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr);
+    <a href="coin.md#0x3_coin_check_account_coin_store_frozen">check_account_coin_store_frozen</a>&lt;CoinType&gt;(ctx, addr);
     <a href="coin.md#0x3_coin_deposit_internal">deposit_internal</a>(ctx, addr, <a href="coin.md#0x3_coin">coin</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_deposit_to_store"></a>
+
+## Function `deposit_to_store`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit_to_store">deposit_to_store</a>&lt;CoinType: store, key&gt;(coin_store: &<b>mut</b> <a href="coin.md#0x3_coin_CoinStore">coin::CoinStore</a>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_deposit_to_store">deposit_to_store</a>&lt;CoinType: key + store&gt;(coin_store: &<b>mut</b> <a href="coin.md#0x3_coin_CoinStore">CoinStore</a>, <a href="coin.md#0x3_coin">coin</a>: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
+    //<a href="coin.md#0x3_coin_check_coin_store_frozen">check_coin_store_frozen</a>&lt;CoinType&gt;(coin_store_ref);
+    //<b>let</b> coin_store = <a href="_borrow_mut">object_ref::borrow_mut</a>(coin_store_ref);
+    <a href="coin.md#0x3_coin_merge_to_store">merge_to_store</a>&lt;CoinType&gt;(coin_store, <a href="coin.md#0x3_coin">coin</a>);
 }
 </code></pre>
 
@@ -1098,8 +1250,8 @@ Any account and module can call this function to transfer coins, the <code>CoinT
     amount: u256,
 ) {
     <b>let</b> from_addr = <a href="_address_of">signer::address_of</a>(from);
-    <a href="coin.md#0x3_coin_check_coin_store_frozen">check_coin_store_frozen</a>&lt;CoinType&gt;(ctx, from_addr);
-    <a href="coin.md#0x3_coin_check_coin_store_frozen">check_coin_store_frozen</a>&lt;CoinType&gt;(ctx, <b>to</b>);
+    <a href="coin.md#0x3_coin_check_account_coin_store_frozen">check_account_coin_store_frozen</a>&lt;CoinType&gt;(ctx, from_addr);
+    <a href="coin.md#0x3_coin_check_account_coin_store_frozen">check_account_coin_store_frozen</a>&lt;CoinType&gt;(ctx, <b>to</b>);
     <a href="coin.md#0x3_coin_transfer_internal">transfer_internal</a>&lt;CoinType&gt;(ctx, from_addr, <b>to</b>, amount);
 }
 </code></pre>
@@ -1162,6 +1314,35 @@ Extracts <code>amount</code> from the passed-in <code><a href="coin.md#0x3_coin"
 
 </details>
 
+<a name="0x3_coin_extract_from_store"></a>
+
+## Function `extract_from_store`
+
+Extracts <code>amount</code> Coin from the balance of the passed-in <code>coin_store</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract_from_store">extract_from_store</a>&lt;CoinType: key&gt;(coin_store: &<b>mut</b> <a href="coin.md#0x3_coin_CoinStore">coin::CoinStore</a>, amount: u256): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_extract_from_store">extract_from_store</a>&lt;CoinType: key&gt;(coin_store: &<b>mut</b> <a href="coin.md#0x3_coin_CoinStore">CoinStore</a>, amount: u256): <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt; {
+    <b>assert</b>!(coin_store.balance.value &gt;= amount, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorInSufficientBalance">ErrorInSufficientBalance</a>));
+    <b>let</b> coin_type = <a href="_type_name">type_info::type_name</a>&lt;CoinType&gt;();
+    <b>assert</b>!(coin_store.coin_type == coin_type, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinTypeAndStoreMismatch">ErrorCoinTypeAndStoreMismatch</a>));
+    coin_store.balance.value = coin_store.balance.value - amount;
+    <a href="coin.md#0x3_coin_Coin">Coin</a> { value: amount }
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x3_coin_extract_all"></a>
 
 ## Function `extract_all`
@@ -1209,6 +1390,34 @@ to the sum of the two coins (<code>dst_coin</code> and <code>source_coin</code>)
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_merge">merge</a>&lt;CoinType: key&gt;(dst_coin: &<b>mut</b> <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;, source_coin: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
     <b>let</b> <a href="coin.md#0x3_coin_Coin">Coin</a> { value } = source_coin;
     dst_coin.value = dst_coin.value + value;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_merge_to_store"></a>
+
+## Function `merge_to_store`
+
+"Merges" the given coins to the balance of the passed-in <code>coin_store</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_merge_to_store">merge_to_store</a>&lt;CoinType: key&gt;(coin_store: &<b>mut</b> <a href="coin.md#0x3_coin_CoinStore">coin::CoinStore</a>, source_coin: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;CoinType&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_merge_to_store">merge_to_store</a>&lt;CoinType: key&gt;(coin_store: &<b>mut</b> <a href="coin.md#0x3_coin_CoinStore">CoinStore</a>, source_coin: <a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;) {
+    <b>let</b> coin_type = <a href="_type_name">type_info::type_name</a>&lt;CoinType&gt;();
+    <b>assert</b>!(coin_store.coin_type == coin_type, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinTypeAndStoreMismatch">ErrorCoinTypeAndStoreMismatch</a>));
+    <b>let</b> <a href="coin.md#0x3_coin_Coin">Coin</a> { value } = source_coin;
+    coin_store.balance.value = coin_store.balance.value + value;
 }
 </code></pre>
 
@@ -1268,13 +1477,13 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 
 </details>
 
-<a name="0x3_coin_exist_coin_store"></a>
+<a name="0x3_coin_exist_account_coin_store"></a>
 
-## Function `exist_coin_store`
+## Function `exist_account_coin_store`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType: key&gt;(ctx: &<a href="_Context">context::Context</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_account_coin_store">exist_account_coin_store</a>&lt;CoinType: key&gt;(ctx: &<a href="_Context">context::Context</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -1283,10 +1492,39 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType: key&gt;(ctx: &Context, addr: <b>address</b>): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_exist_account_coin_store">exist_account_coin_store</a>&lt;CoinType: key&gt;(ctx: &Context, addr: <b>address</b>): bool {
     <b>if</b> (<a href="_global_exists">account_storage::global_exists</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr)) {
         <b>let</b> coin_stores = <a href="_global_borrow">account_storage::global_borrow</a>&lt;<a href="coin.md#0x3_coin_CoinStores">CoinStores</a>&gt;(ctx, addr);
-        <a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(&coin_stores.coin_stores)
+        <b>let</b> coin_type = <a href="_type_name">type_info::type_name</a>&lt;CoinType&gt;();
+        <a href="_contains">table::contains</a>(&coin_stores.coin_stores, coin_type)
+    } <b>else</b> {
+        <b>false</b>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_coin_is_account_coin_store_frozen"></a>
+
+## Function `is_account_coin_store_frozen`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_account_coin_store_frozen">is_account_coin_store_frozen</a>&lt;CoinType: key&gt;(ctx: &<a href="_Context">context::Context</a>, addr: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_account_coin_store_frozen">is_account_coin_store_frozen</a>&lt;CoinType: key&gt;(ctx: &Context, addr: <b>address</b>): bool {
+    <b>if</b> (<a href="coin.md#0x3_coin_exist_account_coin_store">exist_account_coin_store</a>&lt;CoinType&gt;(ctx, addr)) {
+        <a href="coin.md#0x3_coin_borrow_account_coin_store">borrow_account_coin_store</a>&lt;CoinType&gt;(ctx, addr).frozen
     } <b>else</b> {
         <b>false</b>
     }
@@ -1303,7 +1541,7 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType: key&gt;(ctx: &<a href="_Context">context::Context</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType: key&gt;(coin_store_ref: &<a href="_ObjectRef">object_ref::ObjectRef</a>&lt;<a href="coin.md#0x3_coin_CoinStore">coin::CoinStore</a>&gt;): bool
 </code></pre>
 
 
@@ -1312,10 +1550,11 @@ Create a new <code><a href="coin.md#0x3_coin_Coin">Coin</a>&lt;CoinType&gt;</cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType: key&gt;(ctx: &Context, addr: <b>address</b>): bool {
-    <b>if</b> (<a href="coin.md#0x3_coin_exist_coin_store">exist_coin_store</a>&lt;CoinType&gt;(ctx, addr)) {
-        <a href="coin.md#0x3_coin_borrow_coin_store">borrow_coin_store</a>&lt;CoinType&gt;(ctx, addr).frozen
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x3_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType: key&gt;(coin_store_ref: &ObjectRef&lt;<a href="coin.md#0x3_coin_CoinStore">CoinStore</a>&gt;): bool {
+    <b>if</b> (<a href="_contains">object_ref::contains</a>(coin_store_ref)) {
+        <a href="_borrow">object_ref::borrow</a>(coin_store_ref).frozen
     } <b>else</b> {
+        //TODO <b>if</b> the <a href="coin.md#0x3_coin">coin</a> store is not exist, should we <b>return</b> <b>true</b> or <b>false</b>?
         <b>false</b>
     }
 }
@@ -1352,22 +1591,24 @@ This function is protected by <code>private_generics</code>, so it can only be c
 ){
 
     <b>let</b> coin_infos = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="coin.md#0x3_coin_CoinInfos">CoinInfos</a>&gt;(ctx, @rooch_framework);
+    <b>let</b> coin_type = <a href="_type_name">type_info::type_name</a>&lt;CoinType&gt;();
 
     <b>assert</b>!(
-        !<a href="_contains">type_table::contains</a>&lt;<a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(&coin_infos.coin_infos),
+        !<a href="_contains">table::contains</a>(&coin_infos.coin_infos, coin_type),
         <a href="_already_exists">error::already_exists</a>(<a href="coin.md#0x3_coin_ErrorCoinInfoAlreadyRegistered">ErrorCoinInfoAlreadyRegistered</a>),
     );
 
     <b>assert</b>!(<a href="_length">string::length</a>(&name) &lt;= <a href="coin.md#0x3_coin_MAX_COIN_NAME_LENGTH">MAX_COIN_NAME_LENGTH</a>, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinNameTooLong">ErrorCoinNameTooLong</a>));
     <b>assert</b>!(<a href="_length">string::length</a>(&symbol) &lt;= <a href="coin.md#0x3_coin_MAX_COIN_SYMBOL_LENGTH">MAX_COIN_SYMBOL_LENGTH</a>, <a href="_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x3_coin_ErrorCoinSymbolTooLong">ErrorCoinSymbolTooLong</a>));
 
-    <b>let</b> coin_info = <a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt; {
+    <b>let</b> coin_info = <a href="coin.md#0x3_coin_CoinInfo">CoinInfo</a> {
+        coin_type,
         name,
         symbol,
         decimals,
         supply: 0u256,
     };
-    <a href="_add">type_table::add</a>(&<b>mut</b> coin_infos.coin_infos, coin_info);
+    <a href="_add">table::add</a>(&<b>mut</b> coin_infos.coin_infos, coin_type, coin_info);
 }
 </code></pre>
 
@@ -1537,7 +1778,7 @@ Freeze a CoinStore to prevent transfers
     addr: <b>address</b>,
 ) {
     <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_coin_store">borrow_mut_coin_store</a>&lt;CoinType&gt;(ctx, addr);
+    <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_account_coin_store">borrow_mut_account_coin_store</a>&lt;CoinType&gt;(ctx, addr);
     coin_store.frozen = <b>true</b>;
 }
 </code></pre>
@@ -1567,7 +1808,7 @@ Unfreeze a CoinStore to allow transfers
     addr: <b>address</b>,
 ) {
     <a href="coin.md#0x3_coin_ensure_coin_store">ensure_coin_store</a>&lt;CoinType&gt;(ctx, addr);
-    <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_coin_store">borrow_mut_coin_store</a>&lt;CoinType&gt;(ctx, addr);
+    <b>let</b> coin_store = <a href="coin.md#0x3_coin_borrow_mut_account_coin_store">borrow_mut_account_coin_store</a>&lt;CoinType&gt;(ctx, addr);
     coin_store.frozen = <b>false</b>;
 }
 </code></pre>

--- a/crates/rooch-framework/doc/transaction_fee.md
+++ b/crates/rooch-framework/doc/transaction_fee.md
@@ -14,6 +14,7 @@
 
 <pre><code><b>use</b> <a href="">0x2::account_storage</a>;
 <b>use</b> <a href="">0x2::context</a>;
+<b>use</b> <a href="">0x2::object_ref</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
 <b>use</b> <a href="gas_coin.md#0x3_gas_coin">0x3::gas_coin</a>;
 </code></pre>
@@ -37,7 +38,7 @@
 
 <dl>
 <dt>
-<code>fee: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;<a href="gas_coin.md#0x3_gas_coin_GasCoin">gas_coin::GasCoin</a>&gt;</code>
+<code>fee: <a href="_ObjectRef">object_ref::ObjectRef</a>&lt;<a href="coin.md#0x3_coin_CoinStore">coin::CoinStore</a>&gt;</code>
 </dt>
 <dd>
 
@@ -63,8 +64,9 @@
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="transaction_fee.md#0x3_transaction_fee_genesis_init">genesis_init</a>(ctx: &<b>mut</b> Context, genesis_account: &<a href="">signer</a>)  {
+    <b>let</b> fee_store = <a href="coin.md#0x3_coin_create_coin_store">coin::create_coin_store</a>&lt;GasCoin&gt;(ctx);
     <a href="_global_move_to">account_storage::global_move_to</a>(ctx, genesis_account, <a href="transaction_fee.md#0x3_transaction_fee_TransactionFeePool">TransactionFeePool</a>{
-        fee: <a href="coin.md#0x3_coin_zero">coin::zero</a>&lt;GasCoin&gt;(),
+        fee: fee_store,
     })
 }
 </code></pre>
@@ -140,7 +142,8 @@ Returns the gas factor of gas.
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="transaction_fee.md#0x3_transaction_fee_deposit_fee">deposit_fee</a>(ctx: &<b>mut</b> Context, <a href="gas_coin.md#0x3_gas_coin">gas_coin</a>: Coin&lt;GasCoin&gt;) {
     <b>let</b> pool = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="transaction_fee.md#0x3_transaction_fee_TransactionFeePool">TransactionFeePool</a>&gt;(ctx, @rooch_framework);
-    <a href="coin.md#0x3_coin_merge">coin::merge</a>(&<b>mut</b> pool.fee, <a href="gas_coin.md#0x3_gas_coin">gas_coin</a>);
+    <b>let</b> coin_store = <a href="_borrow_mut">object_ref::borrow_mut</a>(&<b>mut</b> pool.fee);
+    <a href="coin.md#0x3_coin_deposit_to_store">coin::deposit_to_store</a>&lt;GasCoin&gt;(coin_store, <a href="gas_coin.md#0x3_gas_coin">gas_coin</a>);
 }
 </code></pre>
 

--- a/crates/rooch-framework/sources/coin.move
+++ b/crates/rooch-framework/sources/coin.move
@@ -7,13 +7,12 @@ module rooch_framework::coin {
     use moveos_std::object_id::ObjectID;
     use moveos_std::table;
     use moveos_std::table::Table;
-    use moveos_std::type_table::TypeTable;
-    use moveos_std::type_table;
     use moveos_std::account_storage;
-    use moveos_std::context::Context;
+    use moveos_std::context::{Self, Context};
     use moveos_std::event;
-    use moveos_std::type_info::{Self, TypeInfo, type_of};
+    use moveos_std::type_info::{Self, type_of};
     use moveos_std::signer;
+    use moveos_std::object_ref::{Self, ObjectRef};
 
     friend rooch_framework::account;
     friend rooch_framework::genesis;
@@ -52,6 +51,9 @@ module rooch_framework::coin {
     /// Global CoinInfos should exist
     const ErrorCoinInfosNotFound: u64 = 9;
 
+    /// The CoinType parameter and CoinType in CoinStore do not match
+    const ErrorCoinTypeAndStoreMismatch: u64 = 10;
+
 
     //
     // Constants
@@ -62,13 +64,19 @@ module rooch_framework::coin {
 
     /// Core data structures
 
-    /// Main structure representing a coin/coin in an account's custody.
+    /// Main structure representing a coin.
     /// Note the `CoinType` must have `key` ability.
     /// if the `CoinType` has `store` ability, the `Coin` is a public coin, the user can operate it directly by coin module's function.
     /// Otherwise, the `Coin` is a private coin, the user can only operate it by `CoinType` module's function.
-    struct Coin<phantom CoinType : key> has store {
+    /// The Coin has no ability, it is a hot potato type, only can handle by Coin module.
+    struct Coin<phantom CoinType : key> {
         /// Amount of coin this address has.
         /// Following the ERC20 standard, both asset balance and supply are expressed in u256
+        value: u256,
+    }
+
+    /// The Balance resource that stores the balance of a specific coin type.
+    struct Balance has store {
         value: u256,
     }
 
@@ -77,8 +85,9 @@ module rooch_framework::coin {
 
     // /// A holder of a specific coin types.
     // /// These are kept in a single resource to ensure locality of data.
-    struct CoinStore<phantom CoinType : key> has key {
-        coin: Coin<CoinType>,
+    struct CoinStore has key {
+        coin_type: string::String,
+        balance: Balance,
         frozen: bool,
     }
 
@@ -87,8 +96,12 @@ module rooch_framework::coin {
 
     const MAX_U256: u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
-    /// Information about a specific coin type. Stored on the creator of the coin's account.
-    struct CoinInfo<phantom CoinType : key> has key {
+    /// Information about a specific coin type. Stored in the global CoinInfos table.
+    struct CoinInfo has store {
+        /// Type of the coin: `address::my_module::XCoin`, same as `moveos_std::type_info::type_name<CoinType>()`.
+        /// The name and symbol can repeat across different coin types, but the coin type must be unique.
+        coin_type: string::String,
+        /// Name of the coin.
         name: string::String,
         /// Symbol of the coin, usually a shorter version of the name.
         /// For example, Singapore Dollar is SGD.
@@ -97,13 +110,13 @@ module rooch_framework::coin {
         /// For example, if `decimals` equals `2`, a balance of `505` coins should
         /// be displayed to a user as `5.05` (`505 / 10 ** 2`).
         decimals: u8,
-        /// The total value for the coin represented by `CoinType`. Mutable.
+        /// The total value for the coin represented by coin type. Mutable.
         supply: u256,
     }
 
     /// A resource that holds the CoinInfo for all accounts.
     struct CoinInfos has key {
-        coin_infos: TypeTable,
+        coin_infos: Table<string::String, CoinInfo>,
     }
 
     /// A resource that holds the AutoAcceptCoin config for all accounts.
@@ -112,23 +125,23 @@ module rooch_framework::coin {
         auto_accept_coins: Table<address, bool>,
     }
 
-    /// A resource that holds all the CoinStore for account.
+    /// A resource that holds all the ObjectRef<CoinStore> for account.
     /// Default Deposit Coin no longer depends on accept coin
     struct CoinStores has key {
-        coin_stores: TypeTable,
+        coin_stores: Table<string::String, ObjectRef<CoinStore>>,
     }
 
     /// Event emitted when some amount of a coin is deposited into an account.
     struct DepositEvent has drop, store {
-        /// The type info for the coin that was sent
-        coin_type_info: TypeInfo,
+        /// The type of the coin that was sent
+        coin_type: string::String,
         amount: u256,
     }
 
     /// Event emitted when some amount of a coin is withdrawn from an account.
     struct WithdrawEvent has drop, store {
-        /// The type info for the coin that was sent
-        coin_type_info: TypeInfo,
+        /// The type of the coin that was sent
+        coin_type: string::String,
         amount: u256,
     }
 
@@ -140,23 +153,23 @@ module rooch_framework::coin {
 
     /// Event emitted when coin minted.
     struct MintEvent has drop, store {
-        /// full info of coin
-        coin_type_info: TypeInfo,
+        /// The type of coin that was minted
+        coin_type: string::String,
         /// coins added to the system
         amount: u256,
     }
 
     /// Event emitted when coin burned.
     struct BurnEvent has drop, store {
-        /// full info of coin
-        coin_type_info: TypeInfo,
+         /// The type of coin that was burned
+        coin_type: string::String,
         /// coins removed from the system
         amount: u256,
     }
 
     public(friend) fun genesis_init(ctx: &mut Context, genesis_account: &signer) {
         let coin_infos = CoinInfos {
-            coin_infos: type_table::new(ctx),
+            coin_infos: table::new(ctx),
         };
         account_storage::global_move_to(ctx, genesis_account, coin_infos);
 
@@ -168,7 +181,7 @@ module rooch_framework::coin {
 
     public(friend) fun init_account_coin_store(ctx: &mut Context, account: &signer){
         let coin_stores = CoinStores {
-            coin_stores: type_table::new(ctx),
+            coin_stores: table::new<string::String, ObjectRef<CoinStore>>(ctx),
         };
         account_storage::global_move_to(ctx, account, coin_stores);
     }
@@ -186,8 +199,8 @@ module rooch_framework::coin {
 
     /// Returns the balance of `addr` for provided `CoinType`.
     public fun balance<CoinType: key>(ctx: &Context, addr: address): u256 {
-        if (exist_coin_store<CoinType>(ctx, addr)) {
-            borrow_coin_store<CoinType>(ctx, addr).coin.value
+        if (exist_account_coin_store<CoinType>(ctx, addr)) {
+            borrow_account_coin_store<CoinType>(ctx, addr).balance.value
         } else {
             0u256
         }
@@ -197,7 +210,8 @@ module rooch_framework::coin {
     public fun is_registered<CoinType: key>(ctx: &Context): bool {
         if (account_storage::global_exists<CoinInfos>(ctx, @rooch_framework)) {
             let coin_infos = account_storage::global_borrow<CoinInfos>(ctx, @rooch_framework);
-            type_table::contains<CoinInfo<CoinType>>(&coin_infos.coin_infos)
+            let coin_type = type_info::type_name<CoinType>();
+            table::contains(&coin_infos.coin_infos, coin_type)
         } else {
             false
         }
@@ -231,39 +245,53 @@ module rooch_framework::coin {
         return type_of<CoinType1>() == type_of<CoinType2>()
     }
 
-    /// Return coin store handle for addr
-    public fun coin_store_handle(ctx: &Context, addr: address): Option<ObjectID> {
-        if (account_storage::global_exists<CoinStores>(ctx, addr))
-        {
+    /// Return the account CoinStore object id for addr
+    public fun coin_store_id<CoinType: key>(ctx: &Context, addr: address): Option<ObjectID> {
+        if (exist_account_coin_store<CoinType>(ctx, addr)) {
             let coin_stores = account_storage::global_borrow<CoinStores>(ctx, addr);
-            option::some(*type_table::handle(&coin_stores.coin_stores))
+            let coin_type = type_info::type_name<CoinType>();
+            let coin_store_ref = table::borrow(&coin_stores.coin_stores, coin_type);
+            option::some(object_ref::id(coin_store_ref))
         } else {
             option::none<ObjectID>()
         }
     }
 
-    /// Return coin info handle
-    public fun coin_info_handle(ctx: &Context): ObjectID {
+    /// Return CoinStores table handle for addr
+    public fun coin_stores_handle(ctx: &Context, addr: address): Option<ObjectID> {
+        if (account_storage::global_exists<CoinStores>(ctx, addr))
+        {
+            let coin_stores = account_storage::global_borrow<CoinStores>(ctx, addr);
+            option::some(*table::handle(&coin_stores.coin_stores))
+        } else {
+            option::none<ObjectID>()
+        }
+    }
+
+    /// Return CoinInfos table handle
+    public fun coin_infos_handle(ctx: &Context): ObjectID {
         // coin info ensured via the Genesis transaction, so it should always exist
         assert!(account_storage::global_exists<CoinInfos>(ctx, @rooch_framework), error::invalid_argument(ErrorCoinInfosNotFound));
         let coin_infos = account_storage::global_borrow<CoinInfos>(ctx, @rooch_framework);
-        *type_table::handle(&coin_infos.coin_infos)
+        *table::handle(&coin_infos.coin_infos)
     }
 
     //
     // Helper functions
     //
 
-    fun borrow_coin_info<CoinType: key>(ctx: &Context): &CoinInfo<CoinType> {
+    fun borrow_coin_info<CoinType: key>(ctx: &Context): &CoinInfo {
         let coin_infos = account_storage::global_borrow<CoinInfos>(ctx, @rooch_framework);
-        check_coin_info_registered<CoinType>(coin_infos);
-        type_table::borrow<CoinInfo<CoinType>>(&coin_infos.coin_infos)
+        let coin_type = type_info::type_name<CoinType>();
+        check_coin_info_registered(coin_infos, coin_type);
+        table::borrow(&coin_infos.coin_infos, coin_type)
     }
 
-    fun borrow_mut_coin_info<CoinType: key>(ctx: &mut Context): &mut CoinInfo<CoinType> {
+    fun borrow_mut_coin_info<CoinType: key>(ctx: &mut Context): &mut CoinInfo {
         let coin_infos = account_storage::global_borrow_mut<CoinInfos>(ctx, @rooch_framework);
-        check_coin_info_registered<CoinType>(coin_infos);
-        type_table::borrow_mut<CoinInfo<CoinType>>(&mut coin_infos.coin_infos)
+        let coin_type = type_info::type_name<CoinType>();
+        check_coin_info_registered(coin_infos, coin_type);
+        table::borrow_mut(&mut coin_infos.coin_infos, coin_type)
     }
 
     fun exist_auto_accept_token(ctx: &Context, addr: address): bool {
@@ -271,56 +299,79 @@ module rooch_framework::coin {
         table::contains<address, bool>(&auto_accept_coins.auto_accept_coins, addr)
     }
 
-    fun borrow_coin_store<CoinType: key>(ctx: &Context, addr: address): &CoinStore<CoinType> {
+    fun borrow_account_coin_store<CoinType: key>(ctx: &Context, addr: address): &CoinStore{
         let coin_stores = account_storage::global_borrow<CoinStores>(ctx, addr);
-        type_table::borrow<CoinStore<CoinType>>(&coin_stores.coin_stores)
+        let coin_type = type_info::type_name<CoinType>();
+        let ref = table::borrow(&coin_stores.coin_stores, coin_type);
+        object_ref::borrow(ref)
     }
 
-    fun borrow_mut_coin_store<CoinType: key>(ctx: &mut Context, addr: address): &mut CoinStore<CoinType> {
+    fun borrow_mut_account_coin_store<CoinType: key>(ctx: &mut Context, addr: address): &mut CoinStore{
         let coin_stores = account_storage::global_borrow_mut<CoinStores>(ctx, addr);
-        type_table::borrow_mut<CoinStore<CoinType>>(&mut coin_stores.coin_stores)
+        let coin_type = type_info::type_name<CoinType>();
+        let ref = table::borrow_mut(&mut coin_stores.coin_stores, coin_type);
+        object_ref::borrow_mut(ref)
     }
 
     fun ensure_coin_store<CoinType: key>(ctx: &mut Context, addr: address) {
-        if (!exist_coin_store<CoinType>(ctx, addr) && can_auto_accept_coin(ctx, addr)) {
-            inner_new_coin_store<CoinType>(ctx, addr)
+        if (!exist_account_coin_store<CoinType>(ctx, addr) && can_auto_accept_coin(ctx, addr)) {
+            create_account_coin_store<CoinType>(ctx, addr)
         }
     }
 
     fun ensure_coin_store_pass_auto_accept_flag<CoinType: key>(ctx: &mut Context, addr: address) {
-        if (!exist_coin_store<CoinType>(ctx, addr)) {
-            inner_new_coin_store<CoinType>(ctx, addr)
+        if (!exist_account_coin_store<CoinType>(ctx, addr)) {
+            create_account_coin_store<CoinType>(ctx, addr)
         }
     }
 
-    fun inner_new_coin_store<CoinType: key>(ctx: &mut Context, addr: address) {
-        let coin_stores = account_storage::global_borrow_mut<CoinStores>(ctx, addr);
-        type_table::add<CoinStore<CoinType>>(&mut coin_stores.coin_stores, CoinStore<CoinType> {
-            coin: Coin { value: 0 },
+    /// Create a new CoinStore Object for `CoinType` and return the ObjectRef
+    public fun create_coin_store<CoinType: key>(ctx: &mut Context): ObjectRef<CoinStore>{
+        //TODO check the CoinType is registered
+        let coin_store_object = context::new_object(ctx, CoinStore{
+            coin_type: type_info::type_name<CoinType>(),
+            balance: Balance { value: 0 },
             frozen: false,
-        })
+        });
+        let ref = object_ref::new(&coin_store_object);
+        context::add_object(ctx, coin_store_object);
+        ref
+    }
+
+    fun create_account_coin_store<CoinType: key>(ctx: &mut Context, addr: address) {
+        let coin_store_ref = create_coin_store<CoinType>(ctx);
+        let coin_stores = account_storage::global_borrow_mut<CoinStores>(ctx, addr);
+        let coin_type = type_info::type_name<CoinType>();
+        table::add(&mut coin_stores.coin_stores, coin_type, coin_store_ref);
     }
 
     fun extract_coin<CoinType: key>(ctx: &mut Context, addr: address, amount: u256): Coin<CoinType> {
-        let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
-        extract<CoinType>(&mut coin_store.coin, amount)
+        let coin_store = borrow_mut_account_coin_store<CoinType>(ctx, addr);
+        extract_from_store<CoinType>(coin_store, amount)
     }
 
     fun merge_coin<CoinType: key>(ctx: &mut Context, addr: address, coin: Coin<CoinType>) {
-        let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
-        merge<CoinType>(&mut coin_store.coin, coin)
+        let coin_store = borrow_mut_account_coin_store<CoinType>(ctx, addr);
+        merge_to_store<CoinType>(coin_store, coin)
     }
 
-    fun check_coin_store_frozen<CoinType: key>(ctx: &Context, addr: address) {
+    fun check_account_coin_store_frozen<CoinType: key>(ctx: &Context, addr: address) {
         assert!(
-            !is_coin_store_frozen<CoinType>(ctx, addr),
+            !is_account_coin_store_frozen<CoinType>(ctx, addr),
             error::permission_denied(ErrorAccountWithCoinFrozen),
         );
     }
 
-    fun check_coin_info_registered<CoinType: key>(coin_infos: &CoinInfos) {
+    fun check_coin_store_frozen<CoinType: key>(coin_store_ref: &ObjectRef<CoinStore>) {
         assert!(
-            type_table::contains<CoinInfo<CoinType>>(&coin_infos.coin_infos),
+            !is_coin_store_frozen<CoinType>(coin_store_ref),
+            error::permission_denied(ErrorAccountWithCoinFrozen),
+        );
+    }
+
+    fun check_coin_info_registered(coin_infos: &CoinInfos, coin_type: string::String) {
+        assert!(
+            table::contains(&coin_infos.coin_infos, coin_type),
             error::not_found(ErrorCoinInfoNotRegistered),
         );
     }
@@ -333,9 +384,9 @@ module rooch_framework::coin {
         amount: u256): Coin<CoinType>{
         let coin_info = borrow_mut_coin_info<CoinType>(ctx);
         coin_info.supply = coin_info.supply + amount;
-        let coin_type_info = type_info::type_of<CoinType>();
+        let coin_type = type_info::type_name<CoinType>();
         event::emit<MintEvent>(ctx, MintEvent {
-            coin_type_info,
+            coin_type,
             amount,
         });
         Coin<CoinType> { value: amount }
@@ -353,9 +404,9 @@ module rooch_framework::coin {
 
         
         ensure_coin_store<CoinType>(ctx, addr);
-        let coin_type_info = type_info::type_of<CoinType>();
+        let coin_type = type_info::type_name<CoinType>();
         event::emit<WithdrawEvent>(ctx, WithdrawEvent {
-            coin_type_info,
+            coin_type,
             amount,
         });
 
@@ -369,9 +420,9 @@ module rooch_framework::coin {
         );
 
         ensure_coin_store<CoinType>(ctx, addr);
-        let coin_type_info = type_info::type_of<CoinType>();
+        let coin_type = type_info::type_name<CoinType>();
         event::emit<DepositEvent>(ctx, DepositEvent {
-            coin_type_info,
+            coin_type,
             amount: value(&coin),
         });
 
@@ -394,11 +445,11 @@ module rooch_framework::coin {
     ) {
         let Coin { value: amount } = coin;
 
-        let coin_type_info = type_info::type_of<CoinType>();
+        let coin_type = type_info::type_name<CoinType>();
         let coin_info = borrow_mut_coin_info<CoinType>(ctx);
         coin_info.supply = coin_info.supply - amount;
         event::emit<BurnEvent>(ctx, BurnEvent {
-            coin_type_info,
+            coin_type,
             amount,
         });
     }
@@ -413,7 +464,7 @@ module rooch_framework::coin {
         if (can_auto_accept_coin(ctx, addr)) {
             true
         } else {
-            exist_coin_store<CoinType>(ctx, addr)
+            exist_account_coin_store<CoinType>(ctx, addr)
         }
     }
 
@@ -458,15 +509,21 @@ module rooch_framework::coin {
     ): Coin<CoinType> {
         let addr = signer::address_of(account);
         // the coin `frozen` only affect user withdraw, does not affect `withdraw_extend`. 
-        check_coin_store_frozen<CoinType>(ctx, addr);
+        check_account_coin_store_frozen<CoinType>(ctx, addr);
         withdraw_internal<CoinType>(ctx, addr, amount) 
     }
 
     /// Deposit the coin into the recipient's account and emit an event.
     /// This public entry function requires the `CoinType` to have `key` and `store` abilities.
     public fun deposit<CoinType: key + store>(ctx: &mut Context, addr: address, coin: Coin<CoinType>) {
-        check_coin_store_frozen<CoinType>(ctx, addr);
+        check_account_coin_store_frozen<CoinType>(ctx, addr);
         deposit_internal(ctx, addr, coin);
+    }
+
+    public fun deposit_to_store<CoinType: key + store>(coin_store: &mut CoinStore, coin: Coin<CoinType>) {
+        //check_coin_store_frozen<CoinType>(coin_store_ref);
+        //let coin_store = object_ref::borrow_mut(coin_store_ref);
+        merge_to_store<CoinType>(coin_store, coin);
     }
 
     /// Transfer `amount` of coins `CoinType` from `from` to `to`.
@@ -478,8 +535,8 @@ module rooch_framework::coin {
         amount: u256,
     ) {
         let from_addr = signer::address_of(from);
-        check_coin_store_frozen<CoinType>(ctx, from_addr);
-        check_coin_store_frozen<CoinType>(ctx, to);
+        check_account_coin_store_frozen<CoinType>(ctx, from_addr);
+        check_account_coin_store_frozen<CoinType>(ctx, to);
         transfer_internal<CoinType>(ctx, from_addr, to, amount);
     }
 
@@ -497,6 +554,15 @@ module rooch_framework::coin {
         Coin { value: amount }
     }
 
+    /// Extracts `amount` Coin from the balance of the passed-in `coin_store`
+    public fun extract_from_store<CoinType: key>(coin_store: &mut CoinStore, amount: u256): Coin<CoinType> {
+        assert!(coin_store.balance.value >= amount, error::invalid_argument(ErrorInSufficientBalance));
+        let coin_type = type_info::type_name<CoinType>();
+        assert!(coin_store.coin_type == coin_type, error::invalid_argument(ErrorCoinTypeAndStoreMismatch));
+        coin_store.balance.value = coin_store.balance.value - amount;
+        Coin { value: amount }
+    }
+
     /// Extracts the entire amount from the passed-in `coin`, where the original coin is modified in place.
     public fun extract_all<CoinType: key>(coin: &mut Coin<CoinType>): Coin<CoinType> {
         let total_value = coin.value;
@@ -511,6 +577,14 @@ module rooch_framework::coin {
         dst_coin.value = dst_coin.value + value;
     }
 
+    /// "Merges" the given coins to the balance of the passed-in `coin_store`.
+    public fun merge_to_store<CoinType: key>(coin_store: &mut CoinStore, source_coin: Coin<CoinType>) {
+        let coin_type = type_info::type_name<CoinType>();
+        assert!(coin_store.coin_type == coin_type, error::invalid_argument(ErrorCoinTypeAndStoreMismatch));
+        let Coin { value } = source_coin;
+        coin_store.balance.value = coin_store.balance.value + value;
+    }
+
     /// Returns the `value` passed in `coin`.
     public fun value<CoinType: key>(coin: &Coin<CoinType>): u256 {
         coin.value
@@ -523,19 +597,29 @@ module rooch_framework::coin {
         }
     }
 
-    public fun exist_coin_store<CoinType: key>(ctx: &Context, addr: address): bool {
+    public fun exist_account_coin_store<CoinType: key>(ctx: &Context, addr: address): bool {
         if (account_storage::global_exists<CoinStores>(ctx, addr)) {
             let coin_stores = account_storage::global_borrow<CoinStores>(ctx, addr);
-            type_table::contains<CoinStore<CoinType>>(&coin_stores.coin_stores)
+            let coin_type = type_info::type_name<CoinType>();
+            table::contains(&coin_stores.coin_stores, coin_type)
         } else {
             false
         }
     }
 
-    public fun is_coin_store_frozen<CoinType: key>(ctx: &Context, addr: address): bool {
-        if (exist_coin_store<CoinType>(ctx, addr)) {
-            borrow_coin_store<CoinType>(ctx, addr).frozen
+    public fun is_account_coin_store_frozen<CoinType: key>(ctx: &Context, addr: address): bool {
+        if (exist_account_coin_store<CoinType>(ctx, addr)) {
+            borrow_account_coin_store<CoinType>(ctx, addr).frozen
         } else {
+            false
+        }
+    }
+
+    public fun is_coin_store_frozen<CoinType: key>(coin_store_ref: &ObjectRef<CoinStore>): bool {
+        if (object_ref::contains(coin_store_ref)) {
+            object_ref::borrow(coin_store_ref).frozen
+        } else {
+            //TODO if the coin store is not exist, should we return true or false?
             false
         }
     }
@@ -557,22 +641,24 @@ module rooch_framework::coin {
     ){
         
         let coin_infos = account_storage::global_borrow_mut<CoinInfos>(ctx, @rooch_framework);
+        let coin_type = type_info::type_name<CoinType>();
         
         assert!(
-            !type_table::contains<CoinInfo<CoinType>>(&coin_infos.coin_infos),
+            !table::contains(&coin_infos.coin_infos, coin_type),
             error::already_exists(ErrorCoinInfoAlreadyRegistered),
-        );
+        ); 
 
         assert!(string::length(&name) <= MAX_COIN_NAME_LENGTH, error::invalid_argument(ErrorCoinNameTooLong));
         assert!(string::length(&symbol) <= MAX_COIN_SYMBOL_LENGTH, error::invalid_argument(ErrorCoinSymbolTooLong));
 
-        let coin_info = CoinInfo<CoinType> {
+        let coin_info = CoinInfo {
+            coin_type,
             name,
             symbol,
             decimals,
             supply: 0u256,
         };
-        type_table::add(&mut coin_infos.coin_infos, coin_info);
+        table::add(&mut coin_infos.coin_infos, coin_type, coin_info);
     }
 
     #[private_generics(CoinType)]
@@ -628,7 +714,7 @@ module rooch_framework::coin {
         addr: address,
     ) {
         ensure_coin_store<CoinType>(ctx, addr);
-        let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
+        let coin_store = borrow_mut_account_coin_store<CoinType>(ctx, addr);
         coin_store.frozen = true;
     }
 
@@ -639,7 +725,7 @@ module rooch_framework::coin {
         addr: address,
     ) {
         ensure_coin_store<CoinType>(ctx, addr);
-        let coin_store = borrow_mut_coin_store<CoinType>(ctx, addr);
+        let coin_store = borrow_mut_account_coin_store<CoinType>(ctx, addr);
         coin_store.frozen = false;
     }
 

--- a/crates/rooch-framework/sources/tests/coin_test.move
+++ b/crates/rooch-framework/sources/tests/coin_test.move
@@ -8,7 +8,7 @@ module rooch_framework::coin_test{
     use rooch_framework::coin;
     use rooch_framework::coin::{register_extend,
         supply, name, symbol, decimals, balance, value, mint_extend, burn_extend, freeze_coin_store_extend, unfreeze_coin_store_extend,
-        is_coin_store_frozen, zero, destroy_zero, is_registered, deposit, extract, transfer, withdraw, withdraw_extend,
+        is_account_coin_store_frozen, zero, destroy_zero, is_registered, deposit, extract, transfer, withdraw, withdraw_extend,
         is_account_accept_coin, do_accept_coin, set_auto_accept_coin
     };
 
@@ -222,22 +222,22 @@ module rooch_framework::coin_test{
     }
 
     #[test(account = @rooch_framework)]
-    public fun test_is_coin_store_frozen(account: signer) {
+    public fun test_is_account_coin_store_frozen(account: signer) {
         let ctx = rooch_framework::genesis::init_for_test();
         let addr = signer::address_of(&account);
         // An non do_accept_coined account is has a frozen coin store by default
-        assert!(!is_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
+        assert!(!is_account_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
 
         register_fake_coin(&mut ctx, 9);
 
-        assert!(!is_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
+        assert!(!is_account_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
         // freeze account
         freeze_coin_store_extend<FakeCoin>(&mut ctx, addr);
-        assert!(is_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
+        assert!(is_account_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
 
         // unfreeze account
         unfreeze_coin_store_extend<FakeCoin>(&mut ctx, addr);
-        assert!(!is_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
+        assert!(!is_account_coin_store_frozen<FakeCoin>(&ctx, addr), 1);
 
         moveos_std::context::drop_test_context(ctx);
     }

--- a/crates/rooch-framework/sources/tests/gas_coin_test.move
+++ b/crates/rooch-framework/sources/tests/gas_coin_test.move
@@ -27,6 +27,7 @@ module rooch_framework::gas_coin_test{
         account::create_account_for_test(&mut genesis_ctx, user);
         let init_gas = 9999u256;
         gas_coin::faucet_for_test(&mut genesis_ctx, user, init_gas); 
+        std::debug::print(&gas_coin::balance(&genesis_ctx, user));
         assert!(gas_coin::balance(&genesis_ctx, user) == init_gas, 1000);
         moveos_std::context::drop_test_context(genesis_ctx);
     }

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -86,8 +86,8 @@
       }
     },
     {
-      "name": "rooch_getBalances",
-      "description": "get account balances by AccountAddress",
+      "name": "rooch_getBalance",
+      "description": "get account balance by AccountAddress and CoinType",
       "params": [
         {
           "name": "account_addr",
@@ -98,8 +98,29 @@
         },
         {
           "name": "coin_type",
+          "required": true,
           "schema": {
             "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+          }
+        }
+      ],
+      "result": {
+        "name": "BalanceInfoView",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/BalanceInfoView"
+        }
+      }
+    },
+    {
+      "name": "rooch_getBalances",
+      "description": "get account balances by AccountAddress",
+      "params": [
+        {
+          "name": "account_addr",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
           }
         },
         {
@@ -121,7 +142,7 @@
         "name": "ListBalanceInfoPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_Nullable_BalanceInfoView_and_alloc::vec::Vec<u8>"
+          "$ref": "#/components/schemas/PageView_for_BalanceInfoView_and_alloc::vec::Vec<u8>"
         }
       }
     },
@@ -539,6 +560,8 @@
           "balance",
           "coin_type",
           "decimals",
+          "name",
+          "supply",
           "symbol"
         ],
         "properties": {
@@ -552,6 +575,12 @@
             "type": "integer",
             "format": "uint8",
             "minimum": 0.0
+          },
+          "name": {
+            "type": "string"
+          },
+          "supply": {
+            "$ref": "#/components/schemas/move_core_types::u256::U256"
           },
           "symbol": {
             "type": "string"
@@ -910,6 +939,35 @@
           }
         ]
       },
+      "PageView_for_BalanceInfoView_and_alloc::vec::Vec<u8>": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
+        "type": "object",
+        "required": [
+          "data",
+          "has_next_page"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BalanceInfoView"
+            }
+          },
+          "has_next_page": {
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
       "PageView_for_Nullable_AnnotatedEventView_and_uint64": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
@@ -958,42 +1016,6 @@
               "anyOf": [
                 {
                   "$ref": "#/components/schemas/AnnotatedStateView"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "has_next_page": {
-            "type": "boolean"
-          },
-          "next_cursor": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        }
-      },
-      "PageView_for_Nullable_BalanceInfoView_and_alloc::vec::Vec<u8>": {
-        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
-        "type": "object",
-        "required": [
-          "data",
-          "has_next_page"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/BalanceInfoView"
                 },
                 {
                   "type": "null"

--- a/crates/rooch-relayer/src/lib.rs
+++ b/crates/rooch-relayer/src/lib.rs
@@ -29,12 +29,12 @@ pub trait TxSubmiter: Send + Sync {
 #[async_trait]
 impl TxSubmiter for Client {
     async fn get_chain_id(&self) -> Result<u64> {
-        self.get_chain_id().await
+        self.rooch.get_chain_id().await
     }
     async fn get_sequence_number(&self, address: RoochAddress) -> Result<u64> {
-        self.get_sequence_number(address).await
+        self.rooch.get_sequence_number(address).await
     }
     async fn submit_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponseView> {
-        self.execute_tx(tx).await
+        self.rooch.execute_tx(tx).await
     }
 }

--- a/crates/rooch-rpc-api/src/api/eth_api.rs
+++ b/crates/rooch-rpc-api/src/api/eth_api.rs
@@ -8,12 +8,11 @@ use crate::jsonrpc_types::{
         transaction::{Transaction, TransactionReceipt, TransactionRequest},
         CallRequest, EthFeeHistory,
     },
-    H176View, H256View, StrView,
+    H256View, StrView,
 };
+use ethers::types::{H160, H256, U256};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
-use move_core_types::u256::U256;
-use moveos_types::h256::H256;
 use rooch_open_rpc_macros::open_rpc;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -31,8 +30,8 @@ impl Default for TransactionType {
     }
 }
 
-#[open_rpc(namespace = "ethereum")]
-#[rpc(server, client, namespace = "ethereum")]
+#[open_rpc]
+#[rpc(server, client)]
 #[async_trait]
 pub trait EthAPI {
     /// Returns the network version.
@@ -41,7 +40,7 @@ pub trait EthAPI {
 
     /// Returns the chain ID of the current network.
     #[method(name = "eth_chainId")]
-    async fn eth_chain_id(&self) -> RpcResult<String>;
+    async fn chain_id(&self) -> RpcResult<String>;
 
     /// Returns the number of most recent block.
     #[method(name = "eth_blockNumber")]
@@ -51,7 +50,7 @@ pub trait EthAPI {
     #[method(name = "eth_getBlockByNumber")]
     async fn get_block_by_number(
         &self,
-        num: BlockNumber,
+        num: StrView<BlockNumber>,
         include_txs: bool,
     ) -> RpcResult<Block<TransactionType>>;
 
@@ -59,8 +58,8 @@ pub trait EthAPI {
     #[method(name = "eth_getBalance")]
     async fn get_balance(
         &self,
-        address: H176View,
-        num: Option<BlockNumber>,
+        address: StrView<H160>,
+        num: Option<StrView<BlockNumber>>,
     ) -> RpcResult<StrView<U256>>;
 
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
@@ -68,7 +67,7 @@ pub trait EthAPI {
     async fn estimate_gas(
         &self,
         request: CallRequest,
-        num: Option<BlockNumber>,
+        num: Option<StrView<BlockNumber>>,
     ) -> RpcResult<StrView<U256>>;
 
     /// Transaction fee history
@@ -76,7 +75,7 @@ pub trait EthAPI {
     async fn fee_history(
         &self,
         block_count: StrView<U256>,
-        newest_block: BlockNumber,
+        newest_block: StrView<BlockNumber>,
         reward_percentiles: Option<Vec<f64>>,
     ) -> RpcResult<EthFeeHistory>;
 
@@ -88,8 +87,8 @@ pub trait EthAPI {
     #[method(name = "eth_getTransactionCount")]
     async fn transaction_count(
         &self,
-        address: H176View,
-        num: Option<BlockNumber>,
+        address: StrView<H160>,
+        num: Option<StrView<BlockNumber>>,
     ) -> RpcResult<StrView<U256>>;
 
     /// Sends transaction; will block waiting for signer to return the

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::jsonrpc_types::account_view::BalanceInfoView;
 use crate::jsonrpc_types::transaction_view::TransactionResultView;
 use crate::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedFunctionResultView, AnnotatedStateView,
@@ -93,12 +94,19 @@ pub trait RoochAPI {
         limit: Option<u64>,
     ) -> RpcResult<TransactionResultPageView>;
 
+    /// get account balance by AccountAddress and CoinType
+    #[method(name = "getBalance")]
+    async fn get_balance(
+        &self,
+        account_addr: AccountAddressView,
+        coin_type: StructTagView,
+    ) -> RpcResult<BalanceInfoView>;
+
     /// get account balances by AccountAddress
     #[method(name = "getBalances")]
     async fn get_balances(
         &self,
         account_addr: AccountAddressView,
-        coin_type: Option<StructTagView>,
         cursor: Option<StrView<Vec<u8>>>,
         limit: Option<usize>,
     ) -> RpcResult<ListBalanceInfoPageView>;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/account_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/account_view.rs
@@ -1,69 +1,28 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::jsonrpc_types::{StrView, StructTagView};
+use super::CoinInfoView;
+use crate::jsonrpc_types::StrView;
 use move_core_types::u256::U256;
-use rooch_types::account::{AccountInfo, BalanceInfo};
+use rooch_types::account::BalanceInfo;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::ops::Div;
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct AccountInfoView {
-    pub sequence_number: u64,
-    pub balances: Vec<Option<BalanceInfoView>>,
-}
-
-impl AccountInfoView {
-    pub fn new(sequence_number: u64, balances: Vec<Option<BalanceInfoView>>) -> Self {
-        Self {
-            sequence_number,
-            balances,
-        }
-    }
-}
-
-impl From<AccountInfo> for AccountInfoView {
-    fn from(account_info: AccountInfo) -> Self {
-        let balances = account_info
-            .balances
-            .iter()
-            .map(|v| v.clone().map(|balance| balance.into()))
-            .collect();
-
-        AccountInfoView {
-            sequence_number: account_info.sequence_number,
-            balances,
-        }
-    }
-}
-
-impl From<AccountInfoView> for AccountInfo {
-    fn from(account_info: AccountInfoView) -> Self {
-        let balances = account_info
-            .balances
-            .iter()
-            .map(|v| v.clone().map(|balance| balance.into()))
-            .collect();
-        AccountInfo {
-            sequence_number: account_info.sequence_number,
-            balances,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct BalanceInfoView {
-    pub coin_type: StructTagView,
-    pub symbol: String,
+    #[serde(flatten)]
+    pub coin_info: CoinInfoView,
     pub balance: StrView<U256>,
-    pub decimals: u8,
 }
 
 impl BalanceInfoView {
     //TODO implements big decimal calculation for Decimal point display
     pub fn get_balance_show(&self) -> String {
-        let balance = U256::div(self.balance.0, U256::from(10u32.pow(self.decimals as u32)));
+        let balance = U256::div(
+            self.balance.0,
+            U256::from(10u32.pow(self.coin_info.decimals as u32)),
+        );
         balance.to_string()
     }
 }
@@ -71,21 +30,8 @@ impl BalanceInfoView {
 impl From<BalanceInfo> for BalanceInfoView {
     fn from(balance_info: BalanceInfo) -> Self {
         BalanceInfoView {
-            coin_type: balance_info.coin_type.into(),
-            symbol: balance_info.symbol,
+            coin_info: balance_info.coin_info.into(),
             balance: balance_info.balance.into(),
-            decimals: balance_info.decimals,
-        }
-    }
-}
-
-impl From<BalanceInfoView> for BalanceInfo {
-    fn from(balance_info: BalanceInfoView) -> Self {
-        BalanceInfo {
-            coin_type: balance_info.coin_type.into(),
-            symbol: balance_info.symbol,
-            balance: balance_info.balance.into(),
-            decimals: balance_info.decimals,
         }
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/eth/call_request.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/eth/call_request.rs
@@ -1,10 +1,10 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::jsonrpc_types::bytes::Bytes;
 use crate::jsonrpc_types::eth::AccessList;
 use crate::jsonrpc_types::StrView;
-use crate::jsonrpc_types::{bytes::Bytes, H176View};
-use move_core_types::u256::U256;
+use ethers::types::{H160, U256};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -17,9 +17,9 @@ pub struct CallRequest {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub transaction_type: Option<StrView<u64>>,
     /// From
-    pub from: Option<H176View>,
+    pub from: Option<StrView<H160>>,
     /// To
-    pub to: Option<H176View>,
+    pub to: Option<StrView<H160>>,
     /// Gas Price
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_price: Option<StrView<U256>>,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/eth/ethereum_types/ens.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/eth/ethereum_types/ens.rs
@@ -1,10 +1,10 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::jsonrpc_types::StrView;
+use ethers::types::H160;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use crate::jsonrpc_types::H176View;
 
 /// ENS name or Ethereum Address. Not RLP encoded/serialized if it's a name.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -13,5 +13,5 @@ pub enum NameOrAddress {
     /// An ENS Name (format does not get checked)
     Name(String),
     /// An Ethereum Address
-    Address(H176View),
+    Address(StrView<H160>),
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/eth/ethereum_types/log.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/eth/ethereum_types/log.rs
@@ -1,19 +1,19 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::u256::U256;
-use schemars::JsonSchema;
 // Adapted from https://github.com/tomusdrw/rust-web3/blob/master/src/types/log.rs
-use serde::{Deserialize, Serialize};
 
-use crate::jsonrpc_types::{bytes::Bytes, H176View, H256View, StrView};
+use crate::jsonrpc_types::{bytes::Bytes, H256View, StrView};
+use ethers::types::{H160, U256};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// A log produced by a transaction.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Log {
     /// H160. the contract that emitted the log
-    pub address: H176View,
+    pub address: StrView<H160>,
 
     /// topics: Array of 0 to 4 32 Bytes of indexed log arguments.
     /// (In solidity: The first topic is the hash of the signature of the event

--- a/crates/rooch-rpc-api/src/jsonrpc_types/eth/ethereum_types/withdrawal.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/eth/ethereum_types/withdrawal.rs
@@ -1,25 +1,24 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::u256::U256;
+use crate::jsonrpc_types::StrView;
+use ethers::types::{H160, U256, U64};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use crate::jsonrpc_types::{H176View, StrView};
 
 /// A validator withdrawal from the consensus layer.
 /// See EIP-4895: Beacon chain push withdrawals as operations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Withdrawal {
     /// Monotonically increasing identifier issued by consensus layer
-    pub index: StrView<u64>,
+    pub index: StrView<U64>,
 
     /// Index of validator associated with withdrawal
     #[serde(rename = "validatorIndex")]
-    pub validator_index: StrView<u64>,
+    pub validator_index: StrView<U64>,
 
     /// Target address for withdrawn ether
-    pub address: H176View,
+    pub address: StrView<H160>,
 
     /// Value of withdrawal (in wei)
     pub amount: StrView<U256>,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/eth/fee_history.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/eth/fee_history.rs
@@ -1,19 +1,17 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::u256::U256;
+use super::ethereum_types::block::BlockNumber;
+use crate::jsonrpc_types::StrView;
+use ethers::types::U256;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use crate::jsonrpc_types::StrView;
-
-use super::ethereum_types::block::BlockNumber;
 
 /// Account information.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EthFeeHistory {
-    pub oldest_block: BlockNumber,
+    pub oldest_block: StrView<BlockNumber>,
     pub base_fee_per_gas: Vec<StrView<U256>>,
     pub gas_used_ratio: Vec<f64>,
     pub reward: Option<Vec<Vec<StrView<U256>>>>,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/eth/transaction.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/eth/transaction.rs
@@ -1,16 +1,14 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::u256::U256;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
-use crate::jsonrpc_types::{bytes::Bytes, H176View, H256View, StrView};
-
 use super::{
     ethereum_types::{bloom::Bloom, ens::NameOrAddress, log::Log, other_fields::OtherFields},
     AccessList,
 };
+use crate::jsonrpc_types::{bytes::Bytes, H256View, StrView};
+use ethers::types::{H160, U256, U64};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// Details of a signed transaction
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -28,19 +26,19 @@ pub struct Transaction {
 
     /// Block number. None when pending.
     #[serde(default, rename = "blockNumber")]
-    pub block_number: Option<StrView<u64>>,
+    pub block_number: Option<StrView<U64>>,
 
     /// Transaction Index. None when pending.
     #[serde(default, rename = "transactionIndex")]
-    pub transaction_index: Option<StrView<u64>>,
+    pub transaction_index: Option<StrView<U64>>,
 
     /// Sender
     #[serde(default)]
-    pub from: H176View,
+    pub from: StrView<H160>,
 
     /// Recipient (None when contract creation)
     #[serde(default)]
-    pub to: Option<H176View>,
+    pub to: Option<StrView<H160>>,
 
     /// Transferred value
     pub value: StrView<U256>,
@@ -56,7 +54,7 @@ pub struct Transaction {
     pub input: Bytes,
 
     /// ECDSA recovery id
-    pub v: StrView<u64>,
+    pub v: StrView<U64>,
 
     /// ECDSA signature r
     pub r: StrView<U256>,
@@ -114,7 +112,7 @@ pub struct Transaction {
     /// Transaction type, Some(2) for EIP-1559 transaction,
     /// Some(1) for AccessList transaction, None for Legacy
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
-    pub transaction_type: Option<StrView<u64>>,
+    pub transaction_type: Option<StrView<U64>>,
 
     // EIP2930
     #[serde(
@@ -165,7 +163,7 @@ pub struct Transaction {
 pub struct TransactionRequest {
     /// Sender address or ENS name
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub from: Option<H176View>,
+    pub from: Option<StrView<H160>>,
 
     /// Recipient address (None for contract creation)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -196,7 +194,7 @@ pub struct TransactionRequest {
     /// Chain ID (None for mainnet)
     #[serde(skip_serializing)]
     #[serde(default, rename = "chainId")]
-    pub chain_id: Option<StrView<u64>>,
+    pub chain_id: Option<StrView<U64>>,
 
     /////////////////  Celo-specific transaction fields /////////////////
     /// The currency fees are paid in (None for native currency)
@@ -227,17 +225,17 @@ pub struct TransactionReceipt {
     pub transaction_hash: H256View,
     /// Index within the block.
     #[serde(rename = "transactionIndex")]
-    pub transaction_index: StrView<u64>,
+    pub transaction_index: StrView<U64>,
     /// Hash of the block this transaction was included within.
     #[serde(rename = "blockHash")]
     pub block_hash: Option<H256View>,
     /// Number of the block this transaction was included within.
     #[serde(rename = "blockNumber")]
-    pub block_number: Option<StrView<u64>>,
+    pub block_number: Option<StrView<U64>>,
     /// address of the sender.
-    pub from: H176View,
+    pub from: StrView<H160>,
     // address of the receiver. null when its a contract creation transaction.
-    pub to: Option<H176View>,
+    pub to: Option<StrView<H160>>,
     /// Cumulative gas used within the block after this was executed.
     #[serde(rename = "cumulativeGasUsed")]
     pub cumulative_gas_used: StrView<U256>,
@@ -248,11 +246,11 @@ pub struct TransactionReceipt {
     pub gas_used: Option<StrView<U256>>,
     /// Contract address created, or `None` if not a deployment.
     #[serde(rename = "contractAddress")]
-    pub contract_address: Option<H176View>,
+    pub contract_address: Option<StrView<H160>>,
     /// Logs generated within this transaction.
     pub logs: Vec<Log>,
     /// Status: either 1 (success) or 0 (failure). Only present after activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
-    pub status: Option<StrView<u64>>,
+    pub status: Option<StrView<U64>>,
     /// State root. Only present before activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub root: Option<H256View>,
@@ -261,7 +259,7 @@ pub struct TransactionReceipt {
     pub logs_bloom: Bloom,
     /// Transaction type, Some(1) for AccessList transaction, None for Legacy
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
-    pub transaction_type: Option<StrView<u64>>,
+    pub transaction_type: Option<StrView<U64>>,
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee).
     /// Both fields in 1559-style transactions are *maximums* (max fee + max priority fee), the
     /// amount that's actually paid by users can only be determined post-execution

--- a/crates/rooch-rpc-api/src/jsonrpc_types/eth/transaction_access_list.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/eth/transaction_access_list.rs
@@ -1,23 +1,23 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::jsonrpc_types::{H256View, StrView};
+use ethers::types::H160;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
-
-use crate::jsonrpc_types::{H176View, H256View};
 
 pub type AccessList = Vec<AccessListItem>;
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AccessListItem {
-    address: H176View,
+    address: StrView<H160>,
     storage_keys: Vec<H256View>,
 }
 
 impl AccessListItem {
-    pub fn new(address: H176View, storage_keys: Vec<H256View>) -> Self {
+    pub fn new(address: StrView<H160>, storage_keys: Vec<H256View>) -> Self {
         Self {
             address,
             storage_keys,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
@@ -3,7 +3,7 @@
 
 use crate::jsonrpc_types::StrView;
 use anyhow::Result;
-use ethers::types::{H160, H64};
+use ethers::types::H64;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
@@ -401,33 +401,6 @@ impl From<H64> for H64View {
 impl From<H64View> for H64 {
     fn from(value: H64View) -> Self {
         H64(value.0)
-    }
-}
-
-// H176View represents 22 byte array for `0x` prefix added H160 hash
-#[serde_as]
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
-pub struct H176View(
-    #[schemars(with = "Hex")]
-    #[serde_as(as = "Readable<Hex, _>")]
-    [u8; 22], // Change the array size to 22 bytes
-);
-
-impl From<H160> for H176View {
-    fn from(value: H160) -> Self {
-        let mut bytes = [0u8; 22];
-        bytes[0] = 0x30; // Set the first byte to '0' (ASCII value)
-        bytes[1] = 0x78; // Set the second byte to 'x' (ASCII value)
-        bytes[2..].copy_from_slice(&value.0);
-        H176View(bytes)
-    }
-}
-
-impl From<H176View> for H160 {
-    fn from(value: H176View) -> Self {
-        let mut bytes = [0u8; 20];
-        bytes.copy_from_slice(&value.0[2..]);
-        H160(bytes)
     }
 }
 

--- a/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
@@ -4,7 +4,8 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{account_address::AccountAddress, u256};
+use ethers::types::{H160, H256};
+use move_core_types::account_address::AccountAddress;
 use schemars::gen::SchemaGenerator;
 use schemars::schema::{InstanceType, Schema, SchemaObject};
 use schemars::JsonSchema;
@@ -62,6 +63,15 @@ where
     }
 }
 
+impl<T> Default for StrView<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self(T::default())
+    }
+}
+
 macro_rules! impl_str_view_for {
     ($($t:ty)*) => {$(
     impl std::fmt::Display for StrView<$t> {
@@ -83,7 +93,7 @@ macro_rules! impl_str_view_for {
     )*}
 }
 
-impl_str_view_for! {u64 i64 u128 i128 u16 i16 u32 i32 u256::U256 }
+impl_str_view_for! {u64 i64 u128 i128 u16 i16 u32 i32 move_core_types::u256::U256 H160 H256}
 
 impl std::fmt::Display for StrView<Vec<u8>> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -129,5 +139,45 @@ impl FromStr for StrView<AccountAddress> {
 impl From<StrView<AccountAddress>> for AccountAddress {
     fn from(value: StrView<AccountAddress>) -> Self {
         value.0
+    }
+}
+
+impl FromStr for StrView<ethers::types::U256> {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(StrView(ethers::types::U256::from_str(s)?))
+    }
+}
+
+impl From<StrView<ethers::types::U256>> for ethers::types::U256 {
+    fn from(value: StrView<ethers::types::U256>) -> Self {
+        value.0
+    }
+}
+
+impl std::fmt::Display for StrView<ethers::types::U256> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        //The U256 in ethereum should display as hex string with `0x` prefix
+        write!(f, "0x{:x}", self.0)
+    }
+}
+
+impl FromStr for StrView<ethers::types::U64> {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(StrView(ethers::types::U64::from_str(s)?))
+    }
+}
+
+impl From<StrView<ethers::types::U64>> for ethers::types::U64 {
+    fn from(value: StrView<ethers::types::U64>) -> Self {
+        value.0
+    }
+}
+
+impl std::fmt::Display for StrView<ethers::types::U64> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        //The U64 in ethereum should display as hex string with `0x` prefix
+        write!(f, "0x{:x}", self.0)
     }
 }

--- a/crates/rooch-rpc-client/src/eth_client.rs
+++ b/crates/rooch-rpc-client/src/eth_client.rs
@@ -1,0 +1,124 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use ethers::types::{H160, H256, U256};
+use jsonrpsee::http_client::HttpClient;
+use rooch_rpc_api::api::eth_api::EthAPIClient;
+use rooch_rpc_api::jsonrpc_types::{H256View, StrView};
+use rooch_rpc_api::{
+    api::eth_api::TransactionType,
+    jsonrpc_types::{
+        bytes::Bytes,
+        eth::{
+            ethereum_types::block::{Block, BlockNumber},
+            CallRequest, EthFeeHistory, Transaction, TransactionReceipt,
+        },
+    },
+};
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct EthRpcClient {
+    http: Arc<HttpClient>,
+}
+
+impl EthRpcClient {
+    pub fn new(http: Arc<HttpClient>) -> Self {
+        Self { http }
+    }
+
+    pub async fn net_version(&self) -> Result<String> {
+        Ok(self.http.net_version().await?)
+    }
+
+    pub async fn chain_id(&self) -> Result<String> {
+        Ok(self.http.chain_id().await?)
+    }
+
+    pub async fn get_block_number(&self) -> Result<String> {
+        Ok(self.http.get_block_number().await?)
+    }
+
+    pub async fn get_block_by_number(
+        &self,
+        num: BlockNumber,
+        include_txs: bool,
+    ) -> Result<Block<TransactionType>> {
+        Ok(self
+            .http
+            .get_block_by_number(num.into(), include_txs)
+            .await?)
+    }
+
+    pub async fn get_balance(
+        &self,
+        address: H160,
+        num: Option<BlockNumber>,
+    ) -> Result<StrView<U256>> {
+        let response = self
+            .http
+            .get_balance(address.into(), num.map(StrView))
+            .await?;
+        Result::Ok(response)
+    }
+
+    pub async fn estimate_gas(
+        &self,
+        request: CallRequest,
+        num: Option<BlockNumber>,
+    ) -> Result<StrView<U256>> {
+        let response = self.http.estimate_gas(request, num.map(StrView)).await?;
+        Result::Ok(response)
+    }
+
+    pub async fn fee_history(
+        &self,
+        block_count: U256,
+        newest_block: BlockNumber,
+        reward_percentiles: Option<Vec<f64>>,
+    ) -> Result<EthFeeHistory> {
+        Ok(self
+            .http
+            .fee_history(block_count.into(), newest_block.into(), reward_percentiles)
+            .await?)
+    }
+
+    pub async fn gas_price(&self) -> Result<StrView<U256>> {
+        let response = self.http.gas_price().await?;
+        Result::Ok(response)
+    }
+
+    pub async fn transaction_count(
+        &self,
+        address: H160,
+        num: Option<BlockNumber>,
+    ) -> Result<StrView<U256>> {
+        let response = self
+            .http
+            .transaction_count(address.into(), num.map(StrView))
+            .await?;
+        Result::Ok(response)
+    }
+
+    pub async fn send_raw_transaction(&self, bytes: Bytes) -> Result<H256View> {
+        let response = self.http.send_raw_transaction(bytes).await?;
+        Result::Ok(response)
+    }
+
+    pub async fn transaction_receipt(&self, hash: H256) -> Result<Option<TransactionReceipt>> {
+        Ok(self.http.transaction_receipt(hash.into()).await?)
+    }
+
+    pub async fn transaction_by_hash(&self, hash: H256) -> Result<Option<Transaction>> {
+        Ok(self.http.transaction_by_hash(hash.into()).await?)
+    }
+
+    pub async fn block_by_hash(
+        &self,
+        hash: H256,
+        include_txs: bool,
+    ) -> Result<Block<TransactionType>> {
+        Ok(self.http.block_by_hash(hash.into(), include_txs).await?)
+    }
+}

--- a/crates/rooch-rpc-client/src/lib.rs
+++ b/crates/rooch-rpc-client/src/lib.rs
@@ -2,45 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use ethers::types::{H160, H256};
+use eth_client::EthRpcClient;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
-use move_core_types::u256::U256;
 use moveos_types::{
-    access_path::AccessPath,
-    function_return_value::FunctionResult,
-    module_binding::MoveFunctionCaller,
-    state::{MoveStructType, State},
-    transaction::FunctionCall,
-    tx_context::TxContext,
+    function_return_value::FunctionResult, module_binding::MoveFunctionCaller,
+    transaction::FunctionCall, tx_context::TxContext,
 };
-use rooch_rpc_api::api::rooch_api::RoochAPIClient;
-use rooch_rpc_api::jsonrpc_types::{
-    account_view::BalanceInfoView, transaction_view::TransactionResultView,
-};
-use rooch_rpc_api::jsonrpc_types::TransactionResultPageView;
-use rooch_rpc_api::jsonrpc_types::{
-    AccessPathView, AccountAddressView, AnnotatedFunctionResultView, EventPageView,
-    ListAnnotatedStatesPageView, ListBalanceInfoPageView, ListStatesPageView, StrView,
-    StructTagView,
-};
-use rooch_rpc_api::{api::eth_api::EthAPIClient, jsonrpc_types::H256View};
-use rooch_rpc_api::{
-    api::eth_api::TransactionType,
-    jsonrpc_types::{
-        bytes::Bytes,
-        eth::{
-            ethereum_types::block::{Block, BlockNumber},
-            CallRequest, EthFeeHistory, Transaction, TransactionReceipt,
-        },
-        AnnotatedStateView, ExecuteTransactionResponseView, StateView,
-    },
-};
-use rooch_types::{account::Account, address::RoochAddress, transaction::rooch::RoochTransaction};
+use rooch_client::RoochRpcClient;
 use std::sync::Arc;
 use std::time::Duration;
 
 pub mod client_config;
+pub mod eth_client;
+pub mod rooch_client;
 pub mod wallet_context;
 
 pub struct ClientBuilder {
@@ -68,14 +43,18 @@ impl ClientBuilder {
     pub async fn build(self, http: impl AsRef<str>) -> Result<Client> {
         // TODO: add verison info
 
-        let http_client = HttpClientBuilder::default()
-            .max_request_body_size(2 << 30)
-            .max_concurrent_requests(self.max_concurrent_requests)
-            .request_timeout(self.request_timeout)
-            .build(http)?;
+        let http_client = Arc::new(
+            HttpClientBuilder::default()
+                .max_request_body_size(2 << 30)
+                .max_concurrent_requests(self.max_concurrent_requests)
+                .request_timeout(self.request_timeout)
+                .build(http)?,
+        );
 
         Ok(Client {
-            rpc: Arc::new(RpcClient { http: http_client }),
+            http: http_client.clone(),
+            rooch: RoochRpcClient::new(http_client.clone()),
+            eth: EthRpcClient::new(http_client),
         })
     }
 }
@@ -90,261 +69,26 @@ impl Default for ClientBuilder {
     }
 }
 
-pub(crate) struct RpcClient {
-    http: HttpClient,
+#[derive(Clone)]
+pub struct Client {
+    http: Arc<HttpClient>,
+    pub rooch: RoochRpcClient,
+    pub eth: EthRpcClient,
 }
 
-impl std::fmt::Debug for RpcClient {
+impl std::fmt::Debug for Client {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "RPC client. Http: {:?}", self.http)
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct Client {
-    rpc: Arc<RpcClient>,
-}
-
-// TODO: call args are uniformly defined in jsonrpc types?
-// example execute_view_function get_events_by_event_handle
 impl Client {
-    pub async fn get_chain_id(&self) -> Result<u64> {
-        Ok(self.rpc.http.get_chain_id().await?.0)
-    }
-
-    pub async fn execute_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponseView> {
-        let tx_payload = bcs::to_bytes(&tx)?;
-        self.rpc
-            .http
-            .execute_raw_transaction(tx_payload.into())
-            .await
-            .map_err(|e| anyhow::anyhow!(e))
-    }
-
-    pub async fn execute_view_function(
-        &self,
-        function_call: FunctionCall,
-    ) -> Result<AnnotatedFunctionResultView> {
-        self.rpc
-            .http
-            .execute_view_function(function_call.into())
-            .await
-            .map_err(|e| anyhow::anyhow!(e))
-    }
-
-    pub async fn get_states(&self, access_path: AccessPath) -> Result<Vec<Option<StateView>>> {
-        Ok(self.rpc.http.get_states(access_path.into()).await?)
-    }
-
-    pub async fn get_annotated_states(
-        &self,
-        access_path: AccessPath,
-    ) -> Result<Vec<Option<AnnotatedStateView>>> {
-        Ok(self
-            .rpc
-            .http
-            .get_annotated_states(access_path.into())
-            .await?)
-    }
-
-    // pub async fn get_transactions_by_hash(&self, hash: H256) -> Result<Option<TransactionView>> {
-    //     Ok(self.rpc.http.get_transaction_by_hash(hash.into()).await?)
-    // }
-
-    pub async fn get_transactions_by_order(
-        &self,
-        cursor: Option<u128>,
-        limit: Option<u64>,
-    ) -> Result<TransactionResultPageView> {
-        Ok(self
-            .rpc
-            .http
-            .get_transactions_by_order(cursor, limit)
-            .await?)
-    }
-
-    pub async fn get_transactions_by_hash(
-        &self,
-        tx_hashes: Vec<H256>,
-    ) -> Result<Vec<Option<TransactionResultView>>> {
-        Ok(self
-            .rpc
-            .http
-            .get_transactions_by_hash(tx_hashes.iter().map(|hash| (*hash).into()).collect())
-            .await?)
-    }
-
-    pub async fn get_sequence_number(&self, sender: RoochAddress) -> Result<u64> {
-        Ok(self
-            .get_states(AccessPath::resource(sender.into(), Account::struct_tag()))
-            .await?
-            .pop()
-            .flatten()
-            .map(|state_view| {
-                let state = State::from(state_view);
-                state.as_move_state::<Account>()
-            })
-            .transpose()?
-            .map_or(0, |account| account.sequence_number))
-    }
-
-    pub async fn get_events_by_event_handle(
-        &self,
-        event_handle_type: StructTagView,
-        cursor: Option<u64>,
-        limit: Option<u64>,
-    ) -> Result<EventPageView> {
-        let s = self
-            .rpc
-            .http
-            .get_events_by_event_handle(event_handle_type, cursor, limit)
-            .await?;
-        Ok(s)
-    }
-
-    pub async fn list_states(
-        &self,
-        access_path: AccessPathView,
-        cursor: Option<StrView<Vec<u8>>>,
-        limit: Option<usize>,
-    ) -> Result<ListStatesPageView> {
-        Ok(self
-            .rpc
-            .http
-            .list_states(access_path, cursor, limit)
-            .await?)
-    }
-
-    pub async fn list_annotated_states(
-        &self,
-        access_path: AccessPathView,
-        cursor: Option<StrView<Vec<u8>>>,
-        limit: Option<usize>,
-    ) -> Result<ListAnnotatedStatesPageView> {
-        Ok(self
-            .rpc
-            .http
-            .list_annotated_states(access_path, cursor, limit)
-            .await?)
-    }
-
-    pub async fn get_balance(
-        &self,
-        account_addr: AccountAddressView,
-        coin_type: StructTagView,
-    ) -> Result<BalanceInfoView> {
-        Ok(self.rpc.http.get_balance(account_addr, coin_type).await?)
-    }
-
-    pub async fn get_balances(
-        &self,
-        account_addr: AccountAddressView,
-        cursor: Option<StrView<Vec<u8>>>,
-        limit: Option<usize>,
-    ) -> Result<ListBalanceInfoPageView> {
-        Ok(self
-            .rpc
-            .http
-            .get_balances(account_addr, cursor, limit)
-            .await?)
-    }
-
     pub async fn request(
         &self,
         method: &str,
         params: Vec<serde_json::Value>,
     ) -> Result<serde_json::Value> {
-        Ok(self.rpc.http.request(method, params).await?)
-    }
-
-    pub async fn net_version(&self) -> Result<String> {
-        Ok(self.rpc.http.net_version().await?)
-    }
-
-    pub async fn eth_chain_id(&self) -> Result<String> {
-        Ok(self.rpc.http.eth_chain_id().await?)
-    }
-
-    pub async fn get_block_number(&self) -> Result<String> {
-        Ok(self.rpc.http.get_block_number().await?)
-    }
-
-    pub async fn get_block_by_number(
-        &self,
-        num: BlockNumber,
-        include_txs: bool,
-    ) -> Result<Block<TransactionType>> {
-        Ok(self.rpc.http.get_block_by_number(num, include_txs).await?)
-    }
-
-    pub async fn get_balance(
-        &self,
-        address: H160,
-        num: Option<BlockNumber>,
-    ) -> Result<StrView<U256>> {
-        let response = self.rpc.http.get_balance(address.into(), num).await?;
-        Result::Ok(response)
-    }
-
-    pub async fn estimate_gas(
-        &self,
-        request: CallRequest,
-        num: Option<BlockNumber>,
-    ) -> Result<StrView<U256>> {
-        let response = self.rpc.http.estimate_gas(request, num).await?;
-        Result::Ok(response)
-    }
-
-    pub async fn fee_history(
-        &self,
-        block_count: U256,
-        newest_block: BlockNumber,
-        reward_percentiles: Option<Vec<f64>>,
-    ) -> Result<EthFeeHistory> {
-        Ok(self
-            .rpc
-            .http
-            .fee_history(block_count.into(), newest_block, reward_percentiles)
-            .await?)
-    }
-
-    pub async fn gas_price(&self) -> Result<StrView<U256>> {
-        let response = self.rpc.http.gas_price().await?;
-        Result::Ok(response)
-    }
-
-    pub async fn transaction_count(
-        &self,
-        address: H160,
-        num: Option<BlockNumber>,
-    ) -> Result<StrView<U256>> {
-        let response = self.rpc.http.transaction_count(address.into(), num).await?;
-        Result::Ok(response)
-    }
-
-    pub async fn send_raw_transaction(&self, bytes: Bytes) -> Result<H256View> {
-        let response = EthAPIClient::send_raw_transaction(&self.rpc.http, bytes).await?;
-        Result::Ok(response)
-    }
-
-    pub async fn transaction_receipt(&self, hash: H256) -> Result<Option<TransactionReceipt>> {
-        Ok(self.rpc.http.transaction_receipt(hash.into()).await?)
-    }
-
-    pub async fn transaction_by_hash(&self, hash: H256) -> Result<Option<Transaction>> {
-        Ok(self.rpc.http.transaction_by_hash(hash.into()).await?)
-    }
-
-    pub async fn block_by_hash(
-        &self,
-        hash: H256,
-        include_txs: bool,
-    ) -> Result<Block<TransactionType>> {
-        Ok(self
-            .rpc
-            .http
-            .block_by_hash(hash.into(), include_txs)
-            .await?)
+        Ok(self.http.request(method, params).await?)
     }
 }
 
@@ -355,7 +99,7 @@ impl MoveFunctionCaller for Client {
         function_call: FunctionCall,
     ) -> Result<FunctionResult> {
         let function_result =
-            futures::executor::block_on(self.execute_view_function(function_call))?;
+            futures::executor::block_on(self.rooch.execute_view_function(function_call))?;
         function_result.try_into()
     }
 }

--- a/crates/rooch-rpc-client/src/lib.rs
+++ b/crates/rooch-rpc-client/src/lib.rs
@@ -15,7 +15,9 @@ use moveos_types::{
     tx_context::TxContext,
 };
 use rooch_rpc_api::api::rooch_api::RoochAPIClient;
-use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionResultView;
+use rooch_rpc_api::jsonrpc_types::{
+    account_view::BalanceInfoView, transaction_view::TransactionResultView,
+};
 use rooch_rpc_api::jsonrpc_types::TransactionResultPageView;
 use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedFunctionResultView, EventPageView,
@@ -226,17 +228,24 @@ impl Client {
             .await?)
     }
 
+    pub async fn get_balance(
+        &self,
+        account_addr: AccountAddressView,
+        coin_type: StructTagView,
+    ) -> Result<BalanceInfoView> {
+        Ok(self.rpc.http.get_balance(account_addr, coin_type).await?)
+    }
+
     pub async fn get_balances(
         &self,
         account_addr: AccountAddressView,
-        coin_type: Option<StructTagView>,
         cursor: Option<StrView<Vec<u8>>>,
         limit: Option<usize>,
     ) -> Result<ListBalanceInfoPageView> {
         Ok(self
             .rpc
             .http
-            .get_balances(account_addr, coin_type, cursor, limit)
+            .get_balances(account_addr, cursor, limit)
             .await?)
     }
 

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -1,0 +1,158 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use jsonrpsee::http_client::HttpClient;
+use moveos_types::h256::H256;
+use moveos_types::{
+    access_path::AccessPath,
+    state::{MoveStructType, State},
+    transaction::FunctionCall,
+};
+use rooch_rpc_api::api::rooch_api::RoochAPIClient;
+use rooch_rpc_api::jsonrpc_types::TransactionResultPageView;
+use rooch_rpc_api::jsonrpc_types::{
+    account_view::BalanceInfoView, transaction_view::TransactionResultView,
+};
+use rooch_rpc_api::jsonrpc_types::{
+    AccessPathView, AccountAddressView, AnnotatedFunctionResultView, EventPageView,
+    ListAnnotatedStatesPageView, ListBalanceInfoPageView, ListStatesPageView, StrView,
+    StructTagView,
+};
+use rooch_rpc_api::jsonrpc_types::{AnnotatedStateView, ExecuteTransactionResponseView, StateView};
+use rooch_types::{account::Account, address::RoochAddress, transaction::rooch::RoochTransaction};
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct RoochRpcClient {
+    http: Arc<HttpClient>,
+}
+
+// TODO: call args are uniformly defined in jsonrpc types?
+// example execute_view_function get_events_by_event_handle
+
+impl RoochRpcClient {
+    pub fn new(http: Arc<HttpClient>) -> Self {
+        Self { http }
+    }
+
+    pub async fn get_chain_id(&self) -> Result<u64> {
+        Ok(self.http.get_chain_id().await?.0)
+    }
+
+    pub async fn execute_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponseView> {
+        let tx_payload = bcs::to_bytes(&tx)?;
+        self.http
+            .execute_raw_transaction(tx_payload.into())
+            .await
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    pub async fn execute_view_function(
+        &self,
+        function_call: FunctionCall,
+    ) -> Result<AnnotatedFunctionResultView> {
+        self.http
+            .execute_view_function(function_call.into())
+            .await
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    pub async fn get_states(&self, access_path: AccessPath) -> Result<Vec<Option<StateView>>> {
+        Ok(self.http.get_states(access_path.into()).await?)
+    }
+
+    pub async fn get_annotated_states(
+        &self,
+        access_path: AccessPath,
+    ) -> Result<Vec<Option<AnnotatedStateView>>> {
+        Ok(self.http.get_annotated_states(access_path.into()).await?)
+    }
+
+    // pub async fn get_transactions_by_hash(&self, hash: H256) -> Result<Option<TransactionView>> {
+    //     Ok(self.http.get_transaction_by_hash(hash.into()).await?)
+    // }
+
+    pub async fn get_transactions_by_order(
+        &self,
+        cursor: Option<u128>,
+        limit: Option<u64>,
+    ) -> Result<TransactionResultPageView> {
+        Ok(self.http.get_transactions_by_order(cursor, limit).await?)
+    }
+
+    pub async fn get_transactions_by_hash(
+        &self,
+        tx_hashes: Vec<H256>,
+    ) -> Result<Vec<Option<TransactionResultView>>> {
+        Ok(self
+            .http
+            .get_transactions_by_hash(tx_hashes.iter().map(|hash| (*hash).into()).collect())
+            .await?)
+    }
+
+    pub async fn get_sequence_number(&self, sender: RoochAddress) -> Result<u64> {
+        Ok(self
+            .get_states(AccessPath::resource(sender.into(), Account::struct_tag()))
+            .await?
+            .pop()
+            .flatten()
+            .map(|state_view| {
+                let state = State::from(state_view);
+                state.as_move_state::<Account>()
+            })
+            .transpose()?
+            .map_or(0, |account| account.sequence_number))
+    }
+
+    pub async fn get_events_by_event_handle(
+        &self,
+        event_handle_type: StructTagView,
+        cursor: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<EventPageView> {
+        let s = self
+            .http
+            .get_events_by_event_handle(event_handle_type, cursor, limit)
+            .await?;
+        Ok(s)
+    }
+
+    pub async fn list_states(
+        &self,
+        access_path: AccessPathView,
+        cursor: Option<StrView<Vec<u8>>>,
+        limit: Option<usize>,
+    ) -> Result<ListStatesPageView> {
+        Ok(self.http.list_states(access_path, cursor, limit).await?)
+    }
+
+    pub async fn list_annotated_states(
+        &self,
+        access_path: AccessPathView,
+        cursor: Option<StrView<Vec<u8>>>,
+        limit: Option<usize>,
+    ) -> Result<ListAnnotatedStatesPageView> {
+        Ok(self
+            .http
+            .list_annotated_states(access_path, cursor, limit)
+            .await?)
+    }
+
+    pub async fn get_balance(
+        &self,
+        account_addr: AccountAddressView,
+        coin_type: StructTagView,
+    ) -> Result<BalanceInfoView> {
+        Ok(self.http.get_balance(account_addr, coin_type).await?)
+    }
+
+    pub async fn get_balances(
+        &self,
+        account_addr: AccountAddressView,
+        cursor: Option<StrView<Vec<u8>>>,
+        limit: Option<usize>,
+    ) -> Result<ListBalanceInfoPageView> {
+        Ok(self.http.get_balances(account_addr, cursor, limit).await?)
+    }
+}

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -108,8 +108,9 @@ impl WalletContext<RoochAddress> {
         action: MoveAction,
     ) -> RoochResult<RoochTransactionData> {
         let client = self.get_client().await?;
-        let chain_id = client.get_chain_id().await?;
+        let chain_id = client.rooch.get_chain_id().await?;
         let sequence_number = client
+            .rooch
             .get_sequence_number(sender)
             .await
             .map_err(RoochError::from)?;
@@ -162,6 +163,7 @@ impl WalletContext<RoochAddress> {
     ) -> RoochResult<ExecuteTransactionResponseView> {
         let client = self.get_client().await?;
         client
+            .rooch
             .execute_tx(tx)
             .await
             .map_err(|e| RoochError::TransactionError(e.to_string()))

--- a/crates/rooch-rpc-server/src/server/eth_server.rs
+++ b/crates/rooch-rpc-server/src/server/eth_server.rs
@@ -328,9 +328,7 @@ impl EthAPIServer for EthServer {
     ) -> RpcResult<StrView<U256>> {
         let account_address = self
             .rpc_service
-            .resolve_address(MultiChainAddress::from(EthereumAddress(
-                address.clone().into(),
-            )))
+            .resolve_address(MultiChainAddress::from(EthereumAddress(address.into())))
             .await?;
 
         info!(

--- a/crates/rooch-rpc-server/src/server/eth_server.rs
+++ b/crates/rooch-rpc-server/src/server/eth_server.rs
@@ -85,9 +85,10 @@ impl EthAPIServer for EthServer {
         num: StrView<BlockNumber>,
         include_txs: bool,
     ) -> RpcResult<Block<TransactionType>> {
-        let block_number = num.0.as_number().ok_or_else(|| {
-            JsonRpcError::Custom("block number should be a number".to_string())
-        })?;
+        let block_number = num
+            .0
+            .as_number()
+            .ok_or_else(|| JsonRpcError::Custom("block number should be a number".to_string()))?;
         let parent_hash =
             H256::from_str("0xe5ece23ec875db0657f964cbc74fa34439eef3ab3dc8664e7f4ae8b5c5c963e1")
                 .unwrap();
@@ -232,7 +233,9 @@ impl EthAPIServer for EthServer {
                     balance_info.balance
                 }
             })?;
-        Ok(StrView(U256::from_little_endian(balance.to_le_bytes().as_ref())))
+        Ok(StrView(U256::from_little_endian(
+            balance.to_le_bytes().as_ref(),
+        )))
     }
 
     async fn estimate_gas(
@@ -273,13 +276,9 @@ impl EthAPIServer for EthServer {
         } else {
             block_count.0.as_usize()
         };
-        let base_fee_per_gas: Vec<U256> = iter::repeat_with(U256::zero)
-            .take(block_count)
-            .collect();
+        let base_fee_per_gas: Vec<U256> = iter::repeat_with(U256::zero).take(block_count).collect();
 
-        let gas_used_ratio: Vec<f64> = iter::repeat_with(|| 0.1)
-            .take(block_count)
-            .collect();
+        let gas_used_ratio: Vec<f64> = iter::repeat_with(|| 0.1).take(block_count).collect();
 
         let reward = match reward_percentiles {
             Some(percentiles) => {

--- a/crates/rooch-rpc-server/src/service/aggregate_service.rs
+++ b/crates/rooch-rpc-server/src/service/aggregate_service.rs
@@ -9,17 +9,15 @@ use moveos_types::access_path::AccessPath;
 use moveos_types::function_return_value::FunctionResult;
 use moveos_types::h256::H256;
 use moveos_types::module_binding::MoveFunctionCaller;
-use moveos_types::move_types::get_first_ty_as_struct_tag;
+use moveos_types::moveos_std::object_ref::ObjectRef;
+use moveos_types::object::ObjectID;
 use moveos_types::state_resolver::resource_tag_to_key;
 use moveos_types::transaction::FunctionCall;
 use moveos_types::tx_context::TxContext;
-use rooch_rpc_api::api::MAX_RESULT_LIMIT_USIZE;
 use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionResult;
 use rooch_types::account::BalanceInfo;
-use rooch_types::addresses::ROOCH_FRAMEWORK_ADDRESS_LITERAL;
-use rooch_types::framework::coin::{AnnotatedCoinInfo, AnnotatedCoinStore, CoinModule};
+use rooch_types::framework::coin::{CoinInfo, CoinModule, CoinStore};
 use std::collections::HashMap;
-use std::str::FromStr;
 use tokio::runtime::Handle;
 
 /// AggregateService is aggregate RPC service and MoveFunctionCaller.
@@ -35,113 +33,145 @@ impl AggregateService {
 }
 
 impl AggregateService {
+    pub async fn get_coin_infos(
+        &self,
+        coin_types: Vec<StructTag>,
+    ) -> Result<HashMap<StructTag, Option<CoinInfo>>> {
+        let coin_module = self.as_module_binding::<CoinModule>();
+        let coin_info_handle = coin_module.coin_infos_handle()?;
+
+        let access_path = AccessPath::table(
+            coin_info_handle,
+            coin_types.iter().map(resource_tag_to_key).collect(),
+        );
+        self.rpc_service
+            .get_states(access_path)
+            .await?
+            .into_iter()
+            .zip(coin_types)
+            .map(|(state_opt, coin_type)| {
+                Ok((
+                    coin_type,
+                    state_opt
+                        .map(|state| state.as_move_state::<CoinInfo>())
+                        .transpose()?,
+                ))
+            })
+            .collect::<Result<HashMap<_, _>>>()
+    }
+
+    pub async fn get_coin_stores(
+        &self,
+        coin_store_ids: Vec<ObjectID>,
+    ) -> Result<Vec<Option<CoinStore>>> {
+        let access_path = AccessPath::objects(coin_store_ids);
+        self.rpc_service
+            .get_states(access_path)
+            .await?
+            .into_iter()
+            .map(|state_opt| {
+                state_opt
+                    .map(|state| Ok(state.as_object::<CoinStore>()?.value))
+                    .transpose()
+            })
+            .collect::<Result<Vec<_>>>()
+    }
+
+    pub async fn get_balance(
+        &self,
+        account_addr: AccountAddress,
+        coin_type: StructTag,
+    ) -> Result<BalanceInfo> {
+        let coin_module = self.as_module_binding::<CoinModule>();
+
+        let coin_info = self
+            .get_coin_infos(vec![coin_type.clone()])
+            .await?
+            .into_values()
+            .flatten()
+            .next()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Can not find CoinInfo with coin_type: {}", coin_type)
+            })?;
+
+        let coin_store_id = coin_module.coin_store_id(account_addr, coin_type.clone())?;
+        let balance = match coin_store_id {
+            Some(coin_store_id) => {
+                let coin_store = self
+                    .get_coin_stores(vec![coin_store_id])
+                    .await?
+                    .pop()
+                    .flatten()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Can not find CoinStore with id: {}", coin_store_id)
+                    })?;
+                coin_store.balance()
+            }
+            None => move_core_types::u256::U256::zero(),
+        };
+        Ok(BalanceInfo::new(coin_info, balance))
+    }
+
     pub async fn get_balances(
         &self,
         account_addr: AccountAddress,
-        coin_type: Option<StructTag>,
         cursor: Option<Vec<u8>>,
         limit: usize,
-    ) -> Result<Vec<Option<(Option<Vec<u8>>, BalanceInfo)>>> {
+    ) -> Result<Vec<(Option<Vec<u8>>, BalanceInfo)>> {
         let coin_module = self.as_module_binding::<CoinModule>();
-        let coin_info_handle = coin_module.coin_info_handle()?;
 
-        // contruct coin info map for handle decimals
-        //TODO Extract to signle module as cache to load all token info, as well as to avoid query every time
-        let mut coin_info_table = HashMap::new();
-        let coin_info_states = self
-            .rpc_service
-            .list_annotated_states(
-                AccessPath::table_without_keys(coin_info_handle),
-                None,
-                MAX_RESULT_LIMIT_USIZE,
-            )
-            .await?;
-        let coin_info_data = coin_info_states
-            .into_iter()
-            .map(|item| {
-                item.map(|(_key, state)| {
-                    AnnotatedCoinInfo::new_from_annotated_move_value(state.move_value)
-                })
-                .transpose()
-            })
-            .collect::<Vec<_>>();
+        let coin_stores_handle_opt = coin_module.coin_stores_handle(account_addr)?;
 
-        for coin_info_opt in coin_info_data.into_iter().flatten() {
-            if coin_info_opt.is_none() {
-                return Err(anyhow::anyhow!("CoinInfo should have value"));
-            };
-            let coin_info = coin_info_opt.unwrap();
-
-            let coin_type = get_first_ty_as_struct_tag(coin_info.get_type())
-                .map_err(|e| anyhow::anyhow!("Coin type convert error :{}", e))?;
-
-            coin_info_table.insert(coin_type, coin_info.value);
-        }
-
-        let mut result = vec![];
-
-        let coin_store_handle_opt = coin_module.coin_store_handle(account_addr)?;
-        if let Some(coin_store_handle) = coin_store_handle_opt {
-            if let Some(coin_type) = coin_type {
-                let coin_store_type = format!(
-                    "{}::coin::CoinStore<0x{}>",
-                    ROOCH_FRAMEWORK_ADDRESS_LITERAL,
-                    coin_type.to_canonical_string()
-                );
-                let key = resource_tag_to_key(&StructTag::from_str(coin_store_type.as_str())?);
-                let keys = vec![key];
-                let mut states = self
+        match coin_stores_handle_opt {
+            Some(coin_stores_handle) => {
+                let coin_store_ids = self
                     .rpc_service
-                    .get_annotated_states(AccessPath::table(coin_store_handle, keys))
-                    .await?;
-
-                let state_opt = states.pop().flatten();
-                let state = state_opt
-                    .ok_or_else(|| anyhow::anyhow!("CoinStore state should have value"))?;
-                let annotated_coin_store =
-                    AnnotatedCoinStore::new_from_annotated_move_value(state.move_value)?;
-
-                let balance_info =
-                    BalanceInfo::new_with_default(coin_type, annotated_coin_store.get_coin_value());
-                result.push(Some((None, balance_info)))
-            } else {
-                //TODO If the coin store list exceeds MAX_RESULT_LIMIT_USIZE, consider supporting traverse or pagination
-                let states = self
-                    .rpc_service
-                    .list_annotated_states(
-                        AccessPath::table_without_keys(coin_store_handle),
+                    .list_states(
+                        AccessPath::table_without_keys(coin_stores_handle),
                         cursor,
                         limit,
                     )
+                    .await?
+                    .into_iter()
+                    .flatten()
+                    .map(|(k, v)| {
+                        let coin_store_ref = v.as_move_state::<ObjectRef<CoinStore>>()?;
+                        Ok((k, coin_store_ref.id))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                let coin_stores = self
+                    .get_coin_stores(coin_store_ids.iter().map(|(_, v)| *v).collect())
                     .await?;
 
-                for (key, state) in states.into_iter().flatten() {
-                    let coin_store =
-                        AnnotatedCoinStore::new_from_annotated_move_value(state.move_value)
-                            .map_err(|e| anyhow::anyhow!("CoinStore convert error :{}", e))?;
+                let coin_types = coin_stores
+                    .iter()
+                    .flatten()
+                    .map(|coin_store| coin_store.coin_type_tag())
+                    .collect::<Vec<_>>();
 
-                    let coin_type = get_first_ty_as_struct_tag(coin_store.get_coin_type())
-                        .map_err(|e| anyhow::anyhow!("Coin type convert should succ :{}", e))?;
-                    let balance_info =
-                        BalanceInfo::new_with_default(coin_type, coin_store.get_coin_value());
-                    let v = (Some(key), balance_info);
-                    result.push(Some(v))
+                let coin_info_map = self.get_coin_infos(coin_types).await?;
+
+                let mut result = vec![];
+                for ((key, object_id), coin_store) in coin_store_ids.into_iter().zip(coin_stores) {
+                    let coin_store = coin_store.ok_or_else(|| {
+                        anyhow::anyhow!("Can not find CoinStore with id: {}", object_id)
+                    })?;
+                    let coin_info = coin_info_map
+                        .get(&coin_store.coin_type_tag())
+                        .cloned()
+                        .flatten()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("Can not find CoinInfo for {}", coin_store.coin_type())
+                        })?;
+                    let balance_info = BalanceInfo::new(coin_info.clone(), coin_store.balance());
+                    result.push((Some(key), balance_info))
                 }
-            };
-        } else {
-            // If the account do not exist, return None
-            result.push(None)
-        }
 
-        for (_key, balance_info) in result.iter_mut().flatten() {
-            let coin_info = coin_info_table
-                .get(&balance_info.coin_type)
-                .ok_or_else(|| anyhow::anyhow!("Get coin info by coin type should succ"))?;
-            balance_info.symbol = coin_info.symbol.clone();
-            balance_info.decimals = coin_info.decimals;
+                Ok(result)
+            }
+            None => Ok(vec![]),
         }
-
-        Ok(result)
     }
 
     pub async fn get_transaction_results_by_hash_and_order(

--- a/crates/rooch-types/src/account.rs
+++ b/crates/rooch-types/src/account.rs
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
-use crate::framework::coin;
-use move_core_types::language_storage::StructTag;
+use crate::framework::coin::CoinInfo;
 use move_core_types::u256::U256;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
 };
-use moveos_types::move_types::random_struct_tag;
 use moveos_types::{
     module_binding::{ModuleBinding, MoveFunctionCaller},
     state::{MoveStructState, MoveStructType},
@@ -90,43 +88,12 @@ impl AccountInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BalanceInfo {
-    pub coin_type: StructTag,
-    pub symbol: String,
+    pub coin_info: CoinInfo,
     pub balance: U256,
-    pub decimals: u8,
 }
 
 impl BalanceInfo {
-    pub fn new(coin_type: StructTag, symbol: String, balance: U256, decimals: u8) -> Self {
-        Self {
-            coin_type,
-            symbol,
-            balance,
-            decimals,
-        }
-    }
-
-    pub fn new_with_default(coin_type: StructTag, balance: U256) -> Self {
-        let default_symbol = coin_type.name.to_string();
-        let default_decimals = coin::DEFAULT_DECIMALS;
-        Self {
-            coin_type,
-            symbol: default_symbol,
-            balance,
-            decimals: default_decimals,
-        }
-    }
-
-    pub fn random() -> Self {
-        let coin_type = random_struct_tag();
-        let balance = U256::zero();
-        let symbol = coin_type.name.to_string();
-
-        BalanceInfo {
-            coin_type,
-            symbol,
-            balance,
-            decimals: 9u8,
-        }
+    pub fn new(coin_info: CoinInfo, balance: U256) -> Self {
+        Self { coin_info, balance }
     }
 }

--- a/crates/rooch-types/src/framework/coin.rs
+++ b/crates/rooch-types/src/framework/coin.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
-use anyhow::{bail, Result};
-use move_core_types::language_storage::StructTag;
+use anyhow::Result;
+use move_core_types::language_storage::{StructTag, TypeTag};
 use move_core_types::u256::U256;
+use move_core_types::value::MoveValue;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
-use move_resource_viewer::AnnotatedMoveValue;
+use moveos_types::move_string::MoveString;
 use moveos_types::object::ObjectID;
-use moveos_types::state::MoveState;
+use moveos_types::state::{MoveStructState, MoveStructType};
 use moveos_types::{
     module_binding::{ModuleBinding, MoveFunctionCaller},
     move_option::MoveOption,
@@ -16,7 +17,6 @@ use moveos_types::{
     tx_context::TxContext,
 };
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 
 pub const DEFAULT_DECIMALS: u8 = 9;
 
@@ -26,13 +26,15 @@ pub struct CoinModule<'a> {
 }
 
 impl<'a> CoinModule<'a> {
-    pub const COIN_STORE_HANDLE_FUNCTION_NAME: &'static IdentStr = ident_str!("coin_store_handle");
-    pub const COIN_INFO_HANDLE_FUNCTION_NAME: &'static IdentStr = ident_str!("coin_info_handle");
+    pub const COIN_STORES_HANDLE_FUNCTION_NAME: &'static IdentStr =
+        ident_str!("coin_stores_handle");
+    pub const COIN_INFOS_HANDLE_FUNCTION_NAME: &'static IdentStr = ident_str!("coin_infos_handle");
+    pub const COIN_STORE_ID: &'static IdentStr = ident_str!("coin_store_id");
 
-    pub fn coin_store_handle(&self, addr: AccountAddress) -> Result<Option<ObjectID>> {
+    pub fn coin_stores_handle(&self, addr: AccountAddress) -> Result<Option<ObjectID>> {
         let ctx = TxContext::zero();
         let call = FunctionCall::new(
-            Self::function_id(Self::COIN_STORE_HANDLE_FUNCTION_NAME),
+            Self::function_id(Self::COIN_STORES_HANDLE_FUNCTION_NAME),
             vec![],
             vec![addr.to_vec()],
         );
@@ -43,18 +45,18 @@ impl<'a> CoinModule<'a> {
             .map_err(|e| anyhow::anyhow!("Call coin store handle error:{}", e))?;
         let object_id = match result.get(0) {
             Some(value) => {
-                let object_id_result = MoveOption::<ObjectID>::from_bytes(&value.value);
-                Option::<ObjectID>::from(object_id_result?)
+                let object_id_result = MoveOption::<ObjectID>::from_bytes(&value.value)?;
+                Option::<ObjectID>::from(object_id_result)
             }
             None => None,
         };
         Ok(object_id)
     }
 
-    pub fn coin_info_handle(&self) -> Result<ObjectID> {
+    pub fn coin_infos_handle(&self) -> Result<ObjectID> {
         let ctx = TxContext::zero();
         let call = FunctionCall::new(
-            Self::function_id(Self::COIN_INFO_HANDLE_FUNCTION_NAME),
+            Self::function_id(Self::COIN_INFOS_HANDLE_FUNCTION_NAME),
             vec![],
             vec![],
         );
@@ -68,6 +70,33 @@ impl<'a> CoinModule<'a> {
             Some(value) => Ok(bcs::from_bytes::<ObjectID>(&value.value)?),
             None => Err(anyhow::anyhow!("Coin info handle should have value")),
         }
+    }
+
+    pub fn coin_store_id(
+        &self,
+        addr: AccountAddress,
+        coin_type: StructTag,
+    ) -> Result<Option<ObjectID>> {
+        let ctx = TxContext::zero();
+        let call = Self::create_function_call(
+            Self::COIN_STORE_ID,
+            vec![TypeTag::Struct(Box::new(coin_type))],
+            vec![MoveValue::Address(addr)],
+        );
+
+        let result = self
+            .caller
+            .call_function(&ctx, call)?
+            .into_result()
+            .map_err(|e| anyhow::anyhow!("Call coin store id error:{}", e))?;
+        let object_id = match result.get(0) {
+            Some(value) => {
+                let object_id_result = MoveOption::<ObjectID>::from_bytes(&value.value)?;
+                Option::<ObjectID>::from(object_id_result)
+            }
+            None => None,
+        };
+        Ok(object_id)
     }
 }
 
@@ -83,302 +112,184 @@ impl<'a> ModuleBinding<'a> for CoinModule<'a> {
     }
 }
 
-#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Coin {
+pub struct Coin<T> {
     pub value: U256,
+    pub phantom: std::marker::PhantomData<T>,
 }
 
-impl Coin {
+impl<T> Coin<T> {
     pub fn new(value: U256) -> Self {
-        Coin { value }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnnotatedCoin {
-    #[serde(rename = "type")]
-    pub type_: StructTag,
-    pub value: Coin,
-}
-
-impl AnnotatedCoin {
-    pub fn new(type_: StructTag, value: Coin) -> Self {
-        AnnotatedCoin { type_, value }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CompoundCoinStore {
-    pub coin: AnnotatedCoin,
-    pub frozen: bool,
-}
-
-impl CompoundCoinStore {
-    pub fn new(coin: AnnotatedCoin, frozen: bool) -> Self {
-        CompoundCoinStore { coin, frozen }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnnotatedCoinStore {
-    #[serde(rename = "type")]
-    pub type_: StructTag,
-    pub value: CompoundCoinStore,
-}
-
-impl AnnotatedCoinStore {
-    pub fn new(type_: StructTag, value: CompoundCoinStore) -> Self {
-        AnnotatedCoinStore { type_, value }
-    }
-
-    /// Create a new AnnotatedCoinStore from a AnnotatedMoveValue
-    pub fn new_from_annotated_move_value(annotated_move_value: AnnotatedMoveValue) -> Result<Self> {
-        match annotated_move_value {
-            AnnotatedMoveValue::Struct(annotated_struct) => {
-                let annotated_coin_store_type = annotated_struct.type_;
-                let mut fields = annotated_struct.value.into_iter();
-                let annotated_coin = match fields
-                    .next()
-                    .ok_or_else(|| anyhow::anyhow!("CoinStore should have coin field"))?
-                {
-                    (field_name, AnnotatedMoveValue::Struct(field_value)) => {
-                        debug_assert!(
-                            field_name.as_str() == "coin",
-                            "CoinStore field name should be coin"
-                        );
-                        let coin_type = field_value.type_;
-
-                        let mut inner_fields = field_value.value.into_iter();
-                        let coin_value = match inner_fields
-                            .next()
-                            .ok_or_else(|| anyhow::anyhow!("CoinValue coin should have value"))?
-                        {
-                            (field_name, AnnotatedMoveValue::U256(inner_field_value)) => {
-                                debug_assert!(
-                                    field_name.as_str() == "value",
-                                    "CoinValue coin field name should be value"
-                                );
-                                inner_field_value
-                            }
-                            _ => bail!("CoinValue coin value field type should be U256"),
-                        };
-                        let coin = Coin { value: coin_value };
-                        AnnotatedCoin {
-                            type_: coin_type,
-                            value: coin,
-                        }
-                    }
-                    _ => bail!("CoinStore coin field type should be Struct"),
-                };
-                let frozen = match fields
-                    .next()
-                    .ok_or_else(|| anyhow::anyhow!("CoinStore should have frozen field"))?
-                {
-                    (field_name, AnnotatedMoveValue::Bool(field_value)) => {
-                        debug_assert!(
-                            field_name.as_str() == "frozen",
-                            "CoinStore field name should be frozen"
-                        );
-                        field_value
-                    }
-                    _ => bail!("CoinStore frozen field type should be Bool"),
-                };
-                let compose_coin_store = CompoundCoinStore {
-                    coin: annotated_coin,
-                    frozen,
-                };
-
-                let annotated_coin_store = AnnotatedCoinStore {
-                    type_: annotated_coin_store_type,
-                    value: compose_coin_store,
-                };
-
-                Ok(annotated_coin_store)
-            }
-            _ => bail!("CoinStore move value type should be Struct"),
+        Coin {
+            value,
+            phantom: std::marker::PhantomData,
         }
     }
+}
 
-    pub fn get_coin_type(&self) -> StructTag {
-        self.value.coin.type_.clone()
+impl<T> MoveStructType for Coin<T>
+where
+    T: MoveStructType,
+{
+    const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = ident_str!("coin");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Coin");
+
+    fn struct_tag() -> move_core_types::language_storage::StructTag {
+        move_core_types::language_storage::StructTag {
+            address: Self::ADDRESS,
+            module: Self::MODULE_NAME.to_owned(),
+            name: Self::STRUCT_NAME.to_owned(),
+            type_params: vec![T::struct_tag().into()],
+        }
     }
+}
 
-    pub fn get_coin_value(&self) -> U256 {
-        self.value.coin.value.value
+impl<T> MoveStructState for Coin<T>
+where
+    T: MoveStructType,
+{
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            move_core_types::value::MoveTypeLayout::U256,
+        ])
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Balance {
+    value: U256,
+}
+
+impl MoveStructType for Balance {
+    const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = ident_str!("coin");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Balance");
+
+    fn struct_tag() -> move_core_types::language_storage::StructTag {
+        move_core_types::language_storage::StructTag {
+            address: Self::ADDRESS,
+            module: Self::MODULE_NAME.to_owned(),
+            name: Self::STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+impl MoveStructState for Balance {
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            move_core_types::value::MoveTypeLayout::U256,
+        ])
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoinStore {
+    coin_type: MoveString,
+    balance: Balance,
+    frozen: bool,
+}
+
+impl MoveStructType for CoinStore {
+    const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = ident_str!("coin");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("CoinStore");
+
+    fn struct_tag() -> move_core_types::language_storage::StructTag {
+        move_core_types::language_storage::StructTag {
+            address: Self::ADDRESS,
+            module: Self::MODULE_NAME.to_owned(),
+            name: Self::STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+impl MoveStructState for CoinStore {
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            MoveString::type_layout(),
+            Balance::type_layout(),
+            move_core_types::value::MoveTypeLayout::Bool,
+        ])
+    }
+}
+
+impl CoinStore {
+    pub fn coin_type(&self) -> String {
+        self.coin_type.to_string()
+    }
+    pub fn coin_type_tag(&self) -> StructTag {
+        let coin_type_str = format!("0x{}", self.coin_type);
+        coin_type_str
+            .parse::<StructTag>()
+            .expect("CoinType in CoinStore should be valid StructTag")
+    }
+    pub fn balance(&self) -> U256 {
+        self.balance.value
+    }
+    pub fn frozen(&self) -> bool {
+        self.frozen
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoinInfo {
-    pub name: String,
-    pub symbol: String,
-    pub decimals: u8,
-    pub supply: U256,
+    coin_type: MoveString,
+    name: MoveString,
+    symbol: MoveString,
+    decimals: u8,
+    supply: U256,
 }
-//
-// #[derive(Debug, Clone, Serialize, Deserialize)]
-// pub struct CoinInfo<T> {
-//     pub name: String,
-//     pub symbol: String,
-//     pub decimals: u8,
-//     pub supply: U256,
-//     pub coin_type: std::marker::PhantomData<T>,
-// }
-//
-// impl<T> MoveStructType for CoinInfo<T>
-//     where T: MoveStructType, {
-//     const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
-//     const MODULE_NAME: &'static IdentStr = ident_str!("coin");
-//     const STRUCT_NAME: &'static IdentStr = ident_str!("CoinInfo");
-//
-//     fn struct_tag() -> move_core_types::language_storage::StructTag {
-//         move_core_types::language_storage::StructTag {
-//             address: Self::ADDRESS,
-//             module: Self::MODULE_NAME.to_owned(),
-//             name: Self::STRUCT_NAME.to_owned(),
-//             type_params: vec![T::type_tag()],
-//         }
-//     }
-// }
-//
-// impl<T> MoveStructState for CoinInfo<T> where T: MoveStructType, {
-//     fn struct_layout() -> move_core_types::value::MoveStructLayout {
-//         move_core_types::value::MoveStructLayout::new(vec![
-//             move_core_types::value::MoveTypeLayout::Vector(Box::new(
-//                 move_core_types::value::MoveTypeLayout::U8,
-//             )),
-//             move_core_types::value::MoveTypeLayout::Vector(Box::new(
-//                 move_core_types::value::MoveTypeLayout::U8,
-//             )),
-//             move_core_types::value::MoveTypeLayout::U8,
-//             move_core_types::value::MoveTypeLayout::U256,
-//         ])
-//     }
-// }
+
+impl MoveStructType for CoinInfo {
+    const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = ident_str!("coin");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("CoinInfo");
+
+    fn struct_tag() -> move_core_types::language_storage::StructTag {
+        move_core_types::language_storage::StructTag {
+            address: Self::ADDRESS,
+            module: Self::MODULE_NAME.to_owned(),
+            name: Self::STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+impl MoveStructState for CoinInfo {
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            MoveString::type_layout(),
+            MoveString::type_layout(),
+            MoveString::type_layout(),
+            move_core_types::value::MoveTypeLayout::U8,
+            move_core_types::value::MoveTypeLayout::U256,
+        ])
+    }
+}
 
 impl CoinInfo {
-    pub fn new(name: String, symbol: String, decimals: u8, supply: U256) -> Self {
-        CoinInfo {
-            name,
-            symbol,
-            decimals,
-            supply,
-        }
+    pub fn coin_type(&self) -> String {
+        self.coin_type.to_string()
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnnotatedCoinInfo {
-    #[serde(rename = "type")]
-    pub type_: StructTag,
-    pub value: CoinInfo,
-}
-
-impl AnnotatedCoinInfo {
-    pub fn new(type_: StructTag, value: CoinInfo) -> Self {
-        AnnotatedCoinInfo { type_, value }
+    pub fn coin_type_tag(&self) -> StructTag {
+        let coin_type_str = format!("0x{}", self.coin_type);
+        coin_type_str
+            .parse::<StructTag>()
+            .expect("CoinType in CoinInfo should be valid StructTag")
     }
-
-    /// Create a new AnnotatedCoinInfo from a AnnotatedMoveValue
-    pub fn new_from_annotated_move_value(annotated_move_value: AnnotatedMoveValue) -> Result<Self> {
-        match annotated_move_value {
-            AnnotatedMoveValue::Struct(annotated_struct) => {
-                let type_ = annotated_struct.type_;
-                let mut fields = annotated_struct.value.into_iter();
-
-                let name = match fields
-                    .next()
-                    .ok_or_else(|| anyhow::anyhow!("CoinInfo should have name field"))?
-                {
-                    (_field_name, AnnotatedMoveValue::Struct(field_value)) => {
-                        let mut inner_fields = field_value.value.into_iter();
-                        match inner_fields.next().ok_or_else(|| {
-                            anyhow::anyhow!("CoinInfo name field should have value")
-                        })? {
-                            (field_name, AnnotatedMoveValue::Bytes(field_value)) => {
-                                debug_assert!(
-                                    field_name.as_str() == "bytes",
-                                    "CoinInfo name inner field name should be Bytes"
-                                );
-                                String::from_utf8(field_value)?
-                            }
-                            _ => bail!("CoinInfo name inner field type should be Bytes"),
-                        }
-                    }
-                    _ => bail!("CoinInfo name field type should be Struct"),
-                };
-                let symbol = match fields
-                    .next()
-                    .ok_or_else(|| anyhow::anyhow!("CoinInfo should have symbol field"))?
-                {
-                    (_field_name, AnnotatedMoveValue::Struct(field_value)) => {
-                        let mut inner_fields = field_value.value.into_iter();
-                        match inner_fields.next().ok_or_else(|| {
-                            anyhow::anyhow!("CoinInfo symbol struct should have value")
-                        })? {
-                            (field_name, AnnotatedMoveValue::Bytes(field_value)) => {
-                                debug_assert!(
-                                    field_name.as_str() == "bytes",
-                                    "CoinInfo symbol inner field name should be bytes"
-                                );
-                                String::from_utf8(field_value)?
-                            }
-                            _ => bail!("CoinInfo symbol inner field type should be Bytes"),
-                        }
-                    }
-                    _ => bail!("CoinInfo symbol field type should be Struct"),
-                };
-                let decimals = match fields
-                    .next()
-                    .ok_or_else(|| anyhow::anyhow!("CoinInfo should have decimals field"))?
-                {
-                    (field_name, AnnotatedMoveValue::U8(field_value)) => {
-                        debug_assert!(
-                            field_name.as_str() == "decimals",
-                            "CoinInfo field name should be decimals"
-                        );
-                        field_value
-                    }
-                    _ => bail!("CoinInfo decimals field type should be U8"),
-                };
-                let supply = match fields
-                    .next()
-                    .ok_or_else(|| anyhow::anyhow!("CoinInfo should have supply field"))?
-                {
-                    (field_name, AnnotatedMoveValue::U256(field_value)) => {
-                        debug_assert!(
-                            field_name.as_str() == "supply",
-                            "CoinInfo field name should be supply"
-                        );
-                        field_value
-                    }
-                    _ => bail!("CoinInfo supply field should be U256"),
-                };
-
-                let coin_info = CoinInfo {
-                    name,
-                    symbol,
-                    decimals,
-                    supply,
-                };
-
-                let annotated_coin_info = AnnotatedCoinInfo {
-                    type_,
-                    value: coin_info,
-                };
-
-                Ok(annotated_coin_info)
-            }
-            _ => bail!("CoinInfo move value type should be Struct"),
-        }
+    pub fn name(&self) -> String {
+        self.name.to_string()
     }
-
-    pub fn get_type(&self) -> StructTag {
-        self.type_.clone()
+    pub fn symbol(&self) -> String {
+        self.symbol.to_string()
     }
-
-    pub fn get_decimals(&self) -> u8 {
-        self.value.decimals
+    pub fn decimals(&self) -> u8 {
+        self.decimals
+    }
+    pub fn supply(&self) -> U256 {
+        self.supply
     }
 }

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -44,28 +44,31 @@ impl CommandAction<()> for BalanceCommand {
 
         let client = context.get_client().await?;
 
-        let data = client
-            .get_balances(
-                address_addr,
-                self.coin_type,
-                None,
-                Some(MAX_RESULT_LIMIT_USIZE),
-            )
-            .await?;
+        let balances = match self.coin_type {
+            Some(coin_type) => {
+                vec![client.get_balance(address_addr, coin_type).await?]
+            }
+            None => {
+                client
+                    .get_balances(address_addr, None, Some(MAX_RESULT_LIMIT_USIZE))
+                    .await?
+                    .data
+            }
+        };
 
         println!(
-            "{0: ^102} | {1: ^16} | {2: ^32} | {3: ^6}",
-            "Coin Type", "Symbol", "Balance", "Decimals"
+            "{0: ^102} | {1: ^16} | {2: ^6} |  {3: ^32} ",
+            "Coin Type", "Symbol", "Decimals", "Balance"
         );
         println!("{}", ["-"; 68].join(""));
 
-        for balance_info in data.data.into_iter().flatten() {
+        for balance_info in balances {
             println!(
-                "{0: ^102} | {1: ^16} | {2: ^32} | {3: ^6}",
-                balance_info.coin_type,
-                balance_info.symbol,
+                "{0: ^102} | {1: ^16} | {2: ^6} | {3: ^32} ",
+                balance_info.coin_info.coin_type,
+                balance_info.coin_info.symbol,
+                balance_info.coin_info.decimals,
                 balance_info.balance,
-                balance_info.decimals
             );
         }
 

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -46,10 +46,11 @@ impl CommandAction<()> for BalanceCommand {
 
         let balances = match self.coin_type {
             Some(coin_type) => {
-                vec![client.get_balance(address_addr, coin_type).await?]
+                vec![client.rooch.get_balance(address_addr, coin_type).await?]
             }
             None => {
                 client
+                    .rooch
                     .get_balances(address_addr, None, Some(MAX_RESULT_LIMIT_USIZE))
                     .await?
                     .data

--- a/crates/rooch/src/commands/event.rs
+++ b/crates/rooch/src/commands/event.rs
@@ -51,6 +51,7 @@ impl CommandAction<EventPageView> for GetEventsByEventHandle {
     async fn execute(self) -> RoochResult<EventPageView> {
         let client = self.context_options.build().await?.get_client().await?;
         let resp = client
+            .rooch
             .get_events_by_event_handle(self.event_handle_type.into(), self.cursor, self.limit)
             .await
             .map_err(RoochError::from)?;

--- a/crates/rooch/src/commands/move_cli/commands/run_view_function.rs
+++ b/crates/rooch/src/commands/move_cli/commands/run_view_function.rs
@@ -68,6 +68,7 @@ impl CommandAction<AnnotatedFunctionResultView> for RunViewFunction {
 
         let client = self.context.build().await?.get_client().await?;
         client
+            .rooch
             .execute_view_function(function_call)
             .await
             .map_err(|e| RoochError::ViewFunctionError(e.to_string()))

--- a/crates/rooch/src/commands/object.rs
+++ b/crates/rooch/src/commands/object.rs
@@ -24,6 +24,7 @@ impl CommandAction<Option<AnnotatedStateView>> for ObjectCommand {
     async fn execute(self) -> RoochResult<Option<AnnotatedStateView>> {
         let client = self.context_options.build().await?.get_client().await?;
         let resp = client
+            .rooch
             .get_annotated_states(AccessPath::object(self.id))
             .await?
             .pop()

--- a/crates/rooch/src/commands/resource.rs
+++ b/crates/rooch/src/commands/resource.rs
@@ -32,6 +32,7 @@ impl CommandAction<Option<AnnotatedStateView>> for ResourceCommand {
         let client = self.context_options.build().await?.get_client().await?;
 
         let resp = client
+            .rooch
             .get_annotated_states(AccessPath::resource(self.address, self.resource))
             .await?
             .pop()

--- a/crates/rooch/src/commands/state.rs
+++ b/crates/rooch/src/commands/state.rs
@@ -29,6 +29,7 @@ impl CommandAction<Vec<Option<AnnotatedStateView>>> for StateCommand {
         let client = self.context_options.build().await?.get_client().await?;
 
         let resp = client
+            .rooch
             .get_annotated_states(self.access_path)
             .await
             .map_err(RoochError::from)?;

--- a/crates/rooch/src/commands/transaction/commands/get_transactions_by_hash.rs
+++ b/crates/rooch/src/commands/transaction/commands/get_transactions_by_hash.rs
@@ -23,7 +23,7 @@ impl CommandAction<Vec<Option<TransactionResultView>>> for GetTransactionsByHash
     async fn execute(self) -> RoochResult<Vec<Option<TransactionResultView>>> {
         let client = self.context_options.build().await?.get_client().await?;
 
-        let resp = client.get_transactions_by_hash(self.hashes).await?;
+        let resp = client.rooch.get_transactions_by_hash(self.hashes).await?;
 
         Ok(resp)
     }

--- a/crates/rooch/src/commands/transaction/commands/get_transactions_by_order.rs
+++ b/crates/rooch/src/commands/transaction/commands/get_transactions_by_order.rs
@@ -26,6 +26,7 @@ impl CommandAction<TransactionResultPageView> for GetTransactionsByOrderCommand 
         let client = self.context_options.build().await?.get_client().await?;
 
         let resp = client
+            .rooch
             .get_transactions_by_order(self.cursor, self.limit)
             .await?;
 

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -4,7 +4,6 @@ Feature: Rooch CLI integration tests
       Then cmd: "init"
       Then cmd: "env switch --alias local"
 
-
     @serial
     Scenario: account
       Given a server for account
@@ -152,9 +151,12 @@ Feature: Rooch CLI integration tests
       Then stop the server
 
   @serial
-    Scenario: rpc test
-      Given a server for rpc
+    Scenario: ethereum rpc test
+      Given a server for ethereum
       Then cmd: "rpc request --method eth_getBalance --params \"0x1111111111111111111111111111111111111111\""
-      Then assert: "{{$.result}}" equals "0x56bc75e2d63100000"
-
+      Then assert: "{{$.rpc[-1]}} == 0x56bc75e2d63100000"
+      Then cmd: "rpc request --method eth_feeHistory --params [\"0x5\",\"0x6524cad7\",[10,20,30]]"
+      Then assert: ""{{$.rpc[-1]}}" contains baseFeePerGas"
       Then stop the server
+
+

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -19,6 +19,7 @@ Feature: Rooch CLI integration tests
       # session key
       Then cmd: "session-key create --sender-account {default} --scope 0x3::empty::empty"
       Then cmd: "move run --function 0x3::empty::empty --sender-account {default} --session-key {{$.session-key[-1].authentication_key}}"
+      Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
       # transaction
       Then cmd: "transaction get-transactions-by-order --cursor 0 --limit 1"
@@ -26,12 +27,16 @@ Feature: Rooch CLI integration tests
 
       # event example
       Then cmd: "move publish -p ../../examples/event --sender-account {default} --named-addresses rooch_examples={default}"
+      Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function {default}::event_test::emit_event --sender-account {default} --args 10u64"
+      Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "event get-events-by-event-handle --event_handle_type {default}::event_test::WithdrawEvent --cursor 0 --limit 1"
 
       # account balance
       Then cmd: "move publish -p ../../examples/coins --sender-account {default} --named-addresses coins={default}"
+      Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function {default}::fixed_supply_coin::faucet --sender-account {default}"
+      Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "account balance"
       Then cmd: "account balance --coin-type {default}::fixed_supply_coin::FSC"
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/README.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/README.md
@@ -23,6 +23,7 @@ This is the reference documentation of the MoveOS standard library.
 -  [`0x2::move_module`](move_module.md#0x2_move_module)
 -  [`0x2::object`](object.md#0x2_object)
 -  [`0x2::object_id`](object_id.md#0x2_object_id)
+-  [`0x2::object_ref`](object_ref.md#0x2_object_ref)
 -  [`0x2::raw_table`](raw_table.md#0x2_raw_table)
 -  [`0x2::rlp`](rlp.md#0x2_rlp)
 -  [`0x2::signer`](signer.md#0x2_signer)

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/context.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/context.md
@@ -24,6 +24,7 @@ and let developers customize the storage
 -  [Function `borrow_object`](#0x2_context_borrow_object)
 -  [Function `borrow_object_mut`](#0x2_context_borrow_object_mut)
 -  [Function `remove_object`](#0x2_context_remove_object)
+-  [Function `remove_object_with_ref`](#0x2_context_remove_object_with_ref)
 -  [Function `add_object`](#0x2_context_add_object)
 -  [Function `contains_object`](#0x2_context_contains_object)
 -  [Function `new_object`](#0x2_context_new_object)
@@ -33,6 +34,7 @@ and let developers customize the storage
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
+<b>use</b> <a href="object_ref.md#0x2_object_ref">0x2::object_ref</a>;
 <b>use</b> <a href="storage_context.md#0x2_storage_context">0x2::storage_context</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="tx_meta.md#0x2_tx_meta">0x2::tx_meta</a>;
@@ -444,6 +446,31 @@ Remove object from object store
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_remove_object">remove_object</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="context.md#0x2_context_Context">Context</a>, <a href="object_id.md#0x2_object_id">object_id</a>: ObjectID): Object&lt;T&gt; {
+    <a href="storage_context.md#0x2_storage_context_remove">storage_context::remove</a>&lt;T&gt;(&<b>mut</b> self.<a href="storage_context.md#0x2_storage_context">storage_context</a>, <a href="object_id.md#0x2_object_id">object_id</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_context_remove_object_with_ref"></a>
+
+## Function `remove_object_with_ref`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_remove_object_with_ref">remove_object_with_ref</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="context.md#0x2_context_Context">context::Context</a>, <a href="object_ref.md#0x2_object_ref">object_ref</a>: <a href="object_ref.md#0x2_object_ref_ObjectRef">object_ref::ObjectRef</a>&lt;T&gt;): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="context.md#0x2_context_remove_object_with_ref">remove_object_with_ref</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="context.md#0x2_context_Context">Context</a>, <a href="object_ref.md#0x2_object_ref">object_ref</a>: ObjectRef&lt;T&gt;): Object&lt;T&gt; {
+    <b>let</b> <a href="object_id.md#0x2_object_id">object_id</a> = <a href="object_ref.md#0x2_object_ref_into_id">object_ref::into_id</a>(<a href="object_ref.md#0x2_object_ref">object_ref</a>);
     <a href="storage_context.md#0x2_storage_context_remove">storage_context::remove</a>&lt;T&gt;(&<b>mut</b> self.<a href="storage_context.md#0x2_storage_context">storage_context</a>, <a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
@@ -14,7 +14,9 @@ The differents with the Object in [Sui](https://github.com/MystenLabs/sui/blob/5
 -  [Function `new`](#0x2_object_new)
 -  [Function `new_with_id`](#0x2_object_new_with_id)
 -  [Function `borrow`](#0x2_object_borrow)
+-  [Function `internal_borrow`](#0x2_object_internal_borrow)
 -  [Function `borrow_mut`](#0x2_object_borrow_mut)
+-  [Function `internal_borrow_mut`](#0x2_object_internal_borrow_mut)
 -  [Function `transfer`](#0x2_object_transfer)
 -  [Function `id`](#0x2_object_id)
 -  [Function `owner`](#0x2_object_owner)
@@ -142,6 +144,30 @@ Create a new object, the object is owned by <code>owner</code>
 
 </details>
 
+<a name="0x2_object_internal_borrow"></a>
+
+## Function `internal_borrow`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_internal_borrow">internal_borrow</a>&lt;T&gt;(self: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): &T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_internal_borrow">internal_borrow</a>&lt;T&gt;(self: &<a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): &T {
+    &self.value
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_object_borrow_mut"></a>
 
 ## Function `borrow_mut`
@@ -159,6 +185,30 @@ Borrow the mutable object value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_mut">borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): &<b>mut</b> T {
+    &<b>mut</b> self.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_internal_borrow_mut"></a>
+
+## Function `internal_borrow_mut`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_internal_borrow_mut">internal_borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): &<b>mut</b> T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_internal_borrow_mut">internal_borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): &<b>mut</b> T {
     &<b>mut</b> self.value
 }
 </code></pre>
@@ -247,7 +297,7 @@ Transfer object to recipient
 Unpack the object, return the id, owner, and value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_unpack">unpack</a>&lt;T&gt;(obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): (<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>, <b>address</b>, T)
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_unpack">unpack</a>&lt;T&gt;(self: <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): (<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>, <b>address</b>, T)
 </code></pre>
 
 
@@ -256,8 +306,8 @@ Unpack the object, return the id, owner, and value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_unpack">unpack</a>&lt;T&gt;(obj: <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): (ObjectID, <b>address</b>, T) {
-    <b>let</b> <a href="object.md#0x2_object_Object">Object</a>{id, owner, value} = obj;
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_unpack">unpack</a>&lt;T&gt;(self: <a href="object.md#0x2_object_Object">Object</a>&lt;T&gt;): (ObjectID, <b>address</b>, T) {
+    <b>let</b> <a href="object.md#0x2_object_Object">Object</a>{id, owner, value} = self;
     (id, owner, value)
 }
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object_ref.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object_ref.md
@@ -1,0 +1,260 @@
+
+<a name="0x2_object_ref"></a>
+
+# Module `0x2::object_ref`
+
+
+
+-  [Resource `ObjectRef`](#0x2_object_ref_ObjectRef)
+-  [Function `new`](#0x2_object_ref_new)
+-  [Function `new_with_id`](#0x2_object_ref_new_with_id)
+-  [Function `borrow`](#0x2_object_ref_borrow)
+-  [Function `borrow_mut`](#0x2_object_ref_borrow_mut)
+-  [Function `id`](#0x2_object_ref_id)
+-  [Function `owner`](#0x2_object_ref_owner)
+-  [Function `contains`](#0x2_object_ref_contains)
+-  [Function `into_id`](#0x2_object_ref_into_id)
+
+
+<pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
+<b>use</b> <a href="raw_table.md#0x2_raw_table">0x2::raw_table</a>;
+</code></pre>
+
+
+
+<a name="0x2_object_ref_ObjectRef"></a>
+
+## Resource `ObjectRef`
+
+ObjectRef<T> is a reference of the Object<T>
+It likes ObjectID, but it contains the type information of the object.
+TODO should we support drop?
+
+
+<pre><code><b>struct</b> <a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a>&lt;T&gt; <b>has</b> <b>copy</b>, drop, store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_object_ref_new"></a>
+
+## Function `new`
+
+Get the object reference
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_new">new</a>&lt;T: key&gt;(<a href="object.md#0x2_object">object</a>: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): <a href="object_ref.md#0x2_object_ref_ObjectRef">object_ref::ObjectRef</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_new">new</a>&lt;T: key&gt;(<a href="object.md#0x2_object">object</a>: &Object&lt;T&gt;) : <a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a>&lt;T&gt; {
+    //TODO should we track the reference count?
+    <a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a> {
+        id: <a href="object.md#0x2_object_id">object::id</a>(<a href="object.md#0x2_object">object</a>),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_ref_new_with_id"></a>
+
+## Function `new_with_id`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_ref.md#0x2_object_ref_new_with_id">new_with_id</a>&lt;T&gt;(id: <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): <a href="object_ref.md#0x2_object_ref_ObjectRef">object_ref::ObjectRef</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object_ref.md#0x2_object_ref_new_with_id">new_with_id</a>&lt;T&gt;(id: ObjectID): <a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a>&lt;T&gt; {
+    <a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a> {
+        id: id,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_ref_borrow"></a>
+
+## Function `borrow`
+
+Borrow the object value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_borrow">borrow</a>&lt;T: key&gt;(self: &<a href="object_ref.md#0x2_object_ref_ObjectRef">object_ref::ObjectRef</a>&lt;T&gt;): &T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_borrow">borrow</a>&lt;T: key&gt;(self: &<a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a>&lt;T&gt;): &T {
+    <b>let</b> obj = <a href="raw_table.md#0x2_raw_table_borrow_from_global">raw_table::borrow_from_global</a>&lt;T&gt;(&self.id);
+    <a href="object.md#0x2_object_internal_borrow">object::internal_borrow</a>(obj)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_ref_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Borrow the object mutable value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_borrow_mut">borrow_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_ref.md#0x2_object_ref_ObjectRef">object_ref::ObjectRef</a>&lt;T&gt;): &<b>mut</b> T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_borrow_mut">borrow_mut</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a>&lt;T&gt;): &<b>mut</b> T {
+    <b>let</b> obj = <a href="raw_table.md#0x2_raw_table_borrow_mut_from_global">raw_table::borrow_mut_from_global</a>&lt;T&gt;(&self.id);
+    <a href="object.md#0x2_object_internal_borrow_mut">object::internal_borrow_mut</a>(obj)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_ref_id"></a>
+
+## Function `id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_id">id</a>&lt;T&gt;(self: &<a href="object_ref.md#0x2_object_ref_ObjectRef">object_ref::ObjectRef</a>&lt;T&gt;): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_id">id</a>&lt;T&gt;(self: &<a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a>&lt;T&gt;): ObjectID {
+    self.id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_ref_owner"></a>
+
+## Function `owner`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_owner">owner</a>&lt;T: key&gt;(self: &<a href="object_ref.md#0x2_object_ref_ObjectRef">object_ref::ObjectRef</a>&lt;T&gt;): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_owner">owner</a>&lt;T: key&gt;(self: &<a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a>&lt;T&gt;): <b>address</b> {
+    <b>let</b> obj = <a href="raw_table.md#0x2_raw_table_borrow_from_global">raw_table::borrow_from_global</a>&lt;T&gt;(&self.id);
+    <a href="object.md#0x2_object_owner">object::owner</a>(obj)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_ref_contains"></a>
+
+## Function `contains`
+
+Check if the object is still contains in the global storage
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_contains">contains</a>&lt;T: key&gt;(self: &<a href="object_ref.md#0x2_object_ref_ObjectRef">object_ref::ObjectRef</a>&lt;T&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_contains">contains</a>&lt;T: key&gt;(self: &<a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a>&lt;T&gt;): bool {
+    <a href="raw_table.md#0x2_raw_table_contains_global">raw_table::contains_global</a>(&self.id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_object_ref_into_id"></a>
+
+## Function `into_id`
+
+Convert the ObjectRef to ObjectID
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_into_id">into_id</a>&lt;T: key&gt;(self: <a href="object_ref.md#0x2_object_ref_ObjectRef">object_ref::ObjectRef</a>&lt;T&gt;): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_ref.md#0x2_object_ref_into_id">into_id</a>&lt;T: key&gt;(self: <a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a>&lt;T&gt;): ObjectID {
+    <b>let</b> <a href="object_ref.md#0x2_object_ref_ObjectRef">ObjectRef</a> {id} = self;
+    id
+}
+</code></pre>
+
+
+
+</details>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/raw_table.md
@@ -11,14 +11,18 @@ This type table is for internal global storage, so all functions are friend.
 -  [Resource `TableInfo`](#0x2_raw_table_TableInfo)
 -  [Resource `Box`](#0x2_raw_table_Box)
 -  [Constants](#@Constants_0)
+-  [Function `global_object_storage_handle`](#0x2_raw_table_global_object_storage_handle)
 -  [Function `add`](#0x2_raw_table_add)
 -  [Function `borrow`](#0x2_raw_table_borrow)
+-  [Function `borrow_from_global`](#0x2_raw_table_borrow_from_global)
 -  [Function `borrow_with_default`](#0x2_raw_table_borrow_with_default)
 -  [Function `borrow_mut`](#0x2_raw_table_borrow_mut)
+-  [Function `borrow_mut_from_global`](#0x2_raw_table_borrow_mut_from_global)
 -  [Function `borrow_mut_with_default`](#0x2_raw_table_borrow_mut_with_default)
 -  [Function `upsert`](#0x2_raw_table_upsert)
 -  [Function `remove`](#0x2_raw_table_remove)
 -  [Function `contains`](#0x2_raw_table_contains)
+-  [Function `contains_global`](#0x2_raw_table_contains_global)
 -  [Function `length`](#0x2_raw_table_length)
 -  [Function `is_empty`](#0x2_raw_table_is_empty)
 -  [Function `drop_unchecked`](#0x2_raw_table_drop_unchecked)
@@ -26,7 +30,8 @@ This type table is for internal global storage, so all functions are friend.
 -  [Function `new_table_handle`](#0x2_raw_table_new_table_handle)
 
 
-<pre><code><b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
+<pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="object_id.md#0x2_object_id">0x2::object_id</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
@@ -129,6 +134,40 @@ Can not found the key in the table
 
 
 
+<a name="0x2_raw_table_GlobalObjectStorageHandle"></a>
+
+
+
+<pre><code><b>const</b> <a href="raw_table.md#0x2_raw_table_GlobalObjectStorageHandle">GlobalObjectStorageHandle</a>: <b>address</b> = 0;
+</code></pre>
+
+
+
+<a name="0x2_raw_table_global_object_storage_handle"></a>
+
+## Function `global_object_storage_handle`
+
+The global object storage's table handle should be <code>0x0</code>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_global_object_storage_handle">global_object_storage_handle</a>(): <a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_global_object_storage_handle">global_object_storage_handle</a>(): ObjectID {
+    <a href="object_id.md#0x2_object_id_address_to_object_id">object_id::address_to_object_id</a>(<a href="raw_table.md#0x2_raw_table_GlobalObjectStorageHandle">GlobalObjectStorageHandle</a>)
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x2_raw_table_add"></a>
 
 ## Function `add`
@@ -148,7 +187,7 @@ table, and cannot be discovered from it.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_add">add</a>&lt;K: <b>copy</b> + drop, V&gt;(table_handle: &ObjectID, key: K, val: V) {
-    <a href="raw_table.md#0x2_raw_table_add_box">add_box</a>&lt;K, V, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;V&gt;&gt;(table_handle, key, <a href="raw_table.md#0x2_raw_table_Box">Box</a> {val} );
+    <a href="raw_table.md#0x2_raw_table_add_box">add_box</a>&lt;K, V, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;V&gt;&gt;(*table_handle, key, <a href="raw_table.md#0x2_raw_table_Box">Box</a> {val} );
 }
 </code></pre>
 
@@ -174,7 +213,31 @@ Aborts if there is no entry for <code>key</code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_borrow">borrow</a>&lt;K: <b>copy</b> + drop, V&gt;(table_handle: &ObjectID, key: K): &V {
-    &<a href="raw_table.md#0x2_raw_table_borrow_box">borrow_box</a>&lt;K, V, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;V&gt;&gt;(table_handle, key).val
+    &<a href="raw_table.md#0x2_raw_table_borrow_box">borrow_box</a>&lt;K, V, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;V&gt;&gt;(*table_handle, key).val
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_raw_table_borrow_from_global"></a>
+
+## Function `borrow_from_global`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_borrow_from_global">borrow_from_global</a>&lt;T: key&gt;(<a href="object_id.md#0x2_object_id">object_id</a>: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_borrow_from_global">borrow_from_global</a>&lt;T: key&gt;(<a href="object_id.md#0x2_object_id">object_id</a>: &ObjectID): &Object&lt;T&gt; {
+    &<a href="raw_table.md#0x2_raw_table_borrow_box">borrow_box</a>&lt;ObjectID, Object&lt;T&gt;, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;Object&lt;T&gt;&gt;&gt;(<a href="raw_table.md#0x2_raw_table_global_object_storage_handle">global_object_storage_handle</a>(), *<a href="object_id.md#0x2_object_id">object_id</a>).val
 }
 </code></pre>
 
@@ -230,7 +293,31 @@ Aborts if there is no entry for <code>key</code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop, V&gt;(table_handle: &ObjectID, key: K): &<b>mut</b> V {
-    &<b>mut</b> <a href="raw_table.md#0x2_raw_table_borrow_box_mut">borrow_box_mut</a>&lt;K, V, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;V&gt;&gt;(table_handle, key).val
+    &<b>mut</b> <a href="raw_table.md#0x2_raw_table_borrow_box_mut">borrow_box_mut</a>&lt;K, V, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;V&gt;&gt;(*table_handle, key).val
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_raw_table_borrow_mut_from_global"></a>
+
+## Function `borrow_mut_from_global`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_borrow_mut_from_global">borrow_mut_from_global</a>&lt;T: key&gt;(<a href="object_id.md#0x2_object_id">object_id</a>: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_borrow_mut_from_global">borrow_mut_from_global</a>&lt;T: key&gt;(<a href="object_id.md#0x2_object_id">object_id</a>: &ObjectID): &<b>mut</b> Object&lt;T&gt; {
+    &<b>mut</b> <a href="raw_table.md#0x2_raw_table_borrow_box_mut">borrow_box_mut</a>&lt;ObjectID, Object&lt;T&gt;, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;Object&lt;T&gt;&gt;&gt;(<a href="raw_table.md#0x2_raw_table_global_object_storage_handle">global_object_storage_handle</a>(), *<a href="object_id.md#0x2_object_id">object_id</a>).val
 }
 </code></pre>
 
@@ -316,7 +403,7 @@ Aborts if there is no entry for <code>key</code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_remove">remove</a>&lt;K: <b>copy</b> + drop, V&gt;(table_handle: &ObjectID, key: K): V {
-    <b>let</b> <a href="raw_table.md#0x2_raw_table_Box">Box</a> { val } = <a href="raw_table.md#0x2_raw_table_remove_box">remove_box</a>&lt;K, V, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;V&gt;&gt;(table_handle, key);
+    <b>let</b> <a href="raw_table.md#0x2_raw_table_Box">Box</a> { val } = <a href="raw_table.md#0x2_raw_table_remove_box">remove_box</a>&lt;K, V, <a href="raw_table.md#0x2_raw_table_Box">Box</a>&lt;V&gt;&gt;(*table_handle, key);
     val
 }
 </code></pre>
@@ -342,7 +429,31 @@ Returns true if <code><a href="table.md#0x2_table">table</a></code> contains an 
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_contains">contains</a>&lt;K: <b>copy</b> + drop&gt;(table_handle: &ObjectID, key: K): bool {
-    <a href="raw_table.md#0x2_raw_table_contains_box">contains_box</a>&lt;K&gt;(table_handle, key)
+    <a href="raw_table.md#0x2_raw_table_contains_box">contains_box</a>&lt;K&gt;(*table_handle, key)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_raw_table_contains_global"></a>
+
+## Function `contains_global`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_contains_global">contains_global</a>(<a href="object_id.md#0x2_object_id">object_id</a>: &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_contains_global">contains_global</a>(<a href="object_id.md#0x2_object_id">object_id</a>: &ObjectID): bool {
+    <a href="raw_table.md#0x2_raw_table_contains_box">contains_box</a>&lt;ObjectID&gt;(<a href="raw_table.md#0x2_raw_table_global_object_storage_handle">global_object_storage_handle</a>(), *<a href="object_id.md#0x2_object_id">object_id</a>)
 }
 </code></pre>
 
@@ -367,7 +478,7 @@ Returns the size of the table, the number of key-value pairs
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_length">length</a>(table_handle: &ObjectID): u64 {
-    <a href="raw_table.md#0x2_raw_table_box_length">box_length</a>(table_handle)
+    <a href="raw_table.md#0x2_raw_table_box_length">box_length</a>(*table_handle)
 }
 </code></pre>
 
@@ -417,7 +528,7 @@ Drop a table even if it is not empty.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_drop_unchecked">drop_unchecked</a>(table_handle: &ObjectID) {
-    <a href="raw_table.md#0x2_raw_table_drop_unchecked_box">drop_unchecked_box</a>(table_handle)
+    <a href="raw_table.md#0x2_raw_table_drop_unchecked_box">drop_unchecked_box</a>(*table_handle)
 }
 </code></pre>
 
@@ -443,7 +554,7 @@ Destroy a table. Aborts if the table is not empty
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="raw_table.md#0x2_raw_table_destroy_empty">destroy_empty</a>(table_handle: &ObjectID) {
     <b>assert</b>!(<a href="raw_table.md#0x2_raw_table_is_empty">is_empty</a>(table_handle), <a href="raw_table.md#0x2_raw_table_ErrorNotEmpty">ErrorNotEmpty</a>);
-    <a href="raw_table.md#0x2_raw_table_drop_unchecked_box">drop_unchecked_box</a>(table_handle)
+    <a href="raw_table.md#0x2_raw_table_drop_unchecked_box">drop_unchecked_box</a>(*table_handle)
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/table.md
@@ -26,6 +26,7 @@ struct itself, while the operations are implemented as native functions. No trav
 -  [Function `length`](#0x2_table_length)
 -  [Function `is_empty`](#0x2_table_is_empty)
 -  [Function `drop`](#0x2_table_drop)
+-  [Function `handle`](#0x2_table_handle)
 
 
 <pre><code><b>use</b> <a href="context.md#0x2_context">0x2::context</a>;
@@ -423,6 +424,31 @@ Usable only if the value type <code>V</code> has the <code>drop</code> ability
 <pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_drop">drop</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(<a href="table.md#0x2_table">table</a>: <a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;) {
     <b>let</b> <a href="table.md#0x2_table_Table">Table</a> { handle } = <a href="table.md#0x2_table">table</a>;
     <a href="raw_table.md#0x2_raw_table_drop_unchecked">raw_table::drop_unchecked</a>(&handle)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_table_handle"></a>
+
+## Function `handle`
+
+Returns table handle of <code><a href="table.md#0x2_table">table</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_handle">handle</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): &<a href="object_id.md#0x2_object_id_ObjectID">object_id::ObjectID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x2_table_handle">handle</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x2_table">table</a>: &<a href="table.md#0x2_table_Table">Table</a>&lt;K, V&gt;): &ObjectID {
+    &<a href="table.md#0x2_table">table</a>.handle
 }
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
@@ -7,6 +7,7 @@
 /// 1. The Object is a struct in Move
 /// 2. The Object is a use case of the Hot Potato pattern in Move. Objects do not have any ability, so they cannot be drop, copy, or store, and can only be handled by StorageContext API after creation.
 module moveos_std::object {
+    
     use moveos_std::tx_context::{Self, TxContext};
     use moveos_std::object_id::ObjectID;
 
@@ -14,6 +15,7 @@ module moveos_std::object {
     friend moveos_std::account_storage;
     friend moveos_std::storage_context;
     friend moveos_std::event;
+    friend moveos_std::object_ref;
    
     /// Box style object
     /// The object can not be copied, droped and stored. It only can be consumed by StorageContext API.
@@ -22,6 +24,7 @@ module moveos_std::object {
         id: ObjectID,
         // The owner of the object
         owner: address,
+        // The value of the object
         // The value must be the last field
         value: T,
     }
@@ -42,9 +45,17 @@ module moveos_std::object {
         &self.value
     }
 
+    public(friend) fun internal_borrow<T>(self: &Object<T>): &T {
+        &self.value
+    }
+
     #[private_generics(T)]
     /// Borrow the mutable object value
     public fun borrow_mut<T>(self: &mut Object<T>): &mut T {
+        &mut self.value
+    }
+
+    public(friend) fun internal_borrow_mut<T>(self: &mut Object<T>): &mut T {
         &mut self.value
     }
 
@@ -64,8 +75,8 @@ module moveos_std::object {
 
     #[private_generics(T)]
     /// Unpack the object, return the id, owner, and value
-    public fun unpack<T>(obj: Object<T>): (ObjectID, address, T) {
-        let Object{id, owner, value} = obj;
+    public fun unpack<T>(self: Object<T>): (ObjectID, address, T) {
+        let Object{id, owner, value} = self;
         (id, owner, value)
     }
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object_ref.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object_ref.move
@@ -1,0 +1,60 @@
+module moveos_std::object_ref {
+
+    use moveos_std::object_id::ObjectID;
+    use moveos_std::object::{Self, Object};
+    use moveos_std::raw_table;
+
+    /// ObjectRef<T> is a reference of the Object<T>
+    /// It likes ObjectID, but it contains the type information of the object.
+    /// TODO should we support drop?
+    struct ObjectRef<phantom T> has key, store, copy, drop {
+        id: ObjectID,
+    }
+
+    #[private_generics(T)]
+    /// Get the object reference
+    public fun new<T: key>(object: &Object<T>) : ObjectRef<T> {
+        //TODO should we track the reference count?
+        ObjectRef {
+            id: object::id(object),
+        }
+    }
+
+    public(friend) fun new_with_id<T>(id: ObjectID): ObjectRef<T> {
+        ObjectRef {
+            id: id,
+        }
+    }
+
+    /// Borrow the object value
+    public fun borrow<T: key>(self: &ObjectRef<T>): &T {
+        let obj = raw_table::borrow_from_global<T>(&self.id);
+        object::internal_borrow(obj)
+    }
+
+    /// Borrow the object mutable value
+    public fun borrow_mut<T: key>(self: &mut ObjectRef<T>): &mut T {
+        let obj = raw_table::borrow_mut_from_global<T>(&self.id);
+        object::internal_borrow_mut(obj)
+    }
+
+    public fun id<T>(self: &ObjectRef<T>): ObjectID {
+        self.id
+    }
+
+    public fun owner<T: key>(self: &ObjectRef<T>): address {
+        let obj = raw_table::borrow_from_global<T>(&self.id);
+        object::owner(obj)
+    }
+
+    /// Check if the object is still contains in the global storage
+    public fun contains<T: key>(self: &ObjectRef<T>): bool {
+        raw_table::contains_global(&self.id)
+    }
+
+    /// Convert the ObjectRef to ObjectID
+    public fun into_id<T: key>(self: ObjectRef<T>): ObjectID {
+        let ObjectRef {id} = self;
+        id
+    }
+}

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/storage_context.move
@@ -15,7 +15,8 @@ module moveos_std::storage_context {
 
     friend moveos_std::account_storage;
     friend moveos_std::context;
-
+    
+    //TODO redesign the global object storage handle
     const GlobalObjectStorageHandle: address = @0x0;
 
     struct StorageContext has store {

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -115,6 +115,11 @@ module moveos_std::table {
     }
 
 
+    /// Returns table handle of `table`.
+    public fun handle<K: copy + drop, V>(table: &Table<K, V>): &ObjectID {
+        &table.handle
+    }
+
     #[test_only]
     struct TableHolder<phantom K: copy + drop, phantom V: drop> has key {
         t: Table<K, V>

--- a/moveos/moveos-types/src/moveos_std/mod.rs
+++ b/moveos/moveos-types/src/moveos_std/mod.rs
@@ -3,6 +3,7 @@
 
 /// This mod contains all the Rust to Move type mapping that are used in MoveosStd
 pub mod module_upgrade_flag;
+pub mod object_ref;
 pub mod tx_meta;
 pub mod tx_result;
 pub mod type_info;

--- a/moveos/moveos-types/src/moveos_std/object_ref.rs
+++ b/moveos/moveos-types/src/moveos_std/object_ref.rs
@@ -1,0 +1,43 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    addresses::MOVEOS_STD_ADDRESS,
+    object::ObjectID,
+    state::{MoveStructState, MoveStructType},
+};
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::TypeTag,
+    value::MoveStructLayout,
+};
+use serde::{Deserialize, Serialize};
+
+pub const MODULE_NAME: &IdentStr = ident_str!("object_ref");
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ObjectRef<T> {
+    pub id: ObjectID,
+    pub ty: std::marker::PhantomData<T>,
+}
+
+impl<T> MoveStructType for ObjectRef<T>
+where
+    T: MoveStructType,
+{
+    const ADDRESS: AccountAddress = MOVEOS_STD_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ObjectRef");
+
+    fn type_params() -> Vec<TypeTag> {
+        vec![T::type_tag()]
+    }
+}
+
+impl<T> MoveStructState for ObjectRef<T>
+where
+    T: MoveStructType,
+{
+    fn struct_layout() -> MoveStructLayout {
+        MoveStructLayout::new(vec![ObjectID::type_layout()])
+    }
+}

--- a/moveos/moveos-types/src/state_resolver.rs
+++ b/moveos/moveos-types/src/state_resolver.rs
@@ -123,6 +123,7 @@ pub trait MoveOSResolver: MoveResolver<Err = anyhow::Error> + StateResolver {}
 
 impl<T> MoveOSResolver for T where T: MoveResolver<Err = anyhow::Error> + StateResolver {}
 
+//TODO define a ResourceKey trait to unify the resource key type, and auto impl it for ObjectID and StructTag.
 pub fn resource_tag_to_key(tag: &StructTag) -> Vec<u8> {
     // The resource key is struct_tag to_canonical_string in bcs serialize format string, not String::into_bytes.
     bcs::to_bytes(&tag.to_canonical_string()).expect("bcs to_bytes String must success.")


### PR DESCRIPTION
## Summary

Implement ObjectRef, refactor CoinStore, and balance RPC.

part of #901 #915 

1. Add `borrow_from_global` `borrow_mut_from_global` to `raw_table`, allowing borrowing Objects directly from global storage without `Context`.
2. Introduce ObjectRef<T>. A struct that holds ObjectRef<T> can directly operate T, and is not restricted by private_generic. 
3. Refactor Coin and CoinStore with ObjectRef. Now, every CoinStore is an Object, And Coin<T> is a hot potato type that can only be handled via coin module, and when storing Coin<T> to CoinStore, the Coin<T> becomes Balance.
4. Remove generic type from CoinInfo<T> and CoinStore<T>, add coin_type field to them.
5. Refactor Balance query logic.


TODO:

1. Refactor `coin.move`, and plan to split it to `coin.move`, `coin_store.move`, `account_coin_store.move`
2. Refactor some examples with ObjectRef and use ObjectRef to replace ObjectID.
3. Now, ObjectRef can be `store`,`copy`,`drop`, do we need to track the reference count for Object? This can ensure developer always can get the Object via ObjectRef.