### PR TITLE
Pass writer executor state to reader executor and verify

### DIFF
--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -1,31 +1,63 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use super::messages::{ExecuteTransactionMessage, ExecuteTransactionResult};
+use super::messages::{
+    ExecuteTransactionMessage, ExecuteTransactionResult, ResolveMessage, ValidateTransactionMessage,
+};
 use accumulator::inmemory::InMemoryAccumulator;
 use anyhow::Result;
 use async_trait::async_trait;
 use coerce::actor::{context::ActorContext, message::Handler, Actor};
-use moveos::moveos::MoveOS;
+use itertools::Itertools;
+use move_binary_format::errors::{Location, PartialVMError, VMResult};
+use move_core_types::account_address::AccountAddress;
+use move_core_types::identifier::{IdentStr, Identifier};
+use move_core_types::language_storage::ModuleId;
+use move_core_types::resolver::ModuleResolver;
+use move_core_types::value::MoveValue;
+use move_core_types::vm_status::{StatusCode, VMStatus};
+use moveos::gas::table::{initial_cost_schedule, MoveOSGasMeter};
+use moveos::moveos::{GasPaymentAccount, MoveOS};
+use moveos::vm::vm_status_explainer::explain_vm_status;
 use moveos_store::transaction_store::TransactionStore;
 use moveos_store::MoveOSStore;
 use moveos_types::genesis_info::GenesisInfo;
 use moveos_types::h256::H256;
-use moveos_types::transaction::TransactionExecutionInfo;
+use moveos_types::module_binding::MoveFunctionCaller;
+use moveos_types::move_types::FunctionId;
+use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::transaction::TransactionOutput;
 use moveos_types::transaction::VerifiedMoveOSTransaction;
+use moveos_types::transaction::{
+    FunctionCall, MoveAction, MoveOSTransaction, TransactionExecutionInfo, VerifiedMoveAction,
+};
+use moveos_verifier::metadata::load_module_metadata;
 use rooch_genesis::RoochGenesis;
 use rooch_store::RoochStore;
+use rooch_types::address::MultiChainAddress;
 use rooch_types::bitcoin::genesis::BitcoinGenesisContext;
+use rooch_types::framework::address_mapping::AddressMapping;
+use rooch_types::framework::auth_validator::{AuthValidatorCaller, TxValidateResult};
 use rooch_types::framework::genesis::GenesisContext;
+use rooch_types::framework::transaction_validator::TransactionValidator;
 use rooch_types::framework::{system_post_execute_functions, system_pre_execute_functions};
-use rooch_types::transaction::AbstractTransaction;
+use rooch_types::transaction::{AbstractTransaction, AuthenticatorInfo};
 
 pub struct ExecutorActor {
     genesis: RoochGenesis,
     moveos: MoveOS,
     rooch_store: RoochStore,
 }
