### PR TITLE
[cli] Support local address mapping

### DIFF
--- a/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/transaction_validator_tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::binding_test;
 use ethers::types::{Bytes, U256};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
@@ -19,8 +20,6 @@ use rooch_types::{
     framework::session_key::SessionScope,
     transaction::{rooch::RoochTransactionData, AbstractTransaction},
 };
-
-use crate::binding_test;
 
 #[test]
 fn test_validate_rooch() {
@@ -112,6 +111,7 @@ fn test_session_key_rooch() {
     assert_eq!(&session_key.authentication_key, session_auth_key.as_ref());
     assert_eq!(session_key.scopes, vec![session_scope]);
     assert_eq!(session_key.max_inactive_interval, max_inactive_interval);
+    keystore.binding_session_key(sender, session_key).unwrap();
 
     // send transaction via session key
 

--- a/crates/rooch-key/src/keystore/account_keystore.rs
+++ b/crates/rooch-key/src/keystore/account_keystore.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use super::types::LocalAccount;
 use crate::key_derive::{
     derive_address_from_private_key, derive_private_key_from_path, encrypt_key,
     generate_derivation_path, generate_new_key_pair, hash_password,
@@ -9,6 +10,7 @@ use crate::keystore::ImportedMnemonic;
 use bip32::DerivationPath;
 use bip39::{Language, Mnemonic, Seed};
 use fastcrypto::encoding::{Base64, Encoding};
+use rooch_types::framework::session_key::SessionKey;
 use rooch_types::key_struct::{MnemonicData, MnemonicResult};
 use rooch_types::{
     address::RoochAddress,
@@ -21,6 +23,8 @@ use rooch_types::{
 use serde::Serialize;
 
 pub trait AccountKeystore {
+    fn get_accounts(&self, password: Option<String>) -> Result<Vec<LocalAccount>, anyhow::Error>;
+
     fn add_address_encryption_data(
         &mut self,
         address: RoochAddress,
@@ -30,6 +34,7 @@ pub trait AccountKeystore {
         &self,
         password: Option<String>,
     ) -> Result<Vec<(RoochAddress, PublicKey)>, anyhow::Error>;
+
     fn get_public_key(&self, password: Option<String>) -> Result<PublicKey, anyhow::Error>;
     fn get_key_pairs(
         &self,
@@ -195,6 +200,13 @@ pub trait AccountKeystore {
         address: &RoochAddress,
         password: Option<String>,
     ) -> Result<AuthenticationKey, anyhow::Error>;
+
+    /// Binding on-chain SessionKey to LocalSessionKey
+    fn binding_session_key(
+        &mut self,
+        address: RoochAddress,
+        session_key: SessionKey,
+    ) -> Result<(), anyhow::Error>;
 
     fn sign_transaction_via_session_key(
         &self,

--- a/crates/rooch-key/src/keystore/base_keystore.rs
+++ b/crates/rooch-key/src/keystore/base_keystore.rs
@@ -93,7 +93,7 @@ impl AccountKeystore for BaseKeyStore {
             };
             accounts.insert(*address, local_account);
         }
-        Ok(accounts.into_values().into_iter().collect())
+        Ok(accounts.into_values().collect())
     }
 
     fn get_key_pair_with_password(

--- a/crates/rooch-key/src/keystore/base_keystore.rs
+++ b/crates/rooch-key/src/keystore/base_keystore.rs
@@ -3,11 +3,12 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::anyhow;
+use super::types::{AddressMapping, LocalAccount, LocalSessionKey};
+use crate::key_derive::{decrypt_key, generate_new_key_pair, retrieve_key_pair};
+use crate::keystore::account_keystore::AccountKeystore;
+use anyhow::{anyhow, ensure};
 use fastcrypto::encoding::{Base64, Encoding};
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
-
+use rooch_types::framework::session_key::SessionKey;
 use rooch_types::key_struct::{MnemonicData, MnemonicResult};
 use rooch_types::{
     address::RoochAddress,
@@ -20,19 +21,25 @@ use rooch_types::{
         rooch::{RoochTransaction, RoochTransactionData},
     },
 };
-
-use crate::key_derive::{decrypt_key, generate_new_key_pair, retrieve_key_pair};
-use crate::keystore::account_keystore::AccountKeystore;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde_as]
 pub(crate) struct BaseKeyStore {
+    #[serde(default)]
     pub(crate) keys: BTreeMap<RoochAddress, EncryptionData>,
+    #[serde(default)]
     pub(crate) mnemonics: BTreeMap<String, MnemonicData>,
+    #[serde(default)]
     #[serde_as(as = "BTreeMap<DisplayFromStr, BTreeMap<DisplayFromStr, _>>")]
-    pub(crate) session_keys: BTreeMap<RoochAddress, BTreeMap<AuthenticationKey, EncryptionData>>,
+    pub(crate) session_keys: BTreeMap<RoochAddress, BTreeMap<AuthenticationKey, LocalSessionKey>>,
+    #[serde(default)]
     pub(crate) password_hash: Option<String>,
+    #[serde(default)]
     pub(crate) is_password_empty: bool,
+    #[serde(default)]
+    pub(crate) address_mapping: AddressMapping,
 }
 
 impl BaseKeyStore {
@@ -43,11 +50,52 @@ impl BaseKeyStore {
             session_keys: BTreeMap::new(),
             password_hash: None,
             is_password_empty: true,
+            address_mapping: AddressMapping::default(),
         }
     }
 }
 
 impl AccountKeystore for BaseKeyStore {
+    fn get_accounts(&self, password: Option<String>) -> Result<Vec<LocalAccount>, anyhow::Error> {
+        let mut accounts = BTreeMap::new();
+        for (address, encryption) in &self.keys {
+            let keypair: RoochKeyPair = retrieve_key_pair(encryption, password.clone())?;
+            let public_key = keypair.public();
+            let multichain_address = self
+                .address_mapping
+                .rooch_to_multichain
+                .get(address)
+                .cloned();
+            let has_session_key = self.session_keys.get(address).is_some();
+            let local_account = LocalAccount {
+                address: *address,
+                multichain_address,
+                public_key: Some(public_key),
+                has_session_key,
+            };
+            accounts.insert(*address, local_account);
+        }
+        for address in self.session_keys.keys() {
+            if accounts.contains_key(address) {
+                continue;
+            }
+            let multichain_address = self
+                .address_mapping
+                .rooch_to_multichain
+                .get(address)
+                .cloned();
+            let has_session_key = true;
+            let local_account = LocalAccount {
+                address: *address,
+                multichain_address,
+                public_key: None,
+                has_session_key,
+            };
+            accounts.insert(*address, local_account);
+        }
+        Ok(accounts.into_values().into_iter().collect())
+    }
+
     fn get_key_pair_with_password(
         &self,
         address: &RoochAddress,
@@ -182,11 +230,27 @@ impl AccountKeystore for BaseKeyStore {
             retrieve_key_pair(&result.key_pair_data.private_key_encryption, password)?;
         let authentication_key = kp.public().authentication_key();
         let inner_map = self.session_keys.entry(*address).or_default();
-        inner_map.insert(
-            authentication_key.clone(),
-            result.key_pair_data.private_key_encryption,
-        );
+        let local_session_key = LocalSessionKey {
+            session_key: None,
+            private_key: result.key_pair_data.private_key_encryption,
+        };
+        inner_map.insert(authentication_key.clone(), local_session_key);
         Ok(authentication_key)
+    }
+
+    fn binding_session_key(
+        &mut self,
+        address: RoochAddress,
+        session_key: SessionKey,
+    ) -> Result<(), anyhow::Error> {
+        let inner_map: &mut BTreeMap<AuthenticationKey, LocalSessionKey> =
+            self.session_keys.entry(address).or_default();
+        let authentication_key = session_key.authentication_key();
+        let local_session_key = inner_map.get_mut(&authentication_key).ok_or_else(||{
+            anyhow::Error::new(RoochError::KeyConversionError(format!("Cannot find session key for address:[{address}] and authentication_key:[{authentication_key}]", address = address, authentication_key = authentication_key)))
+        })?;
+        local_session_key.session_key = Some(session_key);
+        Ok(())
     }
 
     fn sign_transaction_via_session_key(
@@ -196,7 +260,7 @@ impl AccountKeystore for BaseKeyStore {
         authentication_key: &AuthenticationKey,
         password: Option<String>,
     ) -> Result<RoochTransaction, anyhow::Error> {
-        let encryption = self
+        let local_session_key = self
             .session_keys
             .get(address)
             .ok_or_else(|| {
@@ -210,9 +274,16 @@ impl AccountKeystore for BaseKeyStore {
                     "Cannot find SessionKey for authentication_key: [{authentication_key}]"
                 ))
             })?;
-
-        let kp: RoochKeyPair =
-            retrieve_key_pair(encryption, password).map_err(signature::Error::from_source)?;
+        let session_key = local_session_key.session_key.as_ref().ok_or_else(||{
+            signature::Error::from_source(
+                format!("SessionKey for authentication_key:[{authentication_key}] do not binding to on-chain SessionKey")
+            )
+        })?;
+        ensure!(session_key.is_scope_match_with_action(&msg.action), signature::Error::from_source(
+            format!("SessionKey for authentication_key:[{authentication_key}] scope do not match with transaction")
+        ));
+        let kp: RoochKeyPair = retrieve_key_pair(&local_session_key.private_key, password)
+            .map_err(signature::Error::from_source)?;
 
         let signature = Signature::new_hashed(msg.hash().as_bytes(), &kp);
 

--- a/crates/rooch-key/src/keystore/base_keystore.rs
+++ b/crates/rooch-key/src/keystore/base_keystore.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use super::types::{AddressMapping, LocalAccount, LocalSessionKey};
 use crate::key_derive::{decrypt_key, generate_new_key_pair, retrieve_key_pair};
 use crate::keystore::account_keystore::AccountKeystore;
-use anyhow::{anyhow, ensure};
+use anyhow::anyhow;
 use fastcrypto::encoding::{Base64, Encoding};
 use rooch_types::framework::session_key::SessionKey;
 use rooch_types::key_struct::{MnemonicData, MnemonicResult};
@@ -274,14 +274,15 @@ impl AccountKeystore for BaseKeyStore {
                     "Cannot find SessionKey for authentication_key: [{authentication_key}]"
                 ))
             })?;
-        let session_key = local_session_key.session_key.as_ref().ok_or_else(||{
-            signature::Error::from_source(
-                format!("SessionKey for authentication_key:[{authentication_key}] do not binding to on-chain SessionKey")
-            )
-        })?;
-        ensure!(session_key.is_scope_match_with_action(&msg.action), signature::Error::from_source(
-            format!("SessionKey for authentication_key:[{authentication_key}] scope do not match with transaction")
-        ));
+        //TODO should we check the scope of session key here?
+        // let session_key = local_session_key.session_key.as_ref().ok_or_else(||{
+        //     signature::Error::from_source(
+        //         format!("SessionKey for authentication_key:[{authentication_key}] do not binding to on-chain SessionKey")
+        //     )
+        // })?;
+        // ensure!(session_key.is_scope_match_with_action(&msg.action), signature::Error::from_source(
+        //     format!("SessionKey for authentication_key:[{authentication_key}] scope do not match with transaction")
+        // ));
         let kp: RoochKeyPair = retrieve_key_pair(&local_session_key.private_key, password)
             .map_err(signature::Error::from_source)?;
 

--- a/crates/rooch-key/src/keystore/file_keystore.rs
+++ b/crates/rooch-key/src/keystore/file_keystore.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use super::types::LocalAccount;
 use crate::key_derive::retrieve_key_pair;
 use crate::keystore::account_keystore::AccountKeystore;
 use crate::keystore::base_keystore::BaseKeyStore;
@@ -27,6 +28,10 @@ pub struct FileBasedKeystore {
 }
 
 impl AccountKeystore for FileBasedKeystore {
+    fn get_accounts(&self, password: Option<String>) -> Result<Vec<LocalAccount>, anyhow::Error> {
+        self.keystore.get_accounts(password)
+    }
+
     fn add_address_encryption_data(
         &mut self,
         address: RoochAddress,
@@ -136,6 +141,16 @@ impl AccountKeystore for FileBasedKeystore {
         let auth_key = self.keystore.generate_session_key(address, password)?;
         self.save()?;
         Ok(auth_key)
+    }
+
+    fn binding_session_key(
+        &mut self,
+        address: RoochAddress,
+        session_key: rooch_types::framework::session_key::SessionKey,
+    ) -> Result<(), anyhow::Error> {
+        self.keystore.binding_session_key(address, session_key)?;
+        self.save()?;
+        Ok(())
     }
 
     fn sign_transaction_via_session_key(

--- a/crates/rooch-key/src/keystore/memory_keystore.rs
+++ b/crates/rooch-key/src/keystore/memory_keystore.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use super::types::LocalAccount;
 use crate::key_derive::get_key_pair_from_red;
 use crate::keystore::account_keystore::AccountKeystore;
 use crate::keystore::base_keystore::BaseKeyStore;
@@ -21,6 +22,10 @@ pub struct InMemKeystore {
 }
 
 impl AccountKeystore for InMemKeystore {
+    fn get_accounts(&self, password: Option<String>) -> Result<Vec<LocalAccount>, anyhow::Error> {
+        self.keystore.get_accounts(password)
+    }
+
     fn add_address_encryption_data(
         &mut self,
         address: RoochAddress,
@@ -122,6 +127,14 @@ impl AccountKeystore for InMemKeystore {
         password: Option<String>,
     ) -> Result<AuthenticationKey, anyhow::Error> {
         self.keystore.generate_session_key(address, password)
+    }
+
+    fn binding_session_key(
+        &mut self,
+        address: RoochAddress,
+        session_key: rooch_types::framework::session_key::SessionKey,
+    ) -> Result<(), anyhow::Error> {
+        self.keystore.binding_session_key(address, session_key)
     }
 
     fn sign_transaction_via_session_key(

--- a/crates/rooch-key/src/keystore/mod.rs
+++ b/crates/rooch-key/src/keystore/mod.rs
@@ -21,6 +21,7 @@ pub mod account_keystore;
 pub mod base_keystore;
 pub mod file_keystore;
 pub mod memory_keystore;
+pub mod types;
 
 pub struct ImportedMnemonic {
     pub address: RoochAddress,
@@ -35,6 +36,16 @@ pub enum Keystore {
 }
 
 impl AccountKeystore for Keystore {
+    fn get_accounts(
+        &self,
+        password: Option<String>,
+    ) -> Result<Vec<types::LocalAccount>, anyhow::Error> {
+        match self {
+            Keystore::File(file_keystore) => file_keystore.get_accounts(password),
+            Keystore::InMem(inmem_keystore) => inmem_keystore.get_accounts(password),
+        }
+    }
+
     fn sign_transaction_via_session_key(
         &self,
         address: &RoochAddress,
@@ -200,6 +211,21 @@ impl AccountKeystore for Keystore {
             Keystore::File(file_keystore) => file_keystore.generate_session_key(address, password),
             Keystore::InMem(inmem_keystore) => {
                 inmem_keystore.generate_session_key(address, password)
+            }
+        }
+    }
+
+    fn binding_session_key(
+        &mut self,
+        address: RoochAddress,
+        session_key: rooch_types::framework::session_key::SessionKey,
+    ) -> Result<(), anyhow::Error> {
+        match self {
+            Keystore::File(file_keystore) => {
+                file_keystore.binding_session_key(address, session_key)
+            }
+            Keystore::InMem(inmem_keystore) => {
+                inmem_keystore.binding_session_key(address, session_key)
             }
         }
     }

--- a/crates/rooch-key/src/keystore/types.rs
+++ b/crates/rooch-key/src/keystore/types.rs
@@ -24,17 +24,8 @@ pub struct LocalAccount {
     pub has_session_key: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct AddressMapping {
     pub rooch_to_multichain: BTreeMap<RoochAddress, MultiChainAddress>,
     pub multichain_to_rooch: BTreeMap<MultiChainAddress, RoochAddress>,
-}
-
-impl Default for AddressMapping {
-    fn default() -> Self {
-        Self {
-            rooch_to_multichain: BTreeMap::new(),
-            multichain_to_rooch: BTreeMap::new(),
-        }
-    }
 }

--- a/crates/rooch-key/src/keystore/types.rs
+++ b/crates/rooch-key/src/keystore/types.rs
@@ -1,0 +1,40 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use rooch_types::{
+    address::{MultiChainAddress, RoochAddress},
+    crypto::PublicKey,
+    framework::session_key::SessionKey,
+    key_struct::EncryptionData,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LocalSessionKey {
+    pub session_key: Option<SessionKey>,
+    pub private_key: EncryptionData,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LocalAccount {
+    pub address: RoochAddress,
+    pub multichain_address: Option<MultiChainAddress>,
+    pub public_key: Option<PublicKey>,
+    pub has_session_key: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AddressMapping {
+    pub rooch_to_multichain: BTreeMap<RoochAddress, MultiChainAddress>,
+    pub multichain_to_rooch: BTreeMap<MultiChainAddress, RoochAddress>,
+}
+
+impl Default for AddressMapping {
+    fn default() -> Self {
+        Self {
+            rooch_to_multichain: BTreeMap::new(),
+            multichain_to_rooch: BTreeMap::new(),
+        }
+    }
+}

--- a/crates/rooch-rpc-server/src/server/btc_server.rs
+++ b/crates/rooch-rpc-server/src/server/btc_server.rs
@@ -50,7 +50,7 @@ impl BtcAPIServer for BtcServer {
         let resolve_address = match filter.clone() {
             Some(UTXOFilterView::Owner(address)) => {
                 let multi_chain_address = MultiChainAddress::try_from_str_with_multichain_id(
-                    RoochMultiChainID::Bitcoin.multichain_id().id(),
+                    RoochMultiChainID::Bitcoin,
                     address.to_string().as_str(),
                 )?;
                 self.rpc_service
@@ -104,7 +104,7 @@ impl BtcAPIServer for BtcServer {
         let resolve_address = match filter.clone() {
             Some(InscriptionFilterView::Owner(address)) => {
                 let multi_chain_address = MultiChainAddress::try_from_str_with_multichain_id(
-                    RoochMultiChainID::Bitcoin.multichain_id().id(),
+                    RoochMultiChainID::Bitcoin,
                     address.to_string().as_str(),
                 )?;
                 self.rpc_service

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -33,11 +33,11 @@ use rooch_rpc_api::{
     api::{MAX_RESULT_LIMIT, MAX_RESULT_LIMIT_USIZE},
     jsonrpc_types::BytesView,
 };
-use rooch_types::address::MultiChainAddress;
 use rooch_types::indexer::event_filter::IndexerEventID;
 use rooch_types::indexer::state::IndexerStateID;
 use rooch_types::transaction::rooch::RoochTransaction;
 use rooch_types::transaction::{AbstractTransaction, TypedTransaction};
+use rooch_types::{address::MultiChainAddress, multichain_id::RoochMultiChainID};
 use std::cmp::min;
 use tracing::info;
 
@@ -438,7 +438,7 @@ impl RoochAPIServer for RoochServer {
                 address,
             } => {
                 let multi_chain_address = MultiChainAddress::try_from_str_with_multichain_id(
-                    multichain_id,
+                    RoochMultiChainID::try_from(multichain_id)?,
                     address.as_str(),
                 )?;
                 self.rpc_service

--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -170,7 +170,7 @@ impl FromStr for MultiChainAddress {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = s.split(":").collect::<Vec<&str>>();
+        let parts = s.split(':').collect::<Vec<&str>>();
         if parts.len() != 2 {
             bail!("invalid multichain address {}", s);
         }

--- a/crates/rooch-types/src/multichain_id.rs
+++ b/crates/rooch-types/src/multichain_id.rs
@@ -98,7 +98,6 @@ impl Into<u64> for MultiChainID {
 pub enum RoochMultiChainID {
     Bitcoin = BITCOIN,
     Ether = ETHER,
-    Sui = SUI,
     Nostr = NOSTR,
     Rooch = ROOCH,
 }
@@ -108,7 +107,6 @@ impl Display for RoochMultiChainID {
         match self {
             RoochMultiChainID::Bitcoin => write!(f, "bitcoin"),
             RoochMultiChainID::Ether => write!(f, "ether"),
-            RoochMultiChainID::Sui => write!(f, "sui"),
             RoochMultiChainID::Nostr => write!(f, "nostr"),
             RoochMultiChainID::Rooch => write!(f, "rooch"),
         }
@@ -128,7 +126,6 @@ impl TryFrom<u64> for RoochMultiChainID {
         match value {
             BITCOIN => Ok(RoochMultiChainID::Bitcoin),
             ETHER => Ok(RoochMultiChainID::Ether),
-            SUI => Ok(RoochMultiChainID::Sui),
             NOSTR => Ok(RoochMultiChainID::Nostr),
             ROOCH => Ok(RoochMultiChainID::Rooch),
             _ => Err(anyhow::anyhow!("multichain id {} is invalid", value)),
@@ -143,7 +140,6 @@ impl FromStr for RoochMultiChainID {
         match s {
             "bitcoin" => Ok(RoochMultiChainID::Bitcoin),
             "ether" => Ok(RoochMultiChainID::Ether),
-            "sui" => Ok(RoochMultiChainID::Sui),
             "nostr" => Ok(RoochMultiChainID::Nostr),
             "rooch" => Ok(RoochMultiChainID::Rooch),
             s => Err(format_err!("Unknown multichain: {}", s)),
@@ -157,7 +153,6 @@ impl TryFrom<MultiChainID> for RoochMultiChainID {
         Ok(match multichain_id.id() {
             BITCOIN => Self::Bitcoin,
             ETHER => Self::Ether,
-            SUI => Self::Sui,
             NOSTR => Self::Nostr,
             ROOCH => Self::Rooch,
             id => bail!("{} is not a builtin multichain id", id),
@@ -194,10 +189,6 @@ impl RoochMultiChainID {
         matches!(self, RoochMultiChainID::Ether)
     }
 
-    pub fn is_sui(self) -> bool {
-        matches!(self, RoochMultiChainID::Sui)
-    }
-
     pub fn is_nostr(self) -> bool {
         matches!(self, RoochMultiChainID::Nostr)
     }
@@ -210,7 +201,6 @@ impl RoochMultiChainID {
         vec![
             RoochMultiChainID::Bitcoin,
             RoochMultiChainID::Ether,
-            RoochMultiChainID::Sui,
             RoochMultiChainID::Nostr,
             RoochMultiChainID::Rooch,
         ]

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -31,13 +31,17 @@ impl CommandAction<()> for ListCommand {
         };
 
         println!(
-            "{:^66} | {:^48} | {:^16} | {:^12}",
-            "Rooch Address (Ed25519)", "Public Key (Base64)", "Auth Validator ID", "Active Address"
+            "{:^66} | {:^66} | {:^48} | {:^16} | {:^12}",
+            "Rooch Address (Ed25519)",
+            "Multichain Address",
+            "Public Key (Base64)",
+            "Has session key",
+            "Active Address"
         );
         println!("{}", ["-"; 153].join(""));
 
-        for (address, public_key) in context.keystore.get_address_public_keys(password)? {
-            let auth_validator_id = public_key.auth_validator().flag();
+        for account in context.keystore.get_accounts(password)? {
+            let address = account.address;
             let active = if active_address == Some(address) {
                 "True"
             } else {
@@ -45,10 +49,17 @@ impl CommandAction<()> for ListCommand {
             };
 
             println!(
-                "{:^66} | {:^48} | {:^16} | {:^12}",
+                "{:^66} | {:^66} | {:^48} | {:^16} | {:^12}",
                 address,
-                public_key.encode_base64(),
-                auth_validator_id.to_string(),
+                account
+                    .multichain_address
+                    .map(|multichain_address| multichain_address.to_string())
+                    .unwrap_or_default(),
+                account
+                    .public_key
+                    .map(|public_key| public_key.encode_base64())
+                    .unwrap_or_default(),
+                account.has_session_key.to_string(),
                 active
             );
         }

--- a/crates/rooch/src/commands/session_key/commands/create.rs
+++ b/crates/rooch/src/commands/session_key/commands/create.rs
@@ -98,7 +98,9 @@ impl CreateCommand {
                     session_auth_key
                 ))
             })?;
-
+        context
+            .keystore
+            .binding_session_key(sender, session_key.clone())?;
         Ok(session_key)
     }
 }

--- a/moveos/moveos-types/src/move_std/ascii.rs
+++ b/moveos/moveos-types/src/move_std/ascii.rs
@@ -27,6 +27,16 @@ impl MoveAsciiString {
         ensure!(bytes.is_ascii(), "string is not ascii");
         Ok(MoveAsciiString { bytes })
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl From<MoveAsciiString> for String {
+    fn from(value: MoveAsciiString) -> Self {
+        String::from_utf8_lossy(value.as_bytes()).to_string()
+    }
 }
 
 impl std::fmt::Display for MoveAsciiString {


### PR DESCRIPTION
## Summary

1. Record local address mapping to keystore.
2. `account list` command prints multichain_address and only session key address.
3. Refactor `MultiChainAddress` to_string format: `eth:0xa...bc`,`bitcoin:1p..abc`

part of #622 and #1258 