### PR TITLE
add protobuf dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN set -eux; \
         g++ \
         cmake \
         libsqlite3-dev \
+        libprotobuf-dev \
         protobuf-compiler; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Summary about this PR

fix the build docker and deploy seed workflow, with protobuf dependency for ubuntu 22.04