+
+type ValidateAuthenticatorResult = Result<
+    (
+        TxValidateResult,
+        Option<MultiChainAddress>,
+        Vec<FunctionCall>,
+        Vec<FunctionCall>,
+    ),
+    VMStatus,
+>;
 
 impl ExecutorActor {
     pub fn new(
@@ -97,6 +129,18 @@ impl ExecutorActor {
         &self.genesis
     }
 
+    pub fn resolve_or_generate(
+        &self,
+        multi_chain_address_sender: MultiChainAddress,
+    ) -> Result<AccountAddress> {
+        let resolved_sender = {
+            let address_mapping = self.moveos().as_module_binding::<AddressMapping>();
+            address_mapping.resolve_or_generate(multi_chain_address_sender)?
+        };
+
+        Ok(resolved_sender)
+    }
+
     pub fn execute(&mut self, tx: VerifiedMoveOSTransaction) -> Result<ExecuteTransactionResult> {
         let tx_hash = tx.ctx.tx_hash();
         let (state_root, output) = self.moveos.execute_and_apply(tx)?;
@@ -134,9 +178,336 @@ impl ExecutorActor {
             transaction_info,
         })
     }
+
+    pub fn validate<T: AbstractTransaction>(&self, tx: T) -> Result<VerifiedMoveOSTransaction> {
+        let multi_chain_address_sender = tx.sender();
+
+        let resolved_sender = self.resolve_or_generate(multi_chain_address_sender.clone())?;
+        let authenticator = tx.authenticator_info()?;
+
+        let mut moveos_tx = tx.construct_moveos_transaction(resolved_sender)?;
+
+        let vm_result = self.validate_authenticator(&moveos_tx.ctx, authenticator)?;
+
+        let can_pay_gas = self.validate_gas_function(&moveos_tx)?;
+
+        let mut pay_by_module_account = false;
+        let mut gas_payment_account = moveos_tx.ctx.sender;
+
+        if let Some(pay_gas) = can_pay_gas {
+            if pay_gas {
+                let account_balance = self.get_account_balance(&moveos_tx)?;
+                let module_account = {
+                    match &moveos_tx.action {
+                        MoveAction::Function(call) => Some(*call.function_id.module_id.address()),
+                        _ => None,
+                    }
+                };
+
+                let gas_payment_address = {
+                    if account_balance >= moveos_tx.ctx.max_gas_amount as u128 {
+                        pay_by_module_account = true;
+                        module_account.unwrap()
+                    } else {
+                        moveos_tx.ctx.sender
+                    }
+                };
+
+                gas_payment_account = gas_payment_address;
+            }
+        }
+
+        moveos_tx
+            .ctx
+            .add(GasPaymentAccount {
+                account: gas_payment_account,
+                pay_gas_by_module_account: pay_by_module_account,
+            })
+            .expect("adding GasPaymentAccount to tx context failed.");
+
+        match vm_result {
+            Ok((
+                tx_validate_result,
+                multi_chain_address,
+                pre_execute_functions,
+                post_execute_functions,
+            )) => {
+                // Add the original multichain address to the context
+                moveos_tx
+                    .ctx
+                    .add(multi_chain_address.unwrap_or(multi_chain_address_sender))
+                    .expect("add sender to context failed");
+
+                // Add the tx_validate_result to the context
+                moveos_tx
+                    .ctx
+                    .add(tx_validate_result)
+                    .expect("add tx_validate_result failed");
+
+                moveos_tx.append_pre_execute_functions(pre_execute_functions);
+                moveos_tx.append_post_execute_functions(post_execute_functions);
+                Ok(self.moveos().verify(moveos_tx)?)
+            }
+            Err(e) => {
+                let status_view = explain_vm_status(self.moveos.moveos_resolver(), e.clone())?;
+                log::warn!(
+                    "transaction validate vm error, tx_hash: {}, error:{:?}",
+                    moveos_tx.ctx.tx_hash(),
+                    status_view,
+                );
+                //TODO how to return the vm status to rpc client.
+                Err(e.into())
+            }
+        }
+    }
+
+    pub fn validate_authenticator(
+        &self,
+        ctx: &TxContext,
+        authenticator: AuthenticatorInfo,
+    ) -> Result<ValidateAuthenticatorResult> {
+        let tx_validator = self.moveos().as_module_binding::<TransactionValidator>();
+        let tx_validate_function_result = tx_validator
+            .validate(ctx, authenticator.clone())?
+            .into_result();
+
+        let vm_result = match tx_validate_function_result {
+            Ok(tx_validate_result) => {
+                let auth_validator_option = tx_validate_result.auth_validator();
+                match auth_validator_option {
+                    Some(auth_validator) => {
+                        let auth_validator_caller =
+                            AuthValidatorCaller::new(self.moveos(), auth_validator);
+                        let auth_validator_function_result = auth_validator_caller
+                            .validate(ctx, authenticator.authenticator.payload)?
+                            .into_result();
+                        match auth_validator_function_result {
+                            Ok(multi_chain_address) => {
+                                // pre_execute_function: AuthValidator
+                                let pre_execute_functions =
+                                    vec![auth_validator_caller.pre_execute_function_call()];
+                                // post_execute_function: AuthValidator
+                                let post_execute_functions =
+                                    vec![auth_validator_caller.post_execute_function_call()];
+                                Ok((
+                                    tx_validate_result,
+                                    multi_chain_address,
+                                    pre_execute_functions,
+                                    post_execute_functions,
+                                ))
+                            }
+                            Err(vm_status) => Err(vm_status),
+                        }
+                    }
+                    None => {
+                        let pre_execute_functions = vec![];
+                        let post_execute_functions = vec![];
+                        Ok((
+                            tx_validate_result,
+                            None,
+                            pre_execute_functions,
+                            post_execute_functions,
+                        ))
+                    }
+                }
+            }
+            Err(vm_status) => Err(vm_status),
+        };
+        Ok(vm_result)
+    }
+
+    pub fn validate_gas_function(&self, tx: &MoveOSTransaction) -> VMResult<Option<bool>> {
+        let MoveOSTransaction { ctx, .. } = tx;
+
+        let cost_table = initial_cost_schedule();
+        let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
+        gas_meter.set_metering(false);
+
+        let verified_moveos_action = self.moveos().verify(tx.clone())?;
+        let verified_action = verified_moveos_action.action;
+
+        match verified_action {
+            VerifiedMoveAction::Function { call } => {
+                let module_id = &call.function_id.module_id;
+                let loaded_module_bytes_result =
+                    self.moveos().moveos_resolver().get_module(module_id);
+                let loaded_module_bytes = match loaded_module_bytes_result {
+                    Ok(loaded_module_bytes_opt) => match loaded_module_bytes_opt {
+                        None => {
+                            return Err(PartialVMError::new(StatusCode::RESOURCE_DOES_NOT_EXIST)
+                                .with_message(
+                                    "The name of the gas_validate_function does not exist."
+                                        .to_string(),
+                                )
+                                .finish(Location::Module(module_id.clone())));
+                        }
+                        Some(module_bytes) => module_bytes,
+                    },
+                    Err(error) => {
+                        return Err(PartialVMError::new(StatusCode::RESOURCE_DOES_NOT_EXIST)
+                            .with_message(format!(
+                                "Load module data from module_id {:} was failed {:}.",
+                                module_id.clone(),
+                                error
+                            ))
+                            .finish(Location::Module(module_id.clone())));
+                    }
+                };
+
+                let module_metadata = load_module_metadata(module_id, Ok(loaded_module_bytes))?;
+                let gas_free_function_info = {
+                    match module_metadata {
+                        None => None,
+                        Some(runtime_metadata) => Some(runtime_metadata.gas_free_function_map),
+                    }
+                };
+
+                let called_function_name = call.function_id.function_name.to_string();
+                match gas_free_function_info {
+                    None => Ok(None),
+                    Some(gas_func_info) => {
+                        let full_called_function = format!(
+                            "0x{}::{}::{}",
+                            call.function_id.module_id.address().to_hex(),
+                            call.function_id.module_id.name(),
+                            called_function_name
+                        );
+                        let gas_func_info_opt = gas_func_info.get(&full_called_function);
+
+                        if let Some(gas_func_info) = gas_func_info_opt {
+                            let gas_validate_func_name = gas_func_info.gas_validate.clone();
+
+                            let split_function = gas_validate_func_name.split("::").collect_vec();
+                            if split_function.len() != 3 {
+                                return Err(PartialVMError::new(StatusCode::VM_EXTENSION_ERROR)
+                                    .with_message(
+                                        "The name of the gas_validate_function is incorrect."
+                                            .to_string(),
+                                    )
+                                    .finish(Location::Module(call.clone().function_id.module_id)));
+                            }
+                            let real_gas_validate_func_name =
+                                split_function.get(2).unwrap().to_string();
+
+                            let gas_validate_func_call = FunctionCall::new(
+                                FunctionId::new(
+                                    call.function_id.module_id.clone(),
+                                    Identifier::new(real_gas_validate_func_name).unwrap(),
+                                ),
+                                vec![],
+                                vec![],
+                            );
+
+                            let function_execution_result =
+                                self.moveos.execute_view_function(gas_validate_func_call);
+
+                            return if function_execution_result.vm_status == VMStatus::Executed {
+                                let return_value = function_execution_result.return_values.unwrap();
+                                if !return_value.is_empty() {
+                                    let first_return_value = return_value.get(0).unwrap();
+                                    Ok(Some(
+                                        bcs::from_bytes::<bool>(first_return_value.value.as_slice())
+                                            .expect(
+                                                "the return value of gas validate function should be bool",
+                                            ),
+                                    ))
+                                } else {
+                                    return Err(PartialVMError::new(
+                                        StatusCode::VM_EXTENSION_ERROR,
+                                    )
+                                    .with_message(
+                                        "the return value of gas_validate_function is empty."
+                                            .to_string(),
+                                    )
+                                    .finish(Location::Module(call.clone().function_id.module_id)));
+                                }
+                            } else {
+                                Ok(None)
+                            };
+                        };
+
+                        Ok(None)
+                    }
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    pub fn get_account_balance(&self, tx: &MoveOSTransaction) -> VMResult<u128> {
+        let MoveOSTransaction { ctx, .. } = tx;
+
+        let cost_table = initial_cost_schedule();
+        let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
+        gas_meter.set_metering(false);
+
+        let verified_moveos_action = self.moveos().verify(tx.clone())?;
+        let verified_action = verified_moveos_action.action;
+
+        match verified_action {
+            VerifiedMoveAction::Function { call } => {
+                let module_address = call.function_id.module_id.address();
+
+                let gas_coin_module_id = ModuleId::new(
+                    AccountAddress::from_hex_literal("0x3").unwrap(),
+                    Identifier::from(IdentStr::new("gas_coin").unwrap()),
+                );
+                let gas_balance_func_call = FunctionCall::new(
+                    FunctionId::new(gas_coin_module_id, Identifier::new("balance").unwrap()),
+                    vec![],
+                    vec![MoveValue::Address(*module_address)
+                        .simple_serialize()
+                        .unwrap()],
+                );
+
+                let function_execution_result =
+                    self.moveos.execute_view_function(gas_balance_func_call);
+
+                if function_execution_result.vm_status == VMStatus::Executed {
+                    let return_value = function_execution_result.return_values.unwrap();
+                    let first_return_value = return_value.get(0).unwrap();
+
+                    let balance = bcs::from_bytes::<move_core_types::u256::U256>(
+                        first_return_value.value.as_slice(),
+                    )
+                    .expect("the return value of gas validate function should be u128");
+
+                    Ok(balance.unchecked_as_u128())
+                } else {
+                    Ok(0)
+                }
+            }
+            _ => Ok(0),
+        }
+    }
 }
 
 impl Actor for ExecutorActor {}
+
+#[async_trait]
+impl Handler<ResolveMessage> for ExecutorActor {
+    async fn handle(
+        &mut self,
+        msg: ResolveMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<AccountAddress, anyhow::Error> {
+        self.resolve_or_generate(msg.address)
+    }
+}
+
+#[async_trait]
+impl<T> Handler<ValidateTransactionMessage<T>> for ExecutorActor
+where
+    T: 'static + AbstractTransaction + Send + Sync,
+{
+    async fn handle(
+        &mut self,
+        msg: ValidateTransactionMessage<T>,
+        _ctx: &mut ActorContext,
+    ) -> Result<VerifiedMoveOSTransaction> {
+        self.validate(msg.tx)
+    }
+}
 
 #[async_trait]
 impl Handler<ExecuteTransactionMessage> for ExecutorActor {

--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -14,18 +14,16 @@ use moveos_types::h256::H256;
 use moveos_types::transaction::TransactionExecutionInfo;
 use moveos_types::transaction::TransactionOutput;
 use moveos_types::transaction::VerifiedMoveOSTransaction;
-use parking_lot::RwLock;
 use rooch_genesis::RoochGenesis;
 use rooch_store::RoochStore;
 use rooch_types::bitcoin::genesis::BitcoinGenesisContext;
 use rooch_types::framework::genesis::GenesisContext;
 use rooch_types::framework::{system_post_execute_functions, system_pre_execute_functions};
 use rooch_types::transaction::AbstractTransaction;
-use std::sync::Arc;
 
 pub struct ExecutorActor {
     genesis: RoochGenesis,
-    moveos: Arc<RwLock<MoveOS>>,
+    moveos: MoveOS,
     rooch_store: RoochStore,
 }
 
@@ -48,15 +46,15 @@ impl ExecutorActor {
 
         let executor = Self {
             genesis,
-            moveos: Arc::new(RwLock::new(moveos)),
+            moveos,
             rooch_store,
         };
         executor.init_or_check_genesis()
     }
 
     fn init_or_check_genesis(mut self) -> Result<Self> {
-        if self.moveos.read().state().is_genesis() {
-            let genesis_result = self.moveos.write().init_genesis(
+        if self.moveos().state().is_genesis() {
+            let genesis_result = self.moveos.init_genesis(
                 self.genesis.genesis_txs(),
                 self.genesis.genesis_ctx(),
                 self.genesis.bitcoin_genesis_ctx(),
@@ -80,13 +78,9 @@ impl ExecutorActor {
             );
             let genesis_info =
                 GenesisInfo::new(self.genesis.genesis_package_hash(), genesis_state_root);
-            self.moveos
-                .read()
-                .config_store()
-                .save_genesis(genesis_info)?;
+            self.moveos().config_store().save_genesis(genesis_info)?;
         } else {
-            self.genesis
-                .check_genesis(self.moveos.read().config_store())?;
+            self.genesis.check_genesis(self.moveos().config_store())?;
         }
         Ok(self)
     }
@@ -95,8 +89,8 @@ impl ExecutorActor {
         self.rooch_store.clone()
     }
 
-    pub fn moveos(&self) -> Arc<RwLock<MoveOS>> {
-        self.moveos.clone()
+    pub fn moveos(&self) -> &MoveOS {
+        &self.moveos
     }
 
     pub fn genesis(&self) -> &RoochGenesis {
@@ -105,7 +99,7 @@ impl ExecutorActor {
 
     pub fn execute(&mut self, tx: VerifiedMoveOSTransaction) -> Result<ExecuteTransactionResult> {
         let tx_hash = tx.ctx.tx_hash();
-        let (state_root, output) = self.moveos.write().execute_and_apply(tx)?;
+        let (state_root, output) = self.moveos.execute_and_apply(tx)?;
         self.handle_tx_output(tx_hash, state_root, output)
     }
 
@@ -125,8 +119,7 @@ impl ExecutorActor {
             output.gas_used,
             output.status.clone(),
         );
-        self.moveos
-            .read()
+        self.moveos()
             .transaction_store()
             .save_tx_execution_info(transaction_info.clone())
             .map_err(|e| {

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -153,10 +153,11 @@ impl Message for GetAnnotatedStatesByStateMessage {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct UpdateStateRootMessage {
+pub struct RefreshStateMessage {
     pub new_state_root: H256,
+    pub is_upgrade: bool,
 }
 
-impl Message for UpdateStateRootMessage {
+impl Message for RefreshStateMessage {
     type Result = Result<()>;
 }

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -151,3 +151,12 @@ pub struct GetAnnotatedStatesByStateMessage {
 impl Message for GetAnnotatedStatesByStateMessage {
     type Result = Result<Vec<AnnotatedState>>;
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateStateRootMessage {
+    pub new_state_root: H256,
+}
+
+impl Message for UpdateStateRootMessage {
+    type Result = Result<()>;
+}

--- a/crates/rooch-executor/src/actor/reader_executor.rs
+++ b/crates/rooch-executor/src/actor/reader_executor.rs
@@ -3,8 +3,8 @@
 
 use super::messages::{
     AnnotatedStatesMessage, ExecuteViewFunctionMessage, GetAnnotatedEventsByEventHandleMessage,
-    GetAnnotatedStatesByStateMessage, GetEventsByEventHandleMessage, ResolveMessage, StatesMessage,
-    UpdateStateRootMessage, ValidateTransactionMessage,
+    GetAnnotatedStatesByStateMessage, GetEventsByEventHandleMessage, RefreshStateMessage,
+    ResolveMessage, StatesMessage, ValidateTransactionMessage,
 };
 use crate::actor::messages::{
     GetEventsByEventIDsMessage, GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage,
@@ -626,9 +626,12 @@ impl Handler<GetAnnotatedStatesByStateMessage> for ReaderExecutorActor {
 }
 
 #[async_trait]
-impl Handler<UpdateStateRootMessage> for ReaderExecutorActor {
-    async fn handle(&mut self, msg: UpdateStateRootMessage, _ctx: &mut ActorContext) -> Result<()> {
-        let UpdateStateRootMessage { new_state_root } = msg;
-        self.moveos.update_state_root(new_state_root)
+impl Handler<RefreshStateMessage> for ReaderExecutorActor {
+    async fn handle(&mut self, msg: RefreshStateMessage, _ctx: &mut ActorContext) -> Result<()> {
+        let RefreshStateMessage {
+            new_state_root,
+            is_upgrade,
+        } = msg;
+        self.moveos.refresh_state(new_state_root, is_upgrade)
     }
 }

--- a/crates/rooch-executor/src/actor/reader_executor.rs
+++ b/crates/rooch-executor/src/actor/reader_executor.rs
@@ -4,7 +4,7 @@
 use super::messages::{
     AnnotatedStatesMessage, ExecuteViewFunctionMessage, GetAnnotatedEventsByEventHandleMessage,
     GetAnnotatedStatesByStateMessage, GetEventsByEventHandleMessage, RefreshStateMessage,
-    ResolveMessage, StatesMessage, ValidateTransactionMessage,
+    StatesMessage,
 };
 use crate::actor::messages::{
     GetEventsByEventIDsMessage, GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage,
@@ -13,59 +13,35 @@ use crate::actor::messages::{
 use anyhow::Result;
 use async_trait::async_trait;
 use coerce::actor::{context::ActorContext, message::Handler, Actor};
-use itertools::Itertools;
-use move_binary_format::errors::{Location, PartialVMError, VMResult};
-use move_core_types::account_address::AccountAddress;
-use move_core_types::identifier::{IdentStr, Identifier};
-use move_core_types::language_storage::ModuleId;
-use move_core_types::resolver::ModuleResolver;
-use move_core_types::value::MoveValue;
-use move_core_types::vm_status::{StatusCode, VMStatus};
 use move_resource_viewer::MoveValueAnnotator;
-use moveos::gas::table::{initial_cost_schedule, MoveOSGasMeter};
-use moveos::moveos::{GasPaymentAccount, MoveOS};
-use moveos::vm::vm_status_explainer::explain_vm_status;
+use moveos::moveos::MoveOS;
 use moveos_store::transaction_store::TransactionStore;
 use moveos_store::MoveOSStore;
 use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::function_return_value::AnnotatedFunctionReturnValue;
-use moveos_types::module_binding::MoveFunctionCaller;
-use moveos_types::move_types::FunctionId;
 use moveos_types::moveos_std::event::EventHandle;
 use moveos_types::moveos_std::event::{AnnotatedEvent, Event};
-use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::state::{AnnotatedState, State};
 use moveos_types::state_resolver::{AnnotatedStateReader, StateReader};
-use moveos_types::transaction::VerifiedMoveAction;
-use moveos_types::transaction::VerifiedMoveOSTransaction;
-use moveos_types::transaction::{FunctionCall, MoveAction};
-use moveos_types::transaction::{MoveOSTransaction, TransactionExecutionInfo};
-use moveos_verifier::metadata::load_module_metadata;
+use moveos_types::transaction::TransactionExecutionInfo;
 use rooch_genesis::RoochGenesis;
 use rooch_store::RoochStore;
-use rooch_types::address::MultiChainAddress;
-use rooch_types::framework::address_mapping::AddressMapping;
-use rooch_types::framework::auth_validator::AuthValidatorCaller;
-use rooch_types::framework::auth_validator::TxValidateResult;
-use rooch_types::framework::transaction_validator::TransactionValidator;
 use rooch_types::framework::{system_post_execute_functions, system_pre_execute_functions};
-use rooch_types::transaction::AbstractTransaction;
-use rooch_types::transaction::AuthenticatorInfo;
 
 pub struct ReaderExecutorActor {
     moveos: MoveOS,
     rooch_store: RoochStore,
 }
 
-type ValidateAuthenticatorResult = Result<
-    (
-        TxValidateResult,
-        Option<MultiChainAddress>,
-        Vec<FunctionCall>,
-        Vec<FunctionCall>,
-    ),
-    VMStatus,
->;
+// type ValidateAuthenticatorResult = Result<
+//     (
+//         TxValidateResult,
+//         Option<MultiChainAddress>,
+//         Vec<FunctionCall>,
+//         Vec<FunctionCall>,
+//     ),
+//     VMStatus,
+// >;
 
 impl ReaderExecutorActor {
     pub fn new(
@@ -87,319 +63,319 @@ impl ReaderExecutorActor {
         })
     }
 
-    pub fn resolve_or_generate(
-        &self,
-        multi_chain_address_sender: MultiChainAddress,
-    ) -> Result<AccountAddress> {
-        let resolved_sender = {
-            let address_mapping = self.moveos().as_module_binding::<AddressMapping>();
-            address_mapping.resolve_or_generate(multi_chain_address_sender)?
-        };
+    // pub fn resolve_or_generate(
+    //     &self,
+    //     multi_chain_address_sender: MultiChainAddress,
+    // ) -> Result<AccountAddress> {
+    //     let resolved_sender = {
+    //         let address_mapping = self.moveos().as_module_binding::<AddressMapping>();
+    //         address_mapping.resolve_or_generate(multi_chain_address_sender)?
+    //     };
+    //
+    //     Ok(resolved_sender)
+    // }
 
-        Ok(resolved_sender)
-    }
+    // pub fn validate<T: AbstractTransaction>(&self, tx: T) -> Result<VerifiedMoveOSTransaction> {
+    //     let multi_chain_address_sender = tx.sender();
+    //
+    //     let resolved_sender = self.resolve_or_generate(multi_chain_address_sender.clone())?;
+    //     let authenticator = tx.authenticator_info()?;
+    //
+    //     let mut moveos_tx = tx.construct_moveos_transaction(resolved_sender)?;
+    //
+    //     let vm_result = self.validate_authenticator(&moveos_tx.ctx, authenticator)?;
+    //
+    //     let can_pay_gas = self.validate_gas_function(&moveos_tx)?;
+    //
+    //     let mut pay_by_module_account = false;
+    //     let mut gas_payment_account = moveos_tx.ctx.sender;
+    //
+    //     if let Some(pay_gas) = can_pay_gas {
+    //         if pay_gas {
+    //             let account_balance = self.get_account_balance(&moveos_tx)?;
+    //             let module_account = {
+    //                 match &moveos_tx.action {
+    //                     MoveAction::Function(call) => Some(*call.function_id.module_id.address()),
+    //                     _ => None,
+    //                 }
+    //             };
+    //
+    //             let gas_payment_address = {
+    //                 if account_balance >= moveos_tx.ctx.max_gas_amount as u128 {
+    //                     pay_by_module_account = true;
+    //                     module_account.unwrap()
+    //                 } else {
+    //                     moveos_tx.ctx.sender
+    //                 }
+    //             };
+    //
+    //             gas_payment_account = gas_payment_address;
+    //         }
+    //     }
+    //
+    //     moveos_tx
+    //         .ctx
+    //         .add(GasPaymentAccount {
+    //             account: gas_payment_account,
+    //             pay_gas_by_module_account: pay_by_module_account,
+    //         })
+    //         .expect("adding GasPaymentAccount to tx context failed.");
+    //
+    //     match vm_result {
+    //         Ok((
+    //             tx_validate_result,
+    //             multi_chain_address,
+    //             pre_execute_functions,
+    //             post_execute_functions,
+    //         )) => {
+    //             // Add the original multichain address to the context
+    //             moveos_tx
+    //                 .ctx
+    //                 .add(multi_chain_address.unwrap_or(multi_chain_address_sender))
+    //                 .expect("add sender to context failed");
+    //
+    //             // Add the tx_validate_result to the context
+    //             moveos_tx
+    //                 .ctx
+    //                 .add(tx_validate_result)
+    //                 .expect("add tx_validate_result failed");
+    //
+    //             moveos_tx.append_pre_execute_functions(pre_execute_functions);
+    //             moveos_tx.append_post_execute_functions(post_execute_functions);
+    //             Ok(self.moveos().verify(moveos_tx)?)
+    //         }
+    //         Err(e) => {
+    //             let status_view = explain_vm_status(self.moveos.moveos_resolver(), e.clone())?;
+    //             log::warn!(
+    //                 "transaction validate vm error, tx_hash: {}, error:{:?}",
+    //                 moveos_tx.ctx.tx_hash(),
+    //                 status_view,
+    //             );
+    //             //TODO how to return the vm status to rpc client.
+    //             Err(e.into())
+    //         }
+    //     }
+    // }
 
-    pub fn validate<T: AbstractTransaction>(&self, tx: T) -> Result<VerifiedMoveOSTransaction> {
-        let multi_chain_address_sender = tx.sender();
+    // pub fn validate_authenticator(
+    //     &self,
+    //     ctx: &TxContext,
+    //     authenticator: AuthenticatorInfo,
+    // ) -> Result<ValidateAuthenticatorResult> {
+    //     let tx_validator = self.moveos().as_module_binding::<TransactionValidator>();
+    //     let tx_validate_function_result = tx_validator
+    //         .validate(ctx, authenticator.clone())?
+    //         .into_result();
+    //
+    //     let vm_result = match tx_validate_function_result {
+    //         Ok(tx_validate_result) => {
+    //             let auth_validator_option = tx_validate_result.auth_validator();
+    //             match auth_validator_option {
+    //                 Some(auth_validator) => {
+    //                     let auth_validator_caller =
+    //                         AuthValidatorCaller::new(self.moveos(), auth_validator);
+    //                     let auth_validator_function_result = auth_validator_caller
+    //                         .validate(ctx, authenticator.authenticator.payload)?
+    //                         .into_result();
+    //                     match auth_validator_function_result {
+    //                         Ok(multi_chain_address) => {
+    //                             // pre_execute_function: AuthValidator
+    //                             let pre_execute_functions =
+    //                                 vec![auth_validator_caller.pre_execute_function_call()];
+    //                             // post_execute_function: AuthValidator
+    //                             let post_execute_functions =
+    //                                 vec![auth_validator_caller.post_execute_function_call()];
+    //                             Ok((
+    //                                 tx_validate_result,
+    //                                 multi_chain_address,
+    //                                 pre_execute_functions,
+    //                                 post_execute_functions,
+    //                             ))
+    //                         }
+    //                         Err(vm_status) => Err(vm_status),
+    //                     }
+    //                 }
+    //                 None => {
+    //                     let pre_execute_functions = vec![];
+    //                     let post_execute_functions = vec![];
+    //                     Ok((
+    //                         tx_validate_result,
+    //                         None,
+    //                         pre_execute_functions,
+    //                         post_execute_functions,
+    //                     ))
+    //                 }
+    //             }
+    //         }
+    //         Err(vm_status) => Err(vm_status),
+    //     };
+    //     Ok(vm_result)
+    // }
+    //
+    // pub fn validate_gas_function(&self, tx: &MoveOSTransaction) -> VMResult<Option<bool>> {
+    //     let MoveOSTransaction { ctx, .. } = tx;
+    //
+    //     let cost_table = initial_cost_schedule();
+    //     let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
+    //     gas_meter.set_metering(false);
+    //
+    //     let verified_moveos_action = self.moveos().verify(tx.clone())?;
+    //     let verified_action = verified_moveos_action.action;
+    //
+    //     match verified_action {
+    //         VerifiedMoveAction::Function { call } => {
+    //             let module_id = &call.function_id.module_id;
+    //             let loaded_module_bytes_result =
+    //                 self.moveos().moveos_resolver().get_module(module_id);
+    //             let loaded_module_bytes = match loaded_module_bytes_result {
+    //                 Ok(loaded_module_bytes_opt) => match loaded_module_bytes_opt {
+    //                     None => {
+    //                         return Err(PartialVMError::new(StatusCode::RESOURCE_DOES_NOT_EXIST)
+    //                             .with_message(
+    //                                 "The name of the gas_validate_function does not exist."
+    //                                     .to_string(),
+    //                             )
+    //                             .finish(Location::Module(module_id.clone())));
+    //                     }
+    //                     Some(module_bytes) => module_bytes,
+    //                 },
+    //                 Err(error) => {
+    //                     return Err(PartialVMError::new(StatusCode::RESOURCE_DOES_NOT_EXIST)
+    //                         .with_message(format!(
+    //                             "Load module data from module_id {:} was failed {:}.",
+    //                             module_id.clone(),
+    //                             error
+    //                         ))
+    //                         .finish(Location::Module(module_id.clone())));
+    //                 }
+    //             };
+    //
+    //             let module_metadata = load_module_metadata(module_id, Ok(loaded_module_bytes))?;
+    //             let gas_free_function_info = {
+    //                 match module_metadata {
+    //                     None => None,
+    //                     Some(runtime_metadata) => Some(runtime_metadata.gas_free_function_map),
+    //                 }
+    //             };
+    //
+    //             let called_function_name = call.function_id.function_name.to_string();
+    //             match gas_free_function_info {
+    //                 None => Ok(None),
+    //                 Some(gas_func_info) => {
+    //                     let full_called_function = format!(
+    //                         "0x{}::{}::{}",
+    //                         call.function_id.module_id.address().to_hex(),
+    //                         call.function_id.module_id.name(),
+    //                         called_function_name
+    //                     );
+    //                     let gas_func_info_opt = gas_func_info.get(&full_called_function);
+    //
+    //                     if let Some(gas_func_info) = gas_func_info_opt {
+    //                         let gas_validate_func_name = gas_func_info.gas_validate.clone();
+    //
+    //                         let split_function = gas_validate_func_name.split("::").collect_vec();
+    //                         if split_function.len() != 3 {
+    //                             return Err(PartialVMError::new(StatusCode::VM_EXTENSION_ERROR)
+    //                                 .with_message(
+    //                                     "The name of the gas_validate_function is incorrect."
+    //                                         .to_string(),
+    //                                 )
+    //                                 .finish(Location::Module(call.clone().function_id.module_id)));
+    //                         }
+    //                         let real_gas_validate_func_name =
+    //                             split_function.get(2).unwrap().to_string();
+    //
+    //                         let gas_validate_func_call = FunctionCall::new(
+    //                             FunctionId::new(
+    //                                 call.function_id.module_id.clone(),
+    //                                 Identifier::new(real_gas_validate_func_name).unwrap(),
+    //                             ),
+    //                             vec![],
+    //                             vec![],
+    //                         );
+    //
+    //                         let function_execution_result =
+    //                             self.moveos.execute_view_function(gas_validate_func_call);
+    //
+    //                         return if function_execution_result.vm_status == VMStatus::Executed {
+    //                             let return_value = function_execution_result.return_values.unwrap();
+    //                             if !return_value.is_empty() {
+    //                                 let first_return_value = return_value.get(0).unwrap();
+    //                                 Ok(Some(
+    //                                     bcs::from_bytes::<bool>(first_return_value.value.as_slice())
+    //                                         .expect(
+    //                                             "the return value of gas validate function should be bool",
+    //                                         ),
+    //                                 ))
+    //                             } else {
+    //                                 return Err(PartialVMError::new(
+    //                                     StatusCode::VM_EXTENSION_ERROR,
+    //                                 )
+    //                                 .with_message(
+    //                                     "the return value of gas_validate_function is empty."
+    //                                         .to_string(),
+    //                                 )
+    //                                 .finish(Location::Module(call.clone().function_id.module_id)));
+    //                             }
+    //                         } else {
+    //                             Ok(None)
+    //                         };
+    //                     };
+    //
+    //                     Ok(None)
+    //                 }
+    //             }
+    //         }
+    //         _ => Ok(None),
+    //     }
+    // }
 
-        let resolved_sender = self.resolve_or_generate(multi_chain_address_sender.clone())?;
-        let authenticator = tx.authenticator_info()?;
-
-        let mut moveos_tx = tx.construct_moveos_transaction(resolved_sender)?;
-
-        let vm_result = self.validate_authenticator(&moveos_tx.ctx, authenticator)?;
-
-        let can_pay_gas = self.validate_gas_function(&moveos_tx)?;
-
-        let mut pay_by_module_account = false;
-        let mut gas_payment_account = moveos_tx.ctx.sender;
-
-        if let Some(pay_gas) = can_pay_gas {
-            if pay_gas {
-                let account_balance = self.get_account_balance(&moveos_tx)?;
-                let module_account = {
-                    match &moveos_tx.action {
-                        MoveAction::Function(call) => Some(*call.function_id.module_id.address()),
-                        _ => None,
-                    }
-                };
-
-                let gas_payment_address = {
-                    if account_balance >= moveos_tx.ctx.max_gas_amount as u128 {
-                        pay_by_module_account = true;
-                        module_account.unwrap()
-                    } else {
-                        moveos_tx.ctx.sender
-                    }
-                };
-
-                gas_payment_account = gas_payment_address;
-            }
-        }
-
-        moveos_tx
-            .ctx
-            .add(GasPaymentAccount {
-                account: gas_payment_account,
-                pay_gas_by_module_account: pay_by_module_account,
-            })
-            .expect("adding GasPaymentAccount to tx context failed.");
-
-        match vm_result {
-            Ok((
-                tx_validate_result,
-                multi_chain_address,
-                pre_execute_functions,
-                post_execute_functions,
-            )) => {
-                // Add the original multichain address to the context
-                moveos_tx
-                    .ctx
-                    .add(multi_chain_address.unwrap_or(multi_chain_address_sender))
-                    .expect("add sender to context failed");
-
-                // Add the tx_validate_result to the context
-                moveos_tx
-                    .ctx
-                    .add(tx_validate_result)
-                    .expect("add tx_validate_result failed");
-
-                moveos_tx.append_pre_execute_functions(pre_execute_functions);
-                moveos_tx.append_post_execute_functions(post_execute_functions);
-                Ok(self.moveos().verify(moveos_tx)?)
-            }
-            Err(e) => {
-                let status_view = explain_vm_status(self.moveos.moveos_resolver(), e.clone())?;
-                log::warn!(
-                    "transaction validate vm error, tx_hash: {}, error:{:?}",
-                    moveos_tx.ctx.tx_hash(),
-                    status_view,
-                );
-                //TODO how to return the vm status to rpc client.
-                Err(e.into())
-            }
-        }
-    }
-
-    pub fn validate_authenticator(
-        &self,
-        ctx: &TxContext,
-        authenticator: AuthenticatorInfo,
-    ) -> Result<ValidateAuthenticatorResult> {
-        let tx_validator = self.moveos().as_module_binding::<TransactionValidator>();
-        let tx_validate_function_result = tx_validator
-            .validate(ctx, authenticator.clone())?
-            .into_result();
-
-        let vm_result = match tx_validate_function_result {
-            Ok(tx_validate_result) => {
-                let auth_validator_option = tx_validate_result.auth_validator();
-                match auth_validator_option {
-                    Some(auth_validator) => {
-                        let auth_validator_caller =
-                            AuthValidatorCaller::new(self.moveos(), auth_validator);
-                        let auth_validator_function_result = auth_validator_caller
-                            .validate(ctx, authenticator.authenticator.payload)?
-                            .into_result();
-                        match auth_validator_function_result {
-                            Ok(multi_chain_address) => {
-                                // pre_execute_function: AuthValidator
-                                let pre_execute_functions =
-                                    vec![auth_validator_caller.pre_execute_function_call()];
-                                // post_execute_function: AuthValidator
-                                let post_execute_functions =
-                                    vec![auth_validator_caller.post_execute_function_call()];
-                                Ok((
-                                    tx_validate_result,
-                                    multi_chain_address,
-                                    pre_execute_functions,
-                                    post_execute_functions,
-                                ))
-                            }
-                            Err(vm_status) => Err(vm_status),
-                        }
-                    }
-                    None => {
-                        let pre_execute_functions = vec![];
-                        let post_execute_functions = vec![];
-                        Ok((
-                            tx_validate_result,
-                            None,
-                            pre_execute_functions,
-                            post_execute_functions,
-                        ))
-                    }
-                }
-            }
-            Err(vm_status) => Err(vm_status),
-        };
-        Ok(vm_result)
-    }
-
-    pub fn validate_gas_function(&self, tx: &MoveOSTransaction) -> VMResult<Option<bool>> {
-        let MoveOSTransaction { ctx, .. } = tx;
-
-        let cost_table = initial_cost_schedule();
-        let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
-        gas_meter.set_metering(false);
-
-        let verified_moveos_action = self.moveos().verify(tx.clone())?;
-        let verified_action = verified_moveos_action.action;
-
-        match verified_action {
-            VerifiedMoveAction::Function { call } => {
-                let module_id = &call.function_id.module_id;
-                let loaded_module_bytes_result =
-                    self.moveos().moveos_resolver().get_module(module_id);
-                let loaded_module_bytes = match loaded_module_bytes_result {
-                    Ok(loaded_module_bytes_opt) => match loaded_module_bytes_opt {
-                        None => {
-                            return Err(PartialVMError::new(StatusCode::RESOURCE_DOES_NOT_EXIST)
-                                .with_message(
-                                    "The name of the gas_validate_function does not exist."
-                                        .to_string(),
-                                )
-                                .finish(Location::Module(module_id.clone())));
-                        }
-                        Some(module_bytes) => module_bytes,
-                    },
-                    Err(error) => {
-                        return Err(PartialVMError::new(StatusCode::RESOURCE_DOES_NOT_EXIST)
-                            .with_message(format!(
-                                "Load module data from module_id {:} was failed {:}.",
-                                module_id.clone(),
-                                error
-                            ))
-                            .finish(Location::Module(module_id.clone())));
-                    }
-                };
-
-                let module_metadata = load_module_metadata(module_id, Ok(loaded_module_bytes))?;
-                let gas_free_function_info = {
-                    match module_metadata {
-                        None => None,
-                        Some(runtime_metadata) => Some(runtime_metadata.gas_free_function_map),
-                    }
-                };
-
-                let called_function_name = call.function_id.function_name.to_string();
-                match gas_free_function_info {
-                    None => Ok(None),
-                    Some(gas_func_info) => {
-                        let full_called_function = format!(
-                            "0x{}::{}::{}",
-                            call.function_id.module_id.address().to_hex(),
-                            call.function_id.module_id.name(),
-                            called_function_name
-                        );
-                        let gas_func_info_opt = gas_func_info.get(&full_called_function);
-
-                        if let Some(gas_func_info) = gas_func_info_opt {
-                            let gas_validate_func_name = gas_func_info.gas_validate.clone();
-
-                            let split_function = gas_validate_func_name.split("::").collect_vec();
-                            if split_function.len() != 3 {
-                                return Err(PartialVMError::new(StatusCode::VM_EXTENSION_ERROR)
-                                    .with_message(
-                                        "The name of the gas_validate_function is incorrect."
-                                            .to_string(),
-                                    )
-                                    .finish(Location::Module(call.clone().function_id.module_id)));
-                            }
-                            let real_gas_validate_func_name =
-                                split_function.get(2).unwrap().to_string();
-
-                            let gas_validate_func_call = FunctionCall::new(
-                                FunctionId::new(
-                                    call.function_id.module_id.clone(),
-                                    Identifier::new(real_gas_validate_func_name).unwrap(),
-                                ),
-                                vec![],
-                                vec![],
-                            );
-
-                            let function_execution_result =
-                                self.moveos.execute_view_function(gas_validate_func_call);
-
-                            return if function_execution_result.vm_status == VMStatus::Executed {
-                                let return_value = function_execution_result.return_values.unwrap();
-                                if !return_value.is_empty() {
-                                    let first_return_value = return_value.get(0).unwrap();
-                                    Ok(Some(
-                                        bcs::from_bytes::<bool>(first_return_value.value.as_slice())
-                                            .expect(
-                                                "the return value of gas validate function should be bool",
-                                            ),
-                                    ))
-                                } else {
-                                    return Err(PartialVMError::new(
-                                        StatusCode::VM_EXTENSION_ERROR,
-                                    )
-                                    .with_message(
-                                        "the return value of gas_validate_function is empty."
-                                            .to_string(),
-                                    )
-                                    .finish(Location::Module(call.clone().function_id.module_id)));
-                                }
-                            } else {
-                                Ok(None)
-                            };
-                        };
-
-                        Ok(None)
-                    }
-                }
-            }
-            _ => Ok(None),
-        }
-    }
-
-    pub fn get_account_balance(&self, tx: &MoveOSTransaction) -> VMResult<u128> {
-        let MoveOSTransaction { ctx, .. } = tx;
-
-        let cost_table = initial_cost_schedule();
-        let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
-        gas_meter.set_metering(false);
-
-        let verified_moveos_action = self.moveos().verify(tx.clone())?;
-        let verified_action = verified_moveos_action.action;
-
-        match verified_action {
-            VerifiedMoveAction::Function { call } => {
-                let module_address = call.function_id.module_id.address();
-
-                let gas_coin_module_id = ModuleId::new(
-                    AccountAddress::from_hex_literal("0x3").unwrap(),
-                    Identifier::from(IdentStr::new("gas_coin").unwrap()),
-                );
-                let gas_balance_func_call = FunctionCall::new(
-                    FunctionId::new(gas_coin_module_id, Identifier::new("balance").unwrap()),
-                    vec![],
-                    vec![MoveValue::Address(*module_address)
-                        .simple_serialize()
-                        .unwrap()],
-                );
-
-                let function_execution_result =
-                    self.moveos.execute_view_function(gas_balance_func_call);
-
-                if function_execution_result.vm_status == VMStatus::Executed {
-                    let return_value = function_execution_result.return_values.unwrap();
-                    let first_return_value = return_value.get(0).unwrap();
-
-                    let balance = bcs::from_bytes::<move_core_types::u256::U256>(
-                        first_return_value.value.as_slice(),
-                    )
-                    .expect("the return value of gas validate function should be u128");
-
-                    Ok(balance.unchecked_as_u128())
-                } else {
-                    Ok(0)
-                }
-            }
-            _ => Ok(0),
-        }
-    }
+    // pub fn get_account_balance(&self, tx: &MoveOSTransaction) -> VMResult<u128> {
+    //     let MoveOSTransaction { ctx, .. } = tx;
+    //
+    //     let cost_table = initial_cost_schedule();
+    //     let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
+    //     gas_meter.set_metering(false);
+    //
+    //     let verified_moveos_action = self.moveos().verify(tx.clone())?;
+    //     let verified_action = verified_moveos_action.action;
+    //
+    //     match verified_action {
+    //         VerifiedMoveAction::Function { call } => {
+    //             let module_address = call.function_id.module_id.address();
+    //
+    //             let gas_coin_module_id = ModuleId::new(
+    //                 AccountAddress::from_hex_literal("0x3").unwrap(),
+    //                 Identifier::from(IdentStr::new("gas_coin").unwrap()),
+    //             );
+    //             let gas_balance_func_call = FunctionCall::new(
+    //                 FunctionId::new(gas_coin_module_id, Identifier::new("balance").unwrap()),
+    //                 vec![],
+    //                 vec![MoveValue::Address(*module_address)
+    //                     .simple_serialize()
+    //                     .unwrap()],
+    //             );
+    //
+    //             let function_execution_result =
+    //                 self.moveos.execute_view_function(gas_balance_func_call);
+    //
+    //             if function_execution_result.vm_status == VMStatus::Executed {
+    //                 let return_value = function_execution_result.return_values.unwrap();
+    //                 let first_return_value = return_value.get(0).unwrap();
+    //
+    //                 let balance = bcs::from_bytes::<move_core_types::u256::U256>(
+    //                     first_return_value.value.as_slice(),
+    //                 )
+    //                 .expect("the return value of gas validate function should be u128");
+    //
+    //                 Ok(balance.unchecked_as_u128())
+    //             } else {
+    //                 Ok(0)
+    //             }
+    //         }
+    //         _ => Ok(0),
+    //     }
+    // }
 
     pub fn get_rooch_store(&self) -> RoochStore {
         self.rooch_store.clone()
@@ -412,19 +388,19 @@ impl ReaderExecutorActor {
 
 impl Actor for ReaderExecutorActor {}
 
-#[async_trait]
-impl<T> Handler<ValidateTransactionMessage<T>> for ReaderExecutorActor
-where
-    T: 'static + AbstractTransaction + Send + Sync,
-{
-    async fn handle(
-        &mut self,
-        msg: ValidateTransactionMessage<T>,
-        _ctx: &mut ActorContext,
-    ) -> Result<VerifiedMoveOSTransaction> {
-        self.validate(msg.tx)
-    }
-}
+// #[async_trait]
+// impl<T> Handler<ValidateTransactionMessage<T>> for ReaderExecutorActor
+// where
+//     T: 'static + AbstractTransaction + Send + Sync,
+// {
+//     async fn handle(
+//         &mut self,
+//         msg: ValidateTransactionMessage<T>,
+//         _ctx: &mut ActorContext,
+//     ) -> Result<VerifiedMoveOSTransaction> {
+//         self.validate(msg.tx)
+//     }
+// }
 
 #[async_trait]
 impl Handler<ExecuteViewFunctionMessage> for ReaderExecutorActor {
@@ -457,16 +433,16 @@ impl Handler<ExecuteViewFunctionMessage> for ReaderExecutorActor {
     }
 }
 
-#[async_trait]
-impl Handler<ResolveMessage> for ReaderExecutorActor {
-    async fn handle(
-        &mut self,
-        msg: ResolveMessage,
-        _ctx: &mut ActorContext,
-    ) -> Result<AccountAddress, anyhow::Error> {
-        self.resolve_or_generate(msg.address)
-    }
-}
+// #[async_trait]
+// impl Handler<ResolveMessage> for ReaderExecutorActor {
+//     async fn handle(
+//         &mut self,
+//         msg: ResolveMessage,
+//         _ctx: &mut ActorContext,
+//     ) -> Result<AccountAddress, anyhow::Error> {
+//         self.resolve_or_generate(msg.address)
+//     }
+// }
 
 #[async_trait]
 impl Handler<StatesMessage> for ReaderExecutorActor {

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -4,7 +4,7 @@
 use crate::actor::messages::{
     GetAnnotatedStatesByStateMessage, GetEventsByEventHandleMessage, GetEventsByEventIDsMessage,
     GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage, ListStatesMessage,
-    UpdateStateRootMessage,
+    RefreshStateMessage,
 };
 use crate::actor::reader_executor::ReaderExecutorActor;
 use crate::actor::{
@@ -190,9 +190,12 @@ impl ExecutorProxy {
             .await?
     }
 
-    pub async fn update_state_root(&self, new_state_root: H256) -> Result<()> {
+    pub async fn refresh_state(&self, new_state_root: H256, is_upgrade: bool) -> Result<()> {
         self.reader_actor
-            .send(UpdateStateRootMessage { new_state_root })
+            .send(RefreshStateMessage {
+                new_state_root,
+                is_upgrade,
+            })
             .await?
     }
 }

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -4,6 +4,7 @@
 use crate::actor::messages::{
     GetAnnotatedStatesByStateMessage, GetEventsByEventHandleMessage, GetEventsByEventIDsMessage,
     GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage, ListStatesMessage,
+    UpdateStateRootMessage,
 };
 use crate::actor::reader_executor::ReaderExecutorActor;
 use crate::actor::{
@@ -186,6 +187,12 @@ impl ExecutorProxy {
     ) -> Result<Vec<AnnotatedState>> {
         self.reader_actor
             .send(GetAnnotatedStatesByStateMessage { states })
+            .await?
+    }
+
+    pub async fn update_state_root(&self, new_state_root: H256) -> Result<()> {
+        self.reader_actor
+            .send(UpdateStateRootMessage { new_state_root })
             .await?
     }
 }

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -56,9 +56,7 @@ impl ExecutorProxy {
     where
         T: 'static + AbstractTransaction + Send + Sync,
     {
-        self.reader_actor
-            .send(ValidateTransactionMessage { tx })
-            .await?
+        self.actor.send(ValidateTransactionMessage { tx }).await?
     }
 
     //TODO ensure the execute result
@@ -89,9 +87,7 @@ impl ExecutorProxy {
     }
 
     pub async fn resolve_address(&self, mca: MultiChainAddress) -> Result<AccountAddress> {
-        self.reader_actor
-            .send(ResolveMessage { address: mca })
-            .await?
+        self.actor.send(ResolveMessage { address: mca }).await?
     }
 
     pub async fn get_annotated_states(

--- a/crates/rooch-framework-tests/src/binding_test.rs
+++ b/crates/rooch-framework-tests/src/binding_test.rs
@@ -63,7 +63,7 @@ impl RustBindingTest {
         &mut self,
         tx: T,
     ) -> Result<ExecuteTransactionResult> {
-        let verified_tx = self.reader_executor.validate(tx)?;
+        let verified_tx = self.executor.validate(tx)?;
         self.executor.execute(verified_tx)
     }
 }

--- a/crates/rooch-framework-tests/src/binding_test.rs
+++ b/crates/rooch-framework-tests/src/binding_test.rs
@@ -35,7 +35,8 @@ impl RustBindingTest {
             moveos_store.clone(),
             rooch_store.clone(),
         )?;
-        let reader_executor = ReaderExecutorActor::new(executor.moveos().clone(), rooch_store)?;
+        let reader_executor =
+            ReaderExecutorActor::new(executor.genesis().clone(), moveos_store, rooch_store)?;
         Ok(Self {
             executor,
             reader_executor,
@@ -76,7 +77,6 @@ impl MoveFunctionCaller for RustBindingTest {
         let result = self
             .reader_executor
             .moveos()
-            .read()
             .execute_readonly_function(ctx, function_call);
         Ok(result)
     }

--- a/crates/rooch-framework-tests/src/tests/bitcoin_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/bitcoin_light_client_test.rs
@@ -170,9 +170,7 @@ fn check_utxo(txs: Vec<Transaction>, binding_test: &binding_test::RustBindingTes
     );
     let utxo_module = binding_test.as_module_binding::<rooch_types::bitcoin::utxo::UTXOModule>();
 
-    let binding = binding_test.executor().moveos();
-    let moveos = binding.read();
-    let moveos_resolver = moveos.moveos_resolver();
+    let moveos_resolver = binding_test.executor().moveos().moveos_resolver();
 
     for (outpoint, tx_out) in utxo_set.into_iter() {
         let txid = outpoint.txid;

--- a/crates/rooch-indexer/src/actor/mod.rs
+++ b/crates/rooch-indexer/src/actor/mod.rs
@@ -3,3 +3,4 @@
 
 pub mod indexer;
 pub mod messages;
+pub mod reader_indexer;

--- a/crates/rooch-indexer/src/actor/reader_indexer.rs
+++ b/crates/rooch-indexer/src/actor/reader_indexer.rs
@@ -1,0 +1,126 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::actor::messages::{
+    QueryIndexerEventsMessage, QueryIndexerGlobalStatesMessage, QueryIndexerTableStatesMessage,
+    QueryIndexerTransactionsMessage, SyncIndexerStatesMessage,
+};
+use crate::indexer_reader::IndexerReader;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use coerce::actor::{context::ActorContext, message::Handler, Actor};
+use rooch_types::indexer::event_filter::IndexerEvent;
+use rooch_types::indexer::state::{IndexerGlobalState, IndexerTableChangeSet, IndexerTableState};
+use rooch_types::transaction::TransactionWithInfo;
+
+pub struct IndexerReaderActor {
+    indexer_reader: IndexerReader,
+}
+
+impl IndexerReaderActor {
+    pub fn new(indexer_reader: IndexerReader) -> Result<Self> {
+        Ok(Self { indexer_reader })
+    }
+}
+
+impl Actor for IndexerReaderActor {}
+
+#[async_trait]
+impl Handler<QueryIndexerTransactionsMessage> for IndexerReaderActor {
+    async fn handle(
+        &mut self,
+        msg: QueryIndexerTransactionsMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<Vec<TransactionWithInfo>> {
+        let QueryIndexerTransactionsMessage {
+            filter,
+            cursor,
+            limit,
+            descending_order,
+        } = msg;
+        self.indexer_reader
+            .query_transactions_with_filter(filter, cursor, limit, descending_order)
+            .map_err(|e| anyhow!(format!("Failed to query indexer transactions: {:?}", e)))
+    }
+}
+
+#[async_trait]
+impl Handler<QueryIndexerEventsMessage> for IndexerReaderActor {
+    async fn handle(
+        &mut self,
+        msg: QueryIndexerEventsMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<Vec<IndexerEvent>> {
+        let QueryIndexerEventsMessage {
+            filter,
+            cursor,
+            limit,
+            descending_order,
+        } = msg;
+        self.indexer_reader
+            .query_events_with_filter(filter, cursor, limit, descending_order)
+            .map_err(|e| anyhow!(format!("Failed to query indexer events: {:?}", e)))
+    }
+}
+
+#[async_trait]
+impl Handler<QueryIndexerGlobalStatesMessage> for IndexerReaderActor {
+    async fn handle(
+        &mut self,
+        msg: QueryIndexerGlobalStatesMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<Vec<IndexerGlobalState>> {
+        let QueryIndexerGlobalStatesMessage {
+            filter,
+            cursor,
+            limit,
+            descending_order,
+        } = msg;
+        self.indexer_reader
+            .query_global_states_with_filter(filter, cursor, limit, descending_order)
+            .map_err(|e| anyhow!(format!("Failed to query indexer global states: {:?}", e)))
+    }
+}
+
+#[async_trait]
+impl Handler<QueryIndexerTableStatesMessage> for IndexerReaderActor {
+    async fn handle(
+        &mut self,
+        msg: QueryIndexerTableStatesMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<Vec<IndexerTableState>> {
+        let QueryIndexerTableStatesMessage {
+            filter,
+            cursor,
+            limit,
+            descending_order,
+        } = msg;
+        self.indexer_reader
+            .query_table_states_with_filter(filter, cursor, limit, descending_order)
+            .map_err(|e| anyhow!(format!("Failed to query indexer table states: {:?}", e)))
+    }
+}
+
+#[async_trait]
+impl Handler<SyncIndexerStatesMessage> for IndexerReaderActor {
+    async fn handle(
+        &mut self,
+        msg: SyncIndexerStatesMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<Vec<IndexerTableChangeSet>> {
+        let SyncIndexerStatesMessage {
+            filter,
+            cursor,
+            limit,
+            descending_order,
+        } = msg;
+        self.indexer_reader
+            .sync_states(filter, cursor, limit, descending_order)
+            .map_err(|e| {
+                anyhow!(format!(
+                    "Failed to query indexer state change sets: {:?}",
+                    e
+                ))
+            })
+    }
+}

--- a/crates/rooch-indexer/src/proxy/mod.rs
+++ b/crates/rooch-indexer/src/proxy/mod.rs
@@ -7,6 +7,7 @@ use crate::actor::messages::{
     QueryIndexerEventsMessage, QueryIndexerGlobalStatesMessage, QueryIndexerTableStatesMessage,
     QueryIndexerTransactionsMessage, SyncIndexerStatesMessage,
 };
+use crate::actor::reader_indexer::IndexerReaderActor;
 use anyhow::Result;
 use coerce::actor::ActorRef;
 use moveos_types::moveos_std::event::Event;
@@ -23,11 +24,15 @@ use rooch_types::transaction::{TransactionSequenceInfo, TransactionWithInfo, Typ
 #[derive(Clone)]
 pub struct IndexerProxy {
     pub actor: ActorRef<IndexerActor>,
+    pub reader_actor: ActorRef<IndexerReaderActor>,
 }
 
 impl IndexerProxy {
-    pub fn new(actor: ActorRef<IndexerActor>) -> Self {
-        Self { actor }
+    pub fn new(actor: ActorRef<IndexerActor>, reader_actor: ActorRef<IndexerReaderActor>) -> Self {
+        Self {
+            actor,
+            reader_actor,
+        }
     }
 
     pub async fn indexer_states(
@@ -85,7 +90,7 @@ impl IndexerProxy {
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<TransactionWithInfo>> {
-        self.actor
+        self.reader_actor
             .send(QueryIndexerTransactionsMessage {
                 filter,
                 cursor,
@@ -103,7 +108,7 @@ impl IndexerProxy {
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<IndexerEvent>> {
-        self.actor
+        self.reader_actor
             .send(QueryIndexerEventsMessage {
                 filter,
                 cursor,
@@ -121,7 +126,7 @@ impl IndexerProxy {
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<IndexerGlobalState>> {
-        self.actor
+        self.reader_actor
             .send(QueryIndexerGlobalStatesMessage {
                 filter,
                 cursor,
@@ -139,7 +144,7 @@ impl IndexerProxy {
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<IndexerTableState>> {
-        self.actor
+        self.reader_actor
             .send(QueryIndexerTableStatesMessage {
                 filter,
                 cursor,
@@ -157,7 +162,7 @@ impl IndexerProxy {
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<IndexerTableChangeSet>> {
-        self.actor
+        self.reader_actor
             .send(SyncIndexerStatesMessage {
                 filter,
                 cursor,

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -2105,6 +2105,7 @@
         "required": [
           "events",
           "gas_used",
+          "is_upgrade",
           "status",
           "table_changeset"
         ],
@@ -2119,6 +2120,9 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
+          },
+          "is_upgrade": {
+            "type": "boolean"
           },
           "status": {
             "$ref": "#/components/schemas/KeptVMStatusView"

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
@@ -63,7 +63,6 @@ impl UTXOView {
     pub fn try_new_from_utxo(utxo: UTXO) -> Result<UTXOView, anyhow::Error> {
         let bitcoin_txid = Txid::from_byte_array(utxo.txid.into_bytes());
         // reversed bytes of txid
-        // let bitcoin_reverse_bytes = bitcoin_txid.to_byte_array().to_vec().iter().rev().copied().collect();
         let seals_str = serde_json::to_string(&utxo.seals)?;
 
         Ok(UTXOView {
@@ -82,7 +81,7 @@ pub struct UTXOStateView {
     pub owner: AccountAddressView,
     pub owner_bitcoin_address: Option<String>,
     pub flag: u8,
-    pub value: UTXOView,
+    pub value: Option<UTXOView>,
     pub object_type: StructTagView,
     pub tx_order: u64,
     pub state_index: u64,
@@ -99,12 +98,16 @@ impl UTXOStateView {
             Some(baddress) => Some(baddress.format(network)?),
             None => None,
         };
+        let utxo_view = match utxo.value {
+            Some(utxo) => Some(UTXOView::try_new_from_utxo(utxo)?),
+            None => None,
+        };
         Ok(UTXOStateView {
             object_id: utxo.object_id,
             owner: utxo.owner.into(),
             owner_bitcoin_address,
             flag: utxo.flag,
-            value: UTXOView::try_new_from_utxo(utxo.value)?,
+            value: utxo_view,
             object_type: utxo.object_type.into(),
             tx_order: utxo.tx_order,
             state_index: utxo.state_index,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
@@ -142,6 +142,7 @@ pub struct TransactionOutputView {
     pub table_changeset: StateChangeSetView,
     pub events: Vec<EventView>,
     pub gas_used: u64,
+    pub is_upgrade: bool,
 }
 
 impl From<TransactionOutput> for TransactionOutputView {
@@ -155,6 +156,7 @@ impl From<TransactionOutput> for TransactionOutputView {
                 .map(|event| event.into())
                 .collect(),
             gas_used: tx_output.gas_used,
+            is_upgrade: tx_output.is_upgrade,
         }
     }
 }

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -38,6 +38,7 @@ use rooch_executor::actor::executor::ExecutorActor;
 use rooch_executor::actor::reader_executor::ReaderExecutorActor;
 use rooch_executor::proxy::ExecutorProxy;
 use rooch_indexer::actor::indexer::IndexerActor;
+use rooch_indexer::actor::reader_indexer::IndexerReaderActor;
 use rooch_indexer::indexer_reader::IndexerReader;
 use rooch_indexer::proxy::IndexerProxy;
 use rooch_indexer::IndexerStore;
@@ -288,10 +289,13 @@ pub async fn run_start_server(opt: &RoochOpt, mut server_opt: ServerOpt) -> Resu
     timers.push(proposer_timer);
 
     // Init indexer
-    let indexer_executor = IndexerActor::new(indexer_store, indexer_reader, moveos_store)?
+    let indexer_executor = IndexerActor::new(indexer_store, moveos_store)?
         .into_actor(Some("Indexer"), &actor_system)
         .await?;
-    let indexer_proxy = IndexerProxy::new(indexer_executor.into());
+    let indexer_reader_executor = IndexerReaderActor::new(indexer_reader)?
+        .into_actor(Some("IndexerReader"), &actor_system)
+        .await?;
+    let indexer_proxy = IndexerProxy::new(indexer_executor.into(), indexer_reader_executor.into());
 
     let rpc_service = RpcService::new(
         chain_id_opt.chain_id().id(),

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -229,9 +229,13 @@ pub async fn run_start_server(opt: &RoochOpt, mut server_opt: ServerOpt) -> Resu
         moveos_store.clone(),
         rooch_store.clone(),
     )?;
-    let reader_executor = ReaderExecutorActor::new(executor_actor.moveos(), rooch_store.clone())?
-        .into_actor(Some("ReaderExecutor"), &actor_system)
-        .await?;
+    let reader_executor = ReaderExecutorActor::new(
+        executor_actor.genesis().clone(),
+        moveos_store.clone(),
+        rooch_store.clone(),
+    )?
+    .into_actor(Some("ReaderExecutor"), &actor_system)
+    .await?;
     let executor = executor_actor
         .into_actor(Some("Executor"), &actor_system)
         .await?;

--- a/crates/rooch-rpc-server/src/service/aggregate_service.rs
+++ b/crates/rooch-rpc-server/src/service/aggregate_service.rs
@@ -419,11 +419,7 @@ impl AggregateService {
             .into_iter()
             // .enumerate()
             .map(|state| {
-                let utxo = objects
-                    .get(&state.object_id)
-                    .cloned()
-                    .flatten()
-                    .ok_or(anyhow::anyhow!("UTXO should have value"))?;
+                let utxo = objects.get(&state.object_id).cloned().flatten();
                 let reverse_mapping_opt =
                     reverse_address_mapping.get(&state.owner).cloned().flatten();
                 let reverse_address = reverse_mapping_opt.and_then(|m| {

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -81,6 +81,11 @@ impl RpcService {
             .propose_transaction(tx.clone(), execution_info.clone(), sequence_info.clone())
             .await?;
 
+        // Sync lastest state root from writer executor to reader executor
+        self.executor
+            .update_state_root(execution_info.state_root)
+            .await?;
+
         // Last save indexer
         let result = self
             .indexer

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -83,7 +83,7 @@ impl RpcService {
 
         // Sync lastest state root from writer executor to reader executor
         self.executor
-            .update_state_root(execution_info.state_root)
+            .refresh_state(execution_info.state_root, output.is_upgrade)
             .await?;
 
         // Last save indexer

--- a/crates/rooch-types/src/bitcoin/utxo.rs
+++ b/crates/rooch-types/src/bitcoin/utxo.rs
@@ -100,7 +100,10 @@ pub struct UTXOState {
     pub owner: AccountAddress,
     pub owner_bitcoin_address: Option<BitcoinAddress>,
     pub flag: u8,
-    pub value: UTXO,
+    // There is a case when rooch bitcoin relayer synchronizes the bitcoin node data and processes the `process_block`
+    // in the contract, this process takes some time, and the object id in the Global state is deleted, but the ojbect
+    // id in the Indexer is not deleted yet. At this time, utxo is empty.
+    pub value: Option<UTXO>,
     pub object_type: StructTag,
     pub tx_order: u64,
     pub state_index: u64,
@@ -111,7 +114,7 @@ pub struct UTXOState {
 impl UTXOState {
     pub fn new_from_global_state(
         state: IndexerGlobalState,
-        utxo: UTXO,
+        utxo: Option<UTXO>,
         owner_bitcoin_address: Option<BitcoinAddress>,
     ) -> Self {
         Self {

--- a/moveos/moveos-store/src/state_store/statedb.rs
+++ b/moveos/moveos-store/src/state_store/statedb.rs
@@ -112,6 +112,11 @@ where
         self.puts(update_set)
     }
 
+    fn update_state_root(&self, new_state_root: H256) -> Result<()> {
+        self.smt.update_state_root(new_state_root)?;
+        Ok(())
+    }
+
     pub fn dump(&self) -> Result<Vec<(Vec<u8>, State)>> {
         self.smt.dump()
     }
@@ -396,6 +401,12 @@ impl StateDBStore {
             .insert(context::GLOBAL_OBJECT_STORAGE_HANDLE, golbal_table_state);
 
         Ok(table_state_set)
+    }
+
+    // update global table state root
+    pub fn update_state_root(&self, new_state_root: H256) -> Result<()> {
+        self.global_table.update_state_root(new_state_root)?;
+        Ok(())
     }
 }
 

--- a/moveos/moveos-types/src/transaction.rs
+++ b/moveos/moveos-types/src/transaction.rs
@@ -275,6 +275,7 @@ pub struct RawTransactionOutput {
     pub state_changeset: StateChangeSet,
     pub events: Vec<TransactionEvent>,
     pub gas_used: u64,
+    pub is_upgrade: bool,
 }
 
 /// TransactionOutput is the execution result of a MoveOS transaction, and pack TransactionEvent to Event
@@ -286,6 +287,7 @@ pub struct TransactionOutput {
     pub state_changeset: StateChangeSet,
     pub events: Vec<Event>,
     pub gas_used: u64,
+    pub is_upgrade: bool,
 }
 
 impl TransactionOutput {
@@ -309,6 +311,7 @@ impl TransactionOutput {
             state_changeset: transaction_output.state_changeset,
             events,
             gas_used: transaction_output.gas_used,
+            is_upgrade: transaction_output.is_upgrade,
         }
     }
 }

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -164,7 +164,7 @@ impl MoveOS {
 
         // execute main tx
         let execute_result = session.execute_move_action(verified_action);
-        let status = match vm_status_of_result(execute_result).keep_or_discard() {
+        let status = match vm_status_of_result(execute_result.clone()).keep_or_discard() {
             Ok(status) => status,
             Err(discard_status) => {
                 bail!("Discard status: {:?}", discard_status);
@@ -411,6 +411,7 @@ impl MoveOS {
             state_changeset,
             events,
             gas_used: _,
+            is_upgrade: _,
         } = output;
         let new_state_root = self
             .db
@@ -584,9 +585,12 @@ impl MoveOS {
         Ok(output)
     }
 
-    pub fn update_state_root(&self, new_state_root: H256) -> Result<()> {
+    pub fn refresh_state(&self, new_state_root: H256, is_upgrade: bool) -> Result<()> {
         self.state().update_state_root(new_state_root)?;
 
+        if is_upgrade {
+            self.vm.mark_loader_cache_as_invalid();
+        };
         Ok(())
     }
 }

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -583,6 +583,12 @@ impl MoveOS {
         let (_ctx, output) = session.finish_with_extensions(kept_status)?;
         Ok(output)
     }
+
+    pub fn update_state_root(&self, new_state_root: H256) -> Result<()> {
+        self.state().update_state_root(new_state_root)?;
+
+        Ok(())
+    }
 }
 
 impl MoveFunctionCaller for MoveOS {

--- a/moveos/smt/src/lib.rs
+++ b/moveos/smt/src/lib.rs
@@ -204,6 +204,12 @@ where
         Ok(new_state_root)
     }
 
+    pub fn update_state_root(&self, new_state_root: H256) -> Result<()> {
+        *self.root_hash.write() = new_state_root;
+
+        Ok(())
+    }
+
     pub fn is_genesis(&self) -> bool {
         self.root_hash() == *SPARSE_MERKLE_PLACEHOLDER_HASH
     }


### PR DESCRIPTION
## Summary

Follow up https://github.com/rooch-network/rooch/pull/1281

1. The read-write lock of moveos in Executor is removed, and the Reader Executor state is refreshed through Writer Executor message passing.
2. If the transaction is to upgrade the module, the Reader Executor needs to reset the loader cache in movevm
3. There is a case when rooch bitcoin relayer synchronizes the bitcoin node data and processes the `process_block` in the contract, this process takes some time, and the object id in the Global state is deleted, but the object id in the Indexer is not deleted yet. At this time, utxo is empty.

- Closes #issue