### PR TITLE
add `getCode` eth rpc server method

### DIFF
--- a/crates/rooch-rpc-api/src/api/eth_api.rs
+++ b/crates/rooch-rpc-api/src/api/eth_api.rs
@@ -116,6 +116,14 @@ pub trait EthAPI {
         hash: H256View,
         include_txs: bool,
     ) -> RpcResult<Block<TransactionType>>;
+
+    /// Returns the code at the given contract address.
+    #[method(name = "getCode")]
+    async fn get_code(
+        &self,
+        address: H160View,
+        block_number: Option<StrView<BlockNumber>>,
+    ) -> RpcResult<BytesView>;
 }
 
 #[open_rpc]

--- a/crates/rooch-rpc-server/src/server/eth_server.rs
+++ b/crates/rooch-rpc-server/src/server/eth_server.rs
@@ -309,7 +309,7 @@ impl EthAPIServer for EthServer {
             None => {
                 return Err(JsonRpcError::Custom(String::from(
                     "newest_block not a number",
-                )))
+                )));
             }
         }
     }
@@ -563,6 +563,15 @@ impl EthAPIServer for EthServer {
         };
 
         Ok(block)
+    }
+
+    async fn get_code(
+        &self,
+        _address: H160View,
+        _block_number: Option<StrView<BlockNumber>>,
+    ) -> RpcResult<BytesView> {
+        let code = BytesView::from_str("0x").unwrap();
+        Ok(code)
     }
 }
 


### PR DESCRIPTION
## Summary
Add eth_getCode method to the eth rpc server. for now, It just returns "0x"
 
- Closes #1092 