### PR TITLE
[Indexer] Split StateChangeSet into TableChangeSet dimensions to support sync state by table handle

### DIFF
--- a/crates/rooch-indexer/migrations/2023-11-21-122443_leaf_states/up.sql
+++ b/crates/rooch-indexer/migrations/2023-11-21-122443_leaf_states/up.sql
@@ -2,12 +2,12 @@ CREATE TABLE leaf_states
 (
     id                 VARCHAR        NOT NULL      PRIMARY KEY,
     object_id          VARCHAR        NOT NULL,
-    key_str            VARCHAR        NOT NULL,
+    key_hex            VARCHAR        NOT NULL,
     value              VARCHAR        NOT NULL,
     value_type         VARCHAR        NOT NULL,
     created_at         BIGINT         NOT NULL,
     updated_at         BIGINT         NOT NULL,
-    UNIQUE (object_id, key_str)
+    UNIQUE (object_id, key_hex)
 );
 
 CREATE INDEX idx_leaf_states_object_id ON leaf_states (object_id);

--- a/crates/rooch-indexer/migrations/2023-11-30-022342_state_change_sets/down.sql
+++ b/crates/rooch-indexer/migrations/2023-11-30-022342_state_change_sets/down.sql
@@ -1,1 +1,0 @@
-DROP TABLE IF EXISTS state_change_sets;

--- a/crates/rooch-indexer/migrations/2023-11-30-022342_state_change_sets/up.sql
+++ b/crates/rooch-indexer/migrations/2023-11-30-022342_state_change_sets/up.sql
@@ -1,8 +1,0 @@
-CREATE TABLE state_change_sets
-(
-    tx_order           BIGINT         NOT NULL         PRIMARY KEY,
-    state_change_set   VARCHAR        NOT NULL,
-    created_at         BIGINT         NOT NULL
-);
-
-CREATE INDEX idx_state_change_sets_created_at ON state_change_sets (created_at);

--- a/crates/rooch-indexer/migrations/2023-11-30-022342_table_change_sets/down.sql
+++ b/crates/rooch-indexer/migrations/2023-11-30-022342_table_change_sets/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS table_change_sets;

--- a/crates/rooch-indexer/migrations/2023-11-30-022342_table_change_sets/up.sql
+++ b/crates/rooch-indexer/migrations/2023-11-30-022342_table_change_sets/up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE table_change_sets
+(
+    tx_order             BIGINT         NOT NULL,
+    table_handle_index   BIGINT         NOT NULL,
+    table_handle         VARCHAR        NOT NULL,
+    table_change_set     VARCHAR        NOT NULL,
+    created_at           BIGINT         NOT NULL,
+    PRIMARY KEY (tx_order, table_handle_index),
+    UNIQUE (tx_order, table_handle)
+);
+
+CREATE INDEX idx_table_change_sets_table_handle ON table_change_sets (table_handle);
+CREATE INDEX idx_table_change_sets_created_at ON table_change_sets (created_at);

--- a/crates/rooch-indexer/src/actor/messages.rs
+++ b/crates/rooch-indexer/src/actor/messages.rs
@@ -7,7 +7,7 @@ use moveos_types::moveos_std::event::Event;
 use moveos_types::state::StateChangeSet;
 use moveos_types::transaction::{TransactionExecutionInfo, VerifiedMoveOSTransaction};
 use rooch_types::indexer::event_filter::{EventFilter, IndexerEvent, IndexerEventID};
-use rooch_types::indexer::state::IndexerStateChangeSet;
+use rooch_types::indexer::state::{IndexerStateID, IndexerTableChangeSet, StateFilter};
 use rooch_types::indexer::transaction_filter::TransactionFilter;
 use rooch_types::transaction::{TransactionSequenceInfo, TransactionWithInfo, TypedTransaction};
 use serde::{Deserialize, Serialize};
