### PR TITLE
Fixup docker build failed due to missing sqlite lib

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
         libsnappy-dev \
         g++ \
         cmake \
+        libsqlite3-dev \
         protobuf-compiler; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
resolve https://github.com/rooch-network/rooch/issues/1124