### PR TITLE
[bitcoin-move] Ord Inscription refactor

### DIFF
--- a/crates/rooch-types/src/bitcoin/ord.rs
+++ b/crates/rooch-types/src/bitcoin/ord.rs
@@ -9,7 +9,7 @@ use move_core_types::{
 };
 use moveos_types::{
     module_binding::{ModuleBinding, MoveFunctionCaller},
-    move_std::option::MoveOption,
+    move_std::{option::MoveOption, string::MoveString},
     moveos_std::{
         object::{self, ObjectID},
         tx_context::TxContext,
@@ -20,17 +20,79 @@ use serde::{Deserialize, Serialize};
 
 pub const MODULE_NAME: &IdentStr = ident_str!("ord");
 
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Eq)]
+pub struct InscriptionID {
+    pub txid: AccountAddress,
+    pub index: u32,
+}
+
+impl InscriptionID {
+    pub fn new(txid: AccountAddress, index: u32) -> Self {
+        Self { txid, index }
+    }
+}
+
+impl MoveStructType for InscriptionID {
+    const ADDRESS: AccountAddress = BITCOIN_MOVE_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("InscriptionID");
+}
+
+impl MoveStructState for InscriptionID {
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            AccountAddress::type_layout(),
+            u32::type_layout(),
+        ])
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Eq)]
+pub struct Inscription {
+    pub txid: AccountAddress,
+    pub index: u32,
+    pub body: Vec<u8>,
+    pub content_encoding: MoveOption<MoveString>,
+    pub content_type: MoveOption<MoveString>,
+    pub metadata: Vec<u8>,
+    pub metaprotocol: MoveOption<MoveString>,
+    pub parent: MoveOption<ObjectID>,
+    pub pointer: MoveOption<u64>,
+}
+
+impl MoveStructType for Inscription {
+    const ADDRESS: AccountAddress = BITCOIN_MOVE_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Inscription");
+}
+
+impl MoveStructState for Inscription {
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            AccountAddress::type_layout(),
+            u32::type_layout(),
+            Vec::<u8>::type_layout(),
+            MoveOption::<MoveString>::type_layout(),
+            MoveOption::<MoveString>::type_layout(),
+            Vec::<u8>::type_layout(),
+            MoveOption::<MoveString>::type_layout(),
+            MoveOption::<ObjectID>::type_layout(),
+            MoveOption::<u64>::type_layout(),
+        ])
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Eq, Default)]
 pub struct InscriptionRecord {
-    pub body: MoveOption<Vec<u8>>,
-    pub content_encoding: MoveOption<Vec<u8>>,
-    pub content_type: MoveOption<Vec<u8>>,
+    pub body: Vec<u8>,
+    pub content_encoding: MoveOption<MoveString>,
+    pub content_type: MoveOption<MoveString>,
     pub duplicate_field: bool,
     pub incomplete_field: bool,
-    pub metadata: MoveOption<Vec<u8>>,
-    pub metaprotocol: MoveOption<Vec<u8>>,
-    pub parent: MoveOption<Vec<u8>>,
-    pub pointer: MoveOption<Vec<u8>>,
+    pub metadata: Vec<u8>,
+    pub metaprotocol: MoveOption<MoveString>,
+    pub parent: MoveOption<InscriptionID>,
+    pub pointer: MoveOption<u64>,
     pub unrecognized_even_field: bool,
 }
 
