### PR TITLE
[Framework] Refactor Timestamp to object

### DIFF
--- a/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ethereum_light_client_test.rs
@@ -60,11 +60,11 @@ fn test_submit_block() {
     let timestamp_module =
         binding_test.as_module_bundle::<rooch_types::framework::timestamp::TimestampModule>();
 
-    let now_microseconds = timestamp_module.now_microseconds().unwrap();
+    let now_milliseconds = timestamp_module.now_milliseconds().unwrap();
     let duration = std::time::Duration::from_secs(block_header.timestamp.unchecked_as_u64());
     println!(
-        "now_microseconds: {}, header_timestamp: {}",
-        now_microseconds, block_header.timestamp
+        "now_milliseconds: {}, header_timestamp: {}",
+        now_milliseconds, block_header.timestamp
     );
-    assert_eq!(now_microseconds, duration.as_micros() as u64);
+    assert_eq!(now_milliseconds, duration.as_millis() as u64);
 }

--- a/crates/rooch-framework-tests/tests/cases/timestamp/timestamp_test.exp
+++ b/crates/rooch-framework-tests/tests/cases/timestamp/timestamp_test.exp
@@ -1,0 +1,13 @@
+processed 5 tasks
+
+task 1 'run'. lines 4-12:
+status EXECUTED
+
+task 2 'run'. lines 13-25:
+status EXECUTED
+
+task 3 'run'. lines 26-37:
+status EXECUTED
+
+task 4 'run'. lines 38-56:
+status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/timestamp/timestamp_test.move
+++ b/crates/rooch-framework-tests/tests/cases/timestamp/timestamp_test.move
@@ -1,0 +1,57 @@
+//# init --addresses test=0x42
+
+//check the timestamp object id
+//# run --signers test
+script {
+    fun main() {
+        let object_id = moveos_std::object::singleton_object_id<rooch_framework::timestamp::Timestamp>();
+        std::debug::print(&object_id);
+    }
+}
+
+//Timestamp object as argument.
+//# run --signers test --args @0x1e9afd0c19db5da27f8e9a1ad98a551259e51db612dc771a9f78c4142059b391
+script {
+    use moveos_std::object::{Self, Object};
+    use rooch_framework::timestamp::{Self, Timestamp};
+
+    fun main(timestamp_obj: &Object<Timestamp>) {
+        let timestamp = object::borrow(timestamp_obj);
+        let now_secounds = timestamp::seconds(timestamp);
+        std::debug::print(&now_secounds);
+    }
+}
+
+//Get timestamp from context
+//# run --signers test
+script {
+    use moveos_std::context::Context;
+    use rooch_framework::timestamp;
+
+    fun main(ctx: &Context) {
+        let now_secounds = timestamp::now_seconds(ctx);
+        std::debug::print(&now_secounds);
+    }
+}
+
+// Update timestamp
+//# run --signers test --args @0x1e9afd0c19db5da27f8e9a1ad98a551259e51db612dc771a9f78c4142059b391
+script {
+    use moveos_std::context::Context;
+    use moveos_std::object::{Self, Object};
+    use rooch_framework::timestamp::{Self, Timestamp};
+
+    fun main(ctx: &mut Context, timestamp_obj: &Object<Timestamp>) {
+        let timestamp = object::borrow(timestamp_obj);
+        let secounds_from_arg = timestamp::seconds(timestamp);
+        let secounds_from_ctx = timestamp::now_seconds(ctx);
+        assert!(secounds_from_arg == secounds_from_ctx, 1);
+        let seconds = 100;
+        timestamp::fast_forward_seconds_for_local(ctx, seconds);
+        let secounds_from_arg = timestamp::seconds(timestamp);
+        let secounds_from_ctx = timestamp::now_seconds(ctx);
+        assert!(secounds_from_arg == secounds_from_ctx, 2);
+        assert!(secounds_from_arg == seconds, 3); 
+    }
+}
+

--- a/crates/rooch-framework/doc/timestamp.md
+++ b/crates/rooch-framework/doc/timestamp.md
@@ -3,39 +3,43 @@
 
 # Module `0x3::timestamp`
 
-This module keeps a global wall clock that stores the current Unix time in microseconds.
+This module keeps a global wall clock that stores the current Unix time in milliseconds.
 It interacts with the other modules in the following ways:
 * genesis: to initialize the timestamp
 * L1 block: update the timestamp via L1s block header timestamp
 * TickTransaction: update the timestamp via the time offset in the TickTransaction(TODO)
 
 
