### PR TITLE
add dashboard build test

### DIFF
--- a/.github/workflows/check_build_test.yml
+++ b/.github/workflows/check_build_test.yml
@@ -28,25 +28,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: rooch-network/rooch/.github/actions/rust-setup@main
 
-      - name: Use Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: '18.x'
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.OS }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.OS }}-pnpm-
-            ## Build and test app start
-      - name: Install pnpm dependencies
-        run: npm install pnpm -g && pnpm install
-      - name: Gen SDK dependencie Code
-        run: pnpm sdk gen
-      - name: Lint
-        run: pnpm lint
-
       - name: Check code format
         run: cargo fmt -- --check
       - name: Lint rust sources
@@ -71,12 +52,31 @@ jobs:
       - name: Build and test example projects
         run: ./scripts/pr.sh -e
 
-      ### Build and test sdk start
+      # web & sdk & dashboard
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18.x'
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.OS }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.OS }}-pnpm-
+            ## Build and test app start
+      - name: Install pnpm dependencies
+        run: npm install pnpm -g && pnpm install
+      - name: Gen SDK dependencie Code
+        run: pnpm sdk gen
+      - name: Lint
+        run: pnpm lint
       - name: Build SDK
         run: pnpm sdk build
       - name: Test SDK
         run: pnpm sdk test
-      ## Build and test sdk end
+      - name: Build Dashboard
+        run: pnpm dashboard build
 
       - uses: CatChen/check-git-status-action@v1
         with:


### PR DESCRIPTION
## Summary

After the rooch dashboard cmd is deleted, modify the test flow and add build tests for the dashboard.
Avoid When the sdk is modified, the dashboard can run in dev mode, but deployment errors may occur

- Closes #issue