### PR TITLE
refactor event RPC to make a pure event

### DIFF
--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -363,37 +363,15 @@
       "AnnotatedEventView": {
         "type": "object",
         "required": [
-          "event",
-          "parsed_event_data",
-          "sender"
+          "decoded_event_data",
+          "event"
         ],
         "properties": {
+          "decoded_event_data": {
+            "$ref": "#/components/schemas/AnnotatedStateView"
+          },
           "event": {
             "$ref": "#/components/schemas/EventView"
-          },
-          "parsed_event_data": {
-            "$ref": "#/components/schemas/AnnotatedMoveStructView"
-          },
-          "sender": {
-            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
-          },
-          "timestamp_ms": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "tx_hash": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/primitive_types::H256"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         }
       },

--- a/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
@@ -1,7 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use super::H256View;
 use crate::jsonrpc_types::{BytesView, StrView};
 use anyhow::Result;
 use move_core_types::{
@@ -346,13 +345,13 @@ impl FromStr for StrView<ModuleId> {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub enum EventFilterView {
-    /// Query by sender address.
-    Sender(AccountAddressView),
-    /// Return events emitted by the given transaction.
-    Transaction(
-        ///tx hash of the transaction
-        H256View,
-    ),
+    // /// Query by sender address.
+    // Sender(AccountAddressView),
+    // /// Return events emitted by the given transaction.
+    // Transaction(
+    //     ///tx hash of the transaction
+    //     H256View,
+    // ),
     /// Return events with the given move event struct name
     MoveEventType(
         // #[schemars(with = "String")]
@@ -363,18 +362,18 @@ pub enum EventFilterView {
         path: String,
         value: Value,
     },
-    /// Return events emitted in [start_time, end_time) interval
-    // #[serde(rename_all = "camelCase")]
-    TimeRange {
-        /// left endpoint of time interval, milliseconds since epoch, inclusive
-        // #[schemars(with = "u64")]
-        // #[serde_as(as = "u64")]
-        start_time: u64,
-        /// right endpoint of time interval, milliseconds since epoch, exclusive
-        // #[schemars(with = "u64")]
-        // #[serde_as(as = "u64")]
-        end_time: u64,
-    },
+    // /// Return events emitted in [start_time, end_time) interval
+    // // #[serde(rename_all = "camelCase")]
+    // TimeRange {
+    //     /// left endpoint of time interval, milliseconds since epoch, inclusive
+    //     // #[schemars(with = "u64")]
+    //     // #[serde_as(as = "u64")]
+    //     start_time: u64,
+    //     /// right endpoint of time interval, milliseconds since epoch, exclusive
+    //     // #[schemars(with = "u64")]
+    //     // #[serde_as(as = "u64")]
+    //     end_time: u64,
+    // },
     /// Return events emitted in [from_block, to_block) interval
     // #[serde(rename_all = "camelCase")]
     // BlockRange {
@@ -396,17 +395,17 @@ pub enum EventFilterView {
 impl From<EventFilterView> for EventFilter {
     fn from(value: EventFilterView) -> Self {
         match value {
-            EventFilterView::Sender(address) => Self::Sender(address.into()),
-            EventFilterView::Transaction(tx_hash) => Self::Transaction(tx_hash.into()),
+            // EventFilterView::Sender(address) => Self::Sender(address.into()),
+            // EventFilterView::Transaction(tx_hash) => Self::Transaction(tx_hash.into()),
             EventFilterView::MoveEventType(type_tag) => Self::MoveEventType(type_tag.into()),
             EventFilterView::MoveEventField { path, value } => Self::MoveEventField { path, value },
-            EventFilterView::TimeRange {
-                start_time,
-                end_time,
-            } => Self::TimeRange {
-                start_time,
-                end_time,
-            },
+            // EventFilterView::TimeRange {
+            //     start_time,
+            //     end_time,
+            // } => Self::TimeRange {
+            //     start_time,
+            //     end_time,
+            // },
             EventFilterView::All(filters) => {
                 Self::All(filters.into_iter().map(|f| f.into()).collect())
             }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -1,13 +1,11 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use super::AccountAddressView;
 use crate::jsonrpc_types::account_view::BalanceInfoView;
 use crate::jsonrpc_types::transaction_view::TransactionWithInfoView;
 use crate::jsonrpc_types::{
     move_types::{MoveActionTypeView, MoveActionView},
-    AnnotatedMoveStructView, AnnotatedStateView, BytesView, EventView, H256View, StateView,
-    StrView, StructTagView,
+    AnnotatedStateView, BytesView, EventView, StateView, StrView, StructTagView,
 };
 use move_core_types::u256::U256;
 use moveos_types::event::AnnotatedMoveOSEvent;
@@ -87,38 +85,21 @@ impl From<TypedTransaction> for TransactionView {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct AnnotatedEventView {
     pub event: EventView,
-    pub sender: AccountAddressView,
-    pub tx_hash: Option<H256View>,
-    pub timestamp_ms: Option<u64>,
+    // pub sender: AccountAddressView,
+    // pub tx_hash: Option<H256View>,
+    // pub timestamp_ms: Option<u64>,
     // pub block_height: Option<u64>,
-    pub parsed_event_data: AnnotatedMoveStructView,
+    pub decoded_event_data: AnnotatedStateView,
 }
 
 impl From<AnnotatedMoveOSEvent> for AnnotatedEventView {
     fn from(event: AnnotatedMoveOSEvent) -> Self {
         AnnotatedEventView {
             event: event.event.into(),
-            sender: event.sender.into(),
-            tx_hash: event.tx_hash.map(|h256| h256.into()),
-            timestamp_ms: event.timestamp_ms,
-            // block_height: event.block_height,
-            parsed_event_data: event.parsed_event_data.into(),
+            decoded_event_data: event.decoded_event_data.into(),
         }
     }
 }
-
-// impl From<AnnotatedEventView> for AnnotatedMoveOSEvent {
-//     fn from(event: AnnotatedEventView) -> Self {
-//         AnnotatedMoveOSEvent {
-//             event: event.into(),
-//             sender: AccountAddress::try_from(event.sender).unwrap(),
-//             tx_hash: event.tx_hash,
-//             timestamp_ms: event.timestamp_ms,
-//             // block_height: event.block_height,
-//             parsed_event_data: event.parsed_event_data.into(),
-//         }
-//     }
-// }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CoinInfoView {

--- a/moveos/moveos-types/src/event.rs
+++ b/moveos/moveos-types/src/event.rs
@@ -6,7 +6,7 @@
 
 use crate::moveos_std::type_info::TypeInfo;
 use crate::object::ObjectID;
-use crate::state::MoveStructType;
+use crate::state::{AnnotatedState, MoveStructType};
 use anyhow::{ensure, Error, Result};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::{language_storage::StructTag, language_storage::TypeTag};
@@ -20,8 +20,6 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 
 use crate::h256::H256;
-use move_resource_viewer::AnnotatedMoveStruct;
-use serde_with::serde_as;
 
 /// A struct that represents a globally unique id for an Event stream that a user can listen to.
 /// the Unique ID is a combination of event handle id and event seq number.
@@ -233,19 +231,19 @@ impl EventHandle {
 
 // #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 // #[derive(Clone, Debug)]
-#[serde_as]
+// #[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct MoveOSEvent {
     pub event: Event,
-    /// Sender's address.
-    pub sender: AccountAddress,
-    /// Transaction hash
-    pub tx_hash: Option<H256>,
-    /// UTC timestamp in milliseconds since epoch (1/1/1970)
+    // /// Sender's address.
+    // pub sender: AccountAddress,
+    // /// Transaction hash
+    // pub tx_hash: Option<H256>,
+    // /// UTC timestamp in milliseconds since epoch (1/1/1970)
     // #[serde(skip_serializing_if = "Option::is_none")]
     // #[schemars(with = "Option<u64>")]
     // #[serde_as(as = "Option<u64>")]
-    pub timestamp_ms: Option<u64>,
+    // pub timestamp_ms: Option<u64>,
     // block height
     // #[serde(skip_serializing_if = "Option::is_none")]
     // #[schemars(with = "Option<u64>")]
@@ -254,51 +252,27 @@ pub struct MoveOSEvent {
 }
 
 impl MoveOSEvent {
-    pub fn new(
-        event: Event,
-        tx_hash: Option<H256>,
-        timestamp_ms: Option<u64>,
-        // block_height: Option<u64>,
-    ) -> Self {
-        let sender = AccountAddress::ZERO;
-
-        MoveOSEvent {
-            event,
-            sender,
-            tx_hash,
-            timestamp_ms,
-            // block_height,
-        }
+    pub fn new(event: Event) -> Self {
+        MoveOSEvent { event }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct AnnotatedMoveOSEvent {
     pub event: Event,
-    pub sender: AccountAddress,
-    pub tx_hash: Option<H256>,
+    // pub sender: AccountAddress,
+    // pub tx_hash: Option<H256>,
     // pub event_data: Vec<u8>,
-    pub timestamp_ms: Option<u64>,
+    // pub timestamp_ms: Option<u64>,
     // pub block_height: Option<u64>,
-    pub parsed_event_data: AnnotatedMoveStruct,
+    pub decoded_event_data: AnnotatedState,
 }
 
 impl AnnotatedMoveOSEvent {
-    pub fn new(
-        event: Event,
-        parsed_event_data: AnnotatedMoveStruct,
-        tx_hash: Option<H256>,
-        timestamp_ms: Option<u64>,
-        // block_height: Option<u64>,
-    ) -> Self {
-        let sender = AccountAddress::ZERO;
+    pub fn new(event: Event, decoded_event_data: AnnotatedState) -> Self {
         AnnotatedMoveOSEvent {
             event,
-            sender,
-            tx_hash,
-            parsed_event_data,
-            timestamp_ms,
-            // block_height,
+            decoded_event_data,
         }
     }
 }

--- a/moveos/moveos-types/src/event_filter.rs
+++ b/moveos/moveos-types/src/event_filter.rs
@@ -5,10 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::event::MoveOSEvent;
-use crate::h256::H256;
 use crate::move_types::type_tag_match;
 use anyhow::Result;
-use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::TypeTag;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -17,13 +15,13 @@ use serde_with::serde_as;
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EventFilter {
-    /// Query by sender address.
-    Sender(AccountAddress),
-    /// Return events emitted by the given transaction.
-    Transaction(
-        ///tx hash of the transaction
-        H256,
-    ),
+    // /// Query by sender address.
+    // Sender(AccountAddress),
+    // /// Return events emitted by the given transaction.
+    // Transaction(
+    //     ///tx hash of the transaction
+    //     H256,
+    // ),
     /// Return events with the given move event struct name
     MoveEventType(
         // #[schemars(with = "String")]
@@ -34,19 +32,19 @@ pub enum EventFilter {
         path: String,
         value: Value,
     },
-    /// Return events emitted in [start_time, end_time) interval
-    // #[serde(rename_all = "camelCase")]
-    TimeRange {
-        /// left endpoint of time interval, milliseconds since epoch, inclusive
-        // #[schemars(with = "u64")]
-        // #[serde_as(as = "u64")]
-        start_time: u64,
-        /// right endpoint of time interval, milliseconds since epoch, exclusive
-        // #[schemars(with = "u64")]
-        // #[serde_as(as = "u64")]
-        end_time: u64,
-    },
-    /// Return events emitted in [from_block, to_block) interval
+    // /// Return events emitted in [start_time, end_time) interval
+    // // #[serde(rename_all = "camelCase")]
+    // TimeRange {
+    //     /// left endpoint of time interval, milliseconds since epoch, inclusive
+    //     // #[schemars(with = "u64")]
+    //     // #[serde_as(as = "u64")]
+    //     start_time: u64,
+    //     /// right endpoint of time interval, milliseconds since epoch, exclusive
+    //     // #[schemars(with = "u64")]
+    //     // #[serde_as(as = "u64")]
+    //     end_time: u64,
+    // },
+    // /// Return events emitted in [from_block, to_block) interval
     // #[serde(rename_all = "camelCase")]
     // BlockRange {
     //     /// left endpoint of block height, inclusive
@@ -71,11 +69,11 @@ impl EventFilter {
                 type_tag_match(&item.event.type_tag, event_type)
             }
             EventFilter::MoveEventField { path: _, value: _ } => {
-                // matches!(item.parsed_event_data.pointer(path), Some(v) if v == value)
+                // matches!(item.decoded_event_data.pointer(path), Some(v) if v == value)
                 false
             }
 
-            EventFilter::Sender(sender) => &item.sender == sender,
+            // EventFilter::Sender(sender) => &item.sender == sender,
             EventFilter::All(filters) => filters.iter().all(|f| f.matches(item)),
             EventFilter::Any(filters) => filters.iter().any(|f| f.matches(item)),
             EventFilter::And(f1, f2) => {
@@ -83,20 +81,19 @@ impl EventFilter {
             }
             EventFilter::Or(f1, f2) => {
                 EventFilter::Any(vec![*(*f1).clone(), *(*f2).clone()]).matches(item)
-            }
-            EventFilter::Transaction(tx_hash) => {
-                Option::is_some(&item.tx_hash) && (tx_hash == &item.tx_hash.unwrap())
-            }
-            EventFilter::TimeRange {
-                start_time,
-                end_time,
-            } => {
-                if let Some(timestamp) = &item.timestamp_ms {
-                    start_time <= timestamp && end_time > timestamp
-                } else {
-                    false
-                }
-            } // EventFilter::BlockRange {
+            } // EventFilter::Transaction(tx_hash) => {
+              //     Option::is_some(&item.tx_hash) && (tx_hash == &item.tx_hash.unwrap())
+              // }
+              // EventFilter::TimeRange {
+              //     start_time,
+              //     end_time,
+              // } => {
+              //     if let Some(timestamp) = &item.timestamp_ms {
+              //         start_time <= timestamp && end_time > timestamp
+              //     } else {
+              //         false
+              //     }
+              // } // EventFilter::BlockRange {
               //     from_block,
               //     to_block,
               // } => {


### PR DESCRIPTION
resolve https://github.com/rooch-network/rooch/issues/969

Summary
1. refactor event RPC,  and remove `sender `, `tx_hash` and `timestamp`, to make a pure event
2. rename `parsed_event_data` to `encoded_event_data`, and unify with other Annotated state

Todo
1. How to raise an error inner Iterator::filter_map to avoid panic?