### PR TITLE
Parse json to move struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,6 +5230,7 @@ dependencies = [
  "petgraph 0.5.1",
  "serde 1.0.188",
  "serde_bytes",
+ "serde_json",
  "sha3 0.9.1",
  "smallvec 1.11.0",
 ]

--- a/crates/rooch-framework/src/natives/gas_parameter/json.rs
+++ b/crates/rooch-framework/src/natives/gas_parameter/json.rs
@@ -1,0 +1,9 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::natives::gas_parameter::native::MUL;
+use moveos_stdlib::natives::moveos_stdlib::json::GasParameters;
+
+crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "json", [
+    [.from_bytes.base, "from_bytes.base", (5 + 1) * MUL],
+]);

--- a/crates/rooch-framework/src/natives/gas_parameter/mod.rs
+++ b/crates/rooch-framework/src/natives/gas_parameter/mod.rs
@@ -10,6 +10,7 @@ mod encoding;
 mod events;
 pub mod gas_member;
 mod hash;
+mod json;
 mod move_module;
 pub mod move_std;
 pub mod native;

--- a/crates/rooch-framework/src/natives/mod.rs
+++ b/crates/rooch-framework/src/natives/mod.rs
@@ -78,6 +78,7 @@ impl FromOnChainGasSchedule for MoveOSGasParameters {
             signer: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
             move_module: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
             object: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
+            json: FromOnChainGasSchedule::from_on_chain_gas_schedule(gas_schedule).unwrap(),
         })
     }
 }
@@ -96,6 +97,7 @@ impl InitialGasSchedule for MoveOSGasParameters {
             signer: InitialGasSchedule::initial(),
             move_module: InitialGasSchedule::initial(),
             object: InitialGasSchedule::initial(),
+            json: InitialGasSchedule::initial(),
         }
     }
 }

