### PR TITLE
[Rpc] rename TransactionResult to TransactionWithInfo

### DIFF
--- a/.github/workflows/check_build_test.yml
+++ b/.github/workflows/check_build_test.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Check code format
         run: cargo fmt -- --check
       - name: Lint rust sources
-        run: ./scripts/pr.sh -c
+        #FIXME mkdir is a workaroud solution for https://github.com/rooch-network/rooch/issues/968
+        run: mkdir -p crates/rooch/public/dashboard/ && ./scripts/pr.sh -c
       - name: Build
         run: cargo build
       - name: Execute rust tests

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -238,14 +238,14 @@
         }
       ],
       "result": {
-        "name": "Vec<Option<TransactionResultView>>",
+        "name": "Vec<Option<TransactionWithInfoView>>",
         "required": true,
         "schema": {
           "type": "array",
           "items": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/TransactionResultView"
+                "$ref": "#/components/schemas/TransactionWithInfoView"
               },
               {
                 "type": "null"
@@ -279,7 +279,7 @@
         "name": "TransactionResultPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_TransactionResultView_and_uint128"
+          "$ref": "#/components/schemas/PageView_for_TransactionWithInfoView_and_uint128"
         }
       }
     },
@@ -1074,7 +1074,7 @@
           }
         }
       },
-      "PageView_for_TransactionResultView_and_uint128": {
+      "PageView_for_TransactionWithInfoView_and_uint128": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -1085,7 +1085,7 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TransactionResultView"
+              "$ref": "#/components/schemas/TransactionWithInfoView"
             }
           },
           "has_next_page": {
@@ -1266,25 +1266,6 @@
           }
         }
       },