@@ -43,15 +105,15 @@ impl MoveStructType for InscriptionRecord {
 impl MoveStructState for InscriptionRecord {
     fn struct_layout() -> move_core_types::value::MoveStructLayout {
         move_core_types::value::MoveStructLayout::new(vec![
-            MoveOption::<Vec<u8>>::type_layout(),
-            MoveOption::<Vec<u8>>::type_layout(),
-            MoveOption::<Vec<u8>>::type_layout(),
+            Vec::<u8>::type_layout(),
+            MoveOption::<MoveString>::type_layout(),
+            MoveOption::<MoveString>::type_layout(),
             bool::type_layout(),
             bool::type_layout(),
-            MoveOption::<Vec<u8>>::type_layout(),
-            MoveOption::<Vec<u8>>::type_layout(),
-            MoveOption::<Vec<u8>>::type_layout(),
-            MoveOption::<Vec<u8>>::type_layout(),
+            Vec::<u8>::type_layout(),
+            MoveOption::<MoveString>::type_layout(),
+            MoveOption::<InscriptionID>::type_layout(),
+            MoveOption::<u64>::type_layout(),
             bool::type_layout(),
         ])
     }

--- a/frameworks/bitcoin-move/doc/brc20.md
+++ b/frameworks/bitcoin-move/doc/brc20.md
@@ -26,6 +26,7 @@
 <pre><code><b>use</b> <a href="">0x1::debug</a>;
 <b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="">0x1::vector</a>;
 <b>use</b> <a href="">0x2::bcs</a>;
 <b>use</b> <a href="">0x2::context</a>;
 <b>use</b> <a href="">0x2::json</a>;
@@ -231,7 +232,7 @@ https://domo-2.gitbook.io/brc-20-experiment/
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="brc20.md#0x4_brc20_from_inscription">from_inscription</a>(inscription_body: <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;): <a href="_Option">option::Option</a>&lt;<a href="brc20.md#0x4_brc20_Op">brc20::Op</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="brc20.md#0x4_brc20_from_inscription">from_inscription</a>(inscription_body: <a href="">vector</a>&lt;u8&gt;): <a href="_Option">option::Option</a>&lt;<a href="brc20.md#0x4_brc20_Op">brc20::Op</a>&gt;
 </code></pre>
 
 

--- a/frameworks/bitcoin-move/doc/ord.md
+++ b/frameworks/bitcoin-move/doc/ord.md
@@ -156,7 +156,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_body">body</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_body">body</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -167,7 +167,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_content_encoding">content_encoding</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_content_encoding">content_encoding</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="_Option">option::Option</a>&lt;<a href="_String">string::String</a>&gt;
 </code></pre>
 
 
@@ -189,7 +189,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_metadata">metadata</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_metadata">metadata</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -200,7 +200,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_metaprotocol">metaprotocol</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_metaprotocol">metaprotocol</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="_Option">option::Option</a>&lt;<a href="_String">string::String</a>&gt;
 </code></pre>
 
 
@@ -222,7 +222,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_pointer">pointer</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_pointer">pointer</a>(self: &<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>): <a href="_Option">option::Option</a>&lt;u64&gt;
 </code></pre>
 
 
@@ -233,7 +233,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_unpack_record">unpack_record</a>(record: <a href="ord.md#0x4_ord_InscriptionRecord">ord::InscriptionRecord</a>): (<a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, <a href="_Option">option::Option</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_unpack_record">unpack_record</a>(record: <a href="ord.md#0x4_ord_InscriptionRecord">ord::InscriptionRecord</a>): (<a href="">vector</a>&lt;u8&gt;, <a href="_Option">option::Option</a>&lt;<a href="_String">string::String</a>&gt;, <a href="_Option">option::Option</a>&lt;<a href="_String">string::String</a>&gt;, <a href="">vector</a>&lt;u8&gt;, <a href="_Option">option::Option</a>&lt;<a href="_String">string::String</a>&gt;, <a href="_Option">option::Option</a>&lt;<a href="ord.md#0x4_ord_InscriptionID">ord::InscriptionID</a>&gt;, <a href="_Option">option::Option</a>&lt;u64&gt;)
 </code></pre>
 
 

--- a/frameworks/bitcoin-move/sources/brc20.move
+++ b/frameworks/bitcoin-move/sources/brc20.move
@@ -240,8 +240,8 @@ module bitcoin_move::brc20 {
         }
     }
 
-    public fun from_inscription(inscription_body: Option<vector<u8>>) : Option<Op> {
-        if (option::is_none(&inscription_body)) {
+    public fun from_inscription(inscription_body: vector<u8>) : Option<Op> {
+        if (vector::is_empty(&inscription_body)) {
             return option::none()
         };
         //TODO should we check the content type?
@@ -249,8 +249,7 @@ module bitcoin_move::brc20 {
         // if(content_type != string::utf8(b"text/plain;charset=utf-8")){
         //     return option::none()
         // };
-        let body = option::destroy_some(inscription_body);
-        let json_map = json::to_map(body);
+        let json_map = json::to_map(inscription_body);
         if(simple_map::length(&json_map) == 0){
             return option::none()
         };

--- a/frameworks/bitcoin-move/src/natives/ord/inscription.rs
+++ b/frameworks/bitcoin-move/src/natives/ord/inscription.rs
@@ -3,6 +3,7 @@
 // Code from https://github.com/ordinals/ord/
 
 use bitcoin::{hashes::Hash, Txid, Witness};
+use moveos_types::move_std::string::MoveString;
 use {
     super::envelope,
     super::inscription_id::InscriptionId,
@@ -35,16 +36,30 @@ pub struct Inscription {
 
 impl From<Inscription> for rooch_types::bitcoin::ord::InscriptionRecord {
     fn from(val: Inscription) -> Self {
+        let content_encoding = val
+            .content_encoding()
+            .and_then(|v| v.to_str().ok().map(|s| MoveString::from(s.to_owned())))
+            .into();
+        let content_type = val
+            .content_type()
+            .map(|s| MoveString::from(s.to_owned()))
+            .into();
+        let metaprotocol = val
+            .metaprotocol()
+            .map(|s| MoveString::from(s.to_owned()))
+            .into();
+        let parent = val.parent().map(Into::into).into();
+        let pointer = val.pointer().into();
         rooch_types::bitcoin::ord::InscriptionRecord {
-            body: val.body.into(),
-            content_encoding: val.content_encoding.into(),
-            content_type: val.content_type.into(),
+            body: val.body.unwrap_or_default(),
+            content_encoding,
+            content_type,
             duplicate_field: val.duplicate_field,
             incomplete_field: val.incomplete_field,
-            metadata: val.metadata.into(),
-            metaprotocol: val.metaprotocol.into(),
-            parent: val.parent.into(),
-            pointer: val.pointer.into(),
+            metadata: val.metadata.unwrap_or_default(),
+            metaprotocol,
+            parent,
+            pointer,
             unrecognized_even_field: val.unrecognized_even_field,
         }
     }

--- a/frameworks/bitcoin-move/src/natives/ord/inscription_id.rs
+++ b/frameworks/bitcoin-move/src/natives/ord/inscription_id.rs
@@ -3,6 +3,7 @@
 // Code from https://github.com/ordinals/ord/
 
 use bitcoin::{hashes::Hash, Txid};
+use rooch_types::into_address::IntoAddress;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     fmt::{self, Display, Formatter},
@@ -21,6 +22,12 @@ impl Default for InscriptionId {
             txid: Txid::all_zeros(),
             index: 0,
         }
+    }
+}
+
+impl From<InscriptionId> for rooch_types::bitcoin::ord::InscriptionID {
+    fn from(inscription_id: InscriptionId) -> Self {
+        Self::new(inscription_id.txid.into_address(), inscription_id.index)
     }
 }
 

--- a/moveos/moveos-types/src/move_std/string.rs
+++ b/moveos/moveos-types/src/move_std/string.rs
@@ -37,6 +37,14 @@ impl std::fmt::Display for MoveString {
     }
 }
 
+impl From<String> for MoveString {
+    fn from(s: String) -> Self {
+        MoveString {
+            bytes: s.into_bytes(),
+        }
+    }
+}
+
 impl FromStr for MoveString {
     type Err = anyhow::Error;
 


### PR DESCRIPTION
## Summary

1. Use empty `vector<u8>` to replace `Option<vector<u8>>` in Inscription.
2. Parse Inscription fields: `content_type`,`metaprotocol`,`parent` and `pointer`.
3. Add Inscription Object test.

- Closes #1241 