### PR TITLE
Security enhancement for private_generics.

### DIFF
--- a/crates/rooch-framework-tests/tests/cases/private_generics/mismatches_function_definition.exp
+++ b/crates/rooch-framework-tests/tests/cases/private_generics/mismatches_function_definition.exp
@@ -7,4 +7,13 @@ Error: error: type name "T2" not defined in function "0x42::test::create_box"
 6 │     public fun create_box<T1>() {}
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: some type name in private_generics may not have been handled
+  ┌─ /tmp/tempfile:4:1
+  │  
+4 │ ╭ module creator::test {
+5 │ │     #[private_generics(T2)]
+6 │ │     public fun create_box<T1>() {}
+7 │ │ }
+  │ ╰─^
+
 

--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -230,7 +230,7 @@ fn verify_the_type_name_lists(
 
             for attr in attributes {
                 if let Attribute::Apply(_, _, types) = attr {
-                    if types.len() > 0 {
+                    if !types.is_empty() {
                         total_type_name_map.insert(full_func_name.clone(), types.len() as u32);
                     }
                 }

--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -165,10 +165,34 @@ impl<'a> ExtendedChecker<'a> {
         // The `type_name_indices` is used to save the private_generics information of the found function to the metadata of the module.
         // The private_generics information of the function is looked up from `GLOBAL_PRIVATE_GENERICS`.
         let type_name_indices = get_type_name_indices(self.env, module, &mut func_loc_map);
-        // #TODO: Ensure that the length of the private_generics type list is either none or full，but not partly.
-        //if type_name_indices.is_empty() {
-        //    return;
-        //}
+
+        let type_name_lists = verify_the_type_name_lists(self.env, module);
+
+        if type_name_indices.len() != type_name_lists.len() {
+            self.env.error(
+                &module.get_loc(),
+                "some private_generics may not have been handled.",
+            );
+        }
+
+        for (full_func_name, types_size) in type_name_lists.iter() {
+            match type_name_indices.get(full_func_name) {
+                None => {
+                    self.env.error(
+                        &module.get_loc(),
+                        format!("the function {:?} may not exists.", full_func_name).as_str(),
+                    );
+                }
+                Some(type_list) => {
+                    if type_list.len() as u32 != *types_size {
+                        self.env.error(
+                            &module.get_loc(),
+                            "some type name in private_generics may not have been handled",
+                        );
+                    }
+                }
+            }
+        }
 
         // Inspect the bytecode of every function, and if an instruction is CallGeneric,
         // verify that it calls a function with the private_generics attribute as detected earlier.
@@ -191,6 +215,30 @@ impl<'a> ExtendedChecker<'a> {
                 .collect::<Vec<_>>();
         }
     }
+}
+
+fn verify_the_type_name_lists(
+    global_env: &GlobalEnv,
+    module_env: &ModuleEnv,
+) -> BTreeMap<String, u32> {
+    let mut total_type_name_map: BTreeMap<String, u32> = BTreeMap::new();
+
+    for ref fun in module_env.get_functions() {
+        let full_func_name = build_full_func_name(fun, module_env, global_env);
+        if has_attribute(global_env, fun, PRIVATE_GENERICS_ATTRIBUTE) {
+            let attributes = fun.get_attributes();
+
+            for attr in attributes {
+                if let Attribute::Apply(_, _, types) = attr {
+                    if types.len() > 0 {
+                        total_type_name_map.insert(full_func_name.clone(), types.len() as u32);
+                    }
+                }
+            }
+        }
+    }
+
+    total_type_name_map
 }
 
 fn get_type_name_indices(

--- a/moveos/moveos-verifier/src/verifier.rs
+++ b/moveos/moveos-verifier/src/verifier.rs
@@ -392,7 +392,7 @@ where
                         .finish(Location::Module(module.self_id())));
                 }
 
-                let module_address = parts_vec.get(0).unwrap();
+                let module_address = parts_vec.first();
                 let module_name = parts_vec.get(1).unwrap();
 
                 let current_module_address = module.address().to_hex_literal();

--- a/moveos/moveos-verifier/src/verifier.rs
+++ b/moveos/moveos-verifier/src/verifier.rs
@@ -392,7 +392,7 @@ where
                         .finish(Location::Module(module.self_id())));
                 }
 
-                let module_address = parts_vec.first();
+                let module_address = parts_vec.first().unwrap();
                 let module_name = parts_vec.get(1).unwrap();
 
                 let current_module_address = module.address().to_hex_literal();

--- a/moveos/moveos-verifier/src/verifier.rs
+++ b/moveos/moveos-verifier/src/verifier.rs
@@ -380,6 +380,36 @@ where
 
         Some(metadata) => {
             let mut type_name_indices = metadata.private_generics_indices;
+
+            for (full_func_name, _) in type_name_indices.iter() {
+                let func_name_split = full_func_name.split("::");
+                let parts_vec = func_name_split.collect::<Vec<&str>>();
+                if (parts_vec.len() as u32) < 3 {
+                    return Err(PartialVMError::new(StatusCode::MALFORMED)
+                        .with_message(
+                            "incorrect format of the function name in metadata".to_string(),
+                        )
+                        .finish(Location::Module(module.self_id())));
+                }
+
+                let module_address = parts_vec.get(0).unwrap();
+                let module_name = parts_vec.get(1).unwrap();
+
+                let current_module_address = module.address().to_hex_literal();
+                let current_module_name = module.name().to_string();
+
+                if *module_address != current_module_address.as_str()
+                    || *module_name != current_module_name.as_str()
+                {
+                    return Err(PartialVMError::new(StatusCode::MALFORMED)
+                        .with_message(
+                            "the information of private_generics is not belongs to this module"
+                                .to_string(),
+                        )
+                        .finish(Location::Module(module.self_id())));
+                }
+            }
+
             let view = BinaryIndexedView::Module(module);
 
             for func in &module.function_defs {


### PR DESCRIPTION
1. During compilation, ensure that the type information in private_generics is complete and accurate.
2. During module deployment, check if the information in the current module's metadata is correct; otherwise, halt the deployment.