-      "TransactionResultView": {
-        "type": "object",
-        "required": [
-          "execution_info",
-          "sequence_info",
-          "transaction"
-        ],
-        "properties": {
-          "execution_info": {
-            "$ref": "#/components/schemas/TransactionExecutionInfoView"
-          },
-          "sequence_info": {
-            "$ref": "#/components/schemas/TransactionSequenceInfoView"
-          },
-          "transaction": {
-            "$ref": "#/components/schemas/TransactionView"
-          }
-        }
-      },
       "TransactionSequenceInfoView": {
         "type": "object",
         "required": [
@@ -1341,6 +1322,25 @@
           },
           "transaction_type": {
             "$ref": "#/components/schemas/TransactionTypeView"
+          }
+        }
+      },
+      "TransactionWithInfoView": {
+        "type": "object",
+        "required": [
+          "execution_info",
+          "sequence_info",
+          "transaction"
+        ],
+        "properties": {
+          "execution_info": {
+            "$ref": "#/components/schemas/TransactionExecutionInfoView"
+          },
+          "sequence_info": {
+            "$ref": "#/components/schemas/TransactionSequenceInfoView"
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/TransactionView"
           }
         }
       },

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -276,7 +276,7 @@
         }
       ],
       "result": {
-        "name": "TransactionResultPageView",
+        "name": "TransactionWithInfoPageView",
         "required": true,
         "schema": {
           "$ref": "#/components/schemas/PageView_for_TransactionWithInfoView_and_uint128"

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::account_view::BalanceInfoView;
-use crate::jsonrpc_types::transaction_view::TransactionResultView;
+use crate::jsonrpc_types::transaction_view::TransactionWithInfoView;
 use crate::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedFunctionResultView, AnnotatedStateView,
     EventPageView, ExecuteTransactionResponseView, FunctionCallView, H256View,
@@ -85,7 +85,7 @@ pub trait RoochAPI {
     async fn get_transactions_by_hash(
         &self,
         tx_hashes: Vec<H256View>,
-    ) -> RpcResult<Vec<Option<TransactionResultView>>>;
+    ) -> RpcResult<Vec<Option<TransactionWithInfoView>>>;
 
     #[method(name = "getTransactionsByOrder")]
     async fn get_transactions_by_order(

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -7,7 +7,7 @@ use crate::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedFunctionResultView, AnnotatedStateView,
     EventPageView, ExecuteTransactionResponseView, FunctionCallView, H256View,
     ListAnnotatedStatesPageView, ListBalanceInfoPageView, ListStatesPageView, StateView, StrView,
-    StructTagView, TransactionResultPageView,
+    StructTagView, TransactionWithInfoPageView,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -92,7 +92,7 @@ pub trait RoochAPI {
         &self,
         cursor: Option<u128>,
         limit: Option<u64>,
-    ) -> RpcResult<TransactionResultPageView>;
+    ) -> RpcResult<TransactionWithInfoPageView>;
 
     /// get account balance by AccountAddress and CoinType
     #[method(name = "getBalance")]

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -3,7 +3,7 @@
 
 use super::AccountAddressView;
 use crate::jsonrpc_types::account_view::BalanceInfoView;
-use crate::jsonrpc_types::transaction_view::TransactionResultView;
+use crate::jsonrpc_types::transaction_view::TransactionWithInfoView;
 use crate::jsonrpc_types::{
     move_types::{MoveActionTypeView, MoveActionView},
     AnnotatedMoveStructView, AnnotatedStateView, EventView, H256View, StateView, StrView,
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::string::String;
 
 pub type EventPageView = PageView<Option<AnnotatedEventView>, u64>;
-pub type TransactionResultPageView = PageView<TransactionResultView, u128>;
+pub type TransactionResultPageView = PageView<TransactionWithInfoView, u128>;
 pub type ListStatesPageView = PageView<Option<StateView>, StrView<Vec<u8>>>;
 pub type ListAnnotatedStatesPageView = PageView<Option<AnnotatedStateView>, StrView<Vec<u8>>>;
 pub type ListBalanceInfoPageView = PageView<BalanceInfoView, StrView<Vec<u8>>>;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::string::String;
 
 pub type EventPageView = PageView<Option<AnnotatedEventView>, u64>;
-pub type TransactionResultPageView = PageView<TransactionWithInfoView, u128>;
+pub type TransactionWithInfoPageView = PageView<TransactionWithInfoView, u128>;
 pub type ListStatesPageView = PageView<Option<StateView>, StrView<Vec<u8>>>;
 pub type ListAnnotatedStatesPageView = PageView<Option<AnnotatedStateView>, StrView<Vec<u8>>>;
 pub type ListBalanceInfoPageView = PageView<BalanceInfoView, StrView<Vec<u8>>>;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
@@ -9,22 +9,23 @@ use rooch_types::transaction::{TransactionSequenceInfo, TypedTransaction};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// Transaction with sequence info and execution info.
 #[derive(Debug, Clone)]
-pub struct TransactionResult {
+pub struct TransactionWithInfo {
     pub transaction: TypedTransaction,
     pub sequence_info: TransactionSequenceInfo,
     pub execution_info: TransactionExecutionInfo,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct TransactionResultView {
+pub struct TransactionWithInfoView {
     pub transaction: TransactionView,
     pub sequence_info: TransactionSequenceInfoView,
     pub execution_info: TransactionExecutionInfoView,
 }
 
-impl From<TransactionResult> for TransactionResultView {
-    fn from(tx: TransactionResult) -> Self {
+impl From<TransactionWithInfo> for TransactionWithInfoView {
+    fn from(tx: TransactionWithInfo) -> Self {
         Self {
             transaction: tx.transaction.into(),
             sequence_info: tx.sequence_info.into(),

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -12,7 +12,7 @@ use moveos_types::{
 use rooch_rpc_api::api::rooch_api::RoochAPIClient;
 use rooch_rpc_api::jsonrpc_types::TransactionResultPageView;
 use rooch_rpc_api::jsonrpc_types::{
-    account_view::BalanceInfoView, transaction_view::TransactionResultView,
+    account_view::BalanceInfoView, transaction_view::TransactionWithInfoView,
 };
 use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedFunctionResultView, EventPageView,
@@ -84,7 +84,7 @@ impl RoochRpcClient {
     pub async fn get_transactions_by_hash(
         &self,
         tx_hashes: Vec<H256>,
-    ) -> Result<Vec<Option<TransactionResultView>>> {
+    ) -> Result<Vec<Option<TransactionWithInfoView>>> {
         Ok(self
             .http
             .get_transactions_by_hash(tx_hashes.iter().map(|hash| (*hash).into()).collect())

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -10,7 +10,7 @@ use moveos_types::{
     transaction::FunctionCall,
 };
 use rooch_rpc_api::api::rooch_api::RoochAPIClient;
-use rooch_rpc_api::jsonrpc_types::TransactionResultPageView;
+use rooch_rpc_api::jsonrpc_types::TransactionWithInfoPageView;
 use rooch_rpc_api::jsonrpc_types::{
     account_view::BalanceInfoView, transaction_view::TransactionWithInfoView,
 };
@@ -77,7 +77,7 @@ impl RoochRpcClient {
         &self,
         cursor: Option<u128>,
         limit: Option<u64>,
-    ) -> Result<TransactionResultPageView> {
+    ) -> Result<TransactionWithInfoPageView> {
         Ok(self.http.get_transactions_by_order(cursor, limit).await?)
     }
 

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -15,7 +15,7 @@ use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedEventView, AnnotatedStateView, EventPageView,
     ExecuteTransactionResponseView, FunctionCallView, H256View, ListAnnotatedStatesPageView,
     ListBalanceInfoPageView, ListStatesPageView, StateView, StrView, StructTagView,
-    TransactionResultPageView,
+    TransactionWithInfoPageView,
 };
 use rooch_rpc_api::{api::rooch_api::RoochAPIServer, api::DEFAULT_RESULT_LIMIT};
 use rooch_rpc_api::{
@@ -246,7 +246,7 @@ impl RoochAPIServer for RoochServer {
         &self,
         cursor: Option<u128>,
         limit: Option<u64>,
-    ) -> RpcResult<TransactionResultPageView> {
+    ) -> RpcResult<TransactionWithInfoPageView> {
         let last_sequencer_order = self
             .rpc_service
             .get_sequencer_order()
@@ -295,7 +295,7 @@ impl RoochAPIServer for RoochServer {
             .map(TransactionWithInfoView::from)
             .collect::<Vec<_>>();
 
-        Ok(TransactionResultPageView {
+        Ok(TransactionWithInfoPageView {
             data,
             next_cursor,
             has_next_page,

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -10,7 +10,7 @@ use jsonrpsee::{
 use moveos_types::h256::H256;
 use rooch_rpc_api::api::{MAX_RESULT_LIMIT, MAX_RESULT_LIMIT_USIZE};
 use rooch_rpc_api::jsonrpc_types::account_view::BalanceInfoView;
-use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionResultView;
+use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionWithInfoView;
 use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedEventView, AnnotatedStateView, EventPageView,
     ExecuteTransactionResponseView, FunctionCallView, H256View, ListAnnotatedStatesPageView,
@@ -210,7 +210,7 @@ impl RoochAPIServer for RoochServer {
     async fn get_transactions_by_hash(
         &self,
         tx_hashes: Vec<H256View>,
-    ) -> RpcResult<Vec<Option<TransactionResultView>>> {
+    ) -> RpcResult<Vec<Option<TransactionWithInfoView>>> {
         let tx_hashes: Vec<H256> = tx_hashes
             .iter()
             .map(|m| (*m).clone().into())
@@ -236,7 +236,7 @@ impl RoochAPIServer for RoochServer {
             .get_transaction_results_by_hash_and_order(tx_hashes, tx_orders)
             .await?
             .into_iter()
-            .map(|item| Some(TransactionResultView::from(item)))
+            .map(|item| Some(TransactionWithInfoView::from(item)))
             .collect::<Vec<_>>();
 
         Ok(data)
@@ -292,7 +292,7 @@ impl RoochAPIServer for RoochServer {
             .get_transaction_results_by_hash_and_order(tx_hashes, tx_orders)
             .await?
             .into_iter()
-            .map(TransactionResultView::from)
+            .map(TransactionWithInfoView::from)
             .collect::<Vec<_>>();
 
         Ok(TransactionResultPageView {

--- a/crates/rooch-rpc-server/src/service/aggregate_service.rs
+++ b/crates/rooch-rpc-server/src/service/aggregate_service.rs
@@ -14,7 +14,7 @@ use moveos_types::object::ObjectID;
 use moveos_types::state_resolver::resource_tag_to_key;
 use moveos_types::transaction::FunctionCall;
 use moveos_types::tx_context::TxContext;
-use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionResult;
+use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionWithInfo;
 use rooch_types::account::BalanceInfo;
 use rooch_types::framework::account_coin_store::AccountCoinStoreModule;
 use rooch_types::framework::coin::{CoinInfo, CoinModule};
@@ -180,7 +180,7 @@ impl AggregateService {
         &self,
         tx_hashes: Vec<H256>,
         tx_orders: Vec<u128>,
-    ) -> Result<Vec<TransactionResult>> {
+    ) -> Result<Vec<TransactionWithInfo>> {
         let transactions = self
             .rpc_service
             .get_transactions_by_hash(tx_hashes.clone())
@@ -200,9 +200,9 @@ impl AggregateService {
             transactions.len() == sequence_infos.len()
                 && transactions.len() == execution_infos.len()
         );
-        let mut transaction_results: Vec<TransactionResult> = vec![];
+        let mut transaction_with_info: Vec<TransactionWithInfo> = vec![];
         for (index, _tx_hash) in tx_hashes.iter().enumerate() {
-            let transaction_result = TransactionResult {
+            let transaction_result = TransactionWithInfo {
                 transaction: transactions[index].clone().ok_or(anyhow::anyhow!(
                     "Transaction should have value when construct TransactionResult"
                 ))?,
@@ -213,9 +213,9 @@ impl AggregateService {
                     "TransactionExecutionInfo should have value when construct TransactionResult"
                 ))?,
             };
-            transaction_results.push(transaction_result)
+            transaction_with_info.push(transaction_result)
         }
-        Ok(transaction_results)
+        Ok(transaction_with_info)
     }
 }
 

--- a/crates/rooch/build.rs
+++ b/crates/rooch/build.rs
@@ -13,7 +13,8 @@ fn main() {
         let base_path: String;
         let dashboard_dir = "dashboard";
         let output_dir = "crates/rooch/public/dashboard/";
-
+        //make sure the output directory exists
+        fs::create_dir_all(output_dir).expect("Failed to create output directory");
         if let Ok(output) = Command::new("git")
             .args(["rev-parse", "--show-toplevel"])
             .output()

--- a/crates/rooch/src/commands/transaction/commands/get_transactions_by_hash.rs
+++ b/crates/rooch/src/commands/transaction/commands/get_transactions_by_hash.rs
@@ -4,7 +4,7 @@
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
 use moveos_types::h256::H256;
-use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionResultView;
+use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionWithInfoView;
 use rooch_types::error::RoochResult;
 
 /// Get transactions by hashes
@@ -19,8 +19,8 @@ pub struct GetTransactionsByHashCommand {
 }
 
 #[async_trait]
-impl CommandAction<Vec<Option<TransactionResultView>>> for GetTransactionsByHashCommand {
-    async fn execute(self) -> RoochResult<Vec<Option<TransactionResultView>>> {
+impl CommandAction<Vec<Option<TransactionWithInfoView>>> for GetTransactionsByHashCommand {
+    async fn execute(self) -> RoochResult<Vec<Option<TransactionWithInfoView>>> {
         let client = self.context_options.build().await?.get_client().await?;
 
         let resp = client.rooch.get_transactions_by_hash(self.hashes).await?;

--- a/crates/rooch/src/commands/transaction/commands/get_transactions_by_order.rs
+++ b/crates/rooch/src/commands/transaction/commands/get_transactions_by_order.rs
@@ -3,7 +3,7 @@
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
-use rooch_rpc_api::jsonrpc_types::TransactionResultPageView;
+use rooch_rpc_api::jsonrpc_types::TransactionWithInfoPageView;
 use rooch_types::error::RoochResult;
 
 /// Get transactions by order
@@ -21,8 +21,8 @@ pub struct GetTransactionsByOrderCommand {
 }
 
 #[async_trait]
-impl CommandAction<TransactionResultPageView> for GetTransactionsByOrderCommand {
-    async fn execute(self) -> RoochResult<TransactionResultPageView> {
+impl CommandAction<TransactionWithInfoPageView> for GetTransactionsByOrderCommand {
+    async fn execute(self) -> RoochResult<TransactionWithInfoPageView> {
         let client = self.context_options.build().await?.get_client().await?;
 
         let resp = client

--- a/dashboard/src/store/scan/transaction/index.ts
+++ b/dashboard/src/store/scan/transaction/index.ts
@@ -8,7 +8,7 @@ import { createAsyncThunk, Dispatch, AnyAction } from '@reduxjs/toolkit'
 import { CreateGenericSlice, GenericState } from '../../generic'
 
 // ** sdk import
-import { JsonRpcProvider, TransactionResultPageView } from '@rooch/sdk'
+import { JsonRpcProvider, TransactionWithInfoPageView } from '@rooch/sdk'
 
 interface DataParams {
   dispatch: Dispatch<AnyAction>
@@ -37,7 +37,7 @@ export const TransactionSlice = CreateGenericSlice({
   name: 'state',
   initialState: {
     result: {},
-  } as GenericState<TransactionResultPageView>,
+  } as GenericState<TransactionWithInfoPageView>,
   reducers: {},
 })
 

--- a/sdk/typescript/src/provider/json-rpc-provider.ts
+++ b/sdk/typescript/src/provider/json-rpc-provider.ts
@@ -13,7 +13,7 @@ import {
   // TransactionView,
   AnnotatedFunctionResultView,
   AnnotatedStateView,
-  TransactionResultPageView,
+  TransactionWithInfoPageView,
   AnnotatedEventResultPageView,
   ListAnnotatedStateResultPageView,
   StateView,
@@ -144,7 +144,7 @@ export class JsonRpcProvider implements IProvider {
     return await this.client.rooch_getAnnotatedStates(accessPath)
   }
 
-  async getTransactionsByOrder(cursor: number, limit: number): Promise<TransactionResultPageView> {
+  async getTransactionsByOrder(cursor: number, limit: number): Promise<TransactionWithInfoPageView> {
     return this.client.rooch_getTransactionsByOrder(cursor, limit)
   }
 

--- a/sdk/typescript/src/provider/json-rpc-provider.ts
+++ b/sdk/typescript/src/provider/json-rpc-provider.ts
@@ -144,7 +144,10 @@ export class JsonRpcProvider implements IProvider {
     return await this.client.rooch_getAnnotatedStates(accessPath)
   }
 
-  async getTransactionsByOrder(cursor: number, limit: number): Promise<TransactionWithInfoPageView> {
+  async getTransactionsByOrder(
+    cursor: number,
+    limit: number,
+  ): Promise<TransactionWithInfoPageView> {
     return this.client.rooch_getTransactionsByOrder(cursor, limit)
   }
 

--- a/sdk/typescript/src/provider/json-rpc-provider.ts
+++ b/sdk/typescript/src/provider/json-rpc-provider.ts
@@ -18,7 +18,7 @@ import {
   ListAnnotatedStateResultPageView,
   StateView,
   StateResultPageView,
-  TransactionResultView,
+  TransactionWithInfoView,
 } from '../types'
 import { functionIdToStirng, typeTagToString, encodeArg, toHexString } from '../utils'
 import { IProvider } from './interface'
@@ -129,7 +129,7 @@ export class JsonRpcProvider implements IProvider {
     return this.client.rooch_sendRawTransaction(playload)
   }
 
-  async getTransactionsByHash(tx_hashes: string[]): Promise<TransactionResultView | null[]> {
+  async getTransactionsByHash(tx_hashes: string[]): Promise<TransactionWithInfoView | null[]> {
     return await this.client.rooch_getTransactionsByHash(tx_hashes)
   }
 

--- a/sdk/typescript/tools/generator/template/name_mapping.json
+++ b/sdk/typescript/tools/generator/template/name_mapping.json
@@ -6,7 +6,7 @@
     "move_core_types_vm_status_AbortLocation": "AbortLocation",
     "moveos_types_access_path_AccessPath": "AccessPath",
     "moveos_types_move_types_FunctionId": "RoochFunctionId",
-    "PageView_for_TransactionResultView_and_uint128": "TransactionResultPageView",
+    "PageView_for_TransactionWithInfoView_and_uint128": "TransactionWithInfoPageView",
     "PageView_for_Nullable_AnnotatedStateView_and_alloc_vec_Vec_U8Array": "ListAnnotatedStateResultPageView",
     "PageView_for_Nullable_AnnotatedEventView_and_uint64": "AnnotatedEventResultPageView",
     "PageView_for_Nullable_StateView_and_alloc_vec_Vec_U8Array": "StateResultPageView"


### PR DESCRIPTION
## Summary

1. Rename TransactionResult to TransactionWithInfo
2. Rename TransactionResultPageView to TransactionWithInfoPageView

TODO:

1. ExecuteTransactionResponseView should rename to ?
2. The ListView needs to be refactored in a new PR. #965 
