### PR TITLE
use iptables-legacy instead, to fix the docker problem

### DIFF
--- a/kube/runner/Dockerfile
+++ b/kube/runner/Dockerfile
@@ -1,0 +1,3 @@
+FROM summerwind/actions-runner-dind:v2.311.0-ubuntu-22.04-8e48463
+
+RUN sudo update-alternatives --set iptables /usr/sbin/iptables-legacy

--- a/kube/runner/runner.yaml
+++ b/kube/runner/runner.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       nodeSelector:
         cloud.google.com/gke-nodepool: ci-pool
-      image: summerwind/actions-runner-dind:v2.299.1-ubuntu-20.04-acbce4b
+      image: nada9527/actions-runner-dind:v2.311.0-ubuntu-22.04-8e48463
       repository: rooch-network/rooch
       ephemeral: true
       tolerations:

--- a/kube/runner/runner.yaml
+++ b/kube/runner/runner.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       nodeSelector:
         cloud.google.com/gke-nodepool: ci-pool
-      image: summerwind/actions-runner:v2.311.0-ubuntu-22.04-8e48463
+      image: summerwind/actions-runner-dind:v2.299.1-ubuntu-20.04-acbce4b
       repository: rooch-network/rooch
       ephemeral: true
       tolerations:
@@ -24,7 +24,7 @@ spec:
       dockerEnabled: true
       # If set to true, runner pod container only 1 container that's expected to be able to run docker, too.
       # image summerwind/actions-runner-dind or custom one should be used with true -value
-      dockerdWithinRunnerContainer: false
+      dockerdWithinRunnerContainer: true
 
 ---
 apiVersion: actions.summerwind.dev/v1alpha1
@@ -45,5 +45,5 @@ spec:
       checkRun:
         types: ["created"]
         status: "queued"
-    amount: 1
+    amount: 2
     duration: "2m"


### PR DESCRIPTION
## Summary

Summary about this PR

fix action runner docker start failed 

ref: https://github.com/actions/actions-runner-controller/issues/2143#issuecomment-137923367