--- a/moveos/moveos-stdlib/Cargo.toml
+++ b/moveos/moveos-stdlib/Cargo.toml
@@ -21,6 +21,7 @@ linked-hash-map = { workspace = true }
 log = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_bytes = { workspace = true }
 sha3 = { workspace = true }
 smallvec = { workspace = true }

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/README.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/README.md
@@ -21,6 +21,7 @@ This is the reference documentation of the MoveOS standard library.
 -  [`0x2::display`](display.md#0x2_display)
 -  [`0x2::event`](event.md#0x2_event)
 -  [`0x2::hex`](hex.md#0x2_hex)
+-  [`0x2::json`](json.md#0x2_json)
 -  [`0x2::move_module`](move_module.md#0x2_move_module)
 -  [`0x2::object`](object.md#0x2_object)
 -  [`0x2::object_table`](object_table.md#0x2_object_table)

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/json.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/json.md
@@ -20,5 +20,5 @@ Function to deserialize a type T.
 Note the <code>private_generics</code> ensure only the <code>T</code>'s owner module can call this function
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="json.md#0x2_json_from_json">from_json</a>&lt;T&gt;(bytes: <a href="">vector</a>&lt;u8&gt;): T
+<pre><code><b>public</b> <b>fun</b> <a href="json.md#0x2_json_from_json">from_json</a>&lt;T&gt;(json_str: <a href="">vector</a>&lt;u8&gt;): T
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/json.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/json.md
@@ -1,0 +1,24 @@
+
+<a name="0x2_json"></a>
+
+# Module `0x2::json`
+
+
+
+-  [Function `from_json`](#0x2_json_from_json)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x2_json_from_json"></a>
+
+## Function `from_json`
+
+Function to deserialize a type T.
+Note the <code>private_generics</code> ensure only the <code>T</code>'s owner module can call this function
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="json.md#0x2_json_from_json">from_json</a>&lt;T&gt;(bytes: <a href="">vector</a>&lt;u8&gt;): T
+</code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/json.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/json.md
@@ -18,6 +18,7 @@
 
 Function to deserialize a type T.
 Note the <code>private_generics</code> ensure only the <code>T</code>'s owner module can call this function
+The u128 and u256 types must be json String type instead of Number type
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="json.md#0x2_json_from_json">from_json</a>&lt;T&gt;(json_str: <a href="">vector</a>&lt;u8&gt;): T

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/json.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/json.move
@@ -6,25 +6,52 @@ module moveos_std::json{
     #[private_generics(T)]
     /// Function to deserialize a type T.
     /// Note the `private_generics` ensure only the `T`'s owner module can call this function
-    public fun from_json<T>(bytes: vector<u8>): T {
-        native_from_json(bytes)
+    public fun from_json<T>(json_str: vector<u8>): T {
+        native_from_json(json_str)
     }
 
-    native fun native_from_json<T>(bytes: vector<u8>): T;
+    native fun native_from_json<T>(json_str: vector<u8>): T;
 
     #[test_only]
-    struct Test has drop, copy {
+    use std::vector;
+
+    #[test_only]
+    struct Inner has copy, drop, store {
+        value: u64,
+    }
+    #[test_only]
+    struct Test has copy, drop, store {
         balance: u128,
         age: u8,
+        inner: Inner,
+        bytes: vector<u8>, 
+        inner_array: vector<Inner>,
+        account: address,
     }
 
     #[test]
     // #[expected_failure]
     fun test_from_json() {
-        let bytes = b"{\"balance\": \"170141183460469231731687303715884105728\",\"age\":30}";
-        let test = from_json<Test>(bytes);
+        let json_str = b"{\"balance\": \"170141183460469231731687303715884105728\",\"age\":30,\"inner\":{\"value\":100},\"bytes\":[3,3,2,1],\"inner_array\":[{\"value\":101}],\"account\":\"0x42\"}";
+        let obj = from_json<Test>(json_str);
         // let bytes = bcs::to_bytes(&Person{name: 100u128, age: 30u8});
-        assert!(test.age == 30u8, 1);
-        assert!(test.balance == 170141183460469231731687303715884105728u128, 1);
+        
+        assert!(obj.balance == 170141183460469231731687303715884105728u128, 1);
+        assert!(obj.age == 30u8, 2);
+        assert!(obj.inner.value == 100u64, 3);
+
+        // check bytes
+        assert!(vector::length(&obj.bytes) == 4, 4);
+        assert!(vector::borrow(&obj.bytes, 0) == &3u8, 5);
+        assert!(vector::borrow(&obj.bytes, 1) == &3u8, 6);
+        assert!(vector::borrow(&obj.bytes, 2) == &2u8, 7);
+        assert!(vector::borrow(&obj.bytes, 3) == &1u8, 8);
+
+        // check inner_array
+        assert!(vector::length(&obj.inner_array) == 1, 9);
+        assert!(vector::borrow(&obj.inner_array, 0).value == 101u64, 10);
+
+        // check account
+        assert!(obj.account == @0x42, 11);
     }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/json.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/json.move
@@ -1,0 +1,30 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+module moveos_std::json{
+
+    #[private_generics(T)]
+    /// Function to deserialize a type T.
+    /// Note the `private_generics` ensure only the `T`'s owner module can call this function
+    public fun from_json<T>(bytes: vector<u8>): T {
+        native_from_json(bytes)
+    }
+
+    native fun native_from_json<T>(bytes: vector<u8>): T;
+
+    #[test_only]
+    struct Test has drop, copy {
+        balance: u128,
+        age: u8,
+    }
+
+    #[test]
+    // #[expected_failure]
+    fun test_from_json() {
+        let bytes = b"{\"balance\": \"170141183460469231731687303715884105728\",\"age\":30}";
+        let test = from_json<Test>(bytes);
+        // let bytes = bcs::to_bytes(&Person{name: 100u128, age: 30u8});
+        assert!(test.age == 30u8, 1);
+        assert!(test.balance == 170141183460469231731687303715884105728u128, 1);
+    }
+}

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/json.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/json.move
@@ -4,8 +4,10 @@
 module moveos_std::json{
 
     #[private_generics(T)]
+    #[data_struct(T)]
     /// Function to deserialize a type T.
     /// Note the `private_generics` ensure only the `T`'s owner module can call this function
+    /// The u128 and u256 types must be json String type instead of Number type
     public fun from_json<T>(json_str: vector<u8>): T {
         native_from_json(json_str)
     }
@@ -16,10 +18,12 @@ module moveos_std::json{
     use std::vector;
 
     #[test_only]
+    #[data_struct]
     struct Inner has copy, drop, store {
         value: u64,
     }
     #[test_only]
+    #[data_struct]
     struct Test has copy, drop, store {
         balance: u128,
         age: u8,
@@ -30,11 +34,9 @@ module moveos_std::json{
     }
 
     #[test]
-    // #[expected_failure]
     fun test_from_json() {
         let json_str = b"{\"balance\": \"170141183460469231731687303715884105728\",\"age\":30,\"inner\":{\"value\":100},\"bytes\":[3,3,2,1],\"inner_array\":[{\"value\":101}],\"account\":\"0x42\"}";
         let obj = from_json<Test>(json_str);
-        // let bytes = bcs::to_bytes(&Person{name: 100u128, age: 30u8});
         
         assert!(obj.balance == 170141183460469231731687303715884105728u128, 1);
         assert!(obj.age == 30u8, 2);

--- a/moveos/moveos-stdlib/src/natives/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/mod.rs
@@ -22,6 +22,7 @@ pub struct GasParameters {
     pub signer: moveos_stdlib::signer::GasParameters,
     pub move_module: moveos_stdlib::move_module::GasParameters,
     pub object: moveos_stdlib::object::GasParameters,
+    pub json: moveos_stdlib::json::GasParameters,
 }
 
 impl GasParameters {
@@ -38,6 +39,7 @@ impl GasParameters {
             signer: moveos_stdlib::signer::GasParameters::zeros(),
             move_module: moveos_stdlib::move_module::GasParameters::zeros(),
             object: moveos_stdlib::object::GasParameters::zeros(),
+            json: moveos_stdlib::json::GasParameters::zeros(),
         }
     }
 }
@@ -93,6 +95,7 @@ pub fn all_natives(gas_params: GasParameters) -> NativeFunctionTable {
         moveos_stdlib::move_module::make_all(gas_params.move_module)
     );
     add_natives!("object", moveos_stdlib::object::make_all(gas_params.object));
+    add_natives!("json", moveos_stdlib::json::make_all(gas_params.json));
 
     let moveos_native_fun_table = make_table_from_iter(MOVEOS_STD_ADDRESS, natives);
     native_fun_table.extend(moveos_native_fun_table);

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/json.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/json.rs
@@ -1,0 +1,243 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::natives::helpers::{make_module_natives, make_native};
+use anyhow::Result;
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::account_address::AccountAddress;
+use move_core_types::u256::U256;
+use move_core_types::value::MoveStructLayout;
+use move_core_types::vm_status::StatusCode;
+use move_core_types::{gas_algebra::InternalGas, value::MoveTypeLayout};
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Struct, Value, Vector},
+};
+use serde_json;
+use smallvec::smallvec;
+use std::collections::VecDeque;
+use std::str::FromStr;
+
+const E_TYPE_NOT_MATCH: u64 = 1;
+const E_INVALID_JSON_STRING: u64 = 2;
+
+fn parse_struct_value_from_json(
+    layout: &MoveStructLayout,
+    json_value: &serde_json::Value,
+) -> Result<Struct> {
+    if let MoveStructLayout::WithTypes { fields, .. } = layout {
+        let field_values = fields
+            .iter()
+            .map(|field| -> Result<Value> {
+                let name = field.name.as_str();
+                let json_field = json_value
+                    .get(name)
+                    .ok_or_else(|| anyhow::anyhow!("Missing field {}", name))?;
+                parse_move_value_from_json(&field.layout, json_field)
+            })
+            .collect::<Result<Vec<Value>>>()?;
+        Ok(Struct::pack(field_values))
+    } else {
+        Err(anyhow::anyhow!("Invalid MoveStructLayout"))
+    }
+}
+fn parse_move_value_from_json(
+    layout: &MoveTypeLayout,
+    json_value: &serde_json::Value,
+) -> Result<Value> {
+    match layout {
+        MoveTypeLayout::Bool => {
+            let bool_value = json_value
+                .as_bool()
+                .ok_or_else(|| anyhow::anyhow!("Invalid bool value"))?;
+            Ok(Value::bool(bool_value))
+        }
+        MoveTypeLayout::U8 => {
+            let u64_value = json_value
+                .as_u64()
+                .ok_or_else(|| anyhow::anyhow!("Invalid u8 value"))?;
+            if u64_value > (u8::MAX as u64) {
+                return Err(anyhow::anyhow!("Invalid u8 value"));
+            }
+            Ok(Value::u8(u64_value as u8))
+        }
+        MoveTypeLayout::U64 => {
+            let u64_value = json_value
+                .as_u64()
+                .ok_or_else(|| anyhow::anyhow!("Invalid u64 value"))?;
+            Ok(Value::u64(u64_value))
+        }
+        MoveTypeLayout::U128 => {
+            let u128_str = json_value
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Invalid u128 value"))?;
+            let u128_value = u128::from_str_radix(u128_str, 10)
+                .map_err(|_| anyhow::anyhow!("Invalid u128 value"))?;
+            Ok(Value::u128(u128_value))
+        }
+        MoveTypeLayout::Address => {
+            let addr_str = json_value
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Invalid address value"))?;
+            let addr = AccountAddress::from_hex_literal(addr_str)
+                .map_err(|_| anyhow::anyhow!("Invalid address value"))?;
+            Ok(Value::address(addr))
+        }
+        MoveTypeLayout::Vector(item_layout) => {
+            let vec_value = json_value
+                .as_array()
+                .ok_or_else(|| anyhow::anyhow!("Invalid vector value"))?;
+            let _vec = vec_value
+                .iter()
+                .map(|v| parse_move_value_from_json(item_layout, v))
+                .collect::<Result<Vec<_>>>()?;
+            // get type from MoveTypeLayout
+            // pack Vec<Value> to Value
+            todo!()
+        }
+        MoveTypeLayout::Struct(struct_layout) => {
+            let struct_value = parse_struct_value_from_json(struct_layout, json_value)?;
+            Ok(Value::struct_(struct_value))
+        }
+        MoveTypeLayout::Signer => {
+            let addr_str = json_value
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Invalid address value"))?;
+            let addr = AccountAddress::from_hex_literal(addr_str)
+                .map_err(|_| anyhow::anyhow!("Invalid address value"))?;
+            Ok(Value::signer(addr))
+        }
+        MoveTypeLayout::U16 => {
+            let u64_value = json_value
+                .as_u64()
+                .ok_or_else(|| anyhow::anyhow!("Invalid u16 value"))?;
+            if u64_value > (u16::MAX as u64) {
+                return Err(anyhow::anyhow!("Invalid u16 value"));
+            }
+            Ok(Value::u16(u64_value as u16))
+        }
+        MoveTypeLayout::U32 => {
+            let u64_value = json_value
+                .as_u64()
+                .ok_or_else(|| anyhow::anyhow!("Invalid u32 value"))?;
+            if u64_value > (u32::MAX as u64) {
+                return Err(anyhow::anyhow!("Invalid u32 value"));
+            }
+            Ok(Value::u32(u64_value as u32))
+        }
+        MoveTypeLayout::U256 => {
+            let u256_str = json_value
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Invalid u256 value"))?;
+            let u256_value =
+                U256::from_str(u256_str).map_err(|_| anyhow::anyhow!("Invalid u256 value"))?;
+            Ok(Value::u256(u256_value))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FromBytesGasParameters {
+    pub base: InternalGas,
+}
+
+impl FromBytesGasParameters {
+    pub fn zeros() -> Self {
+        Self { base: 0.into() }
+    }
+}
+
+/// Rust implementation of Move's `native public(friend) fun from_bytes<T>(vector<u8>): T in bcs module`
+/// Bytes are in BCS (Binary Canonical Serialization) format.
+#[inline]
+fn native_from_json(
+    gas_params: &FromBytesGasParameters,
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert_eq!(ty_args.len(), 1);
+    debug_assert_eq!(args.len(), 1);
+
+    let cost = gas_params.base;
+
+    // TODO(Gas): charge for getting the layout
+    let layout = context
+        .type_to_fully_annotated_layout(&ty_args[0])?
+        .ok_or_else(|| {
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                format!(
+                    "Failed to get layout of type {:?} -- this should not happen",
+                    ty_args[0]
+                ),
+            )
+        })?;
+
+    let bytes = pop_arg!(args, Vec<u8>);
+    let json_str = match std::str::from_utf8(&bytes) {
+        Ok(s) => s,
+        Err(_) => {
+            return Ok(NativeResult::err(
+                cost,
+                moveos_types::move_std::error::invalid_argument(E_INVALID_JSON_STRING),
+            ));
+        }
+    };
+    let json_obj: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(obj) => obj,
+        Err(_) => {
+            return Ok(NativeResult::err(
+                cost,
+                moveos_types::move_std::error::invalid_argument(E_INVALID_JSON_STRING),
+            ));
+        }
+    };
+
+    // If layout is not MoveTypeLayout::MoveStructLayout, return error
+    if let MoveTypeLayout::Struct(struct_layout) = layout {
+        match parse_struct_value_from_json(&struct_layout, &json_obj) {
+            Ok(val) => Ok(NativeResult::ok(cost, smallvec![Value::struct_(val)])),
+            Err(err) => {
+                println!("parse_struct_value_from_json: {:?}", err);
+                return Ok(NativeResult::err(
+                    cost,
+                    moveos_types::move_std::error::invalid_argument(E_INVALID_JSON_STRING),
+                ));
+            }
+        }
+    } else {
+        return Ok(NativeResult::err(
+            cost,
+            moveos_types::move_std::error::invalid_argument(E_TYPE_NOT_MATCH),
+        ));
+    }
+}
+
+/***************************************************************************************************
+ * module
+ **************************************************************************************************/
+
+#[derive(Debug, Clone)]
+pub struct GasParameters {
+    pub from_bytes: FromBytesGasParameters,
+}
+
+impl GasParameters {
+    pub fn zeros() -> Self {
+        Self {
+            from_bytes: FromBytesGasParameters::zeros(),
+        }
+    }
+}
+
+pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [(
+        "native_from_json",
+        make_native(gas_params.from_bytes, native_from_json),
+    )];
+
+    make_module_natives(natives)
+}

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/json.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/json.rs
@@ -152,8 +152,9 @@ impl FromBytesGasParameters {
     }
 }
 
-/// Rust implementation of Move's `native public(friend) fun from_bytes<T>(vector<u8>): T in bcs module`
-/// Bytes are in BCS (Binary Canonical Serialization) format.
+/// Rust implementation of Move's `native fun native_from_json<T>(json_str: vector<u8>): T` in json module
+/// Input arguments:
+///   - json_str: vector<u8>, string bytes of json object
 #[inline]
 fn native_from_json(
     gas_params: &FromBytesGasParameters,

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod bcs;
 pub mod event;
+pub mod json;
 pub mod move_module;
 pub mod object;
 pub mod raw_table;


### PR DESCRIPTION
## Summary

Add `json::from_json<T>(str: vector<u8>)` to decode json str to move struct.

- Closes #991 