### PR TITLE
[Framework] Resolve CoinStore transfer issue

### DIFF
--- a/crates/rooch-framework/sources/account_coin_store.move
+++ b/crates/rooch-framework/sources/account_coin_store.move
@@ -232,7 +232,7 @@ module rooch_framework::account_coin_store {
 
     fun borrow_mut_account_coin_store<CoinType: key>(ctx: &mut Context, addr: address): &mut Object<CoinStore<CoinType>>{
         let account_coin_store_id = account_coin_store_id<CoinType>(addr);
-        coin_store::borrow_mut_coin_store<CoinType>(ctx, account_coin_store_id)
+        coin_store::borrow_mut_coin_store_internal<CoinType>(ctx, account_coin_store_id)
     }
 
     fun create_or_borrow_mut_account_coin_store<CoinType: key>(ctx: &mut Context, addr: address): &mut Object<CoinStore<CoinType>>{
@@ -240,7 +240,7 @@ module rooch_framework::account_coin_store {
         if(!context::exists_object<CoinStore<CoinType>>(ctx, account_coin_store_id)) {
             create_account_coin_store<CoinType>(ctx, addr);
         };
-        coin_store::borrow_mut_coin_store<CoinType>(ctx, account_coin_store_id)
+        coin_store::borrow_mut_coin_store_internal<CoinType>(ctx, account_coin_store_id)
     }
 
     fun create_account_coin_store<CoinType: key>(ctx: &mut Context, addr: address) {

--- a/crates/rooch-framework/sources/tests/coin_store_test.move
+++ b/crates/rooch-framework/sources/tests/coin_store_test.move
@@ -39,7 +39,8 @@ module rooch_framework::coin_store_test{
         frozen: bool,
     ) {
         let coin_store_id = account_coin_store::account_coin_store_id<FakeCoin>(addr);
-        coin_store::freeze_coin_store_extend<FakeCoin>(ctx, coin_store_id, frozen);
+        let coin_store_obj = coin_store::borrow_mut_coin_store_extend<FakeCoin>(ctx, coin_store_id);
+        coin_store::freeze_coin_store_extend<FakeCoin>(coin_store_obj, frozen);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow #1138 

1. Abort error on the `coin_store::transfer` function. We do not allow direct transfers a CoinStore to the account.
2. Optimize CoinStore event, add `Create`, `Remove`, and `Fraze` events.

Part of #1055 