### PR TITLE
Skip module init when upgrading module through MoveAction::ModuleBundle

### DIFF
--- a/moveos/moveos/src/vm/moveos_vm.rs
+++ b/moveos/moveos/src/vm/moveos_vm.rs
@@ -277,6 +277,11 @@ where
             } => {
                 //TODO check the modules package address with the sender
                 let sender = self.ctx.tx_context.sender();
+                // Check if module is first published. Only the first published module can run init function
+                let modules_with_init = init_function_modules
+                    .into_iter()
+                    .filter(|m| self.session.get_data_store().exists_module(m) == Ok(false))
+                    .collect();
                 //TODO check the compatiblity
                 let compat_config = Compatibility::full_check();
                 self.session.publish_module_bundle_with_compat_config(
@@ -285,7 +290,7 @@ where
                     &mut self.gas_meter,
                     compat_config,
                 )?;
-                self.execute_init_modules(init_function_modules)
+                self.execute_init_modules(modules_with_init)
             }
         };
 


### PR DESCRIPTION
## Summary

1. Use `context::publish_modules_entry` to publish modules in integration tests.
2. Skip module init functions when module is upgrading in `MoveAction::ModuleBundle` mode.

related issue: #1126 