### PR TITLE
[gh-945] fix integration tests for ethereum.

### DIFF
--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -117,7 +117,7 @@ impl ExecutorActor {
     ) -> Result<AccountAddress> {
         let resolved_sender = {
             let address_mapping = self.moveos.as_module_binding::<AddressMapping>();
-            address_mapping.resovle_or_generate(multi_chain_address_sender)?
+            address_mapping.resolve_or_generate(multi_chain_address_sender)?
         };
 
         Ok(resolved_sender)

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -5,16 +5,16 @@ use ethers::types::{Bytes, U256};
 use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_key::keystore::memory_keystore::InMemKeystore;
-use rooch_types::address::MultiChainAddress;
 use rooch_types::framework::empty::Empty;
+use rooch_types::transaction::AbstractTransaction;
+use rooch_types::transaction::ethereum::EthereumTransaction;
 
 use crate::binding_test;
 
-// TODO: resolve conversion from rooch address to ethereum address and rooch tx to ethereum tx
 #[test]
 fn test_validate() {
     let binding_test = binding_test::RustBindingTest::new().unwrap();
-    let _ethereum_validator = binding_test
+    let ethereum_validator = binding_test
         .as_module_bundle::<rooch_types::framework::ethereum_validator::EthereumValidatorModule>(
     );
     let address_mapping =
@@ -22,24 +22,18 @@ fn test_validate() {
 
     let keystore = InMemKeystore::new_insecure_for_tests(1);
     let sender = keystore.addresses()[0];
-    let _sequence_number = U256::zero();
+    let sequence_number = U256::zero();
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
-    let _action_bytes =
+    let action_bytes =
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
-    // let tx_data = EthereumTransactionData::new_for_test(sender_ethereum, sequence_number, action_bytes);
-    // keystore
-    //     .sign_transaction(&sender, tx_data.clone(), None)
-    //     .unwrap();
-    // let auth_info = tx_data.authenticator_info().unwrap();
-    let multichain_address = MultiChainAddress::from(sender);
-    let _resolved_sender = address_mapping
-        .resovle_or_generate(multichain_address)
-        .expect("Resolve multichain address should succeed");
-    // let move_tx = tx_data
-    //     .construct_moveos_transaction(resolved_sender)
-    //     .unwrap();
+    let tx = EthereumTransaction::new_for_test(sender, sequence_number, action_bytes);
 
-    // ethereum_validator
-    //     .validate(&move_tx.ctx, auth_info.authenticator.payload)
-    //     .unwrap()
+    let multi_chain_address_sender = tx.sender();
+    let resolved_sender = address_mapping.resolve_or_generate(multi_chain_address_sender.clone()).unwrap(); 
+    let authenticator = tx.authenticator_info().unwrap(); 
+    let moveos_tx = tx.construct_moveos_transaction(resolved_sender).unwrap(); 
+
+    ethereum_validator
+        .validate(&moveos_tx.ctx, authenticator.authenticator.payload)
+        .unwrap()
 }

--- a/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_validator_tests.rs
@@ -6,8 +6,8 @@ use moveos_types::transaction::MoveAction;
 use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_key::keystore::memory_keystore::InMemKeystore;
 use rooch_types::framework::empty::Empty;
-use rooch_types::transaction::AbstractTransaction;
 use rooch_types::transaction::ethereum::EthereumTransaction;
+use rooch_types::transaction::AbstractTransaction;
 
 use crate::binding_test;
 
@@ -29,9 +29,11 @@ fn test_validate() {
     let tx = EthereumTransaction::new_for_test(sender, sequence_number, action_bytes);
 
     let multi_chain_address_sender = tx.sender();
-    let resolved_sender = address_mapping.resolve_or_generate(multi_chain_address_sender.clone()).unwrap(); 
-    let authenticator = tx.authenticator_info().unwrap(); 
-    let moveos_tx = tx.construct_moveos_transaction(resolved_sender).unwrap(); 
+    let resolved_sender = address_mapping
+        .resolve_or_generate(multi_chain_address_sender.clone())
+        .unwrap();
+    let authenticator = tx.authenticator_info().unwrap();
+    let moveos_tx = tx.construct_moveos_transaction(resolved_sender).unwrap();
 
     ethereum_validator
         .validate(&moveos_tx.ctx, authenticator.authenticator.payload)

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -63,9 +63,11 @@ fn test_validate_ethereum() {
     let tx = EthereumTransaction::new_for_test(sender, sequence_number, action_bytes);
 
     let multi_chain_address_sender = tx.sender();
-    let resolved_sender = address_mapping.resolve_or_generate(multi_chain_address_sender.clone()).unwrap(); 
-    let authenticator = tx.authenticator_info().unwrap(); 
-    let moveos_tx = tx.construct_moveos_transaction(resolved_sender).unwrap(); 
+    let resolved_sender = address_mapping
+        .resolve_or_generate(multi_chain_address_sender.clone())
+        .unwrap();
+    let authenticator = tx.authenticator_info().unwrap();
+    let moveos_tx = tx.construct_moveos_transaction(resolved_sender).unwrap();
 
     transaction_validator
         .validate(&moveos_tx.ctx, authenticator)

--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -11,9 +11,9 @@ use moveos_types::move_types::FunctionId;
 use moveos_types::{module_binding::ModuleBinding, transaction::MoveAction};
 use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_key::keystore::memory_keystore::InMemKeystore;
-use rooch_types::address::MultiChainAddress;
 use rooch_types::framework::session_key::SessionKeyModule;
 use rooch_types::framework::timestamp::TimestampModule;
+use rooch_types::transaction::ethereum::EthereumTransaction;
 use rooch_types::{addresses::ROOCH_FRAMEWORK_ADDRESS, framework::empty::Empty};
 use rooch_types::{
     framework::session_key::SessionScope,
@@ -45,11 +45,10 @@ fn test_validate_rooch() {
         .unwrap();
 }
 
-// TODO: resolve conversion from rooch address to ethereum address and rooch tx to ethereum tx
 #[test]
 fn test_validate_ethereum() {
     let binding_test = binding_test::RustBindingTest::new().unwrap();
-    let _transaction_validator = binding_test
+    let transaction_validator = binding_test
         .as_module_bundle::<rooch_types::framework::transaction_validator::TransactionValidator>(
     );
     let address_mapping =
@@ -57,28 +56,22 @@ fn test_validate_ethereum() {
 
     let keystore = InMemKeystore::new_insecure_for_tests(1);
     let sender = keystore.addresses()[0];
-    let _sequence_number = U256::zero();
+    let sequence_number = U256::zero();
     let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
-    let _action_bytes =
+    let action_bytes =
         Bytes::try_from(bcs::to_bytes(&action).unwrap()).expect("Convert action to bytes failed.");
-    // let tx_data = EthereumTransactionData::new_for_test(sender, sequence_number, action_bytes);
-    // let tx = keystore
-    //     .sign_transaction(&sender, tx_data.clone(), None)
-    //     .unwrap();
-    // let auth_info = tx_data.authenticator_info().unwrap();
-    let multichain_address = MultiChainAddress::from(sender);
-    let _resolved_sender = address_mapping
-        .resovle_or_generate(multichain_address)
-        .expect("Resolve multichain address should succeed");
-    // let move_tx = tx_data
-    //     .construct_moveos_transaction(resolved_sender)
-    //     .unwrap();
+    let tx = EthereumTransaction::new_for_test(sender, sequence_number, action_bytes);
 
-    // transaction_validator
-    //     .validate(&move_tx.ctx, auth_info)
-    //     .unwrap()
-    //     .into_result()
-    //     .unwrap();
+    let multi_chain_address_sender = tx.sender();
+    let resolved_sender = address_mapping.resolve_or_generate(multi_chain_address_sender.clone()).unwrap(); 
+    let authenticator = tx.authenticator_info().unwrap(); 
+    let moveos_tx = tx.construct_moveos_transaction(resolved_sender).unwrap(); 
+
+    transaction_validator
+        .validate(&moveos_tx.ctx, authenticator)
+        .unwrap()
+        .into_result()
+        .unwrap();
 }
 
 #[test]

--- a/crates/rooch-rpc-server/src/server/eth_server.rs
+++ b/crates/rooch-rpc-server/src/server/eth_server.rs
@@ -37,7 +37,7 @@ use rooch_types::{
     framework::gas_coin::GasCoin,
     transaction::{AbstractTransaction, TypedTransaction},
 };
-use rooch_types::{chain_id::ChainID, transaction::ethereum::EthereumTransactionData};
+use rooch_types::{chain_id::ChainID, transaction::ethereum::EthereumTransaction};
 use std::iter;
 use std::str::FromStr;
 use std::time::SystemTime;
@@ -353,7 +353,7 @@ impl EthAPIServer for EthServer {
 
     async fn send_raw_transaction(&self, bytes: BytesView) -> RpcResult<H256View> {
         info!("send_raw_transaction: {:?}", bytes);
-        let eth_tx = EthereumTransactionData::decode(&bytes.0)?;
+        let eth_tx = EthereumTransaction::decode(&bytes.0)?;
         info!("send_raw_transaction input: {:?}", eth_tx.0.input);
         let action = eth_tx.decode_calldata_to_action()?;
         info!(

--- a/crates/rooch-types/src/framework/address_mapping.rs
+++ b/crates/rooch-types/src/framework/address_mapping.rs
@@ -47,7 +47,7 @@ impl<'a> AddressMapping<'a> {
         }
     }
 
-    pub fn resovle_or_generate(
+    pub fn resolve_or_generate(
         &self,
         multichain_address: MultiChainAddress,
     ) -> Result<AccountAddress> {

--- a/crates/rooch-types/src/transaction/ethereum.rs
+++ b/crates/rooch-types/src/transaction/ethereum.rs
@@ -3,7 +3,7 @@
 
 use super::{authenticator::Authenticator, AbstractTransaction, AuthenticatorInfo};
 use crate::{
-    address::EthereumAddress,
+    address::{EthereumAddress, RoochAddress},
     chain_id::RoochChainID,
     error::RoochError,
     framework::{
@@ -28,11 +28,11 @@ use moveos_types::{
 };
 use serde::{Deserialize, Serialize};
 
-// TODO: Remove EthereumTransactionData and only keep Transaction body
+// TODO: Remove EthereumTransaction and only keep Transaction body
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct EthereumTransactionData(pub Transaction);
+pub struct EthereumTransaction(pub Transaction);
 
-pub struct EthereumTransactionDataBuilder {
+pub struct EthereumTransactionBuilder {
     hash: H256,
     nonce: U256,
     block_hash: Option<H256>,
@@ -55,9 +55,9 @@ pub struct EthereumTransactionDataBuilder {
     other: OtherFields,
 }
 
-impl EthereumTransactionDataBuilder {
+impl EthereumTransactionBuilder {
     pub fn new() -> Self {
-        EthereumTransactionDataBuilder {
+        EthereumTransactionBuilder {
             hash: Default::default(),
             nonce: Default::default(),
             block_hash: None,
@@ -181,7 +181,7 @@ impl EthereumTransactionDataBuilder {
         self
     }
 
-    pub fn build(self) -> EthereumTransactionData {
+    pub fn build(self) -> EthereumTransaction {
         let transaction = Transaction {
             hash: self.hash,
             nonce: self.nonce,
@@ -205,19 +205,19 @@ impl EthereumTransactionDataBuilder {
             other: self.other,
         };
 
-        EthereumTransactionData(transaction)
+        EthereumTransaction(transaction)
     }
 }
 
-impl Default for EthereumTransactionDataBuilder {
+impl Default for EthereumTransactionBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl EthereumTransactionData {
+impl EthereumTransaction {
     pub fn new(&self) -> Self {
-        let builder = EthereumTransactionDataBuilder::new();
+        let builder = EthereumTransactionBuilder::new();
         builder
             .nonce(self.0.nonce)
             .hash(self.0.hash)
@@ -242,7 +242,7 @@ impl EthereumTransactionData {
             .build()
     }
 
-    pub fn new_for_test(sender: EthereumAddress, nonce: U256, action: Bytes) -> Self {
+    pub fn new_for_test(sender: RoochAddress, nonce: U256, action: Bytes) -> Self {
         let sender_and_action = (sender, action.clone());
         let tx_hash = h256::sha3_256_of(bcs::to_bytes(&sender_and_action).unwrap().as_slice());
         let transaction = Transaction {
@@ -251,7 +251,7 @@ impl EthereumTransactionData {
             block_hash: None,
             block_number: None,
             transaction_index: None,
-            from: sender.0,
+            from: H160::from_slice(&sender.0.0[..20]), // scrape first 20 bytes as ethereum address
             to: None,
             value: U256::one(),
             gas_price: None,
@@ -324,7 +324,7 @@ impl EthereumTransactionData {
     }
 }
 
-impl AbstractTransaction for EthereumTransactionData {
+impl AbstractTransaction for EthereumTransaction {
     fn transaction_type(&self) -> super::TransactionType {
         super::TransactionType::Ethereum
     }

--- a/crates/rooch-types/src/transaction/ethereum.rs
+++ b/crates/rooch-types/src/transaction/ethereum.rs
@@ -251,7 +251,7 @@ impl EthereumTransaction {
             block_hash: None,
             block_number: None,
             transaction_index: None,
-            from: H160::from_slice(&sender.0.0[..20]), // scrape first 20 bytes as ethereum address
+            from: H160::from_slice(&sender.0 .0[..20]), // scrape first 20 bytes as ethereum address
             to: None,
             value: U256::one(),
             gas_price: None,

--- a/crates/rooch-types/src/transaction/mod.rs
+++ b/crates/rooch-types/src/transaction/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use self::{
-    authenticator::Authenticator, ethereum::EthereumTransactionData, rooch::RoochTransaction,
+    authenticator::Authenticator, rooch::RoochTransaction, ethereum::EthereumTransaction,
 };
 use crate::address::MultiChainAddress;
 use anyhow::Result;
@@ -74,7 +74,7 @@ pub trait AbstractTransaction {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TypedTransaction {
     Rooch(RoochTransaction),
-    Ethereum(EthereumTransactionData),
+    Ethereum(EthereumTransaction),
 }
 
 impl TryFrom<RawTransaction> for TypedTransaction {
@@ -87,7 +87,7 @@ impl TryFrom<RawTransaction> for TypedTransaction {
                 Ok(TypedTransaction::Rooch(tx))
             }
             TransactionType::Ethereum => {
-                let tx = ethereum::EthereumTransactionData::decode(&raw.raw)?;
+                let tx = EthereumTransaction::decode(&raw.raw)?;
                 Ok(TypedTransaction::Ethereum(tx))
             }
         }

--- a/crates/rooch-types/src/transaction/mod.rs
+++ b/crates/rooch-types/src/transaction/mod.rs
@@ -1,9 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use self::{
-    authenticator::Authenticator, rooch::RoochTransaction, ethereum::EthereumTransaction,
-};
+use self::{authenticator::Authenticator, ethereum::EthereumTransaction, rooch::RoochTransaction};
 use crate::address::MultiChainAddress;
 use anyhow::Result;
 use move_core_types::account_address::AccountAddress;


### PR DESCRIPTION
## Summary

1. Construct Move tx for Ethereum validator without signing from key store.
2. Construct Ethereum address from Rooch address from key store with first 20 bytes.

- Closes #945 