--  [Resource `CurrentTimeMicroseconds`](#0x3_timestamp_CurrentTimeMicroseconds)
+-  [Resource `Timestamp`](#0x3_timestamp_Timestamp)
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x3_timestamp_genesis_init)
 -  [Function `update_global_time`](#0x3_timestamp_update_global_time)
 -  [Function `try_update_global_time`](#0x3_timestamp_try_update_global_time)
--  [Function `now_microseconds`](#0x3_timestamp_now_microseconds)
+-  [Function `timestamp`](#0x3_timestamp_timestamp)
+-  [Function `milliseconds`](#0x3_timestamp_milliseconds)
+-  [Function `seconds`](#0x3_timestamp_seconds)
+-  [Function `now_milliseconds`](#0x3_timestamp_now_milliseconds)
 -  [Function `now_seconds`](#0x3_timestamp_now_seconds)
--  [Function `seconds_to_microseconds`](#0x3_timestamp_seconds_to_microseconds)
+-  [Function `seconds_to_milliseconds`](#0x3_timestamp_seconds_to_milliseconds)
 -  [Function `fast_forward_seconds_for_local`](#0x3_timestamp_fast_forward_seconds_for_local)
 
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="">0x2::context</a>;
+<b>use</b> <a href="">0x2::object</a>;
 <b>use</b> <a href="chain_id.md#0x3_chain_id">0x3::chain_id</a>;
 </code></pre>
 
 
 
-<a name="0x3_timestamp_CurrentTimeMicroseconds"></a>
+<a name="0x3_timestamp_Timestamp"></a>
 
-## Resource `CurrentTimeMicroseconds`
+## Resource `Timestamp`
 
-A singleton resource holding the current Unix time in microseconds
+A singleton object holding the current Unix time in milliseconds
 
 
-<pre><code><b>struct</b> <a href="timestamp.md#0x3_timestamp_CurrentTimeMicroseconds">CurrentTimeMicroseconds</a> <b>has</b> key
+<pre><code><b>struct</b> <a href="timestamp.md#0x3_timestamp_Timestamp">Timestamp</a> <b>has</b> key
 </code></pre>
 
 
@@ -55,12 +59,12 @@ An invalid timestamp was provided
 
 
 
-<a name="0x3_timestamp_MICRO_CONVERSION_FACTOR"></a>
+<a name="0x3_timestamp_MILLI_CONVERSION_FACTOR"></a>
 
-Conversion factor between seconds and microseconds
+Conversion factor between seconds and milliseconds
 
 
-<pre><code><b>const</b> <a href="timestamp.md#0x3_timestamp_MICRO_CONVERSION_FACTOR">MICRO_CONVERSION_FACTOR</a>: u64 = 1000000;
+<pre><code><b>const</b> <a href="timestamp.md#0x3_timestamp_MILLI_CONVERSION_FACTOR">MILLI_CONVERSION_FACTOR</a>: u64 = 1000;
 </code></pre>
 
 
@@ -71,7 +75,7 @@ Conversion factor between seconds and microseconds
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_Context">context::Context</a>, genesis_account: &<a href="">signer</a>, initial_time_microseconds: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_genesis_init">genesis_init</a>(ctx: &<b>mut</b> <a href="_Context">context::Context</a>, _genesis_account: &<a href="">signer</a>, initial_time_milliseconds: u64)
 </code></pre>
 
 
@@ -80,10 +84,10 @@ Conversion factor between seconds and microseconds
 
 ## Function `update_global_time`
 
-Updates the wall clock time, if the new time is smaller than the current time, aborts.
+Updates the global clock time, if the new time is smaller than the current time, aborts.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_update_global_time">update_global_time</a>(ctx: &<b>mut</b> <a href="_Context">context::Context</a>, timestamp_microsecs: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_update_global_time">update_global_time</a>(ctx: &<b>mut</b> <a href="_Context">context::Context</a>, timestamp_milliseconds: u64)
 </code></pre>
 
 
@@ -92,22 +96,55 @@ Updates the wall clock time, if the new time is smaller than the current time, a
 
 ## Function `try_update_global_time`
 
-Tries to update the wall clock time, if the new time is smaller than the current time, ignores the update, and returns false.
+Tries to update the global clock time, if the new time is smaller than the current time, ignores the update, and returns false.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_try_update_global_time">try_update_global_time</a>(ctx: &<b>mut</b> <a href="_Context">context::Context</a>, <a href="timestamp.md#0x3_timestamp">timestamp</a>: u64): bool
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="timestamp.md#0x3_timestamp_try_update_global_time">try_update_global_time</a>(ctx: &<b>mut</b> <a href="_Context">context::Context</a>, timestamp_milliseconds: u64): bool
 </code></pre>
 
 
 
-<a name="0x3_timestamp_now_microseconds"></a>
+<a name="0x3_timestamp_timestamp"></a>
 
-## Function `now_microseconds`
-
-Gets the current time in microseconds.
+## Function `timestamp`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_now_microseconds">now_microseconds</a>(ctx: &<a href="_Context">context::Context</a>): u64
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp">timestamp</a>(ctx: &<a href="_Context">context::Context</a>): &<a href="timestamp.md#0x3_timestamp_Timestamp">timestamp::Timestamp</a>
+</code></pre>
+
+
+
+<a name="0x3_timestamp_milliseconds"></a>
+
+## Function `milliseconds`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_milliseconds">milliseconds</a>(self: &<a href="timestamp.md#0x3_timestamp_Timestamp">timestamp::Timestamp</a>): u64
+</code></pre>
+
+
+
+<a name="0x3_timestamp_seconds"></a>
+
+## Function `seconds`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_seconds">seconds</a>(self: &<a href="timestamp.md#0x3_timestamp_Timestamp">timestamp::Timestamp</a>): u64
+</code></pre>
+
+
+
+<a name="0x3_timestamp_now_milliseconds"></a>
+
+## Function `now_milliseconds`
+
+Gets the current time in milliseconds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_now_milliseconds">now_milliseconds</a>(ctx: &<a href="_Context">context::Context</a>): u64
 </code></pre>
 
 
@@ -124,13 +161,13 @@ Gets the current time in seconds.
 
 
 
-<a name="0x3_timestamp_seconds_to_microseconds"></a>
+<a name="0x3_timestamp_seconds_to_milliseconds"></a>
 
-## Function `seconds_to_microseconds`
+## Function `seconds_to_milliseconds`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_seconds_to_microseconds">seconds_to_microseconds</a>(seconds: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="timestamp.md#0x3_timestamp_seconds_to_milliseconds">seconds_to_milliseconds</a>(seconds: u64): u64
 </code></pre>
 
 

--- a/crates/rooch-framework/sources/account.move
+++ b/crates/rooch-framework/sources/account.move
@@ -160,8 +160,6 @@ module rooch_framework::account {
       context::exists_resource<ResourceAccount>(ctx, addr)
    }
 
-
-   #[view]
    public fun exists_at(ctx: &Context, addr: address): bool {
       context::exists_resource<Account>(ctx, addr)
    }

--- a/crates/rooch-framework/sources/ethereum_light_client.move
+++ b/crates/rooch-framework/sources/ethereum_light_client.move
@@ -70,7 +70,7 @@ module rooch_framework::ethereum_light_client{
         table::add(&mut block_store.blocks, block_header.number, block_header);
 
         let timestamp_seconds = (block_header.timestamp as u64);
-        timestamp::try_update_global_time(ctx, timestamp::seconds_to_microseconds(timestamp_seconds));        
+        timestamp::try_update_global_time(ctx, timestamp::seconds_to_milliseconds(timestamp_seconds));        
     }
 
     /// The relay server submit a new Ethereum block to the light client.
@@ -78,7 +78,6 @@ module rooch_framework::ethereum_light_client{
         process_block(ctx, block_header_bytes);
     }
 
-    #[view]
     /// Get block via block_number
     public fun get_block(ctx: &Context, block_number: u64): &BlockHeader{
         let block_store = context::borrow_resource<BlockStore>(ctx, @rooch_framework);

--- a/crates/rooch-framework/sources/timestamp.move
+++ b/crates/rooch-framework/sources/timestamp.move
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-/// This module keeps a global wall clock that stores the current Unix time in microseconds.
+/// This module keeps a global wall clock that stores the current Unix time in milliseconds.
 /// It interacts with the other modules in the following ways:
 /// * genesis: to initialize the timestamp
 /// * L1 block: update the timestamp via L1s block header timestamp
@@ -9,71 +9,91 @@
 module rooch_framework::timestamp {
    
     use std::error;
+    use moveos_std::object;
     use moveos_std::context::{Self, Context};
 
     friend rooch_framework::genesis;
     friend rooch_framework::ethereum_light_client;
 
-    /// A singleton resource holding the current Unix time in microseconds
-    struct CurrentTimeMicroseconds has key {
-        microseconds: u64,
+    /// A singleton object holding the current Unix time in milliseconds
+    struct Timestamp has key {
+        milliseconds: u64,
     }
 
-    /// Conversion factor between seconds and microseconds
-    const MICRO_CONVERSION_FACTOR: u64 = 1000000;
+    /// Conversion factor between seconds and milliseconds
+    const MILLI_CONVERSION_FACTOR: u64 = 1000;
 
     /// An invalid timestamp was provided
     const ErrorInvalidTimestamp: u64 = 1;
 
-    public(friend) fun genesis_init(ctx: &mut Context, genesis_account: &signer, initial_time_microseconds: u64) {
-        let current_time = CurrentTimeMicroseconds { microseconds: initial_time_microseconds };
-        context::move_resource_to(ctx, genesis_account, current_time);
+    public(friend) fun genesis_init(ctx: &mut Context, _genesis_account: &signer, initial_time_milliseconds: u64) {
+        let timestamp = Timestamp { milliseconds: initial_time_milliseconds };
+        context::new_singleton(ctx, timestamp);
     }
 
-    /// Updates the wall clock time, if the new time is smaller than the current time, aborts.
-    public(friend) fun update_global_time(ctx: &mut Context, timestamp_microsecs: u64) {
-        let global_timer = context::borrow_mut_resource<CurrentTimeMicroseconds>(ctx, @rooch_framework);
-        let now = global_timer.microseconds;
-        assert!(now < timestamp_microsecs, error::invalid_argument(ErrorInvalidTimestamp));
-        global_timer.microseconds = timestamp_microsecs;
+    /// Updates the global clock time, if the new time is smaller than the current time, aborts.
+    public(friend) fun update_global_time(ctx: &mut Context, timestamp_milliseconds: u64) {
+        let current_timestamp = timestamp_mut(ctx); 
+        let now = current_timestamp.milliseconds;
+        assert!(now < timestamp_milliseconds, error::invalid_argument(ErrorInvalidTimestamp));
+        current_timestamp.milliseconds = timestamp_milliseconds;
     }
 
-    /// Tries to update the wall clock time, if the new time is smaller than the current time, ignores the update, and returns false.
-    public(friend) fun try_update_global_time(ctx: &mut Context, timestamp: u64) : bool {
-        let global_timer = context::borrow_mut_resource<CurrentTimeMicroseconds>(ctx, @rooch_framework);
-        let now = global_timer.microseconds;
-        if(now < timestamp) {
-            global_timer.microseconds = timestamp;
+    /// Tries to update the global clock time, if the new time is smaller than the current time, ignores the update, and returns false.
+    public(friend) fun try_update_global_time(ctx: &mut Context, timestamp_milliseconds: u64) : bool {
+        let current_timestamp = timestamp_mut(ctx); 
+        let now = current_timestamp.milliseconds;
+        if(now < timestamp_milliseconds) {
+            current_timestamp.milliseconds = timestamp_milliseconds;
             true
         }else{
             false
         }
     }
 
-    #[view]
-    /// Gets the current time in microseconds.
-    public fun now_microseconds(ctx: &Context): u64 {
-        context::borrow_resource<CurrentTimeMicroseconds>(ctx, @rooch_framework).microseconds
+    fun timestamp_mut(ctx: &mut Context): &mut Timestamp {
+        let object_id = object::singleton_object_id<Timestamp>();
+        let obj = context::borrow_mut_object_extend<Timestamp>(ctx, object_id);
+        object::borrow_mut(obj)
     }
 
-    #[view]
+    public fun timestamp(ctx: &Context): &Timestamp {
+        let object_id = object::singleton_object_id<Timestamp>();
+        let obj = context::borrow_object<Timestamp>(ctx, object_id);
+        object::borrow(obj)
+    }
+
+    public fun milliseconds(self: &Timestamp): u64 {
+        self.milliseconds
+    }
+
+    public fun seconds(self: &Timestamp): u64 {
+        self.milliseconds / MILLI_CONVERSION_FACTOR
+    }
+
+    /// Gets the current time in milliseconds.
+    public fun now_milliseconds(ctx: &Context): u64 {
+        let timestamp = timestamp(ctx);
+        timestamp.milliseconds
+    }
+
     /// Gets the current time in seconds.
     public fun now_seconds(ctx: &Context): u64 {
-        now_microseconds(ctx) / MICRO_CONVERSION_FACTOR
+        now_milliseconds(ctx) / MILLI_CONVERSION_FACTOR
     }
 
-    public fun seconds_to_microseconds(seconds: u64): u64 {
-        seconds * MICRO_CONVERSION_FACTOR
+    public fun seconds_to_milliseconds(seconds: u64): u64 {
+        seconds * MILLI_CONVERSION_FACTOR
     }
 
     #[test_only]
-    public fun update_global_time_for_test(ctx: &mut Context, timestamp_microsecs: u64){
-        update_global_time(ctx, timestamp_microsecs);
+    public fun update_global_time_for_test(ctx: &mut Context, timestamp_milliseconds: u64){
+        update_global_time(ctx, timestamp_milliseconds);
     }
 
     #[test_only]
     public fun update_global_time_for_test_secs(ctx: &mut Context, timestamp_seconds: u64) {
-        update_global_time(ctx, timestamp_seconds * MICRO_CONVERSION_FACTOR);
+        update_global_time(ctx, timestamp_seconds * MILLI_CONVERSION_FACTOR);
     }
 
     #[test_only]
@@ -82,8 +102,8 @@ module rooch_framework::timestamp {
     }
 
     fun fast_forward_seconds(ctx: &mut Context, timestamp_seconds: u64) {
-        let now_microseconds = now_microseconds(ctx);
-        update_global_time(ctx, now_microseconds + (timestamp_seconds * MICRO_CONVERSION_FACTOR));
+        let now_milliseconds = now_milliseconds(ctx);
+        update_global_time(ctx, now_milliseconds + (timestamp_seconds * MILLI_CONVERSION_FACTOR));
     }
 
     /// Fast forwards the clock by the given number of seconds, but only if the chain is in local mode.

--- a/crates/rooch-framework/sources/transaction_validator.move
+++ b/crates/rooch-framework/sources/transaction_validator.move
@@ -39,7 +39,6 @@ module rooch_framework::transaction_validator {
     const ErrorValidateNotInstalledAuthValidator: u64 = 1010;
 
 
-    #[view]
     /// This function is for Rooch to validate the transaction sender's authenticator.
     /// If the authenticator is invaid, abort this function.
     public fun validate(

--- a/crates/rooch-framework/tests/timestamp_test.move
+++ b/crates/rooch-framework/tests/timestamp_test.move
@@ -1,0 +1,24 @@
+#[test_only]
+module rooch_framework::timestamp_test{
+
+    use moveos_std::context;
+    use rooch_framework::timestamp;
+    
+    #[test]
+    fun test_timestamp(){
+        let genesis_ctx = rooch_framework::genesis::init_for_test();
+        {
+            let timestamp = timestamp::timestamp(&genesis_ctx);
+            assert!(timestamp::milliseconds(timestamp) == 0, 1);
+        };
+        let seconds:u64 = 1;
+        timestamp::fast_forward_seconds_for_test(&mut genesis_ctx, seconds);
+        assert!(timestamp::now_milliseconds(&genesis_ctx) == timestamp::seconds_to_milliseconds(seconds), 2);
+        assert!(timestamp::now_seconds(&genesis_ctx) == seconds, 3);
+        {
+            let timestamp = timestamp::timestamp(&genesis_ctx);
+            assert!(timestamp::milliseconds(timestamp) == timestamp::seconds_to_milliseconds(seconds), 4);
+        };
+        context::drop_test_context(genesis_ctx); 
+    }
+}

--- a/crates/rooch-types/src/framework/timestamp.rs
+++ b/crates/rooch-types/src/framework/timestamp.rs
@@ -17,17 +17,17 @@ use serde::{Deserialize, Serialize};
 pub const MODULE_NAME: &IdentStr = ident_str!("timestamp");
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub struct CurrentTimeMicroseconds {
+pub struct Timestamp {
     pub microseconds: u64,
 }
 
-impl MoveStructType for CurrentTimeMicroseconds {
+impl MoveStructType for Timestamp {
     const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
     const MODULE_NAME: &'static IdentStr = MODULE_NAME;
-    const STRUCT_NAME: &'static IdentStr = ident_str!("CurrentTimeMicroseconds");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Timestamp");
 }
 
-impl MoveStructState for CurrentTimeMicroseconds {
+impl MoveStructState for Timestamp {
     fn struct_layout() -> move_core_types::value::MoveStructLayout {
         move_core_types::value::MoveStructLayout::new(vec![
             move_core_types::value::MoveTypeLayout::U64,
@@ -41,12 +41,12 @@ pub struct TimestampModule<'a> {
 }
 
 impl<'a> TimestampModule<'a> {
-    pub const NOW_MICROSECONDS_FUNCTION_NAME: &'static IdentStr = ident_str!("now_microseconds");
+    pub const NOW_MICROSECONDS_FUNCTION_NAME: &'static IdentStr = ident_str!("now_milliseconds");
     pub const NOW_SECONDS_FUNCTION_NAME: &'static IdentStr = ident_str!("now_seconds");
     pub const FAST_FORWARD_SECONDS_FOR_LOCAL_FUNCTION_NAME: &'static IdentStr =
         ident_str!("fast_forward_seconds_for_local");
 
-    pub fn now_microseconds(&self) -> Result<u64> {
+    pub fn now_milliseconds(&self) -> Result<u64> {
         let call = FunctionCall::new(
             Self::function_id(Self::NOW_MICROSECONDS_FUNCTION_NAME),
             vec![],

--- a/crates/rooch/src/commands/rpc/commands/request.rs
+++ b/crates/rooch/src/commands/rpc/commands/request.rs
@@ -15,9 +15,9 @@ pub struct RequestCommand {
     pub method: String,
 
     /// The RPC method params, json value.
-    /// --params '"/resource/0x3/0x3::timestamp::CurrentTimeMicroseconds"'
+    /// --params '"/resource/0x3/0x3::account::Account"'
     /// or
-    /// --params '["/resource/0x3/0x3::timestamp::CurrentTimeMicroseconds", {"decode": true}]'
+    /// --params '["/resource/0x3/0x3::account::Account", {"decode": true}]'
     #[clap(long)]
     pub params: Option<serde_json::Value>,
 

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -18,13 +18,16 @@ Feature: Rooch CLI integration tests
     @serial
     Scenario: rooch rpc test
       Given a server for rooch_rpc_test
-      Then cmd: "rpc request --method rooch_getStates --params '["/resource/0x3/0x3::timestamp::CurrentTimeMicroseconds",{"decode":true}]'"
-      Then assert: "{{$.rpc[-1][0].value_type}} == '0x3::timestamp::CurrentTimeMicroseconds'"
-      Then assert: "{{$.rpc[-1][0].decoded_value.value.microseconds}} == 0"
+      Then cmd: "rpc request --method rooch_getStates --params '["/resource/0x3/0x3::account::Account",{"decode":true}]'"
+      Then assert: "{{$.rpc[-1][0].value_type}} == '0x3::account::Account'"
       Then cmd: "rpc request --method rooch_getStates --params '["/object/0x3",{"decode":true}]'"
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x2::object::ObjectEntity<0x2::account_storage::AccountStorage>'"
       Then cmd: "rpc request --method rooch_listStates --params '["/resource/0x3", null, null, {"decode":true}]"
-      Then assert: "'{{$.rpc[-1]}}' contains '0x3::timestamp::CurrentTimeMicroseconds'"
+      Then assert: "'{{$.rpc[-1]}}' contains '0x3::account::Account'"
+      #TODO support access path to singleton object shortcut: /object/0x3::timestamp::Timestamp
+      Then cmd: "rpc request --method rooch_getStates --params '["/object/0x1e9afd0c19db5da27f8e9a1ad98a551259e51db612dc771a9f78c4142059b391",{"decode":true}]'"
+      Then assert: "{{$.rpc[-1][0].value_type}} == '0x2::object::ObjectEntity<0x3::timestamp::Timestamp>'"
+      Then assert: "{{$.rpc[-1][0].decoded_value.value.value.value.milliseconds}} == 0"
       Then stop the server 
     
     @serial

--- a/examples/kv_store/sources/kv_store.move
+++ b/examples/kv_store/sources/kv_store.move
@@ -53,7 +53,6 @@ module rooch_examples::kv_store {
       remove(kv, key);
    }
 
-   #[view]
    public fun get_value(ctx: &mut Context, key: String): String {
       let kv = borrow_kv_store(ctx);
       let value = borrow(kv, key);


### PR DESCRIPTION
## Summary

Refactor timestamp

1. Rename `CurrentTimeMicroseconds` to `Timestamp`. 
2. Make Timestamp to singleton Object.
3. Change the timestamp value from microseconds to milliseconds.
 

Part of #1066 

TODO:
1. provide a shortcut access path for the singleton object: /object/0x3::timestamp::Timestamp.
2. Update documents #825 