@@ -81,12 +81,13 @@ impl Message for QueryIndexerEventsMessage {
 /// Sync Indexer State change sets Message
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SyncIndexerStatesMessage {
+    pub filter: Option<StateFilter>,
     // exclusive cursor if `Some`, otherwise start from the beginning
-    pub cursor: Option<u64>,
+    pub cursor: Option<IndexerStateID>,
     pub limit: usize,
     pub descending_order: bool,
 }
 
 impl Message for SyncIndexerStatesMessage {
-    type Result = Result<Vec<IndexerStateChangeSet>>;
+    type Result = Result<Vec<IndexerTableChangeSet>>;
 }

--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -13,10 +13,10 @@ use diesel::{
 use std::ops::DerefMut;
 
 use crate::models::events::StoredEvent;
-use crate::models::states::StoredStateChangeSet;
-use crate::schema::{events, state_change_sets, transactions};
+use crate::models::states::StoredTableChangeSet;
+use crate::schema::{events, table_change_sets, transactions};
 use rooch_types::indexer::event_filter::{EventFilter, IndexerEvent, IndexerEventID};
-use rooch_types::indexer::state::IndexerStateChangeSet;
+use rooch_types::indexer::state::{IndexerStateID, IndexerTableChangeSet, StateFilter};
 use rooch_types::indexer::transaction_filter::TransactionFilter;
 use rooch_types::transaction::TransactionWithInfo;
 
@@ -31,6 +31,9 @@ pub const EVENT_HANDLE_ID_STR: &str = "event_handle_id";
 pub const EVENT_INDEX_STR: &str = "event_index";
 pub const EVENT_SEQ_STR: &str = "event_seq";
 pub const EVENT_TYPE_STR: &str = "event_type";
+
+pub const STATE_TABLE_HANDLE_STR: &str = "table_handle";
+pub const STATE_TABLE_HANDLE_INDEX_STR: &str = "table_handle_index";
 
 #[derive(Clone)]
 pub(crate) struct InnerIndexerReader {
@@ -302,38 +305,67 @@ impl IndexerReader {
 
     pub fn sync_states(
         &self,
-        cursor: Option<u64>,
+        filter: Option<StateFilter>,
+        // exclusive cursor if `Some`, otherwise start from the beginning
+        cursor: Option<IndexerStateID>,
         limit: usize,
         descending_order: bool,
-    ) -> IndexerResult<Vec<IndexerStateChangeSet>> {
-        let tx_order = if let Some(cursor) = cursor {
-            cursor as i64
+    ) -> IndexerResult<Vec<IndexerTableChangeSet>> {
+        let (tx_order, table_handle_index) = if let Some(cursor) = cursor {
+            let IndexerStateID {
+                tx_order,
+                table_handle_index,
+            } = cursor;
+            (tx_order as i64, table_handle_index as i64)
         } else if descending_order {
-            let max_tx_order: i64 = self.inner_indexer_reader.run_query(|conn| {
-                state_change_sets::dsl::state_change_sets
-                    .select(state_change_sets::tx_order)
-                    .order_by(state_change_sets::tx_order.desc())
-                    .first::<i64>(conn)
-            })?;
-            max_tx_order + 1
+            let (max_tx_order, table_handle_index): (i64, i64) =
+                self.inner_indexer_reader.run_query(|conn| {
+                    table_change_sets::dsl::table_change_sets
+                        .select((
+                            table_change_sets::tx_order,
+                            table_change_sets::table_handle_index,
+                        ))
+                        .order_by((
+                            table_change_sets::tx_order.desc(),
+                            table_change_sets::table_handle_index.desc(),
+                        ))
+                        .first::<(i64, i64)>(conn)
+                })?;
+            (max_tx_order + 1, table_handle_index)
         } else {
-            -1
+            (-1, 0)
         };
 
-        let where_clause = if descending_order {
-            format!(" ({TX_ORDER_STR} < {})", tx_order)
+        let main_where_clause_opt = filter.map(|f| match f {
+            StateFilter::TableHandle(table_handle) => {
+                format!("{STATE_TABLE_HANDLE_STR} = \"{}\"", table_handle)
+            }
+        });
+        let cursor_clause = if descending_order {
+            format!(
+                " ({TX_ORDER_STR} < {} OR ({TX_ORDER_STR} = {} AND {STATE_TABLE_HANDLE_INDEX_STR} < {}))",
+                tx_order, tx_order, table_handle_index
+            )
         } else {
-            format!(" ({TX_ORDER_STR} > {})", tx_order)
+            format!(
+                " ({TX_ORDER_STR} > {} OR ({TX_ORDER_STR} = {} AND {STATE_TABLE_HANDLE_INDEX_STR} > {}))",
+                tx_order, tx_order, table_handle_index
+            )
         };
+        let where_clause = match main_where_clause_opt {
+            Some(main_where_clause) => format!(" {} AND {} ", main_where_clause, cursor_clause),
+            None => format!(" {} ", cursor_clause),
+        };
+
         let order_clause = if descending_order {
-            format!("{TX_ORDER_STR} DESC")
+            format!("{TX_ORDER_STR} DESC, {STATE_TABLE_HANDLE_INDEX_STR} DESC")
         } else {
-            format!("{TX_ORDER_STR} ASC")
+            format!("{TX_ORDER_STR} ASC, {STATE_TABLE_HANDLE_INDEX_STR} ASC")
         };
 
         let query = format!(
             "
-                SELECT * FROM state_change_sets \
+                SELECT * FROM table_change_sets \
                 WHERE {} \
                 ORDER BY {} \
                 LIMIT {}
@@ -342,17 +374,17 @@ impl IndexerReader {
         );
 
         tracing::debug!("sync states: {}", query);
-        let stored_state_change_sets = self
+        let stored_table_change_sets = self
             .inner_indexer_reader
-            .run_query(|conn| diesel::sql_query(query).load::<StoredStateChangeSet>(conn))?;
+            .run_query(|conn| diesel::sql_query(query).load::<StoredTableChangeSet>(conn))?;
 
-        let result = stored_state_change_sets
+        let result = stored_table_change_sets
             .into_iter()
             .map(|t| t.try_into_indexer_state_change_set())
             .collect::<Result<Vec<_>>>()
             .map_err(|e| {
                 IndexerError::SQLiteReadError(format!(
-                    "Cast indexer state change sets failed: {:?}",
+                    "Cast indexer table change sets failed: {:?}",
                     e
                 ))
             })?;

--- a/crates/rooch-indexer/src/lib.rs
+++ b/crates/rooch-indexer/src/lib.rs
@@ -11,7 +11,7 @@ use diesel::sqlite::SqliteConnection;
 use crate::store::sqlite_store::SqliteIndexerStore;
 use crate::store::traits::IndexerStoreTrait;
 use crate::types::{
-    IndexedEvent, IndexedGlobalState, IndexedLeafState, IndexedStateChangeSet, IndexedTransaction,
+    IndexedEvent, IndexedGlobalState, IndexedLeafState, IndexedTableChangeSet, IndexedTransaction,
 };
 use crate::utils::create_all_tables_if_not_exists;
 use errors::IndexerError;
@@ -112,12 +112,12 @@ impl IndexerStoreTrait for IndexerStore {
             .delete_leaf_states_by_table_handle(table_handles)
     }
 
-    fn persist_state_change_sets(
+    fn persist_table_change_sets(
         &self,
-        state_change_sets: Vec<IndexedStateChangeSet>,
+        table_change_sets: Vec<IndexedTableChangeSet>,
     ) -> Result<(), IndexerError> {
         self.sqlite_store
-            .persist_state_change_sets(state_change_sets)
+            .persist_table_change_sets(table_change_sets)
     }
 
     fn persist_transactions(

--- a/crates/rooch-indexer/src/proxy/mod.rs
+++ b/crates/rooch-indexer/src/proxy/mod.rs
@@ -12,7 +12,7 @@ use moveos_types::moveos_std::event::Event;
 use moveos_types::state::StateChangeSet;
 use moveos_types::transaction::{TransactionExecutionInfo, VerifiedMoveOSTransaction};
 use rooch_types::indexer::event_filter::{EventFilter, IndexerEvent, IndexerEventID};
-use rooch_types::indexer::state::IndexerStateChangeSet;
+use rooch_types::indexer::state::{IndexerStateID, IndexerTableChangeSet, StateFilter};
 use rooch_types::indexer::transaction_filter::TransactionFilter;
 use rooch_types::transaction::{TransactionSequenceInfo, TransactionWithInfo, TypedTransaction};
 
@@ -111,13 +111,15 @@ impl IndexerProxy {
 
     pub async fn sync_states(
         &self,
+        filter: Option<StateFilter>,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<u64>,
+        cursor: Option<IndexerStateID>,
         limit: usize,
         descending_order: bool,
-    ) -> Result<Vec<IndexerStateChangeSet>> {
+    ) -> Result<Vec<IndexerTableChangeSet>> {
         self.actor
             .send(SyncIndexerStatesMessage {
+                filter,
                 cursor,
                 limit,
                 descending_order,

--- a/crates/rooch-indexer/src/schema.rs
+++ b/crates/rooch-indexer/src/schema.rs
@@ -34,7 +34,7 @@ diesel::table! {
     leaf_states (id) {
         id -> Text,
         object_id -> Text,
-        key_str -> Text,
+        key_hex -> Text,
         value -> Text,
         value_type -> Text,
         created_at -> BigInt,
@@ -43,9 +43,11 @@ diesel::table! {
 }
 
 diesel::table! {
-    state_change_sets (tx_order) {
+    table_change_sets (tx_order, table_handle_index) {
         tx_order -> BigInt,
-        state_change_set -> Text,
+        table_handle_index -> BigInt,
+        table_handle -> Text,
+        table_change_set -> Text,
         created_at -> BigInt,
     }
 }
@@ -81,6 +83,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     events,
     global_states,
     leaf_states,
-    state_change_sets,
+    table_change_sets,
     transactions,
 );

--- a/crates/rooch-indexer/src/store/traits.rs
+++ b/crates/rooch-indexer/src/store/traits.rs
@@ -3,7 +3,7 @@
 
 use crate::errors::IndexerError;
 use crate::types::{
-    IndexedEvent, IndexedGlobalState, IndexedLeafState, IndexedStateChangeSet, IndexedTransaction,
+    IndexedEvent, IndexedGlobalState, IndexedLeafState, IndexedTableChangeSet, IndexedTransaction,
 };
 
 pub trait IndexerStoreTrait: Send + Sync {
@@ -26,9 +26,9 @@ pub trait IndexerStoreTrait: Send + Sync {
         table_handles: Vec<String>,
     ) -> Result<(), IndexerError>;
 
-    fn persist_state_change_sets(
+    fn persist_table_change_sets(
         &self,
-        state_change_sets: Vec<IndexedStateChangeSet>,
+        table_change_sets: Vec<IndexedTableChangeSet>,
     ) -> Result<(), IndexerError>;
 
     fn persist_transactions(

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -394,9 +394,15 @@
       "description": "Sync state change sets from indexer",
       "params": [
         {
+          "name": "filter",
+          "schema": {
+            "$ref": "#/components/schemas/StateFilterView"
+          }
+        },
+        {
           "name": "cursor",
           "schema": {
-            "$ref": "#/components/schemas/u64"
+            "$ref": "#/components/schemas/IndexerStateID"
           }
         },
         {
@@ -413,10 +419,10 @@
         }
       ],
       "result": {
-        "name": "IndexerStateChangeSetPageView",
+        "name": "IndexerTableChangeSetPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_IndexerStateChangeSetView_and_uint64"
+          "$ref": "#/components/schemas/PageView_for_IndexerTableChangeSetView_and_IndexerStateID"
         }
       }
     }
@@ -887,11 +893,32 @@
           }
         }
       },
-      "IndexerStateChangeSetView": {
+      "IndexerStateID": {
+        "type": "object",
+        "required": [
+          "table_handle_index",
+          "tx_order"
+        ],
+        "properties": {
+          "table_handle_index": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "tx_order": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      },
+      "IndexerTableChangeSetView": {
         "type": "object",
         "required": [
           "created_at",
-          "state_change_set",
+          "table_change_set",
+          "table_handle",
+          "table_handle_index",
           "tx_order"
         ],
         "properties": {
@@ -900,8 +927,16 @@
             "format": "uint64",
             "minimum": 0.0
           },
-          "state_change_set": {
-            "$ref": "#/components/schemas/StateChangeSetView"
+          "table_change_set": {
+            "$ref": "#/components/schemas/TableChangeSetView"
+          },
+          "table_handle": {
+            "$ref": "#/components/schemas/ObjectID"
+          },
+          "table_handle_index": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "tx_order": {
             "type": "integer",
@@ -1252,7 +1287,7 @@
           }
         }
       },
-      "PageView_for_IndexerStateChangeSetView_and_uint64": {
+      "PageView_for_IndexerTableChangeSetView_and_IndexerStateID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -1263,19 +1298,21 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IndexerStateChangeSetView"
+              "$ref": "#/components/schemas/IndexerTableChangeSetView"
             }
           },
           "has_next_page": {
             "type": "boolean"
           },
           "next_cursor": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint64",
-            "minimum": 0.0
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IndexerStateID"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
       },
@@ -1403,6 +1440,23 @@
           }
         }
       },
+      "StateFilterView": {
+        "oneOf": [
+          {
+            "description": "Query by table handle.",
+            "type": "object",
+            "required": [
+              "table_handle"
+            ],
+            "properties": {
+              "table_handle": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "StateOptions": {
         "type": "object",
         "properties": {
@@ -1435,6 +1489,35 @@
           },
           "value_type": {
             "$ref": "#/components/schemas/move_core_types::language_storage::TypeTag"
+          }
+        }
+      },
+      "TableChangeSetView": {
+        "type": "object",
+        "required": [
+          "changes",
+          "new_tables",
+          "removed_tables"
+        ],
+        "properties": {
+          "changes": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/TableChangeView"
+            }
+          },
+          "new_tables": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/TableTypeInfoView"
+            }
+          },
+          "removed_tables": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectID"
+            },
+            "uniqueItems": true
           }
         }
       },

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -7,13 +7,14 @@ use crate::jsonrpc_types::transaction_view::{TransactionFilterView, TransactionW
 use crate::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedFunctionResultView, BalanceInfoPageView,
     BytesView, EventOptions, EventPageView, ExecuteTransactionResponseView, FunctionCallView,
-    H256View, IndexerEventPageView, IndexerStateChangeSetPageView, StateOptions, StateView,
-    StatesPageView, StrView, StructTagView, TransactionWithInfoPageView,
+    H256View, IndexerEventPageView, IndexerTableChangeSetPageView, StateFilterView, StateOptions,
+    StateView, StatesPageView, StrView, StructTagView, TransactionWithInfoPageView,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use rooch_open_rpc_macros::open_rpc;
 use rooch_types::indexer::event_filter::IndexerEventID;
+use rooch_types::indexer::state::IndexerStateID;
 
 #[open_rpc(namespace = "rooch")]
 #[rpc(server, client, namespace = "rooch")]
@@ -129,9 +130,10 @@ pub trait RoochAPI {
     #[method(name = "syncStates")]
     async fn sync_states(
         &self,
+        filter: Option<StateFilterView>,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<StrView<u64>>,
+        cursor: Option<IndexerStateID>,
         limit: Option<StrView<usize>>,
         descending_order: Option<bool>,
-    ) -> RpcResult<IndexerStateChangeSetPageView>;
+    ) -> RpcResult<IndexerTableChangeSetPageView>;
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -6,11 +6,12 @@ use crate::jsonrpc_types::event_view::{EventView, IndexerEventView};
 use crate::jsonrpc_types::transaction_view::TransactionWithInfoView;
 use crate::jsonrpc_types::{
     move_types::{MoveActionTypeView, MoveActionView},
-    BytesView, IndexerStateChangeSetView, StateView, StrView, StructTagView,
+    BytesView, IndexerTableChangeSetView, StateView, StrView, StructTagView,
 };
 use move_core_types::u256::U256;
 use rooch_types::framework::coin::CoinInfo;
 use rooch_types::indexer::event_filter::IndexerEventID;
+use rooch_types::indexer::state::IndexerStateID;
 use rooch_types::transaction::{AbstractTransaction, TransactionType, TypedTransaction};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -21,7 +22,7 @@ pub type TransactionWithInfoPageView = PageView<TransactionWithInfoView, u64>;
 pub type StatesPageView = PageView<StateView, BytesView>;
 pub type BalanceInfoPageView = PageView<BalanceInfoView, BytesView>;
 pub type IndexerEventPageView = PageView<IndexerEventView, IndexerEventID>;
-pub type IndexerStateChangeSetPageView = PageView<IndexerStateChangeSetView, u64>;
+pub type IndexerTableChangeSetPageView = PageView<IndexerTableChangeSetView, IndexerStateID>;
 
 /// `next_cursor` points to the last item in the page;
 /// Reading with `next_cursor` will start from the next item after `next_cursor` if

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -19,7 +19,7 @@ use rooch_sequencer::proxy::SequencerProxy;
 use rooch_types::account::Account;
 use rooch_types::address::{MultiChainAddress, RoochAddress};
 use rooch_types::indexer::event_filter::{EventFilter, IndexerEvent, IndexerEventID};
-use rooch_types::indexer::state::IndexerStateChangeSet;
+use rooch_types::indexer::state::{IndexerStateID, IndexerTableChangeSet, StateFilter};
 use rooch_types::indexer::transaction_filter::TransactionFilter;
 use rooch_types::sequencer::SequencerOrder;
 use rooch_types::transaction::rooch::RoochTransaction;
@@ -280,14 +280,15 @@ impl RpcService {
 
     pub async fn sync_states(
         &self,
+        filter: Option<StateFilter>,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<u64>,
+        cursor: Option<IndexerStateID>,
         limit: usize,
         descending_order: bool,
-    ) -> Result<Vec<IndexerStateChangeSet>> {
+    ) -> Result<Vec<IndexerTableChangeSet>> {
         let resp = self
             .indexer
-            .sync_states(cursor, limit, descending_order)
+            .sync_states(filter, cursor, limit, descending_order)
             .await?;
         Ok(resp)
     }

--- a/crates/rooch-types/src/indexer/state.rs
+++ b/crates/rooch-types/src/indexer/state.rs
@@ -1,11 +1,73 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use moveos_types::state::StateChangeSet;
+use crate::indexer::Filter;
+use anyhow::Result;
+use moveos_types::moveos_std::object::ObjectID;
+use moveos_types::state::{StateChangeSet, TableChangeSet};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
 pub struct IndexerStateChangeSet {
     pub tx_order: u64,
     pub state_change_set: StateChangeSet,
     pub created_at: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexerTableChangeSet {
+    pub tx_order: u64,
+    pub table_handle_index: u64,
+    pub table_handle: ObjectID,
+    pub table_change_set: TableChangeSet,
+    pub created_at: u64,
+}
+
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize, JsonSchema,
+)]
+pub struct IndexerStateID {
+    pub tx_order: u64,
+    pub table_handle_index: u64,
+}
+
+impl std::fmt::Display for IndexerStateID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "IndexerStateID[tx order: {:?}, table handle  index: {}]",
+            self.tx_order, self.table_handle_index,
+        )
+    }
+}
+
+impl IndexerStateID {
+    pub fn new(tx_order: u64, table_handle_index: u64) -> Self {
+        IndexerStateID {
+            tx_order,
+            table_handle_index,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum StateFilter {
+    /// Query by table handle.
+    TableHandle(ObjectID),
+}
+
+impl StateFilter {
+    fn try_matches(&self, item: &IndexerTableChangeSet) -> Result<bool> {
+        Ok(match self {
+            StateFilter::TableHandle(table_handle) => table_handle == &item.table_handle,
+        })
+    }
+}
+
+impl Filter<IndexerTableChangeSet> for StateFilter {
+    fn matches(&self, item: &IndexerTableChangeSet) -> bool {
+        self.try_matches(item).unwrap_or_default()
+    }
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -130,14 +130,10 @@ Feature: Rooch CLI integration tests
     Then assert: "{{$.rpc[-1].has_next_page}} == false"
 
     # Sync states
-    Then cmd: "rpc request --method rooch_syncStates --params '[null, "2", false]'"
+    Then cmd: "rpc request --method rooch_syncStates --params '[null, null, "2", false]'"
     Then assert: "{{$.rpc[-1].data[0].tx_order}} == 0"
-    Then assert: "{{$.rpc[-1].next_cursor}} == 1"
+    Then assert: "{{$.rpc[-1].next_cursor.table_handle_index}} == 1"
     Then assert: "{{$.rpc[-1].has_next_page}} == true"
-    Then cmd: "rpc request --method rooch_syncStates --params '["1", "1", false]'"
-    Then assert: "{{$.rpc[-1].data[0].tx_order}} == 2"
-    Then assert: "{{$.rpc[-1].next_cursor}} == 2"
-    Then assert: "{{$.rpc[-1].has_next_page}} == false"
 
     Then stop the server
 

--- a/moveos/moveos-types/src/state.rs
+++ b/moveos/moveos-types/src/state.rs
@@ -510,6 +510,7 @@ impl StateChangeSet {
         table_change.entries.insert(key, op);
     }
 }
+
 /// A change of a single table.
 #[derive(Default, Clone, Debug)]
 pub struct TableChange {
@@ -532,5 +533,57 @@ impl StateSet {
         v: UpdateSet<Vec<u8>, State>,
     ) -> Option<UpdateSet<Vec<u8>, State>> {
         self.state_sets.insert(k, v)
+    }
+}
+
+/// A change set of a single table.
+/// Consistent with the StateChangeSet format. Use for state sync.
+#[derive(Default, Clone, Debug)]
+pub struct TableChangeSet {
+    pub new_tables: BTreeMap<ObjectID, TableTypeInfo>,
+    pub removed_tables: BTreeSet<ObjectID>,
+    pub changes: BTreeMap<ObjectID, TableChange>,
+}
+
+impl TableChangeSet {
+    pub fn get_or_insert_table_change(&mut self, object_id: ObjectID) -> &mut TableChange {
+        match self.changes.entry(object_id) {
+            btree_map::Entry::Occupied(entry) => entry.into_mut(),
+            btree_map::Entry::Vacant(entry) => entry.insert(TableChange::default()),
+        }
+    }
+
+    pub fn add_op(&mut self, handle: ObjectID, key: Vec<u8>, op: Op<State>) {
+        let table_change = self.get_or_insert_table_change(handle);
+        table_change.entries.insert(key, op);
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct SplitStateChangeSet {
+    pub table_change_sets: BTreeMap<ObjectID, TableChangeSet>,
+}
+
+impl SplitStateChangeSet {
+    pub fn get_or_insert_table_change_set(&mut self, object_id: ObjectID) -> &mut TableChangeSet {
+        match self.table_change_sets.entry(object_id) {
+            btree_map::Entry::Occupied(entry) => entry.into_mut(),
+            btree_map::Entry::Vacant(entry) => entry.insert(TableChangeSet::default()),
+        }
+    }
+
+    pub fn add_new_table(&mut self, table_handle: ObjectID, table_info: TableTypeInfo) {
+        let table_change_set = self.get_or_insert_table_change_set(table_handle);
+        table_change_set.new_tables.insert(table_handle, table_info);
+    }
+
+    pub fn add_table_change(&mut self, table_handle: ObjectID, table_change: TableChange) {
+        let table_change_set = self.get_or_insert_table_change_set(table_handle);
+        table_change_set.changes.insert(table_handle, table_change);
+    }
+
+    pub fn add_remove_table(&mut self, table_handle: ObjectID) {
+        let table_change_set = self.get_or_insert_table_change_set(table_handle);
+        table_change_set.removed_tables.insert(table_handle);
     }
 }


### PR DESCRIPTION
… handle

Follow up https://github.com/rooch-network/rooch/pull/1190 TODOs.

TableChangeSet represents A change set of a single table. And consistent with the StateChangeSet format.
Use for state sync.

1. Split StateChangeSet into TableChangeSet dimensions to store
2. Support sync state by table handle by StateFilter
3. Rename `key_str`  to `key_hex`  for leaf_states table
4.  Updated typescript `TableChangeView`.

TODO
1. Check SQLite Schema compatibility at startup, otherwise the server can start normally after modifying the Schema, but the transaction execution will fail.

- Closes #issue