### PR TITLE
[event] Refactor event, make Event API stateless

### DIFF
--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -635,7 +635,7 @@ impl Handler<GetEventsByEventIDsMessage> for ExecutorActor {
             .map(|v| match v {
                 Some(event) => {
                     let event_move_value = MoveValueAnnotator::new(resolver)
-                        .view_resource(event.struct_tag(), event.event_data())?;
+                        .view_resource(event.event_type(), event.event_data())?;
                     Ok(Some(AnnotatedEvent::new(event, event_move_value)))
                 }
                 None => Ok(None),
@@ -660,7 +660,7 @@ impl Handler<GetEventsMessage> for ExecutorActor {
             .into_iter()
             .map(|event| {
                 let event_move_value = MoveValueAnnotator::new(resolver)
-                    .view_resource(&event.struct_tag, &event.event_data)?;
+                    .view_resource(&event.event_type, &event.event_data)?;
                 Ok(AnnotatedEvent::new(event, event_move_value))
             })
             .collect::<Result<Vec<_>>>()

--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -33,7 +33,7 @@ use moveos_types::function_return_value::AnnotatedFunctionReturnValue;
 use moveos_types::genesis_info::GenesisInfo;
 use moveos_types::h256::H256;
 use moveos_types::module_binding::MoveFunctionCaller;
-use moveos_types::move_types::{as_struct_tag, FunctionId};
+use moveos_types::move_types::FunctionId;
 use moveos_types::moveos_std::event::AnnotatedEvent;
 use moveos_types::moveos_std::event::EventHandle;
 use moveos_types::moveos_std::tx_context::TxContext;
@@ -634,10 +634,8 @@ impl Handler<GetEventsByEventIDsMessage> for ExecutorActor {
             .into_iter()
             .map(|v| match v {
                 Some(event) => {
-                    let event_move_value = MoveValueAnnotator::new(resolver).view_resource(
-                        &as_struct_tag(event.type_tag.clone())?,
-                        event.event_data(),
-                    )?;
+                    let event_move_value = MoveValueAnnotator::new(resolver)
+                        .view_resource(event.struct_tag(), event.event_data())?;
                     Ok(Some(AnnotatedEvent::new(event, event_move_value)))
                 }
                 None => Ok(None),
@@ -661,9 +659,8 @@ impl Handler<GetEventsMessage> for ExecutorActor {
         events
             .into_iter()
             .map(|event| {
-                let struct_tag = as_struct_tag(event.type_tag.clone())?;
                 let event_move_value = MoveValueAnnotator::new(resolver)
-                    .view_resource(&struct_tag, event.event_data())?;
+                    .view_resource(&event.struct_tag, &event.event_data)?;
                 Ok(AnnotatedEvent::new(event, event_move_value))
             })
             .collect::<Result<Vec<_>>>()

--- a/crates/rooch-framework-tests/tests/cases/event/basic.exp
+++ b/crates/rooch-framework-tests/tests/cases/event/basic.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
-task 1 'publish'. lines 3-18:
+task 1 'publish'. lines 3-17:
 status EXECUTED
 
-task 2 'run'. lines 19-28:
+task 2 'run'. lines 18-27:
 status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/event/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/event/basic.move
@@ -3,8 +3,7 @@
 //# publish
 module test::m {
     use moveos_std::event;
-    use moveos_std::context::Context;
-    struct WithdrawEvent{
+    struct WithdrawEvent has drop {
         addr: address,
         amount: u64
     }

--- a/crates/rooch-framework-tests/tests/cases/event/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/event/basic.move
@@ -9,9 +9,9 @@ module test::m {
         amount: u64
     }
 
-    public fun emit_withdraw_event(ctx: &mut Context, addr: address, amount: u64) {
+    public fun emit_withdraw_event(addr: address, amount: u64) {
         let withdraw_event = WithdrawEvent{addr, amount};
-        event::emit<WithdrawEvent>(ctx, withdraw_event);
+        event::emit<WithdrawEvent>(withdraw_event);
     }
 }
 
@@ -23,6 +23,6 @@ script {
 
     fun main(ctx: &mut Context) {
         let sender_addr = context::sender(ctx);
-        m::emit_withdraw_event(ctx, sender_addr, 100);
+        m::emit_withdraw_event(sender_addr, 100);
     }
 }

--- a/crates/rooch-framework/sources/account_coin_store.move
+++ b/crates/rooch-framework/sources/account_coin_store.move
@@ -145,11 +145,7 @@ module rooch_framework::account_coin_store {
         let auto_accept_coins = account_storage::global_borrow_mut<AutoAcceptCoins>(ctx, @rooch_framework);
         table::upsert<address, bool>(&mut auto_accept_coins.auto_accept_coins, addr, enable);
 
-        event::emit<AcceptCoinEvent>(ctx,
-            AcceptCoinEvent {
-                enable,
-            },
-        );
+        event::emit<AcceptCoinEvent>(AcceptCoinEvent { enable});
     }
 
     /// Withdraw specifed `amount` of coin `CoinType` from the signing account.

--- a/crates/rooch-framework/sources/coin.move
+++ b/crates/rooch-framework/sources/coin.move
@@ -282,7 +282,7 @@ module rooch_framework::coin {
         let coin_info = borrow_mut_coin_info<CoinType>(ctx);
         coin_info.supply = coin_info.supply + amount;
         let coin_type = type_info::type_name<CoinType>();
-        event::emit<MintEvent>(ctx, MintEvent {
+        event::emit<MintEvent>(MintEvent {
             coin_type,
             amount,
         });
@@ -298,7 +298,7 @@ module rooch_framework::coin {
         let coin_type = type_info::type_name<CoinType>();
         let coin_info = borrow_mut_coin_info<CoinType>(ctx);
         coin_info.supply = coin_info.supply - amount;
-        event::emit<BurnEvent>(ctx, BurnEvent {
+        event::emit<BurnEvent>(BurnEvent {
             coin_type,
             amount,
         });

--- a/crates/rooch-indexer/src/models/events.rs
+++ b/crates/rooch-indexer/src/models/events.rs
@@ -16,7 +16,7 @@ pub struct StoredEvent {
     pub event_seq: i64,
     /// the type of the event data
     #[diesel(sql_type = diesel::sql_types::Text)]
-    pub struct_tag: String,
+    pub event_type: String,
     /// the data payload of the event
     #[diesel(sql_type = diesel::sql_types::Blob)]
     pub event_data: Vec<u8>,
@@ -45,7 +45,7 @@ impl From<IndexedEvent> for StoredEvent {
         Self {
             event_handle_id: event.event_handle_id.to_string(),
             event_seq: event.event_seq as i64,
-            struct_tag: event.struct_tag.to_canonical_string(),
+            event_type: event.event_type.to_canonical_string(),
             event_data: event.event_data,
             event_index: event.event_index as i64,
 

--- a/crates/rooch-indexer/src/models/events.rs
+++ b/crates/rooch-indexer/src/models/events.rs
@@ -16,7 +16,7 @@ pub struct StoredEvent {
     pub event_seq: i64,
     /// the type of the event data
     #[diesel(sql_type = diesel::sql_types::Text)]
-    pub type_tag: String,
+    pub struct_tag: String,
     /// the data payload of the event
     #[diesel(sql_type = diesel::sql_types::Blob)]
     pub event_data: Vec<u8>,
@@ -45,7 +45,7 @@ impl From<IndexedEvent> for StoredEvent {
         Self {
             event_handle_id: event.event_handle_id.to_string(),
             event_seq: event.event_seq as i64,
-            type_tag: event.type_tag.to_canonical_string(),
+            struct_tag: event.struct_tag.to_canonical_string(),
             event_data: event.event_data,
             event_index: event.event_index as i64,
 

--- a/crates/rooch-indexer/src/schema.rs
+++ b/crates/rooch-indexer/src/schema.rs
@@ -7,7 +7,7 @@ diesel::table! {
     events (event_handle_id, event_seq) {
         event_handle_id -> Text,
         event_seq -> BigInt,
-        type_tag -> Text,
+        event_type -> Text,
         event_data -> Binary,
         event_index -> BigInt,
         tx_hash -> Text,

--- a/crates/rooch-indexer/src/types.rs
+++ b/crates/rooch-indexer/src/types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::errors::IndexerError;
-use move_core_types::language_storage::TypeTag;
+use move_core_types::language_storage::StructTag;
 use move_core_types::vm_status::KeptVMStatus;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::object::ObjectID;
@@ -57,7 +57,7 @@ pub struct IndexedEvent {
     /// the number of messages that have been emitted to the path previously
     pub event_seq: u64,
     /// the type of the event data
-    pub type_tag: TypeTag,
+    pub event_type: StructTag,
     /// the data payload of the event
     pub event_data: Vec<u8>,
     /// event index in the transaction events

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -517,7 +517,7 @@
           "event_data",
           "event_id",
           "event_index",
-          "type_tag"
+          "event_type"
         ],
         "properties": {
           "decoded_event_data": {
@@ -541,8 +541,8 @@
             "format": "uint64",
             "minimum": 0.0
           },
-          "type_tag": {
-            "$ref": "#/components/schemas/move_core_types::language_storage::TypeTag"
+          "event_type": {
+            "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
           }
         }
       },
@@ -1106,6 +1106,37 @@
           }
         }
       },
+      "TransactionEventView": {
+        "type": "object",
+        "required": [
+          "event_data",
+          "event_index",
+          "event_type"
+        ],
+        "properties": {
+          "decoded_event_data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AnnotatedMoveStructView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "event_data": {
+            "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
+          },
+          "event_index": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "event_type": {
+            "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+          }
+        }
+      },
       "TransactionExecutionInfoView": {
         "type": "object",
         "required": [
@@ -1147,7 +1178,7 @@
           "events": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EventView"
+              "$ref": "#/components/schemas/TransactionEventView"
             }
           },
           "gas_used": {

--- a/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
@@ -1,9 +1,9 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use super::BytesView;
+use super::{BytesView, TransactionEventView};
 use super::{ModuleIdView, StateChangeSetView, StrView};
-use crate::jsonrpc_types::{EventView, H256View};
+use crate::jsonrpc_types::H256View;
 use move_core_types::vm_status::{AbortLocation, KeptVMStatus};
 use moveos_types::transaction::TransactionExecutionInfo;
 use moveos_types::transaction::TransactionOutput;
@@ -139,8 +139,7 @@ pub struct TransactionOutputView {
     //TODO The changeset will be removed in the future
     //pub changeset: ChangeSetView,
     pub table_changeset: StateChangeSetView,
-    // pub events: Vec<Event>,
-    pub events: Vec<EventView>,
+    pub events: Vec<TransactionEventView>,
     pub gas_used: u64,
 }
 
@@ -151,8 +150,8 @@ impl From<TransactionOutput> for TransactionOutputView {
             table_changeset: tx_output.state_changeset.into(),
             events: tx_output
                 .events
-                .iter()
-                .map(|event| event.clone().into())
+                .into_iter()
+                .map(|event| event.into())
                 .collect(),
             gas_used: tx_output.gas_used,
         }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
@@ -422,7 +422,7 @@ impl From<EventFilterView> for EventFilter {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct TransactionEventView {
-    pub struct_tag: StructTagView,
+    pub event_type: StructTagView,
     pub event_data: StrView<Vec<u8>>,
     pub event_index: u64,
     pub decoded_event_data: Option<AnnotatedMoveStructView>,
@@ -431,7 +431,7 @@ pub struct TransactionEventView {
 impl From<TransactionEvent> for TransactionEventView {
     fn from(event: TransactionEvent) -> Self {
         TransactionEventView {
-            struct_tag: event.struct_tag.into(),
+            event_type: event.event_type.into(),
             event_data: StrView(event.event_data),
             event_index: event.event_index,
             decoded_event_data: None,
@@ -442,7 +442,7 @@ impl From<TransactionEvent> for TransactionEventView {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct EventView {
     pub event_id: EventID,
-    pub struct_tag: StructTagView,
+    pub event_type: StructTagView,
     pub event_data: BytesView,
     pub event_index: u64,
     pub decoded_event_data: Option<AnnotatedMoveStructView>,
@@ -452,7 +452,7 @@ impl From<Event> for EventView {
     fn from(event: Event) -> Self {
         EventView {
             event_id: event.event_id,
-            struct_tag: event.struct_tag.into(),
+            event_type: event.event_type.into(),
             event_data: StrView(event.event_data),
             event_index: event.event_index,
             decoded_event_data: None,
@@ -464,7 +464,7 @@ impl From<EventView> for Event {
     fn from(event: EventView) -> Self {
         Event {
             event_id: event.event_id,
-            struct_tag: event.struct_tag.into(),
+            event_type: event.event_type.into(),
             event_data: event.event_data.0,
             event_index: event.event_index,
         }
@@ -475,7 +475,7 @@ impl From<AnnotatedEvent> for EventView {
     fn from(event: AnnotatedEvent) -> Self {
         EventView {
             event_id: event.event.event_id,
-            struct_tag: event.event.struct_tag.into(),
+            event_type: event.event.event_type.into(),
             event_data: StrView(event.event.event_data),
             event_index: event.event.event_index,
             decoded_event_data: Some(event.decoded_event_data.into()),

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -187,10 +187,11 @@ impl RoochAPIServer for RoochServer {
         };
 
         let has_next_page = (data.len() as u64) > limit_of;
-        data.truncate(limit_of as usize);
         let next_cursor = data
             .last()
             .map_or(cursor, |event| Some(event.event_id.event_seq));
+
+        data.truncate(limit_of as usize);
 
         Ok(EventPageView {
             data,

--- a/crates/rooch-rpc-server/src/service/aggregate_service.rs
+++ b/crates/rooch-rpc-server/src/service/aggregate_service.rs
@@ -9,7 +9,6 @@ use moveos_types::access_path::AccessPath;
 use moveos_types::function_return_value::FunctionResult;
 use moveos_types::h256::H256;
 use moveos_types::module_binding::MoveFunctionCaller;
-use moveos_types::moveos_std::event::EventModule;
 use moveos_types::moveos_std::object::{Object, ObjectID};
 use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::state_resolver::resource_tag_to_key;
@@ -241,14 +240,6 @@ impl AggregateService {
                 }
             })
             .collect::<Result<Vec<_>>>()
-    }
-
-    pub async fn get_event_handle(
-        &self,
-        event_handle_type: StructTag,
-    ) -> Result<(ObjectID, AccountAddress, u64)> {
-        let event_module = self.as_module_binding::<EventModule>();
-        event_module.get_event_handle(event_handle_type)
     }
 }
 

--- a/crates/rooch/src/commands/move_cli/commands/unit_test.rs
+++ b/crates/rooch/src/commands/move_cli/commands/unit_test.rs
@@ -10,6 +10,7 @@ use move_package::BuildConfig;
 use move_unit_test::extensions::set_extension_hook;
 use move_vm_runtime::native_extensions::NativeContextExtensions;
 use moveos_stdlib::natives::moveos_stdlib::{
+    event::NativeEventContext,
     move_module::NativeModuleContext,
     raw_table::{NativeTableContext, TableData},
 };
@@ -108,7 +109,8 @@ fn new_moveos_natives_runtime(ext: &mut NativeContextExtensions) {
     let table_data = Arc::new(RwLock::new(TableData::default()));
     let table_ext = NativeTableContext::new(statedb, table_data);
     let module_ext = NativeModuleContext::new(statedb);
-
+    let event_ext = NativeEventContext::default();
     ext.add(table_ext);
     ext.add(module_ext);
+    ext.add(event_ext);
 }

--- a/examples/blog/sources/article.move
+++ b/examples/blog/sources/article.move
@@ -31,7 +31,7 @@ module rooch_examples::article {
     const ErrorNotGenesisAccount: u64 = 105;
     const ErrorIdNotFound: u64 = 106;
 
-    struct CommentTableItemAdded has key {
+    struct CommentTableItemAdded has drop {
         article_id: ObjectID,
         comment_seq_id: u64,
     }
@@ -96,11 +96,10 @@ module rooch_examples::article {
         let comment_seq_id = comment::comment_seq_id(&comment);
         assert!(!table::contains(&article.comments, comment_seq_id), ErrorIdAlreadyExists);
         table::add(&mut article.comments, comment_seq_id, comment);
-        //TODO enable event after refactor event API to remove `&mut Context`
-        // event::emit(ctx, CommentTableItemAdded {
-        //     article_id: id(article_obj),
-        //     comment_seq_id,
-        // });
+        event::emit(CommentTableItemAdded {
+             article_id: id(article_obj),
+             comment_seq_id,
+        });
     }
 
     public(friend) fun remove_comment(article_obj: &mut Object<Article>, comment_seq_id: u64) {
@@ -138,7 +137,7 @@ module rooch_examples::article {
         }
     }
 
-    struct CommentUpdated has key {
+    struct CommentUpdated has drop {
         id: ObjectID,
         version: u64,
         comment_seq_id: u64,
@@ -185,7 +184,7 @@ module rooch_examples::article {
         }
     }
 
-    struct CommentRemoved has key {
+    struct CommentRemoved has drop {
         id: ObjectID,
         version: u64,
         comment_seq_id: u64,
@@ -211,7 +210,7 @@ module rooch_examples::article {
         }
     }
 
-    struct CommentAdded has key {
+    struct CommentAdded has drop {
         id: ObjectID,
         version: u64,
         comment_seq_id: u64,
@@ -258,7 +257,7 @@ module rooch_examples::article {
         }
     }
 
-    struct ArticleCreated has key {
+    struct ArticleCreated has drop {
         id: option::Option<ObjectID>,
         title: String,
         body: String,
@@ -291,7 +290,7 @@ module rooch_examples::article {
         }
     }
 
-    struct ArticleUpdated has key {
+    struct ArticleUpdated has drop {
         id: ObjectID,
         version: u64,
         title: String,
@@ -324,7 +323,7 @@ module rooch_examples::article {
         }
     }
 
-    struct ArticleDeleted has key {
+    struct ArticleDeleted has drop {
         id: ObjectID,
         version: u64,
     }
@@ -394,28 +393,28 @@ module rooch_examples::article {
         table::destroy_empty(comments);
     }
 
-    public(friend) fun emit_comment_updated(ctx: &mut Context, comment_updated: CommentUpdated) {
-        event::emit(ctx, comment_updated);
+    public(friend) fun emit_comment_updated(comment_updated: CommentUpdated) {
+        event::emit(comment_updated);
     }
 
-    public(friend) fun emit_comment_removed(ctx: &mut Context, comment_removed: CommentRemoved) {
-        event::emit(ctx, comment_removed);
+    public(friend) fun emit_comment_removed(comment_removed: CommentRemoved) {
+        event::emit(comment_removed);
     }
 
-    public(friend) fun emit_comment_added(ctx: &mut Context, comment_added: CommentAdded) {
-        event::emit(ctx, comment_added);
+    public(friend) fun emit_comment_added(comment_added: CommentAdded) {
+        event::emit(comment_added);
     }
 
-    public(friend) fun emit_article_created(ctx: &mut Context, article_created: ArticleCreated) {
-        event::emit(ctx, article_created);
+    public(friend) fun emit_article_created(article_created: ArticleCreated) {
+        event::emit(article_created);
     }
 
-    public(friend) fun emit_article_updated(ctx: &mut Context, article_updated: ArticleUpdated) {
-        event::emit(ctx, article_updated);
+    public(friend) fun emit_article_updated(article_updated: ArticleUpdated) {
+        event::emit(article_updated);
     }
 
-    public(friend) fun emit_article_deleted(ctx: &mut Context, article_deleted: ArticleDeleted) {
-        event::emit(ctx, article_deleted);
+    public(friend) fun emit_article_deleted(article_deleted: ArticleDeleted) {
+        event::emit(article_deleted);
     }
 
 }

--- a/examples/blog/sources/article_aggregate.move
+++ b/examples/blog/sources/article_aggregate.move
@@ -42,7 +42,7 @@ module rooch_examples::article_aggregate {
             article_obj,
         );
         article::update_version(article_obj);
-        article::emit_comment_updated(ctx, comment_updated);
+        article::emit_comment_updated(comment_updated);
     }
 
     public entry fun remove_comment(
@@ -63,7 +63,7 @@ module rooch_examples::article_aggregate {
             article_obj,
         );
         article::update_version(article_obj);
-        article::emit_comment_removed(ctx, comment_removed);
+        article::emit_comment_removed(comment_removed);
     }
 
     public entry fun add_comment(
@@ -86,7 +86,7 @@ module rooch_examples::article_aggregate {
             article_obj,
         );
         article::update_version(article_obj);
-        article::emit_comment_added(ctx, comment_added);
+        article::emit_comment_added(comment_added);
     }
 
     public entry fun create(
@@ -107,7 +107,7 @@ module rooch_examples::article_aggregate {
             &article_created,
         );
         article::set_article_created_id(&mut article_created, article_id);
-        article::emit_article_created(ctx, article_created);
+        article::emit_article_created(article_created);
     }
 
     public entry fun update(
@@ -130,7 +130,7 @@ module rooch_examples::article_aggregate {
             article_obj,
         );
         article::update_version(article_obj);
-        article::emit_article_updated(ctx, article_updated);
+        article::emit_article_updated(article_updated);
     }
 
     public entry fun delete(
@@ -150,7 +150,7 @@ module rooch_examples::article_aggregate {
             id,
         );
         article::drop_article(updated_article_obj);
-        article::emit_article_deleted(ctx, article_deleted);
+        article::emit_article_deleted(article_deleted);
     }
 
 }

--- a/examples/blog/sources/blog.move
+++ b/examples/blog/sources/blog.move
@@ -68,7 +68,7 @@ module rooch_examples::blog {
         }
     }
 
-    struct ArticleAddedToBlog has key {
+    struct ArticleAddedToBlog has drop {
         version: u64,
         article_id: ObjectID,
     }
@@ -87,7 +87,7 @@ module rooch_examples::blog {
         }
     }
 
-    struct ArticleRemovedFromBlog has key {
+    struct ArticleRemovedFromBlog has drop {
         version: u64,
         article_id: ObjectID,
     }
@@ -106,7 +106,7 @@ module rooch_examples::blog {
         }
     }
 
-    struct BlogCreated has key {
+    struct BlogCreated has drop {
         name: String,
     }
 
@@ -122,7 +122,7 @@ module rooch_examples::blog {
         }
     }
 
-    struct BlogUpdated has key {
+    struct BlogUpdated has drop {
         version: u64,
         name: String,
     }
@@ -141,7 +141,7 @@ module rooch_examples::blog {
         }
     }
 
-    struct BlogDeleted has key {
+    struct BlogDeleted has drop {
         version: u64,
     }
 
@@ -196,24 +196,24 @@ module rooch_examples::blog {
         blog.version = blog.version + 1;
     }
 
-    public(friend) fun emit_article_added_to_blog(ctx: &mut Context, article_added_to_blog: ArticleAddedToBlog) {
-        event::emit(ctx, article_added_to_blog);
+    public(friend) fun emit_article_added_to_blog(article_added_to_blog: ArticleAddedToBlog) {
+        event::emit(article_added_to_blog);
     }
 
-    public(friend) fun emit_article_removed_from_blog(ctx: &mut Context, article_removed_from_blog: ArticleRemovedFromBlog) {
-        event::emit(ctx, article_removed_from_blog);
+    public(friend) fun emit_article_removed_from_blog(article_removed_from_blog: ArticleRemovedFromBlog) {
+        event::emit(article_removed_from_blog);
     }
 
-    public(friend) fun emit_blog_created(ctx: &mut Context, blog_created: BlogCreated) {
-        event::emit(ctx, blog_created);
+    public(friend) fun emit_blog_created(blog_created: BlogCreated) {
+        event::emit(blog_created);
     }
 
-    public(friend) fun emit_blog_updated(ctx: &mut Context, blog_updated: BlogUpdated) {
-        event::emit(ctx, blog_updated);
+    public(friend) fun emit_blog_updated(blog_updated: BlogUpdated) {
+        event::emit(blog_updated);
     }
 
-    public(friend) fun emit_blog_deleted(ctx: &mut Context, blog_deleted: BlogDeleted) {
-        event::emit(ctx, blog_deleted);
+    public(friend) fun emit_blog_deleted(blog_deleted: BlogDeleted) {
+        event::emit(blog_deleted);
     }
 
 }

--- a/examples/blog/sources/blog_aggregate.move
+++ b/examples/blog/sources/blog_aggregate.move
@@ -39,7 +39,7 @@ module rooch_examples::blog_aggregate {
             mut_blog,
         );
         blog::update_version(mut_blog);
-        blog::emit_article_added_to_blog(ctx, article_added_to_blog);
+        blog::emit_article_added_to_blog(article_added_to_blog);
     }
 
     public(friend) fun remove_article(
@@ -57,7 +57,7 @@ module rooch_examples::blog_aggregate {
             mut_blog,
         );
         blog::update_version(mut_blog);
-        blog::emit_article_removed_from_blog(ctx, article_removed_from_blog);
+        blog::emit_article_removed_from_blog(article_removed_from_blog);
         article_obj
     }
 
@@ -77,7 +77,7 @@ module rooch_examples::blog_aggregate {
             &blog_created,
         );
         blog::add_blog(ctx, account, blog);
-        blog::emit_blog_created(ctx, blog_created);
+        blog::emit_blog_created(blog_created);
     }
 
     public entry fun update(
@@ -99,7 +99,7 @@ module rooch_examples::blog_aggregate {
             blog,
         );
         blog::update_version_and_add(ctx, account, updated_blog);
-        blog::emit_blog_updated(ctx, blog_updated);
+        blog::emit_blog_updated(blog_updated);
     }
 
     public entry fun delete(
@@ -119,7 +119,7 @@ module rooch_examples::blog_aggregate {
             blog,
         );
         blog::drop_blog(updated_blog);
-        blog::emit_blog_deleted(ctx, blog_deleted);
+        blog::emit_blog_deleted(blog_deleted);
     }
 
 }

--- a/examples/entry_function_arguments/sources/entry_function.move
+++ b/examples/entry_function_arguments/sources/entry_function.move
@@ -7,110 +7,110 @@ module rooch_examples::entry_function {
    use moveos_std::object::ObjectID;
    use moveos_std::context::Context;
 
-   struct BoolEvent {
+   struct BoolEvent has drop {
       value: bool
    }
-   public entry fun emit_bool(ctx: &mut Context, value: bool) {
-      event::emit<BoolEvent>(ctx, BoolEvent { value });
+   public entry fun emit_bool(_ctx: &mut Context, value: bool) {
+      event::emit<BoolEvent>(BoolEvent { value });
    }
 
-   struct U8Event {
+   struct U8Event has drop {
         value: u8
    }
-   public entry fun emit_u8(ctx: &mut Context, value: u8) {
-      event::emit<U8Event>(ctx, U8Event { value });
+   public entry fun emit_u8(_ctx: &mut Context, value: u8) {
+      event::emit<U8Event>(U8Event { value });
    }
 
-   struct U16Event {
+   struct U16Event has drop {
       value: u16
    }
-   public entry fun emit_u16(ctx: &mut Context, value: u16) {
-      event::emit<U16Event>(ctx, U16Event { value });
+   public entry fun emit_u16(_ctx: &mut Context, value: u16) {
+      event::emit<U16Event>(U16Event { value });
    }
 
-   struct U32Event {
+   struct U32Event has drop {
       value: u32
    }
-   public entry fun emit_u32(ctx: &mut Context, value: u32) {
-      event::emit<U32Event>(ctx, U32Event { value });
+   public entry fun emit_u32(_ctx: &mut Context, value: u32) {
+      event::emit<U32Event>(U32Event { value });
    }
 
-   struct U64Event {
+   struct U64Event has drop {
       value: u64
    }
-   public entry fun emit_u64(ctx: &mut Context, value: u64) {
-      event::emit<U64Event>(ctx, U64Event { value });
+   public entry fun emit_u64(_ctx: &mut Context, value: u64) {
+      event::emit<U64Event>(U64Event { value });
    }
 
-   struct U128Event {
+   struct U128Event has drop {
       value: u128
    }
-   public entry fun emit_u128(ctx: &mut Context, value: u128) {
-      event::emit<U128Event>(ctx, U128Event { value });
+   public entry fun emit_u128(_ctx: &mut Context, value: u128) {
+      event::emit<U128Event>(U128Event { value });
    }
 
-   struct U256Event {
+   struct U256Event has drop {
       value: u256
    }
-   public entry fun emit_u256(ctx: &mut Context, value: u256) {
-      event::emit<U256Event>(ctx, U256Event { value });
+   public entry fun emit_u256(_ctx: &mut Context, value: u256) {
+      event::emit<U256Event>(U256Event { value });
    }
 
-   struct AddressEvent {
+   struct AddressEvent has drop {
       value: address
    }
-   public entry fun emit_address(ctx: &mut Context, value: address) {
-      event::emit<AddressEvent>(ctx, AddressEvent { value });
+   public entry fun emit_address(_ctx: &mut Context, value: address) {
+      event::emit<AddressEvent>(AddressEvent { value });
    }
 
-   struct ObjectIdEvent {
+   struct ObjectIdEvent has drop {
       value: ObjectID
    }
-   public entry fun emit_object_id(ctx: &mut Context, value: ObjectID) {
-      event::emit<ObjectIdEvent>(ctx, ObjectIdEvent { value });
+   public entry fun emit_object_id(_ctx: &mut Context, value: ObjectID) {
+      event::emit<ObjectIdEvent>(ObjectIdEvent { value });
    }
 
-   struct StringEvent {
+   struct StringEvent has drop {
       value: std::string::String
    }
-   public entry fun emit_string(ctx: &mut Context, value: std::string::String) {
-      event::emit<StringEvent>(ctx, StringEvent { value });
+   public entry fun emit_string(_ctx: &mut Context, value: std::string::String) {
+      event::emit<StringEvent>(StringEvent { value });
    }
 
-   struct VecU8Event {
+   struct VecU8Event has drop {
       value: vector<u8>
    }
-   public entry fun emit_vec_u8(ctx: &mut Context, value: vector<u8>) {
-      event::emit<VecU8Event>(ctx, VecU8Event { value });
+   public entry fun emit_vec_u8(_ctx: &mut Context, value: vector<u8>) {
+      event::emit<VecU8Event>(VecU8Event { value });
    }
 
-   struct VecObjectIDEvent {
+   struct VecObjectIDEvent has drop {
       value: vector<ObjectID>
    }
    
-   public entry fun emit_vec_object_id(ctx: &mut Context, value: vector<ObjectID>) {
-      event::emit<VecObjectIDEvent>(ctx, VecObjectIDEvent { value });
+   public entry fun emit_vec_object_id(_ctx: &mut Context, value: vector<ObjectID>) {
+      event::emit<VecObjectIDEvent>(VecObjectIDEvent { value });
    }
 
-   public entry fun emit_mix(ctx: &mut Context, value1: u8, value2: vector<ObjectID>) {
-      event::emit<U8Event>(ctx, U8Event { value: value1 });
-      event::emit<VecObjectIDEvent>(ctx, VecObjectIDEvent { value: value2 });     
+   public entry fun emit_mix(_ctx: &mut Context, value1: u8, value2: vector<ObjectID>) {
+      event::emit<U8Event>(U8Event { value: value1 });
+      event::emit<VecObjectIDEvent>(VecObjectIDEvent { value: value2 });     
    }
 
    struct TestStruct has key{}
 
-   struct ObjectEvent{
+   struct ObjectEvent has drop{
       is_mut: bool,
       value: ObjectID,
    }
 
-   public entry fun emit_object(ctx: &mut Context, obj: &Object<TestStruct>) {
+   public entry fun emit_object(_ctx: &mut Context, obj: &Object<TestStruct>) {
       let object_id = object::id(obj);
-      event::emit<ObjectEvent>(ctx, ObjectEvent { is_mut: false, value: object_id });
+      event::emit<ObjectEvent>(ObjectEvent { is_mut: false, value: object_id });
    }
 
-   public entry fun emit_object_mut(ctx: &mut Context, obj: &mut Object<TestStruct>) {
+   public entry fun emit_object_mut(_ctx: &mut Context, obj: &mut Object<TestStruct>) {
       let object_id = object::id(obj);
-      event::emit<ObjectEvent>(ctx, ObjectEvent { is_mut: true, value: object_id });
+      event::emit<ObjectEvent>(ObjectEvent { is_mut: true, value: object_id });
    }
 }

--- a/examples/entry_function_arguments_old/sources/entry_function.move
+++ b/examples/entry_function_arguments_old/sources/entry_function.move
@@ -6,89 +6,89 @@ module rooch_examples::entry_function {
    use moveos_std::object::ObjectID;
    use moveos_std::context::Context;
 
-   struct BoolEvent {
+   struct BoolEvent has drop {
       value: bool
    }
-   public entry fun emit_bool(ctx: &mut Context, value: bool) {
-      event::emit<BoolEvent>(ctx, BoolEvent { value });
+   public entry fun emit_bool(_ctx: &mut Context, value: bool) {
+      event::emit<BoolEvent>(BoolEvent { value });
    }
 
-   struct U8Event {
+   struct U8Event has drop {
         value: u8
    }
-   public entry fun emit_u8(ctx: &mut Context, value: u8) {
-      event::emit<U8Event>(ctx, U8Event { value });
+   public entry fun emit_u8(_ctx: &mut Context, value: u8) {
+      event::emit<U8Event>(U8Event { value });
    }
 
-   struct U16Event {
+   struct U16Event has drop {
       value: u16
    }
-   public entry fun emit_u16(ctx: &mut Context, value: u16) {
-      event::emit<U16Event>(ctx, U16Event { value });
+   public entry fun emit_u16(_ctx: &mut Context, value: u16) {
+      event::emit<U16Event>(U16Event { value });
    }
 
-   struct U32Event {
+   struct U32Event has drop {
       value: u32
    }
-   public entry fun emit_u32(ctx: &mut Context, value: u32) {
-      event::emit<U32Event>(ctx, U32Event { value });
+   public entry fun emit_u32(_ctx: &mut Context, value: u32) {
+      event::emit<U32Event>(U32Event { value });
    }
 
-   struct U64Event {
+   struct U64Event has drop {
       value: u64
    }
-   public entry fun emit_u64(ctx: &mut Context, value: u64) {
-      event::emit<U64Event>(ctx, U64Event { value });
+   public entry fun emit_u64(_ctx: &mut Context, value: u64) {
+      event::emit<U64Event>(U64Event { value });
    }
 
-   struct U128Event {
+   struct U128Event has drop {
       value: u128
    }
-   public entry fun emit_u128(ctx: &mut Context, value: u128) {
-      event::emit<U128Event>(ctx, U128Event { value });
+   public entry fun emit_u128(_ctx: &mut Context, value: u128) {
+      event::emit<U128Event>(U128Event { value });
    }
 
-   struct U256Event {
+   struct U256Event has drop {
       value: u256
    }
-   public entry fun emit_u256(ctx: &mut Context, value: u256) {
-      event::emit<U256Event>(ctx, U256Event { value });
+   public entry fun emit_u256(_ctx: &mut Context, value: u256) {
+      event::emit<U256Event>(U256Event { value });
    }
 
-   struct AddressEvent {
+   struct AddressEvent has drop {
       value: address
    }
-   public entry fun emit_address(ctx: &mut Context, value: address) {
-      event::emit<AddressEvent>(ctx, AddressEvent { value });
+   public entry fun emit_address(_ctx: &mut Context, value: address) {
+      event::emit<AddressEvent>(AddressEvent { value });
    }
 
-   struct ObjectIdEvent {
+   struct ObjectIdEvent has drop {
       value: ObjectID
    }
-   public entry fun emit_object_id(ctx: &mut Context, value: ObjectID) {
-      event::emit<ObjectIdEvent>(ctx, ObjectIdEvent { value });
+   public entry fun emit_object_id(_ctx: &mut Context, value: ObjectID) {
+      event::emit<ObjectIdEvent>(ObjectIdEvent { value });
    }
 
-   struct StringEvent {
+   struct StringEvent has drop {
       value: std::string::String
    }
-   public entry fun emit_string(ctx: &mut Context, value: std::string::String) {
-      event::emit<StringEvent>(ctx, StringEvent { value });
+   public entry fun emit_string(_ctx: &mut Context, value: std::string::String) {
+      event::emit<StringEvent>(StringEvent { value });
    }
 
-   struct VecU8Event {
+   struct VecU8Event has drop {
       value: vector<u8>
    }
-   public entry fun emit_vec_u8(ctx: &mut Context, value: vector<u8>) {
-      event::emit<VecU8Event>(ctx, VecU8Event { value });
+   public entry fun emit_vec_u8(_ctx: &mut Context, value: vector<u8>) {
+      event::emit<VecU8Event>(VecU8Event { value });
    }
 
-   struct VecObjectIDEvent {
+   struct VecObjectIDEvent has drop {
       value: vector<ObjectID>
    }
    
-   public entry fun emit_vec_object_id(ctx: &mut Context, value: vector<ObjectID>) {
-      event::emit<VecObjectIDEvent>(ctx, VecObjectIDEvent { value });
+   public entry fun emit_vec_object_id(_ctx: &mut Context, value: vector<ObjectID>) {
+      event::emit<VecObjectIDEvent>(VecObjectIDEvent { value });
    }
 
    // public entry fun emit_mix(ctx: &mut Context, value1: u8, value2: vector<ObjectID>) {

--- a/examples/event/sources/event_test.move
+++ b/examples/event/sources/event_test.move
@@ -5,44 +5,28 @@ module rooch_examples::event_test {
     use moveos_std::context::{Self, Context};
     use moveos_std::event;
 
-    #[test_only]
-    use std::debug;
-
-
-    struct WithdrawEvent {
+    struct WithdrawEvent has copy, drop {
         addr: address,
         amount: u64
     }
 
     public entry fun emit_event(
         ctx: &mut Context,
-        // addr: address,
         amount: u64,
     ) {
         let addr = context::sender(ctx);
-        event::emit<WithdrawEvent>(ctx, WithdrawEvent {
+        event::emit<WithdrawEvent>(WithdrawEvent {
             addr,
             amount,
         });
     }
 
-    #[test]
-    fun test_get_test_event_handle() {
-        let event_handle_id = event::derive_event_handle_id<WithdrawEvent>();
-        debug::print(&120120);
-        debug::print(&event_handle_id);
+    #[test(sender = @042)]
+    fun test_event_emit(sender: address) {
+    
+        event::emit<WithdrawEvent>(WithdrawEvent {
+            addr: sender,
+            amount: 100,
+        });
     }
-
-    // #[test(sender = @042)]
-    // fun test_event_emit(sender: signer) {
-    //     let sender_addr = signer::address_of(&sender);
-    //     let ctx = context::new_test_context(sender_addr);
-    //
-    //     event::emit<WithdrawEvent>(&mut ctx, WithdrawEvent {
-    //         addr: signer::address_of(&sender),
-    //         amount: 100,
-    //     });
-    //
-    //     context::drop_test_context(ctx);
-    // }
 }

--- a/examples/nft/sources/collection.move
+++ b/examples/nft/sources/collection.move
@@ -67,7 +67,6 @@ module nft::collection{
         );
         let collection_id = object::id(&collection_obj);
         event::emit(
-            ctx,
             CreateCollectionEvent {
                 object_id: collection_id,
                 name,

--- a/examples/nft/sources/collection.move
+++ b/examples/nft/sources/collection.move
@@ -26,7 +26,7 @@ module nft::collection{
         maximum: Option<u64>,
     }
 
-    struct CreateCollectionEvent{
+    struct CreateCollectionEvent has drop {
         object_id: ObjectID,
         name: String,
         creator: address,

--- a/examples/simple_blog/sources/simple_article.move
+++ b/examples/simple_blog/sources/simple_article.move
@@ -22,16 +22,16 @@ module simple_blog::simple_article {
         body: String,
     }
 
-    struct ArticleCreatedEvent has copy,store {
+    struct ArticleCreatedEvent has copy,store,drop {
         id: ObjectID,
     }
 
-    struct ArticleUpdatedEvent has copy,store {
+    struct ArticleUpdatedEvent has copy,store,drop {
         id: ObjectID,
         version: u64,
     }
 
-    struct ArticleDeletedEvent has copy,store {
+    struct ArticleDeletedEvent has copy,store,drop {
         id: ObjectID,
         version: u64,
     }
@@ -62,14 +62,13 @@ module simple_blog::simple_article {
         let article_created_event = ArticleCreatedEvent {
             id,
         };
-        event::emit(ctx, article_created_event);
+        event::emit(article_created_event);
         object::transfer(article_obj, owner_addr);
         id
     }
 
     /// Update article
     public fun update_article(
-        ctx: &mut Context,
         article_obj: &mut Object<Article>,
         new_title: String,
         new_body: String,
@@ -87,12 +86,11 @@ module simple_blog::simple_article {
             id,
             version: article.version,
         };
-        event::emit(ctx, article_update_event);
+        event::emit(article_update_event);
     }
 
     /// Delete article
     public fun delete_article(
-        ctx: &mut Context,
         article_obj: Object<Article>,
     ) {
         let id = object::id(&article_obj);
@@ -102,7 +100,7 @@ module simple_blog::simple_article {
             id,
             version: article.version,
         };
-        event::emit(ctx, article_deleted_event);
+        event::emit(article_deleted_event);
         drop_article(article);
     }
 

--- a/examples/simple_blog/sources/simple_blog.move
+++ b/examples/simple_blog/sources/simple_blog.move
@@ -82,12 +82,11 @@ module simple_blog::simple_blog {
     }
 
     public entry fun update_article(
-        ctx: &mut Context,
         article_obj: &mut Object<Article>,
         new_title: String,
         new_body: String,
     ) {
-        simple_article::update_article(ctx, article_obj, new_title, new_body);
+        simple_article::update_article(article_obj, new_title, new_body);
     }
 
     public entry fun delete_article(
@@ -97,6 +96,6 @@ module simple_blog::simple_blog {
     ) {
         delete_article_from_myblog(ctx, owner, article_id);
         let article_obj = context::take_object(ctx, owner, article_id); 
-        simple_article::delete_article(ctx, article_obj);
+        simple_article::delete_article(article_obj);
     }
 }

--- a/examples/steal_split/sources/steal_split.move
+++ b/examples/steal_split/sources/steal_split.move
@@ -167,7 +167,7 @@ module rooch_examples::rooch_examples {
             simple_map::add(&mut state_mut_ref.games, next_game_id, new_game);
         };
         account_coin_store::transfer<WGBCOIN>(ctx, account, resouce_address, prize_pool_amount);
-        event::emit(ctx,
+        event::emit(
             CreateGameEvent {
                 game_id: next_game_id,
                 prize_pool_amount,
@@ -204,7 +204,7 @@ module rooch_examples::rooch_examples {
         option::fill(&mut player_data_mut_ref.decision_hash, decision_hash);
         option::fill(&mut player_data_mut_ref.salt_hash, salt_hash);
 
-        event::emit(ctx,
+        event::emit(
             SubmitDecisionEvent {
                 game_id,
                 player_address,
@@ -270,7 +270,7 @@ module rooch_examples::rooch_examples {
                 }else {
                     account_coin_store::transfer<WGBCOIN>(ctx, resouce_account_signer, @rooch_examples, game.prize_pool_amount);
                 };
-                event::emit(ctx,
+                event::emit(
                     ConcludeGameEvent {
                         game_id,
                         player_one_decision: game.player_one.decision,
@@ -283,7 +283,7 @@ module rooch_examples::rooch_examples {
             (game_id, player_address, decision)
         };
         {
-            event::emit(ctx,
+            event::emit(
                 RevealDecisionEvent {
                     game_id,
                     player_address,
@@ -333,7 +333,7 @@ module rooch_examples::rooch_examples {
             );
         };
 
-        event::emit(ctx,
+        event::emit(
             ReleaseFundsAfterExpirationEvent {
                 game_id,
                 player_one_decision: game.player_one.decision,

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/event.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/event.md
@@ -3,74 +3,12 @@
 
 # Module `0x2::event`
 
-<code><a href="event.md#0x2_event_EventHandle">EventHandle</a></code>s with unique event handle id (GUID). It contains a counter for the number
-of <code><a href="event.md#0x2_event_EventHandle">EventHandle</a></code>s it generates. An <code><a href="event.md#0x2_event_EventHandle">EventHandle</a></code> is used to count the number of
-events emitted to a handle and emit events to the event store.
 
 
--  [Resource `EventHandle`](#0x2_event_EventHandle)
--  [Function `derive_event_handle_id`](#0x2_event_derive_event_handle_id)
--  [Function `get_event_handle`](#0x2_event_get_event_handle)
--  [Function `ensure_event_handle`](#0x2_event_ensure_event_handle)
 -  [Function `emit`](#0x2_event_emit)
 
 
-<pre><code><b>use</b> <a href="">0x1::hash</a>;
-<b>use</b> <a href="bcs.md#0x2_bcs">0x2::bcs</a>;
-<b>use</b> <a href="context.md#0x2_context">0x2::context</a>;
-<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
-<b>use</b> <a href="type_info.md#0x2_type_info">0x2::type_info</a>;
-</code></pre>
-
-
-
-<a name="0x2_event_EventHandle"></a>
-
-## Resource `EventHandle`
-
-A handle for an event such that:
-1. Other modules can emit events to this handle.
-2. Storage can use this handle to prove the total number of events that happened in the past.
-
-
-<pre><code><b>struct</b> <a href="event.md#0x2_event_EventHandle">EventHandle</a> <b>has</b> key
-</code></pre>
-
-
-
-<a name="0x2_event_derive_event_handle_id"></a>
-
-## Function `derive_event_handle_id`
-
-A globally unique ID for this event stream. event handler id equal to guid.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_derive_event_handle_id">derive_event_handle_id</a>&lt;T&gt;(): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
-</code></pre>
-
-
-
-<a name="0x2_event_get_event_handle"></a>
-
-## Function `get_event_handle`
-
-Method to get event handle Metadata
-If event_handle_id doesn't exist, sender will be default address 0x0
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_get_event_handle">get_event_handle</a>&lt;T&gt;(ctx: &<a href="context.md#0x2_context_Context">context::Context</a>): (<a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, <b>address</b>, u64)
-</code></pre>
-
-
-
-<a name="0x2_event_ensure_event_handle"></a>
-
-## Function `ensure_event_handle`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_ensure_event_handle">ensure_event_handle</a>&lt;T&gt;(ctx: &<b>mut</b> <a href="context.md#0x2_context_Context">context::Context</a>)
-</code></pre>
+<pre><code></code></pre>
 
 
 
@@ -87,5 +25,5 @@ The type T is the main way to index the event, and can contain
 phantom parameters, eg. emit(MyEvent<phantom T>).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_emit">emit</a>&lt;T&gt;(_ctx: &<b>mut</b> <a href="context.md#0x2_context_Context">context::Context</a>, <a href="event.md#0x2_event">event</a>: T)
+<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_emit">emit</a>&lt;T: drop&gt;(<a href="event.md#0x2_event">event</a>: T)
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/event.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/event.md
@@ -87,5 +87,5 @@ The type T is the main way to index the event, and can contain
 phantom parameters, eg. emit(MyEvent<phantom T>).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_emit">emit</a>&lt;T&gt;(ctx: &<b>mut</b> <a href="context.md#0x2_context_Context">context::Context</a>, <a href="event.md#0x2_event">event</a>: T)
+<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_emit">emit</a>&lt;T&gt;(_ctx: &<b>mut</b> <a href="context.md#0x2_context_Context">context::Context</a>, <a href="event.md#0x2_event">event</a>: T)
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/event.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/event.move
@@ -101,16 +101,15 @@ module moveos_std::event {
     ///
     /// The type T is the main way to index the event, and can contain
     /// phantom parameters, eg. emit(MyEvent<phantom T>).
-    public fun emit<T>(ctx: &mut Context, event: T) {
-        ensure_event_handle<T>(ctx);
-        let event_handle_id = derive_event_handle_id<T>();
-        let event_handle_ref = borrow_event_handle_mut<T>(ctx);
-        native_emit<T>(&event_handle_id, event_handle_ref.counter, event);
-        event_handle_ref.counter = event_handle_ref.counter + 1;
+    public fun emit<T>(_ctx: &mut Context, event: T) {
+        //ensure_event_handle<T>(ctx);
+        //let event_handle_ref = borrow_event_handle_mut<T>(ctx);
+        native_emit<T>(event);
+        //event_handle_ref.counter = event_handle_ref.counter + 1;
     }
 
     /// Native procedure that writes to the actual event stream in Event store
-    native fun native_emit<T>(event_handle_id: &ObjectID, count: u64, event: T);
+    native fun native_emit<T>(event: T);
 
     #[test_only]
     struct WithdrawEvent has key {

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/event.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/event.move
@@ -1,97 +1,8 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-/// `EventHandle`s with unique event handle id (GUID). It contains a counter for the number
-/// of `EventHandle`s it generates. An `EventHandle` is used to count the number of
-/// events emitted to a handle and emit events to the event store.
 module moveos_std::event {
     
-    use std::hash;
-    use moveos_std::bcs;
-    use moveos_std::context::{Self, Context};
-    use moveos_std::object::{Self, ObjectID};
-    use moveos_std::type_info;
-
-    #[test_only]
-    use std::debug;
-    #[test_only]
-    use std::signer;
-
-    /// A handle for an event such that:
-    /// 1. Other modules can emit events to this handle.
-    /// 2. Storage can use this handle to prove the total number of events that happened in the past.
-    struct EventHandle has key {
-        /// Total number of events emitted to this event stream.
-        counter: u64,
-    }
-
-    /// A globally unique ID for this event stream. event handler id equal to guid.
-    public fun derive_event_handle_id<T>(): ObjectID {
-        let type_info = type_info::type_of<T>();
-        let event_handle_address = bcs::to_address(hash::sha3_256(bcs::to_bytes(&type_info)));
-        object::address_to_object_id(event_handle_address)
-    }
-
-    fun exists_event_handle<T>(ctx: &Context): bool {
-        let event_handle_id = derive_event_handle_id<T>();
-        context::exist_object<EventHandle>(ctx, event_handle_id)
-    }
-
-    /// Borrow a event handle from the object storage
-    fun borrow_event_handle<T>(ctx: &Context): &EventHandle {
-        let event_handle_id = derive_event_handle_id<T>();
-        let object = context::borrow_object<EventHandle>(ctx, event_handle_id);
-        object::borrow(object)
-    }
-
-    /// Borrow a mut event handle from the object storage
-    fun borrow_event_handle_mut<T>(ctx: &mut Context): &mut EventHandle {
-        let event_handle_id = derive_event_handle_id<T>();
-        let object = context::borrow_mut_object_extend<EventHandle>(ctx, event_handle_id);
-        object::borrow_mut(object)
-    }
-
-    /// Get event handle owner
-    fun get_event_handle_owner<T>(ctx: &Context): address {
-        let event_handle_id = derive_event_handle_id<T>();
-        let object = context::borrow_object<EventHandle>(ctx, event_handle_id);
-        object::owner(object)
-    }
-
-    /// Method to get event handle Metadata
-    /// If event_handle_id doesn't exist, sender will be default address 0x0
-    public fun get_event_handle<T>(ctx: &Context): (ObjectID, address, u64) {
-        let event_handle_id = derive_event_handle_id<T>();
-        let sender = @0x0;
-        let event_seq = 0;
-        if (exists_event_handle<T>(ctx)) {
-            let event_handle = borrow_event_handle<T>(ctx);
-            event_seq = event_handle.counter;
-            sender = get_event_handle_owner<T>(ctx);
-        };
-        (event_handle_id, sender, event_seq)
-    }
-
-    /// Use EventHandle to generate a unique event handle
-    /// user doesn't need to call this method directly
-    fun new_event_handle<T>(ctx: &mut Context) {
-        let event_handle_id = derive_event_handle_id<T>();
-        let event_handle = EventHandle {
-            counter: 0,
-        };
-        //TODO refactor EventHandle with singleton Object.
-        let obj = context::new_object_with_id(ctx, event_handle_id, event_handle);
-        // The event handle should be a shared object
-        // Any one can emit event to this handle
-        // TODO provide a emit event function with event handle
-        object::to_shared(obj);
-    }
-
-    public fun ensure_event_handle<T>(ctx: &mut Context) {
-        if (!exists_event_handle<T>(ctx)) {
-            new_event_handle<T>(ctx);
-        }
-    }
 
     #[private_generics(T)]
     /// Emit a custom Move event, sending the data offchain.
@@ -101,49 +12,32 @@ module moveos_std::event {
     ///
     /// The type T is the main way to index the event, and can contain
     /// phantom parameters, eg. emit(MyEvent<phantom T>).
-    public fun emit<T>(_ctx: &mut Context, event: T) {
-        //ensure_event_handle<T>(ctx);
-        //let event_handle_ref = borrow_event_handle_mut<T>(ctx);
+    public fun emit<T: drop>(event: T) {
         native_emit<T>(event);
-        //event_handle_ref.counter = event_handle_ref.counter + 1;
     }
 
     /// Native procedure that writes to the actual event stream in Event store
     native fun native_emit<T>(event: T);
 
     #[test_only]
-    struct WithdrawEvent has key {
+    struct WithdrawEvent has drop {
         addr: address,
         amount: u64
     }
 
-    #[test(sender = @0x1)]
-    fun test_event(sender: signer) {
-        let sender_addr = signer::address_of(&sender);
-        let ctx = context::new_test_context(sender_addr);
+    #[test(sender = @0x42)]
+    fun test_event(sender: address) {
 
-        emit<WithdrawEvent>(&mut ctx, WithdrawEvent {
-            addr: signer::address_of(&sender),
+        emit<WithdrawEvent>(WithdrawEvent {
+            addr: sender,
             amount: 100,
         });
-        emit<WithdrawEvent>(&mut ctx, WithdrawEvent {
-            addr: signer::address_of(&sender),
+        emit<WithdrawEvent>(WithdrawEvent {
+            addr: sender,
             amount: 102,
         });
 
-        let (event_hanlde_id, event_sender_addr, event_seq) = get_event_handle<WithdrawEvent>(&ctx);
-        debug::print(&event_hanlde_id);
-        debug::print(&event_sender_addr);
-        debug::print(&event_seq);
-
-        context::drop_test_context(ctx);
     }
 
-    #[test]
-    fun test_bytes_to_object_id() {
-        let event_handle_id = derive_event_handle_id<WithdrawEvent>();
-        debug::print(&200200);
-        debug::print(&event_handle_id);
-    }
 }
 

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/event.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/event.rs
@@ -1,19 +1,31 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::errors::{Location, PartialVMError, PartialVMResult};
-use move_core_types::{gas_algebra::InternalGas, vm_status::StatusCode};
+use crate::natives::helpers;
+use better_any::{Tid, TidAble};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{
+    gas_algebra::InternalGas,
+    language_storage::{StructTag, TypeTag},
+    vm_status::StatusCode,
+};
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
 use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
-    pop_arg,
-    values::{StructRef, Value},
+    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
 
-use crate::natives::helpers;
+#[derive(Default, Tid)]
+pub struct NativeEventContext {
+    events: Vec<(StructTag, Vec<u8>)>,
+}
+
+impl NativeEventContext {
+    pub fn into_events(self) -> Vec<(StructTag, Vec<u8>)> {
+        self.events
+    }
+}
 
 // pub const MaxEmitSize: u64 = 256000;
 
@@ -42,24 +54,31 @@ pub fn native_emit(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.len() == 1);
-    debug_assert!(args.len() == 3);
+    debug_assert!(args.len() == 1);
 
     // TODO(Gas): Charge the arg size dependent costs
 
     let ty = ty_args.pop().unwrap();
+    let type_tag = context.type_to_type_tag(&ty)?;
+    let struct_tag = match type_tag {
+        TypeTag::Struct(struct_tag) => *struct_tag,
+        _ => {
+            debug_assert!(false, "Event type should be a struct");
+            return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR));
+        }
+    };
     let msg = args.pop_back().unwrap();
-    let seq_num = pop_arg!(args, u64);
-    let raw_event_handler_id = pop_arg!(args, StructRef);
-    // event_handler_id equal to guid
-    let event_handler_id = helpers::get_object_id(raw_event_handler_id)?;
-
-    let _result = context
-        .save_event(event_handler_id.to_bytes(), seq_num, ty, msg)
-        .map_err(|e| {
-            PartialVMError::new(StatusCode::ABORTED)
-                .with_message(e.to_string())
-                .finish(Location::Undefined)
-        });
+    let layout = context.type_to_type_layout(&ty)?.ok_or_else(|| {
+        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(format!(
+            "Failed to get layout of type {:?} -- this should not happen",
+            ty
+        ))
+    })?;
+    let event_data = msg
+        .simple_serialize(&layout)
+        .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
+    let event_context = context.extensions_mut().get_mut::<NativeEventContext>();
+    event_context.events.push((struct_tag, event_data));
 
     Ok(NativeResult::ok(gas_params.base, smallvec![]))
 }

--- a/moveos/moveos-store/src/event_store/mod.rs
+++ b/moveos/moveos-store/src/event_store/mod.rs
@@ -1,19 +1,20 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{EVENT_HANDLE_PREFIX_NAME, EVENT_INDEX_PREFIX_NAME, EVENT_PREFIX_NAME};
 use anyhow::{anyhow, Result};
-use move_core_types::language_storage::TypeTag;
+use move_core_types::language_storage::StructTag;
 use moveos_types::event_filter::EventFilter;
 use moveos_types::h256::H256;
-use moveos_types::move_types::type_tag_match;
-use moveos_types::moveos_std::event::{Event, EventID};
+use moveos_types::moveos_std::event::{Event, EventHandle, EventID, TransactionEvent};
 use moveos_types::moveos_std::object::ObjectID;
-
-use crate::{EVENT_INDEX_PREFIX_NAME, EVENT_PREFIX_NAME};
 use raw_store::{derive_store, CodecKVStore, StoreInstance};
+use std::cmp::min;
+use std::collections::{HashMap, HashSet};
 
 derive_store!(EventDBBaseStore, (ObjectID, u64), Event, EVENT_PREFIX_NAME);
 
+//TODO the EventIndexDBStore is not used now, should remove it, and use the Indexer to get the event by tx_hash
 derive_store!(
     EventIndexDBStore,
     (H256, u64),
@@ -21,10 +22,15 @@ derive_store!(
     EVENT_INDEX_PREFIX_NAME
 );
 
-pub trait EventStore {
-    fn save_event(&self, event: Event) -> Result<()>;
+derive_store!(
+    EventHandleDBStore,
+    ObjectID,
+    EventHandle,
+    EVENT_HANDLE_PREFIX_NAME
+);
 
-    fn save_events(&self, events: Vec<Event>) -> Result<()>;
+pub trait EventStore {
+    fn save_events(&self, events: Vec<TransactionEvent>) -> Result<Vec<EventID>>;
 
     fn get_event(&self, event_id: EventID) -> Result<Option<Event>>;
 
@@ -38,7 +44,12 @@ pub trait EventStore {
         limit: u64,
     ) -> Result<Vec<Event>>;
 
-    fn get_events_by_event_handle_type(&self, event_handle_type: &TypeTag) -> Result<Vec<Event>>;
+    fn get_events_by_event_handle_type(
+        &self,
+        event_handle_type: &StructTag,
+        cursor: Option<u64>,
+        limit: u64,
+    ) -> Result<Vec<Event>>;
 
     fn get_events_with_filter(&self, filter: EventFilter) -> Result<Vec<Event>>;
 }
@@ -47,33 +58,77 @@ pub trait EventStore {
 pub struct EventDBStore {
     event_store: EventDBBaseStore,
     indexer_store: EventIndexDBStore,
+    event_handle_store: EventHandleDBStore,
 }
 
 impl EventDBStore {
     pub fn new(instance: StoreInstance) -> Self {
         EventDBStore {
             event_store: EventDBBaseStore::new(instance.clone()),
-            indexer_store: EventIndexDBStore::new(instance),
+            indexer_store: EventIndexDBStore::new(instance.clone()),
+            event_handle_store: EventHandleDBStore::new(instance),
         }
     }
 
-    pub fn save_event(&self, event: Event) -> Result<()> {
-        let key = (event.event_id.event_handle_id, event.event_id.event_seq);
-        self.event_store.kv_put(key, event)
+    fn get_event_handle(&self, event_handle_id: ObjectID) -> Result<Option<EventHandle>> {
+        self.event_handle_store.kv_get(event_handle_id)
     }
 
-    pub fn save_events(&self, events: Vec<Event>) -> Result<()> {
-        self.event_store.put_all(
-            events
-                .into_iter()
-                .map(|event| {
-                    (
-                        (event.event_id.event_handle_id, event.event_id.event_seq),
-                        event,
-                    )
-                })
-                .collect(),
-        )
+    fn get_or_create_event_handle(&self, event_handle_type: StructTag) -> Result<EventHandle> {
+        let event_handle_id = EventHandle::derive_event_handle_id(event_handle_type);
+        let event_handle = self.get_event_handle(event_handle_id)?;
+        if let Some(event_handle) = event_handle {
+            return Ok(event_handle);
+        }
+        let event_handle = EventHandle::new(event_handle_id, 0);
+        self.save_event_handle(event_handle.clone())?;
+        Ok(event_handle)
+    }
+
+    fn save_event_handle(&self, event_handle: EventHandle) -> Result<()> {
+        self.event_handle_store
+            .put_all(vec![(event_handle.id, event_handle)])
+    }
+
+    pub fn save_events(&self, tx_events: Vec<TransactionEvent>) -> Result<Vec<EventID>> {
+        let event_types = tx_events
+            .iter()
+            .map(|event| event.struct_tag.clone())
+            .collect::<HashSet<_>>();
+        let mut event_handles = event_types
+            .into_iter()
+            .map(|event_type| {
+                let handle = self.get_or_create_event_handle(event_type.clone())?;
+                Ok((event_type, handle))
+            })
+            .collect::<Result<HashMap<_, _>>>()?;
+        let mut event_ids = vec![];
+        let events = tx_events
+            .into_iter()
+            .map(|tx_event| {
+                let handle = event_handles
+                    .get_mut(&tx_event.struct_tag)
+                    .expect("Event handle must exist");
+                let event_id = EventID::new(handle.id, handle.count);
+                let event = Event::new(
+                    event_id,
+                    tx_event.struct_tag,
+                    tx_event.event_data,
+                    tx_event.event_index,
+                );
+                handle.count += 1;
+                event_ids.push(event_id);
+                ((event_id.event_handle_id, event_id.event_seq), event)
+            })
+            .collect::<Vec<_>>();
+        self.event_store.put_all(events)?;
+        self.event_handle_store.put_all(
+            event_handles
+                .into_values()
+                .map(|handle| (handle.id, handle))
+                .collect::<Vec<_>>(),
+        )?;
+        Ok(event_ids)
     }
 
     pub fn get_event(&self, event_id: EventID) -> Result<Option<Event>> {
@@ -115,59 +170,33 @@ impl EventDBStore {
         cursor: Option<u64>,
         limit: u64,
     ) -> Result<Vec<Event>> {
-        //  will not cross the boundary even if the size exceeds the storage capacity,
-        let start = cursor.unwrap_or(0);
-        let end = start + limit;
-        let mut iter = self.event_store.iter()?;
-        let seek_key = (*event_handle_id, start);
-        iter.seek(bcs::to_bytes(&seek_key)?).map_err(|e| {
-            anyhow::anyhow!("EventStore get_events_by_event_handle_id seek: {:?}", e)
+        let event_handle = self.get_event_handle(*event_handle_id)?.ok_or_else(|| {
+            anyhow!(
+                "Can not find event handle by id: {}",
+                event_handle_id.to_string()
+            )
         })?;
-
-        let data: Vec<Event> = iter
-            .filter_map(|item| {
-                let ((handle_id, event_seq), event) = item.unwrap_or_else(|err| {
-                    panic!(
-                        "{}",
-                        format!("Get events by event handle id error, {:?}", err)
-                    )
-                });
-                if Option::is_some(&cursor) {
-                    if handle_id == *event_handle_id && (event_seq > start && event_seq <= end) {
-                        return Some(event);
-                    }
-                } else if handle_id == *event_handle_id && (event_seq >= start && event_seq < end) {
-                    return Some(event);
-                }
-                None
-            })
+        let last_seq = event_handle.count;
+        let start = cursor.unwrap_or(0);
+        let end = min(start + limit, last_seq);
+        let event_ids = (start..end)
+            .map(|v| (EventID::new(*event_handle_id, v)))
             .collect::<Vec<_>>();
-        Ok(data)
+        Ok(self
+            .multi_get_events(event_ids)?
+            .into_iter()
+            .flatten()
+            .collect())
     }
 
     pub fn get_events_by_event_handle_type(
         &self,
-        event_handle_type: &TypeTag,
+        event_handle_type: &StructTag,
+        cursor: Option<u64>,
+        limit: u64,
     ) -> Result<Vec<Event>> {
-        let mut iter = self.event_store.iter()?;
-        //TODO choose the right seek key to optimize performance
-        iter.seek_to_first();
-        let data: Vec<_> = iter
-            .filter_map(|item| {
-                let ((_event_handle_id, _event_seq), event) = item.unwrap_or_else(|err| {
-                    panic!(
-                        "{}",
-                        format!("Get events by event handle type error, {:?}", err)
-                    )
-                });
-                if type_tag_match(event.type_tag(), event_handle_type) {
-                    Some(event)
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        Ok(data)
+        let event_handle_id = EventHandle::derive_event_handle_id(event_handle_type.clone());
+        self.get_events_by_event_handle_id(&event_handle_id, cursor, limit)
     }
 
     // TODO The complete event filter implementation depends on Indexer
@@ -180,7 +209,7 @@ impl EventDBStore {
             }
             // EventFilter::Transaction(tx_hash) => self.get_events_by_tx_hash(&tx_hash)?,
             EventFilter::MoveEventType(move_event_type) => {
-                self.get_events_by_event_handle_type(&move_event_type)?
+                self.get_events_by_event_handle_type(&move_event_type, Some(0), 100)?
             }
             // EventFilter::Sender(_sender) => {
             //     return Err(anyhow!(

--- a/moveos/moveos-store/src/event_store/mod.rs
+++ b/moveos/moveos-store/src/event_store/mod.rs
@@ -93,7 +93,7 @@ impl EventDBStore {
     pub fn save_events(&self, tx_events: Vec<TransactionEvent>) -> Result<Vec<EventID>> {
         let event_types = tx_events
             .iter()
-            .map(|event| event.struct_tag.clone())
+            .map(|event| event.event_type.clone())
             .collect::<HashSet<_>>();
         let mut event_handles = event_types
             .into_iter()
@@ -107,12 +107,12 @@ impl EventDBStore {
             .into_iter()
             .map(|tx_event| {
                 let handle = event_handles
-                    .get_mut(&tx_event.struct_tag)
+                    .get_mut(&tx_event.event_type)
                     .expect("Event handle must exist");
                 let event_id = EventID::new(handle.id, handle.count);
                 let event = Event::new(
                     event_id,
-                    tx_event.struct_tag,
+                    tx_event.event_type,
                     tx_event.event_data,
                     tx_event.event_index,
                 );

--- a/moveos/moveos-store/src/tests/test_store.rs
+++ b/moveos/moveos-store/src/tests/test_store.rs
@@ -113,13 +113,13 @@ fn test_event_store() {
     let event_ids = store.save_events(tx_events.clone()).unwrap();
     assert_eq!(event_ids.len(), 2);
     let event0 = store.get_event(event_ids[0]).unwrap().unwrap();
-    assert_eq!(event0.struct_tag, tx_events[0].struct_tag);
+    assert_eq!(event0.event_type, tx_events[0].event_type);
     assert_eq!(event0.event_data, tx_events[0].event_data);
     assert_eq!(event0.event_index, tx_events[0].event_index);
     assert_eq!(event0.event_id.event_seq, 0);
 
     let event1 = store.get_event(event_ids[1]).unwrap().unwrap();
-    assert_eq!(event1.struct_tag, tx_events[1].struct_tag);
+    assert_eq!(event1.event_type, tx_events[1].event_type);
     assert_eq!(event1.event_data, tx_events[1].event_data);
     assert_eq!(event1.event_index, tx_events[1].event_index);
     assert_eq!(event1.event_id.event_seq, 1);

--- a/moveos/moveos-store/src/tests/test_store.rs
+++ b/moveos/moveos-store/src/tests/test_store.rs
@@ -11,7 +11,7 @@ use move_core_types::language_storage::{StructTag, TypeTag};
 use move_core_types::vm_status::KeptVMStatus;
 use moveos_config::store_config::RocksdbConfig;
 use moveos_types::h256::H256;
-use moveos_types::moveos_std::event::{Event, EventID};
+use moveos_types::moveos_std::event::TransactionEvent;
 use moveos_types::transaction::TransactionExecutionInfo;
 use raw_store::rocks::{RocksDB, DEFAULT_PREFIX_NAME};
 use raw_store::traits::DBStore;
@@ -105,19 +105,24 @@ fn test_event_store() {
         name: Identifier::new("Name").unwrap(),
         type_params: vec![TypeTag::Bool],
     };
-    let test_type_tag = TypeTag::Struct(Box::new(test_struct_tag));
-    let event1 = Event::new(
-        EventID::new(AccountAddress::random().into(), rand::random()),
-        test_type_tag,
-        b"testeventdata".to_vec(),
-        rand::random(),
-    );
+    let tx_events = vec![
+        TransactionEvent::new(test_struct_tag.clone(), b"data0".to_vec(), 100),
+        TransactionEvent::new(test_struct_tag, b"data1".to_vec(), 101),
+    ];
 
-    let _id = (event1.event_id.event_handle_id, event1.event_id.event_seq);
-    store.save_event(event1.clone()).unwrap();
-    let event2 = store.get_event(event1.event_id).unwrap();
-    assert!(event2.is_some());
-    assert_eq!(event1, event2.unwrap());
+    let event_ids = store.save_events(tx_events.clone()).unwrap();
+    assert_eq!(event_ids.len(), 2);
+    let event0 = store.get_event(event_ids[0]).unwrap().unwrap();
+    assert_eq!(event0.struct_tag, tx_events[0].struct_tag);
+    assert_eq!(event0.event_data, tx_events[0].event_data);
+    assert_eq!(event0.event_index, tx_events[0].event_index);
+    assert_eq!(event0.event_id.event_seq, 0);
+
+    let event1 = store.get_event(event_ids[1]).unwrap().unwrap();
+    assert_eq!(event1.struct_tag, tx_events[1].struct_tag);
+    assert_eq!(event1.event_data, tx_events[1].event_data);
+    assert_eq!(event1.event_index, tx_events[1].event_index);
+    assert_eq!(event1.event_id.event_seq, 1);
 }
 
 #[test]

--- a/moveos/moveos-types/src/event_filter.rs
+++ b/moveos/moveos-types/src/event_filter.rs
@@ -66,7 +66,7 @@ impl EventFilter {
     fn try_matches(&self, item: &Event) -> Result<bool> {
         Ok(match self {
             EventFilter::MoveEventType(event_type) => {
-                struct_tag_match(&item.struct_tag, event_type)
+                struct_tag_match(&item.event_type, event_type)
             }
             EventFilter::MoveEventField { path: _, value: _ } => {
                 // matches!(item.decoded_event_data.pointer(path), Some(v) if v == value)

--- a/moveos/moveos-types/src/event_filter.rs
+++ b/moveos/moveos-types/src/event_filter.rs
@@ -4,10 +4,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::move_types::type_tag_match;
+use crate::move_types::struct_tag_match;
 use crate::moveos_std::event::Event;
 use anyhow::Result;
-use move_core_types::language_storage::TypeTag;
+use move_core_types::language_storage::StructTag;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::serde_as;
@@ -26,7 +26,7 @@ pub enum EventFilter {
     MoveEventType(
         // #[schemars(with = "String")]
         // #[serde_as(as = "TypeTag")]
-        TypeTag,
+        StructTag,
     ),
     MoveEventField {
         path: String,
@@ -65,7 +65,9 @@ pub enum EventFilter {
 impl EventFilter {
     fn try_matches(&self, item: &Event) -> Result<bool> {
         Ok(match self {
-            EventFilter::MoveEventType(event_type) => type_tag_match(&item.type_tag, event_type),
+            EventFilter::MoveEventType(event_type) => {
+                struct_tag_match(&item.struct_tag, event_type)
+            }
             EventFilter::MoveEventField { path: _, value: _ } => {
                 // matches!(item.decoded_event_data.pointer(path), Some(v) if v == value)
                 false

--- a/moveos/moveos-types/src/moveos_std/event.rs
+++ b/moveos/moveos-types/src/moveos_std/event.rs
@@ -149,7 +149,7 @@ impl EventID {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TransactionEvent {
     /// The type of the data
-    pub struct_tag: StructTag,
+    pub event_type: StructTag,
     /// The data payload of the event
     #[serde(with = "serde_bytes")]
     pub event_data: Vec<u8>,
@@ -158,9 +158,9 @@ pub struct TransactionEvent {
 }
 
 impl TransactionEvent {
-    pub fn new(struct_tag: StructTag, event_data: Vec<u8>, event_index: u64) -> Self {
+    pub fn new(event_type: StructTag, event_data: Vec<u8>, event_index: u64) -> Self {
         Self {
-            struct_tag,
+            event_type,
             event_data,
             event_index,
         }
@@ -180,7 +180,7 @@ pub struct Event {
     /// The unique event_id that the event was emitted to
     pub event_id: EventID,
     /// The type of the data
-    pub struct_tag: StructTag,
+    pub event_type: StructTag,
     /// The data payload of the event
     #[serde(with = "serde_bytes")]
     pub event_data: Vec<u8>,
@@ -191,13 +191,13 @@ pub struct Event {
 impl Event {
     pub fn new(
         event_id: EventID,
-        struct_tag: StructTag,
+        event_type: StructTag,
         event_data: Vec<u8>,
         event_index: u64,
     ) -> Self {
         Self {
             event_id,
-            struct_tag,
+            event_type,
             event_data,
             event_index,
         }
@@ -215,12 +215,12 @@ impl Event {
         bcs::from_bytes(self.event_data.as_slice()).map_err(Into::into)
     }
 
-    pub fn struct_tag(&self) -> &StructTag {
-        &self.struct_tag
+    pub fn event_type(&self) -> &StructTag {
+        &self.event_type
     }
 
     pub fn is<EventType: MoveStructType>(&self) -> bool {
-        self.struct_tag == EventType::struct_tag()
+        self.event_type == EventType::struct_tag()
     }
 }
 
@@ -230,8 +230,7 @@ impl std::fmt::Debug for Event {
             f,
             "Event {{ event_id: {:?}, type: {:?}, event_data: {:?} }}",
             self.event_id,
-            // self.sequence_number,
-            self.struct_tag,
+            self.event_type,
             hex::encode(&self.event_data)
         )
     }

--- a/moveos/moveos-types/src/moveos_std/event.rs
+++ b/moveos/moveos-types/src/moveos_std/event.rs
@@ -146,14 +146,41 @@ impl EventID {
 }
 
 /// Entry produced via a call to the `emit_event` builtin.
-#[derive(Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TransactionEvent {
+    /// The type of the data
+    pub struct_tag: StructTag,
+    /// The data payload of the event
+    #[serde(with = "serde_bytes")]
+    pub event_data: Vec<u8>,
+    /// event index in the transaction events.
+    pub event_index: u64,
+}
+
+impl TransactionEvent {
+    pub fn new(struct_tag: StructTag, event_data: Vec<u8>, event_index: u64) -> Self {
+        Self {
+            struct_tag,
+            event_data,
+            event_index,
+        }
+    }
+
+    /// The event hashs of the transaction will be collect to build the transaction merkle tree root.
+    /// The event hash is the hash of the event data, does not incloude other fields.
+    pub fn hash(&self) -> H256 {
+        h256::sha3_256_of(&self.event_data)
+    }
+}
+
+/// The Event type in the event store
+/// We generate the EventID in the event store, not in the event module.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Event {
     /// The unique event_id that the event was emitted to
     pub event_id: EventID,
-    // /// For expansion: The number of messages that have been emitted to the path previously
-    // pub sequence_number: u64,
     /// The type of the data
-    pub type_tag: TypeTag,
+    pub struct_tag: StructTag,
     /// The data payload of the event
     #[serde(with = "serde_bytes")]
     pub event_data: Vec<u8>,
@@ -164,13 +191,13 @@ pub struct Event {
 impl Event {
     pub fn new(
         event_id: EventID,
-        type_tag: TypeTag,
+        struct_tag: StructTag,
         event_data: Vec<u8>,
         event_index: u64,
     ) -> Self {
         Self {
             event_id,
-            type_tag,
+            struct_tag,
             event_data,
             event_index,
         }
@@ -188,16 +215,12 @@ impl Event {
         bcs::from_bytes(self.event_data.as_slice()).map_err(Into::into)
     }
 
-    pub fn type_tag(&self) -> &TypeTag {
-        &self.type_tag
+    pub fn struct_tag(&self) -> &StructTag {
+        &self.struct_tag
     }
 
     pub fn is<EventType: MoveStructType>(&self) -> bool {
-        self.type_tag == TypeTag::Struct(Box::new(EventType::struct_tag()))
-    }
-
-    pub fn hash(&self) -> H256 {
-        h256::sha3_256_of(bcs::to_bytes(self).as_ref().unwrap())
+        self.struct_tag == EventType::struct_tag()
     }
 }
 
@@ -208,7 +231,7 @@ impl std::fmt::Debug for Event {
             "Event {{ event_id: {:?}, type: {:?}, event_data: {:?} }}",
             self.event_id,
             // self.sequence_number,
-            self.type_tag,
+            self.struct_tag,
             hex::encode(&self.event_data)
         )
     }
@@ -223,34 +246,27 @@ impl std::fmt::Display for Event {
 /// A Rust representation of an Event Handle Resource.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EventHandle {
-    /// Number of events in the event stream.
-    count: u64,
     /// each event handle corresponds to a unique event handle id
-    event_handle_id: ObjectID,
-    /// event handle create address
-    sender: AccountAddress,
+    pub id: ObjectID,
+    /// Number of events in the event stream.
+    pub count: u64,
 }
 
 impl EventHandle {
     /// Constructs a new Event Handle
-    pub fn new(event_handle_id: ObjectID, count: u64, sender: AccountAddress) -> Self {
-        EventHandle {
-            event_handle_id,
-            count,
-            sender,
-        }
+    pub fn new(id: ObjectID, count: u64) -> Self {
+        EventHandle { id, count }
     }
 
     /// Return the event_id to where this event is stored in EventDB.
-    pub fn event_handle_id(&self) -> &ObjectID {
-        &self.event_handle_id
+    pub fn id(&self) -> &ObjectID {
+        &self.id
     }
     /// Return the counter for the handle
     pub fn count(&self) -> u64 {
         self.count
     }
 
-    #[cfg(any(test, feature = "fuzzing"))]
     pub fn count_mut(&mut self) -> &mut u64 {
         &mut self.count
     }

--- a/moveos/moveos-types/src/transaction.rs
+++ b/moveos/moveos-types/src/transaction.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    gas_config::GasConfig, h256, h256::H256, move_types::FunctionId, moveos_std::event::Event,
-    moveos_std::tx_context::TxContext, moveos_std::tx_meta::TxMeta, state::StateChangeSet,
+    gas_config::GasConfig, h256, h256::H256, move_types::FunctionId,
+    moveos_std::event::TransactionEvent, moveos_std::tx_context::TxContext,
+    moveos_std::tx_meta::TxMeta, state::StateChangeSet,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -258,7 +259,7 @@ pub struct TransactionOutput {
     pub status: KeptVMStatus,
     pub changeset: ChangeSet,
     pub state_changeset: StateChangeSet,
-    pub events: Vec<Event>,
+    pub events: Vec<TransactionEvent>,
     pub gas_used: u64,
 }
 


### PR DESCRIPTION
Follow #1090 

## Summary

Refactor events and make Event API stateless.

1. Remove EventHandle from Move.
2. Introduce TransactionEvent, and the events of TransactionOutput are TransactionEvent.
3. Record EventHandle in the event store.
4. Removet `&mut Context` from `event::emit`
5. Add the `drop` ability requirement to event `emit<T: drop>(e:T)`
6. Refactor Framework & Examples
7. Rename `Event::type_tag` to `Event::event_type`, and change type to `struct_tag`.

- Closes #1056 