### PR TITLE
[rpc] The event RPC treat cursor None as -1

### DIFF
--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -8,7 +8,7 @@ use move_core_types::language_storage::StructTag;
 use moveos_types::access_path::AccessPath;
 use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
-use moveos_types::moveos_std::event::{AnnotatedEvent, EventID};
+use moveos_types::moveos_std::event::{AnnotatedEvent, Event, EventID};
 use moveos_types::state::{AnnotatedState, State};
 use moveos_types::transaction::FunctionCall;
 use moveos_types::transaction::TransactionExecutionInfo;
@@ -104,6 +104,17 @@ impl Message for ListAnnotatedStatesMessage {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct GetAnnotatedEventsByEventHandleMessage {
+    pub event_handle_type: StructTag,
+    pub cursor: Option<u64>,
+    pub limit: u64,
+}
+
+impl Message for GetAnnotatedEventsByEventHandleMessage {
+    type Result = Result<Vec<AnnotatedEvent>>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetEventsByEventHandleMessage {
     pub event_handle_type: StructTag,
     pub cursor: Option<u64>,
@@ -111,7 +122,7 @@ pub struct GetEventsByEventHandleMessage {
 }
 
 impl Message for GetEventsByEventHandleMessage {
-    type Result = Result<Vec<AnnotatedEvent>>;
+    type Result = Result<Vec<Event>>;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::actor::messages::{
-    GetEventsByEventIDsMessage, GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage,
-    ListStatesMessage,
+    GetEventsByEventHandleMessage, GetEventsByEventIDsMessage, GetTxExecutionInfosByHashMessage,
+    ListAnnotatedStatesMessage, ListStatesMessage,
 };
 use crate::actor::{
     executor::ExecutorActor,
     messages::{
-        AnnotatedStatesMessage, ExecuteViewFunctionMessage, GetEventsByEventHandleMessage,
+        AnnotatedStatesMessage, ExecuteViewFunctionMessage, GetAnnotatedEventsByEventHandleMessage,
         ResolveMessage, StatesMessage, ValidateTransactionMessage,
     },
 };
@@ -18,7 +18,7 @@ use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::StructTag;
 use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
-use moveos_types::moveos_std::event::EventID;
+use moveos_types::moveos_std::event::{Event, EventID};
 use moveos_types::transaction::FunctionCall;
 use moveos_types::transaction::TransactionExecutionInfo;
 use moveos_types::transaction::TransactionOutput;
@@ -113,12 +113,27 @@ impl ExecutorProxy {
             .await?
     }
 
-    pub async fn get_events_by_event_handle(
+    pub async fn get_annotated_events_by_event_handle(
         &self,
         event_handle_type: StructTag,
         cursor: Option<u64>,
         limit: u64,
     ) -> Result<Vec<AnnotatedEvent>> {
+        self.actor
+            .send(GetAnnotatedEventsByEventHandleMessage {
+                event_handle_type,
+                cursor,
+                limit,
+            })
+            .await?
+    }
+
+    pub async fn get_events_by_event_handle(
+        &self,
+        event_handle_type: StructTag,
+        cursor: Option<u64>,
+        limit: u64,
+    ) -> Result<Vec<Event>> {
         self.actor
             .send(GetEventsByEventHandleMessage {
                 event_handle_type,

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -7,7 +7,7 @@ use move_core_types::language_storage::StructTag;
 use moveos_types::access_path::AccessPath;
 use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
-use moveos_types::moveos_std::event::{AnnotatedEvent, EventID};
+use moveos_types::moveos_std::event::{AnnotatedEvent, Event, EventID};
 use moveos_types::state::{AnnotatedState, MoveStructType, State};
 use moveos_types::transaction::{FunctionCall, TransactionExecutionInfo};
 use rooch_executor::proxy::ExecutorProxy;
@@ -145,12 +145,25 @@ impl RpcService {
             .await
     }
 
-    pub async fn get_events_by_event_handle(
+    pub async fn get_annotated_events_by_event_handle(
         &self,
         event_handle_type: StructTag,
         cursor: Option<u64>,
         limit: u64,
     ) -> Result<Vec<AnnotatedEvent>> {
+        let resp = self
+            .executor
+            .get_annotated_events_by_event_handle(event_handle_type, cursor, limit)
+            .await?;
+        Ok(resp)
+    }
+
+    pub async fn get_events_by_event_handle(
+        &self,
+        event_handle_type: StructTag,
+        cursor: Option<u64>,
+        limit: u64,
+    ) -> Result<Vec<Event>> {
         let resp = self
             .executor
             .get_events_by_event_handle(event_handle_type, cursor, limit)

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -90,12 +90,19 @@ Feature: Rooch CLI integration tests
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
     Then cmd: "move run --function default::event_test::emit_event  --args 11u64"
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-    Then cmd: "event get-events-by-event-handle -t default::event_test::WithdrawEvent --cursor 0 --limit 1"
+    Then cmd: "move run --function default::event_test::emit_event  --args 11u64"
+    Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
+    #cursor is None
+    Then cmd: "event get-events-by-event-handle -t default::event_test::WithdrawEvent --limit 1"
     Then assert: "{{$.event[-1].data[0].event_id.event_seq}} == 0"
+    Then assert: "{{$.event[-1].next_cursor}} == 0"
+    Then assert: "{{$.event[-1].has_next_page}} == true"
+    Then cmd: "event get-events-by-event-handle -t default::event_test::WithdrawEvent --cursor 0 --limit 1"
+    Then assert: "{{$.event[-1].data[0].event_id.event_seq}} == 1"
     Then assert: "{{$.event[-1].next_cursor}} == 1"
     Then assert: "{{$.event[-1].has_next_page}} == true"
     Then cmd: "event get-events-by-event-handle -t default::event_test::WithdrawEvent --cursor 1 --limit 1"
-    Then assert: "{{$.event[-1].data[0].event_id.event_seq}} == 1"
+    Then assert: "{{$.event[-1].data[0].event_id.event_seq}} == 2"
     Then assert: "{{$.event[-1].has_next_page}} == false"
     Then stop the server
 

--- a/moveos/moveos-store/src/event_store/mod.rs
+++ b/moveos/moveos-store/src/event_store/mod.rs
@@ -129,6 +129,9 @@ impl EventDBStore {
         self.event_store.multiple_get(keys)
     }
 
+    /// Get events by event handle id
+    /// The cursor is the previous last event seq
+    /// So, do not include the result
     pub fn get_events_by_event_handle_id(
         &self,
         event_handle_id: &ObjectID,
@@ -142,7 +145,12 @@ impl EventDBStore {
             )
         })?;
         let last_seq = event_handle.count;
-        let start = cursor.unwrap_or(0);
+        let start = match cursor {
+            //The cursor do not include the result
+            Some(cursor) => cursor + 1,
+            //None means start from -1
+            None => 0,
+        };
         let end = min(start + limit, last_seq);
         let event_ids = (start..end)
             .map(|v| (EventID::new(*event_handle_id, v)))


### PR DESCRIPTION
## Summary

1. Unify event cursor logic and treat cursor None as -1. Address the comment in #1108.
2. Implement get events without Annotated function.

- Closes #issue