### PR TITLE
make from_bytes is decorated by data_struct

### DIFF
--- a/crates/rooch-framework/doc/README.md
+++ b/crates/rooch-framework/doc/README.md
@@ -19,6 +19,7 @@ This is the reference documentation of the Rooch Framework.
 -  [`0x3::auth_validator`](auth_validator.md#0x3_auth_validator)
 -  [`0x3::auth_validator_registry`](auth_validator_registry.md#0x3_auth_validator_registry)
 -  [`0x3::bcs`](bcs.md#0x3_bcs)
+-  [`0x3::bcs_friend`](bcs_friend.md#0x3_bcs_friend)
 -  [`0x3::bitcoin_address`](bitcoin_address.md#0x3_bitcoin_address)
 -  [`0x3::builtin_validators`](builtin_validators.md#0x3_builtin_validators)
 -  [`0x3::chain_id`](chain_id.md#0x3_chain_id)

--- a/crates/rooch-framework/doc/bcs.md
+++ b/crates/rooch-framework/doc/bcs.md
@@ -114,5 +114,5 @@ Function to deserialize a type T.
 Note the <code>private_generics</code> ensure only the <code>MoveValue</code>'s owner module can call this function
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bcs.md#0x3_bcs_from_bytes">from_bytes</a>&lt;MoveValue&gt;(bytes: <a href="">vector</a>&lt;u8&gt;): MoveValue
+<pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x3_bcs_from_bytes">from_bytes</a>&lt;MoveValue&gt;(bytes: <a href="">vector</a>&lt;u8&gt;): MoveValue
 </code></pre>

--- a/crates/rooch-framework/doc/bcs_friend.md
+++ b/crates/rooch-framework/doc/bcs_friend.md
@@ -1,0 +1,118 @@
+
+<a name="0x3_bcs_friend"></a>
+
+# Module `0x3::bcs_friend`
+
+Source from https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-stdlib/sources/from_bcs.move
+This module provides a number of functions to convert _primitive_ types from their representation in <code>std::bcs</code>
+to values. This is the opposite of <code><a href="_to_bytes">bcs::to_bytes</a></code>. Note that it is not safe to define a generic public <code>from_bytes</code>
+function because this can violate implicit struct invariants, therefore only primitive types are offerred. If
+a general conversion back-and-force is needed, consider the <code>moveos_std::Any</code> type which preserves invariants.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `to_bytes`](#0x3_bcs_friend_to_bytes)
+-  [Function `to_bool`](#0x3_bcs_friend_to_bool)
+-  [Function `to_u8`](#0x3_bcs_friend_to_u8)
+-  [Function `to_u64`](#0x3_bcs_friend_to_u64)
+-  [Function `to_u128`](#0x3_bcs_friend_to_u128)
+-  [Function `to_address`](#0x3_bcs_friend_to_address)
+-  [Function `from_bytes`](#0x3_bcs_friend_from_bytes)
+
+
+<pre><code><b>use</b> <a href="">0x1::bcs</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x3_bcs_friend_ErrorTypeNotMatch"></a>
+
+The request Move type is not match with input Move type.
+
+
+<pre><code><b>const</b> <a href="bcs_friend.md#0x3_bcs_friend_ErrorTypeNotMatch">ErrorTypeNotMatch</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x3_bcs_friend_to_bytes"></a>
+
+## Function `to_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x3_bcs_friend_to_bytes">to_bytes</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<a name="0x3_bcs_friend_to_bool"></a>
+
+## Function `to_bool`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x3_bcs_friend_to_bool">to_bool</a>(v: <a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<a name="0x3_bcs_friend_to_u8"></a>
+
+## Function `to_u8`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x3_bcs_friend_to_u8">to_u8</a>(v: <a href="">vector</a>&lt;u8&gt;): u8
+</code></pre>
+
+
+
+<a name="0x3_bcs_friend_to_u64"></a>
+
+## Function `to_u64`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x3_bcs_friend_to_u64">to_u64</a>(v: <a href="">vector</a>&lt;u8&gt;): u64
+</code></pre>
+
+
+
+<a name="0x3_bcs_friend_to_u128"></a>
+
+## Function `to_u128`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x3_bcs_friend_to_u128">to_u128</a>(v: <a href="">vector</a>&lt;u8&gt;): u128
+</code></pre>
+
+
+
+<a name="0x3_bcs_friend_to_address"></a>
+
+## Function `to_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x3_bcs_friend_to_address">to_address</a>(v: <a href="">vector</a>&lt;u8&gt;): <b>address</b>
+</code></pre>
+
+
+
+<a name="0x3_bcs_friend_from_bytes"></a>
+
+## Function `from_bytes`
+
+Function to deserialize a type T.
+Note the <code>private_generics</code> ensure only the <code>MoveValue</code>'s owner module can call this function
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bcs_friend.md#0x3_bcs_friend_from_bytes">from_bytes</a>&lt;MoveValue&gt;(bytes: <a href="">vector</a>&lt;u8&gt;): MoveValue
+</code></pre>

--- a/crates/rooch-framework/doc/ethereum_light_client.md
+++ b/crates/rooch-framework/doc/ethereum_light_client.md
@@ -16,7 +16,7 @@
 <pre><code><b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="">0x2::context</a>;
 <b>use</b> <a href="">0x2::table</a>;
-<b>use</b> <a href="bcs.md#0x3_bcs">0x3::bcs</a>;
+<b>use</b> <a href="bcs_friend.md#0x3_bcs_friend">0x3::bcs_friend</a>;
 <b>use</b> <a href="ethereum_address.md#0x3_ethereum_address">0x3::ethereum_address</a>;
 <b>use</b> <a href="timestamp.md#0x3_timestamp">0x3::timestamp</a>;
 </code></pre>

--- a/crates/rooch-framework/sources/bcs_friend.move
+++ b/crates/rooch-framework/sources/bcs_friend.move
@@ -7,7 +7,7 @@
 /// to values. This is the opposite of `bcs::to_bytes`. Note that it is not safe to define a generic public `from_bytes`
 /// function because this can violate implicit struct invariants, therefore only primitive types are offerred. If
 /// a general conversion back-and-force is needed, consider the `moveos_std::Any` type which preserves invariants.
-module rooch_framework::bcs {
+module rooch_framework::bcs_friend {
 
     /// The request Move type is not match with input Move type.
     const ErrorTypeNotMatch: u64 = 1;
@@ -42,8 +42,9 @@ module rooch_framework::bcs {
     //2. The fields contained in `T` are either primitive types or are defined by the module that calls from_bytes.
     //We need to find a solution to this problem. If we cannot solve it, then we cannot set from_bytes to public.
     // #[private_generics(MoveValue)]
-    #[data_struct(MoveValue)]
     /// Function to deserialize a type T.
     /// Note the `private_generics` ensure only the `MoveValue`'s owner module can call this function
-    native public fun from_bytes<MoveValue>(bytes: vector<u8>): MoveValue;
+    native public(friend) fun from_bytes<MoveValue>(bytes: vector<u8>): MoveValue;
+
+    friend rooch_framework::ethereum_light_client;
 }

--- a/crates/rooch-framework/sources/ethereum_light_client.move
+++ b/crates/rooch-framework/sources/ethereum_light_client.move
@@ -8,7 +8,7 @@ module rooch_framework::ethereum_light_client{
     use moveos_std::table::{Self, Table};
     use rooch_framework::ethereum_address::ETHAddress;
     use rooch_framework::timestamp;    
-    use rooch_framework::bcs;
+    use rooch_framework::bcs_friend;
 
     friend rooch_framework::genesis;
 
@@ -58,7 +58,7 @@ module rooch_framework::ethereum_light_client{
 
     fun process_block(ctx: &mut Context, block_header_bytes: vector<u8>){
         //TODO find a way to deserialize the block header, do not use bcs::from_bytes
-        let block_header = bcs::from_bytes<BlockHeader>(block_header_bytes);
+        let block_header = bcs_friend::from_bytes<BlockHeader>(block_header_bytes);
         //TODO validate the block hash
         //TODO validate the block via ethereum consensus(pos validators)
         let block_store = context::borrow_mut_resource<BlockStore>(ctx, @rooch_framework);

--- a/crates/rooch-framework/src/natives/gas_parameter/bcd_friend.rs
+++ b/crates/rooch-framework/src/natives/gas_parameter/bcd_friend.rs
@@ -1,0 +1,14 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::natives::gas_parameter::native::MUL;
+use crate::natives::rooch_framework::bcs_friend::GasParameters as RoochFrameGasParameters;
+use moveos_stdlib::natives::moveos_stdlib::bcs_friend::GasParameters;
+
+crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "bcs_friend", [
+    [.from_bytes.base, "from_bytes.base", (5 + 1) * MUL],
+]);
+
+crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(RoochFrameGasParameters, "bcs_friend", [
+    [.from_bytes.base, "from_bytes.base", (5 + 1) * MUL],
+]);

--- a/crates/rooch-framework/src/natives/gas_parameter/mod.rs
+++ b/crates/rooch-framework/src/natives/gas_parameter/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 mod account;
 mod bcd;
+mod bcd_friend;
 mod decoding;
 mod ecdsa_k1;
 mod ecdsa_k1_recoverable;

--- a/crates/rooch-framework/src/natives/mod.rs
+++ b/crates/rooch-framework/src/natives/mod.rs
@@ -25,6 +25,7 @@ pub struct GasParameters {
     encoding: rooch_framework::crypto::encoding::GasParameters,
     decoding: rooch_framework::crypto::decoding::GasParameters,
     bcs: rooch_framework::bcs::GasParameters,
+    bsc_friend: rooch_framework::bcs_friend::GasParameters,
 }
 
 impl FromOnChainGasSchedule for GasParameters {
@@ -42,6 +43,7 @@ impl FromOnChainGasSchedule for GasParameters {
             encoding: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
             decoding: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
             bcs: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
+            bsc_friend: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
         })
     }
 }
@@ -59,6 +61,7 @@ impl InitialGasSchedule for GasParameters {
             encoding: InitialGasSchedule::initial(),
             decoding: InitialGasSchedule::initial(),
             bcs: InitialGasSchedule::initial(),
+            bsc_friend: InitialGasSchedule::initial(),
         }
     }
 }
@@ -73,6 +76,7 @@ impl FromOnChainGasSchedule for MoveOSGasParameters {
             type_info: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
             rlp: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
             bcd: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
+            bcd_friend: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
             events: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
             test_helper: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
             signer: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
@@ -91,6 +95,7 @@ impl InitialGasSchedule for MoveOSGasParameters {
             type_info: InitialGasSchedule::initial(),
             rlp: InitialGasSchedule::initial(),
             bcd: InitialGasSchedule::initial(),
+            bcd_friend: InitialGasSchedule::initial(),
             events: InitialGasSchedule::initial(),
             test_helper: InitialGasSchedule::initial(),
             signer: InitialGasSchedule::initial(),
@@ -119,6 +124,7 @@ impl GasParameters {
             encoding: rooch_framework::crypto::encoding::GasParameters::zeros(),
             decoding: rooch_framework::crypto::decoding::GasParameters::zeros(),
             bcs: rooch_framework::bcs::GasParameters::zeros(),
+            bsc_friend: rooch_framework::bcs_friend::GasParameters::zeros(),
         }
     }
 }
@@ -170,6 +176,10 @@ pub fn all_natives(gas_params: GasParameters) -> NativeFunctionTable {
         rooch_framework::crypto::decoding::make_all(gas_params.decoding)
     );
     add_natives!("bcs", rooch_framework::bcs::make_all(gas_params.bcs));
+    add_natives!(
+        "bcs_friend",
+        rooch_framework::bcs_friend::make_all(gas_params.bsc_friend)
+    );
 
     let rooch_native_fun_table = make_table_from_iter(ROOCH_FRAMEWORK_ADDRESS, natives);
     native_fun_table.extend(rooch_native_fun_table);

--- a/crates/rooch-framework/src/natives/rooch_framework/bcs_friend.rs
+++ b/crates/rooch-framework/src/natives/rooch_framework/bcs_friend.rs
@@ -1,0 +1,89 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::natives::helpers::{make_module_natives, make_native};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::gas_algebra::InternalGas;
+use move_core_types::vm_status::StatusCode;
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+const E_TYPE_NOT_MATCH: u64 = 1;
+
+#[derive(Debug, Clone)]
+pub struct FromBytesGasParameters {
+    pub base: InternalGas,
+}
+
+impl FromBytesGasParameters {
+    pub fn zeros() -> Self {
+        Self { base: 0.into() }
+    }
+}
+
+/// Rust implementation of Move's `native public(friend) fun from_bytes<T>(vector<u8>): T in bcs module`
+/// Bytes are in BCS (Binary Canonical Serialization) format.
+#[inline]
+fn native_from_bytes(
+    gas_params: &FromBytesGasParameters,
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert_eq!(ty_args.len(), 1);
+    debug_assert_eq!(args.len(), 1);
+
+    let cost = gas_params.base;
+
+    // TODO(Gas): charge for getting the layout
+    let layout = context.type_to_type_layout(&ty_args[0])?.ok_or_else(|| {
+        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(format!(
+            "Failed to get layout of type {:?} -- this should not happen",
+            ty_args[0]
+        ))
+    })?;
+
+    let bytes = pop_arg!(args, Vec<u8>);
+    let val = match Value::simple_deserialize(&bytes, &layout) {
+        Some(val) => val,
+        None => {
+            return Ok(NativeResult::err(
+                cost,
+                moveos_types::move_std::error::invalid_argument(E_TYPE_NOT_MATCH),
+            ));
+        }
+    };
+    // TODO(gas): charge gas for deserialization
+
+    Ok(NativeResult::ok(cost, smallvec![val]))
+}
+
+/***************************************************************************************************
+ * module
+ **************************************************************************************************/
+
+#[derive(Debug, Clone)]
+pub struct GasParameters {
+    pub from_bytes: FromBytesGasParameters,
+}
+
+impl GasParameters {
+    pub fn zeros() -> Self {
+        Self {
+            from_bytes: FromBytesGasParameters::zeros(),
+        }
+    }
+}
+
+pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [(
+        "from_bytes",
+        make_native(gas_params.from_bytes, native_from_bytes),
+    )];
+
+    make_module_natives(natives)
+}

--- a/crates/rooch-framework/src/natives/rooch_framework/mod.rs
+++ b/crates/rooch-framework/src/natives/rooch_framework/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod account;
 pub mod bcs;
+pub(crate) mod bcs_friend;
 pub mod crypto;

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/README.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/README.md
@@ -16,6 +16,7 @@ This is the reference documentation of the MoveOS standard library.
 -  [`0x2::address`](address.md#0x2_address)
 -  [`0x2::any`](any.md#0x2_any)
 -  [`0x2::bcs`](bcs.md#0x2_bcs)
+-  [`0x2::bcs_friend`](bcs_friend.md#0x2_bcs_friend)
 -  [`0x2::context`](context.md#0x2_context)
 -  [`0x2::copyable_any`](copyable_any.md#0x2_copyable_any)
 -  [`0x2::display`](display.md#0x2_display)

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/any.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/any.md
@@ -14,7 +14,7 @@
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="">0x1::string</a>;
-<b>use</b> <a href="bcs.md#0x2_bcs">0x2::bcs</a>;
+<b>use</b> <a href="bcs_friend.md#0x2_bcs_friend">0x2::bcs_friend</a>;
 <b>use</b> <a href="type_info.md#0x2_type_info">0x2::type_info</a>;
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/bcs_friend.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/bcs_friend.md
@@ -1,0 +1,118 @@
+
+<a name="0x2_bcs_friend"></a>
+
+# Module `0x2::bcs_friend`
+
+Source from https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-stdlib/sources/from_bcs.move
+This module provides a number of functions to convert _primitive_ types from their representation in <code>std::bcs</code>
+to values. This is the opposite of <code><a href="_to_bytes">bcs::to_bytes</a></code>. Note that it is not safe to define a generic public <code>from_bytes</code>
+function because this can violate implicit struct invariants, therefore only primitive types are offerred. If
+a general conversion back-and-force is needed, consider the <code>moveos_std::Any</code> type which preserves invariants.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `to_bytes`](#0x2_bcs_friend_to_bytes)
+-  [Function `to_bool`](#0x2_bcs_friend_to_bool)
+-  [Function `to_u8`](#0x2_bcs_friend_to_u8)
+-  [Function `to_u64`](#0x2_bcs_friend_to_u64)
+-  [Function `to_u128`](#0x2_bcs_friend_to_u128)
+-  [Function `to_address`](#0x2_bcs_friend_to_address)
+-  [Function `from_bytes`](#0x2_bcs_friend_from_bytes)
+
+
+<pre><code><b>use</b> <a href="">0x1::bcs</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_bcs_friend_ErrorTypeNotMatch"></a>
+
+The request Move type is not match with input Move type.
+
+
+<pre><code><b>const</b> <a href="bcs_friend.md#0x2_bcs_friend_ErrorTypeNotMatch">ErrorTypeNotMatch</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x2_bcs_friend_to_bytes"></a>
+
+## Function `to_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x2_bcs_friend_to_bytes">to_bytes</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<a name="0x2_bcs_friend_to_bool"></a>
+
+## Function `to_bool`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x2_bcs_friend_to_bool">to_bool</a>(v: <a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<a name="0x2_bcs_friend_to_u8"></a>
+
+## Function `to_u8`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x2_bcs_friend_to_u8">to_u8</a>(v: <a href="">vector</a>&lt;u8&gt;): u8
+</code></pre>
+
+
+
+<a name="0x2_bcs_friend_to_u64"></a>
+
+## Function `to_u64`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x2_bcs_friend_to_u64">to_u64</a>(v: <a href="">vector</a>&lt;u8&gt;): u64
+</code></pre>
+
+
+
+<a name="0x2_bcs_friend_to_u128"></a>
+
+## Function `to_u128`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x2_bcs_friend_to_u128">to_u128</a>(v: <a href="">vector</a>&lt;u8&gt;): u128
+</code></pre>
+
+
+
+<a name="0x2_bcs_friend_to_address"></a>
+
+## Function `to_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bcs_friend.md#0x2_bcs_friend_to_address">to_address</a>(v: <a href="">vector</a>&lt;u8&gt;): <b>address</b>
+</code></pre>
+
+
+
+<a name="0x2_bcs_friend_from_bytes"></a>
+
+## Function `from_bytes`
+
+Function to deserialize a type T.
+Note the <code>private_generics</code> ensure only the <code>MoveValue</code>'s owner module can call this function
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bcs_friend.md#0x2_bcs_friend_from_bytes">from_bytes</a>&lt;MoveValue&gt;(bytes: <a href="">vector</a>&lt;u8&gt;): MoveValue
+</code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/copyable_any.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/copyable_any.md
@@ -15,7 +15,7 @@ Source from https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framew
 
 <pre><code><b>use</b> <a href="">0x1::error</a>;
 <b>use</b> <a href="">0x1::string</a>;
-<b>use</b> <a href="bcs.md#0x2_bcs">0x2::bcs</a>;
+<b>use</b> <a href="bcs_friend.md#0x2_bcs_friend">0x2::bcs_friend</a>;
 <b>use</b> <a href="type_info.md#0x2_type_info">0x2::type_info</a>;
 </code></pre>
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/any.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/any.move
@@ -8,7 +8,7 @@ module moveos_std::any {
     use std::error;
     use std::string::String;    
     use moveos_std::type_info;
-    use moveos_std::bcs;
+    use moveos_std::bcs_friend;
 
     friend moveos_std::copyable_any;
 
@@ -36,14 +36,14 @@ module moveos_std::any {
     public fun pack<T: drop + store>(x: T): Any {
         Any {
             type_name: type_info::type_name<T>(),
-            data: bcs::to_bytes(&x)
+            data: bcs_friend::to_bytes(&x)
         }
     }
 
     /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
     public fun unpack<T>(x: Any): T {
         assert!(type_info::type_name<T>() == x.type_name, error::invalid_argument(ErrorTypeMismatch));
-        bcs::from_bytes<T>(x.data)
+        bcs_friend::from_bytes<T>(x.data)
     }
 
     /// Returns the type name of this Any

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/bcs.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/bcs.move
@@ -42,12 +42,10 @@ module moveos_std::bcs{
     //2. The fields contained in `T` are either primitive types or are defined by the module that calls from_bytes. 
     //We need to find a solution to this problem. If we cannot solve it, then we cannot set from_bytes to public.
     // #[private_generics(MoveValue)]
+    #[data_struct(MoveValue)]
     /// Function to deserialize a type T.
     /// Note the `private_generics` ensure only the `MoveValue`'s owner module can call this function
     native public fun from_bytes<MoveValue>(bytes: vector<u8>): MoveValue;
-    
-    friend moveos_std::any;
-    friend moveos_std::copyable_any;
 
     // TODO: add test cases for this module.
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/bcs_friend.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/bcs_friend.move
@@ -7,12 +7,12 @@
 /// to values. This is the opposite of `bcs::to_bytes`. Note that it is not safe to define a generic public `from_bytes`
 /// function because this can violate implicit struct invariants, therefore only primitive types are offerred. If
 /// a general conversion back-and-force is needed, consider the `moveos_std::Any` type which preserves invariants.
-module rooch_framework::bcs {
+module moveos_std::bcs_friend{
 
     /// The request Move type is not match with input Move type.
     const ErrorTypeNotMatch: u64 = 1;
-
-    public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8> {
+    
+    public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8>{
         std::bcs::to_bytes(v)
     }
 
@@ -39,11 +39,15 @@ module rooch_framework::bcs {
     //TODO https://github.com/rooch-network/rooch/issues/145
     //Relying on private_generics alone cannot guarantee type safety. In order to achieve type safety for from_bytes, several conditions must be met:
     //1. The caller of from_bytes is the module that defines the `T`. This is ensured by private_generics.
-    //2. The fields contained in `T` are either primitive types or are defined by the module that calls from_bytes.
+    //2. The fields contained in `T` are either primitive types or are defined by the module that calls from_bytes. 
     //We need to find a solution to this problem. If we cannot solve it, then we cannot set from_bytes to public.
     // #[private_generics(MoveValue)]
-    #[data_struct(MoveValue)]
     /// Function to deserialize a type T.
     /// Note the `private_generics` ensure only the `MoveValue`'s owner module can call this function
-    native public fun from_bytes<MoveValue>(bytes: vector<u8>): MoveValue;
+    native public(friend) fun from_bytes<MoveValue>(bytes: vector<u8>): MoveValue;
+
+    friend moveos_std::any;
+    friend moveos_std::copyable_any;
+
+    // TODO: add test cases for this module.
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/copyable_any.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/copyable_any.move
@@ -8,7 +8,7 @@ module moveos_std::copyable_any {
     use std::error;
     use std::string::String;
     use moveos_std::type_info;
-    use moveos_std::bcs;
+    use moveos_std::bcs_friend;
 
     /// The type provided for `unpack` is not the same as was given for `pack`.
     const ErrorTypeMismatch: u64 = 1;
@@ -24,14 +24,14 @@ module moveos_std::copyable_any {
     public fun pack<T: drop + store + copy>(x: T): Any {
         Any {
             type_name: type_info::type_name<T>(),
-            data: bcs::to_bytes(&x)
+            data: bcs_friend::to_bytes(&x)
         }
     }
 
     /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
     public fun unpack<T>(x: Any): T {
         assert!(type_info::type_name<T>() == x.type_name, error::invalid_argument(ErrorTypeMismatch));
-        bcs::from_bytes<T>(x.data)
+        bcs_friend::from_bytes<T>(x.data)
     }
 
     /// Returns the type name of this Any

--- a/moveos/moveos-stdlib/src/natives/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/mod.rs
@@ -17,6 +17,7 @@ pub struct GasParameters {
     pub type_info: moveos_stdlib::type_info::GasParameters,
     pub rlp: moveos_stdlib::rlp::GasParameters,
     pub bcd: moveos_stdlib::bcs::GasParameters,
+    pub bcd_friend: moveos_stdlib::bcs_friend::GasParameters,
     pub events: moveos_stdlib::event::GasParameters,
     pub test_helper: moveos_stdlib::test_helper::GasParameters,
     pub signer: moveos_stdlib::signer::GasParameters,
@@ -33,6 +34,7 @@ impl GasParameters {
             type_info: moveos_stdlib::type_info::GasParameters::zeros(),
             rlp: moveos_stdlib::rlp::GasParameters::zeros(),
             bcd: moveos_stdlib::bcs::GasParameters::zeros(),
+            bcd_friend: moveos_stdlib::bcs_friend::GasParameters::zeros(),
             events: moveos_stdlib::event::GasParameters::zeros(),
             test_helper: moveos_stdlib::test_helper::GasParameters::zeros(),
             signer: moveos_stdlib::signer::GasParameters::zeros(),
@@ -82,6 +84,10 @@ pub fn all_natives(gas_params: GasParameters) -> NativeFunctionTable {
     );
     add_natives!("rlp", moveos_stdlib::rlp::make_all(gas_params.rlp));
     add_natives!("bcs", moveos_stdlib::bcs::make_all(gas_params.bcd));
+    add_natives!(
+        "bcs_friend",
+        moveos_stdlib::bcs_friend::make_all(gas_params.bcd_friend)
+    );
     add_natives!("event", moveos_stdlib::event::make_all(gas_params.events));
     add_natives!(
         "test_helper",

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/bcs_friend.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/bcs_friend.rs
@@ -1,0 +1,89 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::natives::helpers::{make_module_natives, make_native};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::gas_algebra::InternalGas;
+use move_core_types::vm_status::StatusCode;
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+const E_TYPE_NOT_MATCH: u64 = 1;
+
+#[derive(Debug, Clone)]
+pub struct FromBytesGasParameters {
+    pub base: InternalGas,
+}
+
+impl FromBytesGasParameters {
+    pub fn zeros() -> Self {
+        Self { base: 0.into() }
+    }
+}
+
+/// Rust implementation of Move's `native public(friend) fun from_bytes<T>(vector<u8>): T in bcs module`
+/// Bytes are in BCS (Binary Canonical Serialization) format.
+#[inline]
+fn native_from_bytes(
+    gas_params: &FromBytesGasParameters,
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert_eq!(ty_args.len(), 1);
+    debug_assert_eq!(args.len(), 1);
+
+    let cost = gas_params.base;
+
+    // TODO(Gas): charge for getting the layout
+    let layout = context.type_to_type_layout(&ty_args[0])?.ok_or_else(|| {
+        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(format!(
+            "Failed to get layout of type {:?} -- this should not happen",
+            ty_args[0]
+        ))
+    })?;
+
+    let bytes = pop_arg!(args, Vec<u8>);
+    let val = match Value::simple_deserialize(&bytes, &layout) {
+        Some(val) => val,
+        None => {
+            return Ok(NativeResult::err(
+                cost,
+                moveos_types::move_std::error::invalid_argument(E_TYPE_NOT_MATCH),
+            ));
+        }
+    };
+    // TODO(gas): charge gas for deserialization
+
+    Ok(NativeResult::ok(cost, smallvec![val]))
+}
+
+/***************************************************************************************************
+ * module
+ **************************************************************************************************/
+
+#[derive(Debug, Clone)]
+pub struct GasParameters {
+    pub from_bytes: FromBytesGasParameters,
+}
+
+impl GasParameters {
+    pub fn zeros() -> Self {
+        Self {
+            from_bytes: FromBytesGasParameters::zeros(),
+        }
+    }
+}
+
+pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [(
+        "from_bytes",
+        make_native(gas_params.from_bytes, native_from_bytes),
+    )];
+
+    make_module_natives(natives)
+}

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod bcs;
+pub mod bcs_friend;
 pub mod event;
 pub mod move_module;
 pub mod object;

--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -1187,6 +1187,11 @@ fn check_func_data_struct(
             (false, format!("The type argument {} of #[data_struct] for function {} in the module {} is not allowed.",
             full_struct_name, func_name, full_module_name))
         }
+        SignatureToken::Address => (true, "".to_string()),
+        SignatureToken::U128 => (true, "".to_string()),
+        SignatureToken::U64 => (true, "".to_string()),
+        SignatureToken::U8 => (true, "".to_string()),
+        SignatureToken::Bool => (true, "".to_string()),
         _ => {
             let module_id = view.self_id().unwrap().to_string();
             (false, format!("The type argument of #[data_struct] for function {} in the module {} is not allowed.",


### PR DESCRIPTION
make from_bytes is decorated by data_struct and provides the bcs_friend module, addressing the issue of not being able to use generic parameters in moveos_std::any.