### PR TITLE
[moveos_std] Refactor simple_map and simple_multimap, Support no copy and drop struct as value

### DIFF
--- a/crates/rooch-framework-tests/tests/cases/data_struct/data_struct_incorrect_field.exp
+++ b/crates/rooch-framework-tests/tests/cases/data_struct/data_struct_incorrect_field.exp
@@ -1,22 +1,22 @@
 processed 2 tasks
 
-task 1 'publish'. lines 3-24:
-Error: error: The field [simple_map] in struct 0x42::test1::DisallowedStruct is not allowed.
+task 1 'publish'. lines 3-25:
+Error: error: The struct test1::DisallowedStruct must have the 'copy' and 'drop' ability
    ┌─ /tmp/tempfile:9:5
    │  
- 9 │ ╭     struct DisallowedStruct<Key: store, Value: store> has copy, drop {
-10 │ │         simple_map: SimpleMap<Key, Value>,
+ 9 │ ╭     struct DisallowedStruct has drop{
+10 │ │         value: NonDataStruct,
 11 │ │     }
    │ ╰─────^
 
-error: The type argument of #[data_struct] for function test1::f2 in the module 0000000000000000000000000000000000000000000000000000000000000042::test1 is not allowed.
+error: The type argument 0x42::test1::DisallowedStruct of #[data_struct] for function test1::f2 in the module 0x42::test1 is not allowed.
    ┌─ /tmp/tempfile:15:5
    │  
 15 │ ╭     public fun f2(_ctx: &mut Context) {
 16 │ │         let disallowed_struct = DisallowedStruct {
-17 │ │             simple_map: simple_map::create<u8, u8>()
+17 │ │             value: NonDataStruct {},
 18 │ │         };
-19 │ │         f1<DisallowedStruct<u8, u8>>(disallowed_struct);
+19 │ │         f1<DisallowedStruct>(disallowed_struct);
 20 │ │     }
    │ ╰─────^
 

--- a/crates/rooch-framework-tests/tests/cases/data_struct/data_struct_incorrect_field.move
+++ b/crates/rooch-framework-tests/tests/cases/data_struct/data_struct_incorrect_field.move
@@ -3,23 +3,24 @@
 //# publish
 module creator::test1 {
     use moveos_std::context::Context;
-    use moveos_std::simple_map::SimpleMap;
-    use moveos_std::simple_map;
+
+    struct NonDataStruct has drop,store{
+    }
 
     #[data_struct]
-    struct DisallowedStruct<Key: store, Value: store> has copy, drop {
-        simple_map: SimpleMap<Key, Value>,
+    struct DisallowedStruct has drop{
+        value: NonDataStruct,
     }
 
     #[data_struct(T)]
-    public fun f1<T: copy+drop>(_data: T) {
+    public fun f1<T: drop>(_data: T) {
     }
 
     public fun f2(_ctx: &mut Context) {
         let disallowed_struct = DisallowedStruct {
-            simple_map: simple_map::create<u8, u8>()
+            value: NonDataStruct {},
         };
-        f1<DisallowedStruct<u8, u8>>(disallowed_struct);
+        f1<DisallowedStruct>(disallowed_struct);
     }
 }
 

--- a/frameworks/bitcoin-move/doc/brc20.md
+++ b/frameworks/bitcoin-move/doc/brc20.md
@@ -12,6 +12,7 @@
 -  [Struct `MintOp`](#0x4_brc20_MintOp)
 -  [Struct `TransferOp`](#0x4_brc20_TransferOp)
 -  [Function `genesis_init`](#0x4_brc20_genesis_init)
+-  [Function `drop_op`](#0x4_brc20_drop_op)
 -  [Function `is_brc20`](#0x4_brc20_is_brc20)
 -  [Function `is_deploy`](#0x4_brc20_is_deploy)
 -  [Function `as_deploy`](#0x4_brc20_as_deploy)
@@ -70,7 +71,7 @@
 The brc20 operation
 
 
-<pre><code><b>struct</b> <a href="brc20.md#0x4_brc20_Op">Op</a> <b>has</b> <b>copy</b>, drop, store
+<pre><code><b>struct</b> <a href="brc20.md#0x4_brc20_Op">Op</a> <b>has</b> store
 </code></pre>
 
 
@@ -149,6 +150,17 @@ https://domo-2.gitbook.io/brc-20-experiment/
 
 
 
+<a name="0x4_brc20_drop_op"></a>
+
+## Function `drop_op`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="brc20.md#0x4_brc20_drop_op">drop_op</a>(op: <a href="brc20.md#0x4_brc20_Op">brc20::Op</a>)
+</code></pre>
+
+
+
 <a name="0x4_brc20_is_brc20"></a>
 
 ## Function `is_brc20`
@@ -177,7 +189,7 @@ https://domo-2.gitbook.io/brc-20-experiment/
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="brc20.md#0x4_brc20_as_deploy">as_deploy</a>(self: &<a href="brc20.md#0x4_brc20_Op">brc20::Op</a>): <a href="_Option">option::Option</a>&lt;<a href="brc20.md#0x4_brc20_DeployOp">brc20::DeployOp</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="brc20.md#0x4_brc20_as_deploy">as_deploy</a>(self: <a href="brc20.md#0x4_brc20_Op">brc20::Op</a>): <a href="_Option">option::Option</a>&lt;<a href="brc20.md#0x4_brc20_DeployOp">brc20::DeployOp</a>&gt;
 </code></pre>
 
 
@@ -199,7 +211,7 @@ https://domo-2.gitbook.io/brc-20-experiment/
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="brc20.md#0x4_brc20_as_mint">as_mint</a>(self: &<a href="brc20.md#0x4_brc20_Op">brc20::Op</a>): <a href="_Option">option::Option</a>&lt;<a href="brc20.md#0x4_brc20_MintOp">brc20::MintOp</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="brc20.md#0x4_brc20_as_mint">as_mint</a>(self: <a href="brc20.md#0x4_brc20_Op">brc20::Op</a>): <a href="_Option">option::Option</a>&lt;<a href="brc20.md#0x4_brc20_MintOp">brc20::MintOp</a>&gt;
 </code></pre>
 
 
@@ -221,7 +233,7 @@ https://domo-2.gitbook.io/brc-20-experiment/
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="brc20.md#0x4_brc20_as_transfer">as_transfer</a>(self: &<a href="brc20.md#0x4_brc20_Op">brc20::Op</a>): <a href="_Option">option::Option</a>&lt;<a href="brc20.md#0x4_brc20_TransferOp">brc20::TransferOp</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="brc20.md#0x4_brc20_as_transfer">as_transfer</a>(self: <a href="brc20.md#0x4_brc20_Op">brc20::Op</a>): <a href="_Option">option::Option</a>&lt;<a href="brc20.md#0x4_brc20_TransferOp">brc20::TransferOp</a>&gt;
 </code></pre>
 
 

--- a/frameworks/bitcoin-move/doc/ord.md
+++ b/frameworks/bitcoin-move/doc/ord.md
@@ -112,7 +112,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_spend_utxo">spend_utxo</a>(ctx: &<b>mut</b> <a href="_Context">context::Context</a>, utxo_obj: &<a href="_Object">object::Object</a>&lt;<a href="utxo.md#0x4_utxo_UTXO">utxo::UTXO</a>&gt;, tx: &<a href="types.md#0x4_types_Transaction">types::Transaction</a>): <a href="">vector</a>&lt;<a href="utxo.md#0x4_utxo_SealOut">utxo::SealOut</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_spend_utxo">spend_utxo</a>(ctx: &<b>mut</b> <a href="_Context">context::Context</a>, utxo_obj: &<b>mut</b> <a href="_Object">object::Object</a>&lt;<a href="utxo.md#0x4_utxo_UTXO">utxo::UTXO</a>&gt;, tx: &<a href="types.md#0x4_types_Transaction">types::Transaction</a>): <a href="">vector</a>&lt;<a href="utxo.md#0x4_utxo_SealOut">utxo::SealOut</a>&gt;
 </code></pre>
 
 

--- a/frameworks/bitcoin-move/doc/utxo.md
+++ b/frameworks/bitcoin-move/doc/utxo.md
@@ -19,6 +19,7 @@
 -  [Function `seal`](#0x4_utxo_seal)
 -  [Function `has_seal`](#0x4_utxo_has_seal)
 -  [Function `get_seals`](#0x4_utxo_get_seals)
+-  [Function `remove_seals`](#0x4_utxo_remove_seals)
 -  [Function `add_seal`](#0x4_utxo_add_seal)
 -  [Function `transfer`](#0x4_utxo_transfer)
 -  [Function `take`](#0x4_utxo_take)
@@ -195,6 +196,17 @@ Seal the UTXO with a protocol, the T is the protocol object
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="utxo.md#0x4_utxo_get_seals">get_seals</a>&lt;T&gt;(<a href="utxo.md#0x4_utxo">utxo</a>: &<a href="utxo.md#0x4_utxo_UTXO">utxo::UTXO</a>): <a href="">vector</a>&lt;<a href="_ObjectID">object::ObjectID</a>&gt;
+</code></pre>
+
+
+
+<a name="0x4_utxo_remove_seals"></a>
+
+## Function `remove_seals`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="utxo.md#0x4_utxo_remove_seals">remove_seals</a>&lt;T&gt;(<a href="utxo.md#0x4_utxo">utxo</a>: &<b>mut</b> <a href="utxo.md#0x4_utxo_UTXO">utxo::UTXO</a>): <a href="">vector</a>&lt;<a href="_ObjectID">object::ObjectID</a>&gt;
 </code></pre>
 
 

--- a/frameworks/bitcoin-move/sources/light_client.move
+++ b/frameworks/bitcoin-move/sources/light_client.move
@@ -130,7 +130,7 @@ module bitcoin_move::light_client{
             if(table::contains(&btc_utxo_store.utxo, outpoint)){
                 let object_id = table::remove(&mut btc_utxo_store.utxo, outpoint);
                 let utxo_obj = utxo::take(ctx, object_id);
-                let seal_outs = ord::spend_utxo(ctx, &utxo_obj, tx);
+                let seal_outs = ord::spend_utxo(ctx, &mut utxo_obj, tx);
                 if(!vector::is_empty(&seal_outs)){
                     let protocol = type_info::type_name<Inscription>();
                     let j = 0;
@@ -143,7 +143,9 @@ module bitcoin_move::light_client{
                         j = j + 1;
                     };
                 };
-                utxo::remove(utxo_obj);
+                let seals = utxo::remove(utxo_obj);
+                //The seals should be empty after utxo is spent
+                simple_multimap::destroy_empty(seals);
             }else{
                 //We allow the utxo not exists in the utxo store, because we may not sync the block from genesis
             };
@@ -175,11 +177,11 @@ module bitcoin_move::light_client{
             let utxo_obj = utxo::new(ctx, txid, vout, value);
             let utxo = object::borrow_mut(&mut utxo_obj);
             if(simple_multimap::contains_key(&output_seals, &idx)){
-                let utxo_seals = *simple_multimap::borrow(&output_seals, &idx);
+                let utxo_seals = simple_multimap::borrow_mut(&mut output_seals, &idx);
                 let j = 0;
-                let utxo_seals_len = vector::length(&utxo_seals);
+                let utxo_seals_len = vector::length(utxo_seals);
                 while(j < utxo_seals_len){
-                    let utxo_seal = vector::pop_back(&mut utxo_seals);
+                    let utxo_seal = vector::pop_back(utxo_seals);
                     utxo::add_seal(utxo, utxo_seal);
                     j = j + 1;
                 };
@@ -189,7 +191,8 @@ module bitcoin_move::light_client{
             let owner_address = types::txout_object_address(txout);
             utxo::transfer(utxo_obj, owner_address); 
             idx = idx + 1;
-        }
+        };
+        simple_multimap::destroy_empty(output_seals);
     }
 
 

--- a/frameworks/bitcoin-move/sources/ord.move
+++ b/frameworks/bitcoin-move/sources/ord.move
@@ -88,9 +88,9 @@ module bitcoin_move::ord {
         context::borrow_object(ctx, object_id)
     }
 
-    public fun spend_utxo(ctx: &mut Context, utxo_obj: &Object<UTXO>, tx: &Transaction): vector<SealOut>{
-        let utxo = object::borrow(utxo_obj);
-        let seal_object_ids = utxo::get_seals<Inscription>(utxo);
+    public fun spend_utxo(ctx: &mut Context, utxo_obj: &mut Object<UTXO>, tx: &Transaction): vector<SealOut>{
+        let utxo = object::borrow_mut(utxo_obj);
+        let seal_object_ids = utxo::remove_seals<Inscription>(utxo);
         let seal_outs = vector::empty();
         if(vector::is_empty(&seal_object_ids)){
             return seal_outs

--- a/frameworks/bitcoin-move/sources/utxo.move
+++ b/frameworks/bitcoin-move/sources/utxo.move
@@ -122,6 +122,16 @@ module bitcoin_move::utxo{
         }
     }
 
+    public fun remove_seals<T>(utxo: &mut UTXO): vector<ObjectID> {
+        let protocol = type_info::type_name<T>();
+        if(simple_multimap::contains_key(&utxo.seals, &protocol)){
+            let(_k, value) = simple_multimap::remove(&mut utxo.seals, &protocol);
+            value
+        }else{
+            vector::empty()
+        }
+    }
+
     public(friend) fun add_seal(utxo: &mut UTXO, utxo_seal: UTXOSeal){
         let UTXOSeal{protocol, object_id} = utxo_seal;
         simple_multimap::add(&mut utxo.seals, protocol, object_id);

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/simple_map.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/simple_map.md
@@ -24,6 +24,7 @@ This module provides a solution for unsorted maps, that is it has the properties
 -  [Function `borrow_mut`](#0x2_simple_map_borrow_mut)
 -  [Function `contains_key`](#0x2_simple_map_contains_key)
 -  [Function `destroy_empty`](#0x2_simple_map_destroy_empty)
+-  [Function `drop`](#0x2_simple_map_drop)
 -  [Function `add`](#0x2_simple_map_add)
 -  [Function `upsert`](#0x2_simple_map_upsert)
 -  [Function `keys`](#0x2_simple_map_keys)
@@ -44,7 +45,7 @@ This module provides a solution for unsorted maps, that is it has the properties
 
 
 
-<pre><code><b>struct</b> <a href="simple_map.md#0x2_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt; <b>has</b> <b>copy</b>, drop, store
+<pre><code><b>struct</b> <a href="simple_map.md#0x2_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt; <b>has</b> store
 </code></pre>
 
 
@@ -55,7 +56,7 @@ This module provides a solution for unsorted maps, that is it has the properties
 
 
 
-<pre><code><b>struct</b> <a href="simple_map.md#0x2_simple_map_Element">Element</a>&lt;Key, Value&gt; <b>has</b> <b>copy</b>, drop, store
+<pre><code><b>struct</b> <a href="simple_map.md#0x2_simple_map_Element">Element</a>&lt;Key, Value&gt; <b>has</b> store
 </code></pre>
 
 
@@ -173,6 +174,18 @@ This function is deprecated, use <code>new</code> instead.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x2_simple_map_destroy_empty">destroy_empty</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_map.md#0x2_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;)
+</code></pre>
+
+
+
+<a name="0x2_simple_map_drop"></a>
+
+## Function `drop`
+
+Drop all keys and values in the map. This requires keys and values to be dropable.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x2_simple_map_drop">drop</a>&lt;Key: <b>copy</b>, drop, Value: drop&gt;(map: <a href="simple_map.md#0x2_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;)
 </code></pre>
 
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/simple_multimap.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/simple_multimap.md
@@ -18,6 +18,7 @@ A simple map that stores key/value pairs in a vector, and support multi values f
 -  [Function `borrow_first_with_default`](#0x2_simple_multimap_borrow_first_with_default)
 -  [Function `contains_key`](#0x2_simple_multimap_contains_key)
 -  [Function `destroy_empty`](#0x2_simple_multimap_destroy_empty)
+-  [Function `drop`](#0x2_simple_multimap_drop)
 -  [Function `add`](#0x2_simple_multimap_add)
 -  [Function `keys`](#0x2_simple_multimap_keys)
 -  [Function `values`](#0x2_simple_multimap_values)
@@ -37,7 +38,7 @@ A simple map that stores key/value pairs in a vector, and support multi values f
 
 
 
-<pre><code><b>struct</b> <a href="simple_multimap.md#0x2_simple_multimap_SimpleMultiMap">SimpleMultiMap</a>&lt;Key, Value&gt; <b>has</b> <b>copy</b>, drop, store
+<pre><code><b>struct</b> <a href="simple_multimap.md#0x2_simple_multimap_SimpleMultiMap">SimpleMultiMap</a>&lt;Key, Value&gt; <b>has</b> store
 </code></pre>
 
 
@@ -48,7 +49,7 @@ A simple map that stores key/value pairs in a vector, and support multi values f
 
 
 
-<pre><code><b>struct</b> <a href="simple_multimap.md#0x2_simple_multimap_Element">Element</a>&lt;Key, Value&gt; <b>has</b> <b>copy</b>, drop, store
+<pre><code><b>struct</b> <a href="simple_multimap.md#0x2_simple_multimap_Element">Element</a>&lt;Key, Value&gt; <b>has</b> store
 </code></pre>
 
 
@@ -164,6 +165,18 @@ Create an empty SimpleMultiMap.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_multimap.md#0x2_simple_multimap_destroy_empty">destroy_empty</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_multimap.md#0x2_simple_multimap_SimpleMultiMap">simple_multimap::SimpleMultiMap</a>&lt;Key, Value&gt;)
+</code></pre>
+
+
+
+<a name="0x2_simple_multimap_drop"></a>
+
+## Function `drop`
+
+Drop all keys and values in the map. This requires keys and values to be dropable.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="simple_multimap.md#0x2_simple_multimap_drop">drop</a>&lt;Key: <b>copy</b>, drop, Value: drop&gt;(map: <a href="simple_multimap.md#0x2_simple_multimap_SimpleMultiMap">simple_multimap::SimpleMultiMap</a>&lt;Key, Value&gt;)
 </code></pre>
 
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/tx_context.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/tx_context.md
@@ -22,6 +22,7 @@
 -  [Function `tx_gas_payment_account`](#0x2_tx_context_tx_gas_payment_account)
 -  [Function `tx_result`](#0x2_tx_context_tx_result)
 -  [Function `set_module_upgrade_flag`](#0x2_tx_context_set_module_upgrade_flag)
+-  [Function `drop`](#0x2_tx_context_drop)
 
 
 <pre><code><b>use</b> <a href="">0x1::hash</a>;
@@ -59,7 +60,7 @@ This cannot be constructed by a transaction--it is a privileged object created b
 the VM, stored in a <code>Context</code> and passed in to the entrypoint of the transaction as <code>&<b>mut</b> Context</code>.
 
 
-<pre><code><b>struct</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a> <b>has</b> drop
+<pre><code><b>struct</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>
 </code></pre>
 
 
@@ -240,4 +241,15 @@ The result is only available in the <code>post_execute</code> function.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_set_module_upgrade_flag">set_module_upgrade_flag</a>(self: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>, is_upgrade: bool)
+</code></pre>
+
+
+
+<a name="0x2_tx_context_drop"></a>
+
+## Function `drop`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_drop">drop</a>(self: <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/json.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/json.move
@@ -34,6 +34,7 @@ module moveos_std::json{
     public fun to_map(json_str: vector<u8>): SimpleMap<String,String>{
         let opt_result = native_from_json<SimpleMap<String,String>>(json_str);
         if(option::is_none(&opt_result)){
+            option::destroy_none(opt_result);
             return simple_map::create()
         };
         option::destroy_some(opt_result)
@@ -101,6 +102,7 @@ module moveos_std::json{
         assert!(simple_map::borrow(&map, &string::utf8(b"inner")) == &string::utf8(b"{\"value\":100}"), 8);
         assert!(simple_map::borrow(&map, &string::utf8(b"bytes")) == &string::utf8(b"[3,3,2,1]"), 9);
         assert!(simple_map::borrow(&map, &string::utf8(b"inner_array")) == &string::utf8(b"[{\"value\":101}]"), 10);
+        simple_map::drop(map);
     }
 
     #[test]
@@ -108,6 +110,7 @@ module moveos_std::json{
         let invalid_json = b"abcd";
         let map = to_map(invalid_json);
         assert!(simple_map::length(&map) == 0, 1);
+        simple_map::drop(map);
     }
 
     #[test]

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
@@ -367,12 +367,13 @@ module moveos_std::object {
 
         let test_obj = remove(obj);
         let TestStruct{count: _count} = test_obj;
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
     fun test_shared(sender: address){
-        let ctx = moveos_std::tx_context::new_test_context(sender);
-        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut ctx));
+        let tx_context = moveos_std::tx_context::new_test_context(sender);
+        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut tx_context));
         let obj_enitty = new_internal(object_id, TestStruct { count: 1 });
         assert!(!is_shared_internal(&obj_enitty), 1000);
         assert!(!is_frozen_internal(&obj_enitty), 1001);
@@ -380,12 +381,13 @@ module moveos_std::object {
         assert!(is_shared_internal(&obj_enitty), 1002);
         assert!(!is_frozen_internal(&obj_enitty), 1003);
         add_to_global(obj_enitty);
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
     fun test_frozen(sender: address){
-        let ctx = moveos_std::tx_context::new_test_context(sender);
-        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut ctx));
+        let tx_context = moveos_std::tx_context::new_test_context(sender);
+        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut tx_context));
         let obj_enitty = new_internal(object_id, TestStruct { count: 1 });
         assert!(!is_shared_internal(&obj_enitty), 1000);
         assert!(!is_frozen_internal(&obj_enitty), 1001);
@@ -393,14 +395,15 @@ module moveos_std::object {
         assert!(!is_shared_internal(&obj_enitty), 1002);
         assert!(is_frozen_internal(&obj_enitty), 1003);
         add_to_global(obj_enitty);
+        moveos_std::tx_context::drop(tx_context);
     }
 
     // An object can not be shared and frozen at the same time
     // This test just ensure the flag can be set at the same time
     #[test(sender = @0x42)]
     fun test_all_flag(sender: address){
-        let ctx = moveos_std::tx_context::new_test_context(sender);
-        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut ctx));
+        let tx_context = moveos_std::tx_context::new_test_context(sender);
+        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut tx_context));
         let obj_enitty = new_internal(object_id, TestStruct { count: 1 });
         assert!(!is_shared_internal(&obj_enitty), 1000);
         assert!(!is_frozen_internal(&obj_enitty), 1001);
@@ -409,39 +412,42 @@ module moveos_std::object {
         assert!(is_shared_internal(&obj_enitty), 1002);
         assert!(is_frozen_internal(&obj_enitty), 1003);
         add_to_global(obj_enitty);
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
     #[expected_failure(abort_code = 2, location = moveos_std::raw_table)]
     fun test_borrow_not_exist_failure(sender: signer) {
         let sender_addr = std::signer::address_of(&sender);
-        let ctx = moveos_std::tx_context::new_test_context(sender_addr);
-        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut ctx));
+        let tx_context = moveos_std::tx_context::new_test_context(sender_addr);
+        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut tx_context));
         let obj = new_with_id(object_id, TestStruct { count: 1 });
         let TestStruct { count : _ } = remove(obj); 
         let _obj_ref = borrow_from_global<TestStruct>(object_id);
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
     #[expected_failure(abort_code = 2, location = moveos_std::raw_table)]
     fun test_double_remove_failure(sender: signer) {
         let sender_addr = std::signer::address_of(&sender);
-        let ctx = moveos_std::tx_context::new_test_context(sender_addr);
-        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut ctx));
+        let tx_context = moveos_std::tx_context::new_test_context(sender_addr);
+        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut tx_context));
         let object = new_with_id(object_id, TestStruct { count: 1 });
         
         let ObjectEntity{ id:_,owner:_,flag:_, value:test_struct1} = remove_from_global<TestStruct>(object_id);
         let test_struct2 = remove(object);
         let TestStruct { count : _ } = test_struct1;
         let TestStruct { count : _ } = test_struct2;
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
     #[expected_failure(abort_code = 2, location = moveos_std::raw_table)]
     fun test_type_mismatch(sender: signer) {
         let sender_addr = std::signer::address_of(&sender);
-        let ctx = moveos_std::tx_context::new_test_context(sender_addr);
-        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut ctx));
+        let tx_context = moveos_std::tx_context::new_test_context(sender_addr);
+        let object_id = address_to_object_id(moveos_std::tx_context::fresh_address(&mut tx_context));
         let obj = new_with_id(object_id, TestStruct { count: 1 });
         {
             let test_struct_ref = borrow(&obj);
@@ -452,6 +458,7 @@ module moveos_std::object {
             assert!(test_struct2_object_entity.value.count == 1, 1002);
         };
         drop(obj);
+        moveos_std::tx_context::drop(tx_context);
     }
 
     struct TestStructID has store, copy, drop{

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/simple_map.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/simple_map.move
@@ -18,11 +18,11 @@ module moveos_std::simple_map {
     /// Map key is not found
     const ErrorKeyNotFound: u64 = 2;
 
-    struct SimpleMap<Key, Value> has copy, drop, store {
+    struct SimpleMap<Key, Value> has store {
         data: vector<Element<Key, Value>>,
     }
 
-    struct Element<Key, Value> has copy, drop, store {
+    struct Element<Key, Value> has store {
         key: Key,
         value: Value,
     }
@@ -90,6 +90,14 @@ module moveos_std::simple_map {
     public fun destroy_empty<Key: store, Value: store>(map: SimpleMap<Key, Value>) {
         let SimpleMap { data } = map;
         vector::destroy_empty(data);
+    }
+
+    /// Drop all keys and values in the map. This requires keys and values to be dropable.
+    public fun drop<Key: copy + drop, Value: drop>(map: SimpleMap<Key, Value>) {
+        let SimpleMap { data } = map;
+        vector::for_each(data, |e| {
+            let Element { key:_, value:_ } = e;
+        });
     }
 
     public fun add<Key: store, Value: store>(
@@ -241,6 +249,7 @@ module moveos_std::simple_map {
         add(&mut map, 3, 1);
 
         assert!(keys(&map) == vector[2, 3], 0);
+        drop(map);
     }
 
     #[test]
@@ -251,6 +260,7 @@ module moveos_std::simple_map {
         add(&mut map, 3, 2);
 
         assert!(values(&map) == vector[1, 2], 0);
+        drop(map);
     }
 
     #[test]
@@ -297,5 +307,7 @@ module moveos_std::simple_map {
         assert!(length(&map) == 3, 7);
         assert!(contains_key(&map, &1), 8);
         assert!(borrow(&map, &1) == &4, 9);
+
+        drop(map);
     }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/simple_multimap.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/simple_multimap.move
@@ -10,11 +10,11 @@ module moveos_std::simple_multimap {
     /// Map key is not found
     const ErrorKeyNotFound: u64 = 1;
 
-    struct SimpleMultiMap<Key, Value> has copy, drop, store {
+    struct SimpleMultiMap<Key, Value> has store {
         data: vector<Element<Key, Value>>,
     }
 
-    struct Element<Key, Value> has copy, drop, store {
+    struct Element<Key, Value> has store {
         key: Key,
         value: vector<Value>,
     }
@@ -101,6 +101,14 @@ module moveos_std::simple_multimap {
     public fun destroy_empty<Key: store, Value: store>(map: SimpleMultiMap<Key, Value>) {
         let SimpleMultiMap { data } = map;
         vector::destroy_empty(data);
+    }
+
+    /// Drop all keys and values in the map. This requires keys and values to be dropable.
+    public fun drop<Key: copy + drop, Value: drop>(map: SimpleMultiMap<Key, Value>) {
+        let SimpleMultiMap { data } = map;
+        vector::for_each(data, |e| {
+            let Element { key:_, value:_ } = e;
+        });
     }
 
     public fun add<Key: store + drop, Value: store>(
@@ -227,6 +235,7 @@ module moveos_std::simple_multimap {
         remove(&mut map, &3);
         assert!(length(&map) == 0, 12);
         assert!(!contains_key(&map, &3), 13);
+        drop(map);
     }
 
     #[test]
@@ -237,6 +246,7 @@ module moveos_std::simple_multimap {
         add(&mut map, 3, 1);
 
         assert!(keys(&map) == vector[2, 3], 1);
+        drop(map);
     }
 
     #[test]
@@ -249,6 +259,7 @@ module moveos_std::simple_multimap {
         let values = values(&map);
         assert!(vector::length(&values) == 3, 1);
         assert!(values == vector[1,2,3], 2);
+        drop(map);
     }
 
     #[test]

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -146,6 +146,7 @@ module moveos_std::table {
         assert!(*borrow(&t, key) == 23, error_code);
 
         drop_unchecked(t);
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -161,6 +162,7 @@ module moveos_std::table {
         assert!(*borrow_with_default(&t, key, &12) == 1, error_code);
 
         drop_unchecked(t);
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -181,6 +183,7 @@ module moveos_std::table {
         };
         assert!(*borrow(&t, key) == 1, 1003);
         drop_unchecked(t);
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -198,6 +201,7 @@ module moveos_std::table {
         remove(&mut t, key);
         assert!(!contains(&t, key), error_code);
         drop_unchecked(t);
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -211,7 +215,7 @@ module moveos_std::table {
         add(&mut t, key, 2);
 
         drop_unchecked(t);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -224,7 +228,7 @@ module moveos_std::table {
         let _ = borrow(&mut t, key);
 
         drop_unchecked(t);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -237,7 +241,7 @@ module moveos_std::table {
         let _ = borrow_mut(&mut t, key);
 
         drop_unchecked(t);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -250,7 +254,7 @@ module moveos_std::table {
         remove(&mut t, key);
 
         drop_unchecked(t);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -283,7 +287,7 @@ module moveos_std::table {
         
         drop_unchecked(t3); // No need to drop t2 as t2 shares same handle with t3
         drop_unchecked(t1);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -296,7 +300,7 @@ module moveos_std::table {
         add(&mut t, key, 1);
 
         destroy_empty(t);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -320,7 +324,7 @@ module moveos_std::table {
         assert!(*borrow(&t2, t2_key) == 32u32, 1);
 
         drop_unchecked(t2);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/tx_context.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/tx_context.move
@@ -37,7 +37,7 @@ module moveos_std::tx_context {
     /// Information about the transaction currently being executed.
     /// This cannot be constructed by a transaction--it is a privileged object created by
     /// the VM, stored in a `Context` and passed in to the entrypoint of the transaction as `&mut Context`.
-    struct TxContext has drop {
+    struct TxContext {
         /// The address of the user that signed the current transaction
         sender: address,
         /// Sequence number of this transaction corresponding to sender's account.
@@ -162,6 +162,18 @@ module moveos_std::tx_context {
         
     }
 
+    public fun drop(self: TxContext){
+        let TxContext {
+            sender: _,
+            sequence_number: _,
+            max_gas_amount: _,
+            tx_hash: _,
+            ids_created: _,
+            map,
+        } = self;
+        simple_map::drop(map);
+    }
+
     #[test_only]
     /// Create a TxContext for unit test
     public fun new_test_context(sender: address): TxContext {
@@ -189,10 +201,11 @@ module moveos_std::tx_context {
 
     #[test(sender=@0x42)]
     fun test_context(sender: address) {
-        let ctx = new_test_context(sender);
+        let tx_context = new_test_context(sender);
         let value = TestValue{value: 42};
-        add(&mut ctx, value);
-        let value2 = get<TestValue>(&ctx);
+        add(&mut tx_context, value);
+        let value2 = get<TestValue>(&tx_context);
         assert!(value == option::extract(&mut value2), 1000);
+        moveos_std::tx_context::drop(tx_context);
     }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/type_table.move
@@ -118,7 +118,7 @@ module moveos_std::type_table {
         assert!(!contains<TestType>(&table), 5);
 
         drop_unchecked(table);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -141,7 +141,7 @@ module moveos_std::type_table {
         add<TestType>(&mut table, t);
 
         drop_unchecked(table);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -153,7 +153,7 @@ module moveos_std::type_table {
         let _ = borrow<TestType>(&table).val;
 
         drop_unchecked(table);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -166,7 +166,7 @@ module moveos_std::type_table {
         t.val = 1;
 
         drop_unchecked(table);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 
     #[test(sender = @0x42)]
@@ -178,7 +178,7 @@ module moveos_std::type_table {
         let TestType { val: _} = remove<TestType>(&mut table);
 
         drop_unchecked(table);
-        
+        moveos_std::tx_context::drop(tx_context); 
     }
 
     #[test(sender = @0x42)]
@@ -193,6 +193,6 @@ module moveos_std::type_table {
         add<TestType>(&mut table, t);
 
         destroy_empty(table);
-        
+        moveos_std::tx_context::drop(tx_context);
     }
 }


### PR DESCRIPTION
## Summary

1. Remove the `copy` and `drop` abilities from `SimpleMap` and `SimpleMultiMap`.
2. Support no copy and drop struct as value