### PR TITLE
[Framework] Transaction validator accept future sequence_number.

### DIFF
--- a/crates/rooch-framework/doc/account.md
+++ b/crates/rooch-framework/doc/account.md
@@ -419,15 +419,16 @@ Return the current sequence number at <code>addr</code>
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x3_account_increment_sequence_number">increment_sequence_number</a>(ctx: &<b>mut</b> Context) {
    <b>let</b> sender = <a href="_sender">context::sender</a>(ctx);
+   <b>let</b> tx_sequence_number = <a href="_sequence_number">context::sequence_number</a>(ctx);
 
-   <b>let</b> sequence_number = &<b>mut</b> <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, sender).sequence_number;
+   <b>let</b> <a href="account.md#0x3_account">account</a> = <a href="_global_borrow_mut">account_storage::global_borrow_mut</a>&lt;<a href="account.md#0x3_account_Account">Account</a>&gt;(ctx, sender);
 
    <b>assert</b>!(
-      (*sequence_number <b>as</b> u128) &lt; <a href="account.md#0x3_account_MAX_U64">MAX_U64</a>,
+      (<a href="account.md#0x3_account">account</a>.sequence_number <b>as</b> u128) &lt; <a href="account.md#0x3_account_MAX_U64">MAX_U64</a>,
       <a href="_out_of_range">error::out_of_range</a>(<a href="account.md#0x3_account_ErrorSequenceNumberTooBig">ErrorSequenceNumberTooBig</a>)
    );
 
-   *sequence_number = *sequence_number + 1;
+   <a href="account.md#0x3_account">account</a>.sequence_number = tx_sequence_number + 1;
 }
 </code></pre>
 

--- a/crates/rooch-framework/doc/transaction_validator.md
+++ b/crates/rooch-framework/doc/transaction_validator.md
@@ -174,10 +174,13 @@ If the authenticator is invaid, abort this function.
 
     // Check that the transaction's sequence number matches the
     // current sequence number. Otherwise sequence number is too new.
-    <b>assert</b>!(
-        tx_sequence_number == account_sequence_number,
-        <a href="_invalid_argument">error::invalid_argument</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateSequenceNumberTooNew">ErrorValidateSequenceNumberTooNew</a>)
-    );
+    //FIXME we temporarily disable this check, in order <b>to</b> improve the devnet experience
+    //Because the devnet will be reset frequently, so the sequence number will be reset <b>to</b> 0
+    //But the sequence number(nonce) in MetaMask will not be reset, so the transaction will be rejected
+    // <b>assert</b>!(
+    //     tx_sequence_number == account_sequence_number,
+    //     <a href="_invalid_argument">error::invalid_argument</a>(<a href="transaction_validator.md#0x3_transaction_validator_ErrorValidateSequenceNumberTooNew">ErrorValidateSequenceNumberTooNew</a>)
+    // );
 
     <b>let</b> sender = <a href="_sender">context::sender</a>(ctx);
 

--- a/crates/rooch-framework/sources/account.move
+++ b/crates/rooch-framework/sources/account.move
@@ -137,15 +137,16 @@ module rooch_framework::account {
 
    public(friend) fun increment_sequence_number(ctx: &mut Context) {
       let sender = context::sender(ctx);
+      let tx_sequence_number = context::sequence_number(ctx);
 
-      let sequence_number = &mut account_storage::global_borrow_mut<Account>(ctx, sender).sequence_number;
+      let account = account_storage::global_borrow_mut<Account>(ctx, sender);
 
       assert!(
-         (*sequence_number as u128) < MAX_U64,
+         (account.sequence_number as u128) < MAX_U64,
          error::out_of_range(ErrorSequenceNumberTooBig)
       );
 
-      *sequence_number = *sequence_number + 1;
+      account.sequence_number = tx_sequence_number + 1;
    }
 
    /// Helper to return the sequence number field for given `account`

--- a/crates/rooch-framework/sources/transaction_validator.move
+++ b/crates/rooch-framework/sources/transaction_validator.move
@@ -70,10 +70,13 @@ module rooch_framework::transaction_validator {
 
         // Check that the transaction's sequence number matches the
         // current sequence number. Otherwise sequence number is too new.
-        assert!(
-            tx_sequence_number == account_sequence_number,
-            error::invalid_argument(ErrorValidateSequenceNumberTooNew)
-        );
+        //FIXME we temporarily disable this check, in order to improve the devnet experience
+        //Because the devnet will be reset frequently, so the sequence number will be reset to 0
+        //But the sequence number(nonce) in MetaMask will not be reset, so the transaction will be rejected 
+        // assert!(
+        //     tx_sequence_number == account_sequence_number,
+        //     error::invalid_argument(ErrorValidateSequenceNumberTooNew)
+        // );
 
         let sender = context::sender(ctx);
 


### PR DESCRIPTION
## Summary

Transaction validator temporarily accepts future sequence_number for devnet experience.

Because the devnet will be reset frequently, the sequence number will be reset to 0
However, the sequence number(nonce) in MetaMask will not be reset, so the transaction will be rejected. 

case: #994