### PR TITLE
Feature owen sdk support object type

### DIFF
--- a/crates/rooch-key/src/keystore/types.rs
+++ b/crates/rooch-key/src/keystore/types.rs
@@ -16,7 +16,7 @@ pub struct LocalSessionKey {
     pub private_key: EncryptionData,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct LocalAccount {
     pub address: RoochAddress,
     pub multichain_address: Option<MultiChainAddress>,

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -4,11 +4,11 @@
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
-use serde::{Deserialize, Serialize};
-use rooch_key::keystore::types::LocalAccount;
 use rooch_key::keystore::account_keystore::AccountKeystore;
+use rooch_key::keystore::types::LocalAccount;
 use rooch_types::{crypto::EncodeDecodeBase64, error::RoochResult};
 use rpassword::prompt_password;
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 /// List all keys by its Rooch address, Base64 encoded public key
@@ -25,7 +25,7 @@ pub struct ListCommand {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AccountView {
     pub local_account: LocalAccount,
-    pub active: bool
+    pub active: bool,
 }
 
 #[async_trait]
@@ -45,15 +45,16 @@ impl CommandAction<()> for ListCommand {
         let accounts: Vec<LocalAccount> = context.keystore.get_accounts(password)?;
 
         if self.json {
-            let accont_views: Vec<AccountView> = accounts.into_iter().map(| account : LocalAccount| {
-                AccountView {
+            let accont_views: Vec<AccountView> = accounts
+                .into_iter()
+                .map(|account: LocalAccount| AccountView {
                     local_account: account.clone(),
-                    active: Some(account.address) == active_address
-                }
-            }).collect();
+                    active: Some(account.address) == active_address,
+                })
+                .collect();
 
             println!("{}", serde_json::to_string_pretty(&accont_views).unwrap());
-            return Ok(())
+            return Ok(());
         }
 
         println!(

--- a/sdk/typescript/rooch-sdk/src/account/interface.ts
+++ b/sdk/typescript/rooch-sdk/src/account/interface.ts
@@ -86,4 +86,16 @@ export interface IAccount {
    * @param authKey the auth key
    */
   isSessionKeyExpired(authKey: AccountAddress): Promise<boolean>
+
+  /**
+   * Get the gas coin balance
+   */
+  gasCoinBalance(): Promise<bigint>
+
+  /**
+   * Query coin balance
+   *
+   * @param coinType string coin type
+   */
+  coinBalance(coinType: string): Promise<bigint>
 }

--- a/sdk/typescript/rooch-sdk/src/types/rooch.ts
+++ b/sdk/typescript/rooch-sdk/src/types/rooch.ts
@@ -35,8 +35,11 @@ export interface StructTag {
 export type TypeTag =
   | 'Bool'
   | 'U8'
+  | 'U16'
+  | 'U32'
   | 'U64'
   | 'U128'
+  | 'U256'
   | 'Address'
   | 'Signer'
   | 'Ascii'
@@ -46,9 +49,6 @@ export type TypeTag =
   | 'Raw'
   | { Vector: TypeTag }
   | { Struct: StructTag }
-  | 'U16'
-  | 'U32'
-  | 'U256'
 
 export type ParsedObjectID = AccountAddress | StructTag
 

--- a/sdk/typescript/rooch-sdk/src/types/rooch.ts
+++ b/sdk/typescript/rooch-sdk/src/types/rooch.ts
@@ -41,11 +41,15 @@ export type TypeTag =
   | 'Signer'
   | 'Ascii'
   | 'String'
+  | 'Object'
+  | 'ObjectID'
   | { Vector: TypeTag }
   | { Struct: StructTag }
   | 'U16'
   | 'U32'
   | 'U256'
+
+export type ParsedObjectID = AccountAddress | StructTag
 
 export type ArgType =
   | Bool
@@ -58,6 +62,7 @@ export type ArgType =
   | string
   | AccountAddress
   | Serializable
+  | ParsedObjectID
   | ArgType[]
 
 export type Arg = {

--- a/sdk/typescript/rooch-sdk/src/types/rooch.ts
+++ b/sdk/typescript/rooch-sdk/src/types/rooch.ts
@@ -43,6 +43,7 @@ export type TypeTag =
   | 'String'
   | 'Object'
   | 'ObjectID'
+  | 'Raw'
   | { Vector: TypeTag }
   | { Struct: StructTag }
   | 'U16'
@@ -60,6 +61,7 @@ export type ArgType =
   | U128
   | U256
   | string
+  | Uint8Array
   | AccountAddress
   | Serializable
   | ParsedObjectID

--- a/sdk/typescript/rooch-sdk/src/utils/encode.ts
+++ b/sdk/typescript/rooch-sdk/src/utils/encode.ts
@@ -52,6 +52,15 @@ export function normalizeRoochAddress(value: string, forceAdd0x: boolean = false
   return `0x${address.padStart(ROOCH_ADDRESS_LENGTH, '0')}`
 }
 
+export function canonicalRoochAddress(value: string, forceAdd0x: boolean = false): string {
+  let address = value.toLowerCase()
+  if (!forceAdd0x && address.startsWith('0x')) {
+    address = address.slice(2)
+  }
+
+  return `${address.padStart(ROOCH_ADDRESS_LENGTH, '0')}`
+}
+
 export function typeTagToString(type_tag: TypeTag): string {
   if (typeof type_tag === 'string') {
     return type_tag

--- a/sdk/typescript/rooch-sdk/src/utils/encode.ts
+++ b/sdk/typescript/rooch-sdk/src/utils/encode.ts
@@ -1,7 +1,10 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
+
+import { hexlify } from '@ethersproject/bytes'
+import { sha3_256 } from '@noble/hashes/sha3'
 import { ROOCH_ADDRESS_LENGTH } from '../constants'
-import { FunctionId, AccountAddress, Identifier, TypeTag } from '../types'
+import { FunctionId, AccountAddress, Identifier, TypeTag, StructTag } from '../types'
 
 export function functionIdToStirng(functionId: FunctionId): string {
   if (typeof functionId !== 'string') {
@@ -81,4 +84,33 @@ export function typeTagToString(type_tag: TypeTag): string {
   }
 
   throw new Error(`Unknown type tag: ${JSON.stringify(type_tag)}`)
+}
+
+export function structTagToCanonicalString(structTag: StructTag): string {
+  let result = `${canonicalRoochAddress(structTag.address)}::${structTag.module}::${structTag.name}`
+
+  if (structTag.type_params && structTag.type_params.length > 0) {
+    const typeParams = structTag.type_params.map(typeTagToCanonicalString).join(',')
+    result += `<${typeParams}>`
+  }
+
+  return result
+}
+
+export function typeTagToCanonicalString(typeTag: TypeTag): string {
+  if (typeof typeTag === 'string') {
+    return typeTag.toLocaleLowerCase()
+  } else if ('Vector' in typeTag) {
+    return `vector<${typeTagToCanonicalString(typeTag.Vector)}>`
+  } else if ('Struct' in typeTag) {
+    return structTagToCanonicalString(typeTag.Struct)
+  } else {
+    throw new Error(`Unknown TypeTag: ${JSON.stringify(typeTag)}`)
+  }
+}
+
+export function structTagToObjectID(structTag: StructTag): string {
+  const canonicalString = structTagToCanonicalString(structTag)
+  const hash = sha3_256(canonicalString)
+  return hexlify(hash)
 }

--- a/sdk/typescript/rooch-sdk/src/utils/tx.test.ts
+++ b/sdk/typescript/rooch-sdk/src/utils/tx.test.ts
@@ -9,9 +9,6 @@ import {
   addressToSCS,
   encodeStructTypeTags,
   encodeArg,
-  strcutTagToString,
-  typeTagToString,
-  strcutTagToObjectID,
 } from './tx'
 import { toHexString } from './hex'
 import { TypeTag, StructTag, AccountAddress, Arg } from '../types'
@@ -92,118 +89,5 @@ describe('encodeArg', () => {
     const result = encodeArg(arg)
 
     expect(toHexString(result)).toBe('0x0164')
-  })
-})
-
-describe('strcutTagToString', () => {
-  it('strcutTagToString with no type_params', () => {
-    const structTag: StructTag = {
-      address: '00000000000000000000000000000001',
-      module: 'module1',
-      name: 'name1',
-    }
-
-    const result = strcutTagToString(structTag)
-    expect(result).toBe(
-      '0000000000000000000000000000000000000000000000000000000000000001::module1::name1',
-    )
-  })
-
-  it('strcutTagToString with type_params', () => {
-    const structTag: StructTag = {
-      address: '00000000000000000000000000000001',
-      module: 'module1',
-      name: 'name1',
-      type_params: [
-        'U8',
-        { Vector: 'U64' },
-        {
-          Struct: {
-            address: '0000000000000000000000000000000a',
-            module: 'module2',
-            name: 'name2',
-          },
-        },
-      ],
-    }
-
-    const result = strcutTagToString(structTag)
-    expect(result).toBe(
-      '0000000000000000000000000000000000000000000000000000000000000001::module1::name1<U8,Vector<U64>,000000000000000000000000000000000000000000000000000000000000000a::module2::name2>',
-    )
-  })
-})
-
-describe('typeTagToString', () => {
-  it('typeTagToString with string type', () => {
-    const typeTag: TypeTag = 'U8'
-
-    const result = typeTagToString(typeTag)
-    expect(result).toBe('U8')
-  })
-
-  it('typeTagToString with Vector type', () => {
-    const typeTag: TypeTag = { Vector: 'U64' }
-
-    const result = typeTagToString(typeTag)
-    expect(result).toBe('Vector<U64>')
-  })
-
-  it('typeTagToString with Struct type', () => {
-    const typeTag: TypeTag = {
-      Struct: {
-        address: '0000000000000000000000000000000a',
-        module: 'module2',
-        name: 'name2',
-      },
-    }
-
-    const result = typeTagToString(typeTag)
-    expect(result).toBe(
-      '000000000000000000000000000000000000000000000000000000000000000a::module2::name2',
-    )
-  })
-
-  it('typeTagToString with unknown type', () => {
-    const typeTag: any = { Unknown: 'U64' }
-
-    expect(() => typeTagToString(typeTag)).toThrowError()
-  })
-})
-
-describe('strcutTagToObjectID', () => {
-  it('test_named_object_id', () => {
-    const structTag: StructTag = {
-      address: '0x3',
-      module: 'timestamp',
-      name: 'Timestamp',
-      type_params: [],
-    }
-
-    const timestamp_object_id = strcutTagToObjectID(structTag)
-    const object_id = '0x711ab0301fd517b135b88f57e84f254c94758998a602596be8ae7ba56a0d14b3'
-    expect(timestamp_object_id).toBe(object_id)
-  })
-
-  it('test_account_named_object_id', () => {
-    const structTag: StructTag = {
-      address: '0x3',
-      module: 'coin_store',
-      name: 'CoinStore',
-      type_params: [
-        {
-          Struct: {
-            address: '0x3',
-            module: 'gas_coin',
-            name: 'GasCoin',
-            type_params: [],
-          },
-        },
-      ],
-    }
-
-    const coin_store_object_id = strcutTagToObjectID(structTag)
-    const object_id = '0xd073508b9582eff4e01078dc2e62489c15bbef91b6a2e568ac8fb33f0cf54daa'
-    expect(coin_store_object_id).toBe(object_id)
   })
 })

--- a/sdk/typescript/rooch-sdk/test/e2e/cli/rooch-cli.ts
+++ b/sdk/typescript/rooch-sdk/test/e2e/cli/rooch-cli.ts
@@ -3,6 +3,7 @@
 import { spawn, ChildProcess } from 'child_process'
 
 export class RoochCli {
+  private debug: boolean = false
   private child: ChildProcess | undefined
 
   async execute(args: Array<string>): Promise<any> {
@@ -14,12 +15,18 @@ export class RoochCli {
       if (this.child) {
         this.child.stdout?.on('data', (data) => {
           output += data
-          process.stdout.write(data)
+
+          if (this.debug) {
+            process.stdout.write(`${data}`)
+          }
         })
 
         this.child.stderr?.on('data', (data) => {
           errorMsg += data
-          process.stderr.write(`${data}`)
+
+          if (this.debug) {
+            process.stderr.write(`${data}`)
+          }
         })
 
         this.child.on('close', (code) => {

--- a/sdk/typescript/rooch-sdk/test/e2e/cli/rooch-cli.ts
+++ b/sdk/typescript/rooch-sdk/test/e2e/cli/rooch-cli.ts
@@ -1,0 +1,87 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+import { spawn, ChildProcess } from 'child_process'
+
+export class RoochCli {
+  private child: ChildProcess | undefined
+
+  async execute(args: Array<string>): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let output = ''
+      let errorMsg = ''
+      this.child = spawn('cargo', ['run', '--bin', 'rooch'].concat(args))
+
+      if (this.child) {
+        this.child.stdout?.on('data', (data) => {
+          output += data
+          process.stdout.write(data)
+        })
+
+        this.child.stderr?.on('data', (data) => {
+          errorMsg += data
+          process.stderr.write(`${data}`)
+        })
+
+        this.child.on('close', (code) => {
+          if (code !== 0) {
+            process.stderr.write(`Child process exit, exit code ${code}`)
+            reject(new Error(`Child process exited with code ${code}, error message: ${errorMsg}`))
+          } else {
+            try {
+              const jsonText = this.extractJSON(output)
+              const json = JSON.parse(jsonText)
+              resolve(json)
+            } catch (err) {
+              resolve(output)
+            }
+          }
+        })
+
+        this.child.on('error', (err) => {
+          reject(err)
+        })
+      }
+    })
+  }
+
+  extractJSON(output: string): string {
+    const lines = output.trim().split('\n')
+    let jsonStartIndex = -1
+
+    // Find the line where JSON starts (first occurrence of '{')
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes('{') || lines[i].includes('[')) {
+        jsonStartIndex = i
+        break
+      }
+    }
+
+    // If '{' was found, join all lines from there to the end into a single string
+    if (jsonStartIndex !== -1) {
+      return lines.slice(jsonStartIndex).join('')
+    }
+
+    // If no '{' was found, return the original output
+    return output
+  }
+
+  /**
+   * Retrieves the default account address.
+   *
+   * This method lists all accounts and returns the address of the first active account found.
+   * If no active account is present, it throws an error.
+   *
+   * @returns {Promise<string>} A promise that resolves with the address of the default account.
+   * @throws {Error} When no active account address is found.
+   */
+  public async defaultAccountAddress(): Promise<string> {
+    const accounts = await this.execute(['account', 'list', '--json'])
+    for (const account of accounts) {
+      if (account.active) {
+        return account.local_account.address
+      }
+    }
+
+    throw new Error('No active account address')
+  }
+}

--- a/sdk/typescript/rooch-sdk/test/e2e/debug.test.ts
+++ b/sdk/typescript/rooch-sdk/test/e2e/debug.test.ts
@@ -1,12 +1,73 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+
+import { RoochClient, Ed25519Keypair, PrivateKeyAuth, Account, LocalChain } from '../../src'
+import { RoochServer } from './servers/rooch-server'
+import { RoochCli } from './cli/rooch-cli'
 
 describe('SDK', () => {
+  let server: RoochServer
+  let cli: RoochCli
+  let defaultAddress: string
+
+  beforeAll(async () => {
+    // start rooch server
+    server = new RoochServer()
+    await server.start()
+
+    // deploy example app
+    cli = new RoochCli()
+
+    await cli.execute([
+      'move',
+      'publish',
+      '-p',
+      '../../../examples/entry_function_arguments/',
+      '--named-addresses',
+      'rooch_examples=default',
+    ])
+
+    defaultAddress = await cli.defaultAccountAddress()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
   describe('#debug', () => {
-    it('Remove session key should be ok', async () => {
+    it('Test', async () => {
       expect(true).toBeTruthy()
+    })
+
+    it('call function with objectid be ok', async () => {
+      const client = new RoochClient(LocalChain)
+
+      const kp = Ed25519Keypair.deriveKeypair(
+        'nose aspect organ harbor move prepare raven manage lamp consider oil front',
+      )
+      const roochAddress = kp.getPublicKey().toRoochAddress()
+      const authorizer = new PrivateKeyAuth(kp)
+
+      const account = new Account(client, roochAddress, authorizer)
+      expect(account).toBeDefined()
+
+      const tx = await account.runFunction(
+        `${defaultAddress}::entry_function::emit_object_id`,
+        [],
+        [
+          {
+            type: 'ObjectID',
+            value: '0x3134',
+          },
+        ],
+        {
+          maxGasAmount: 2000000,
+        },
+      )
+
+      expect(tx).toBeDefined()
     })
   })
 })

--- a/sdk/typescript/rooch-sdk/test/e2e/debug.test.ts
+++ b/sdk/typescript/rooch-sdk/test/e2e/debug.test.ts
@@ -1,73 +1,12 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-
-import { RoochClient, Ed25519Keypair, PrivateKeyAuth, Account, LocalChain } from '../../src'
-import { RoochServer } from './servers/rooch-server'
-import { RoochCli } from './cli/rooch-cli'
+import { describe, it, expect } from 'vitest'
 
 describe('SDK', () => {
-  let server: RoochServer
-  let cli: RoochCli
-  let defaultAddress: string
-
-  beforeAll(async () => {
-    // start rooch server
-    server = new RoochServer()
-    await server.start()
-
-    // deploy example app
-    cli = new RoochCli()
-
-    await cli.execute([
-      'move',
-      'publish',
-      '-p',
-      '../../../examples/entry_function_arguments/',
-      '--named-addresses',
-      'rooch_examples=default',
-    ])
-
-    defaultAddress = await cli.defaultAccountAddress()
-  })
-
-  afterAll(async () => {
-    await server.stop()
-  })
-
   describe('#debug', () => {
     it('Test', async () => {
       expect(true).toBeTruthy()
-    })
-
-    it('call function with objectid be ok', async () => {
-      const client = new RoochClient(LocalChain)
-
-      const kp = Ed25519Keypair.deriveKeypair(
-        'nose aspect organ harbor move prepare raven manage lamp consider oil front',
-      )
-      const roochAddress = kp.getPublicKey().toRoochAddress()
-      const authorizer = new PrivateKeyAuth(kp)
-
-      const account = new Account(client, roochAddress, authorizer)
-      expect(account).toBeDefined()
-
-      const tx = await account.runFunction(
-        `${defaultAddress}::entry_function::emit_object_id`,
-        [],
-        [
-          {
-            type: 'ObjectID',
-            value: '0x3134',
-          },
-        ],
-        {
-          maxGasAmount: 2000000,
-        },
-      )
-
-      expect(tx).toBeDefined()
     })
   })
 })

--- a/sdk/typescript/rooch-sdk/test/e2e/sdk.test.ts
+++ b/sdk/typescript/rooch-sdk/test/e2e/sdk.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+import { arrayify } from '@ethersproject/bytes'
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import {
   RoochClient,
@@ -17,15 +18,16 @@ import { RoochCli } from './cli/rooch-cli'
 describe('SDK', () => {
   let server: RoochServer
   let cli: RoochCli
-  //let defaultAddress: string
+  let defaultAddress: string
 
   beforeAll(async () => {
     // start rooch server
     server = new RoochServer()
     await server.start()
 
-    // deploy example app
     cli = new RoochCli()
+
+    // deploy example entry_function_arguments
     await cli.execute([
       'move',
       'publish',
@@ -35,7 +37,27 @@ describe('SDK', () => {
       'rooch_examples=default',
     ])
 
-    //defaultAddress = await cli.defaultAccountAddress()
+    // deploy example counter
+    await cli.execute([
+      'move',
+      'publish',
+      '-p',
+      '../../../examples/counter/',
+      '--named-addresses',
+      'rooch_examples=default',
+    ])
+
+    // deploy example coins
+    await cli.execute([
+      'move',
+      'publish',
+      '-p',
+      '../../../examples/coins/',
+      '--named-addresses',
+      'coins=default',
+    ])
+
+    defaultAddress = await cli.defaultAccountAddress()
   })
 
   afterAll(async () => {
@@ -143,6 +165,131 @@ describe('SDK', () => {
       )
 
       expect(tx).toBeDefined()
+    })
+
+    it('call function with objectid be ok', async () => {
+      const client = new RoochClient(LocalChain)
+
+      const kp = Ed25519Keypair.deriveKeypair(
+        'nose aspect organ harbor move prepare raven manage lamp consider oil front',
+      )
+      const roochAddress = kp.getPublicKey().toRoochAddress()
+      const authorizer = new PrivateKeyAuth(kp)
+
+      const account = new Account(client, roochAddress, authorizer)
+      expect(account).toBeDefined()
+
+      const tx = await account.runFunction(
+        `${defaultAddress}::entry_function::emit_object_id`,
+        [],
+        [
+          {
+            type: 'ObjectID',
+            value: '0x3134',
+          },
+        ],
+        {
+          maxGasAmount: 2000000,
+        },
+      )
+
+      expect(tx).toBeDefined()
+    })
+
+    it('call function with object be ok', async () => {
+      const client = new RoochClient(LocalChain)
+
+      const kp = Ed25519Keypair.deriveKeypair(
+        'nose aspect organ harbor move prepare raven manage lamp consider oil front',
+      )
+      const roochAddress = kp.getPublicKey().toRoochAddress()
+      const authorizer = new PrivateKeyAuth(kp)
+
+      const account = new Account(client, roochAddress, authorizer)
+      expect(account).toBeDefined()
+
+      const tx = await account.runFunction(
+        `${defaultAddress}::entry_function::emit_object`,
+        [],
+        [
+          {
+            type: 'Object',
+            value: {
+              address: defaultAddress,
+              module: 'entry_function',
+              name: 'TestStruct',
+            },
+          },
+        ],
+        {
+          maxGasAmount: 2000000,
+        },
+      )
+
+      expect(tx).toBeDefined()
+    })
+
+    it('call function with raw be ok', async () => {
+      const client = new RoochClient(LocalChain)
+
+      const kp = Ed25519Keypair.deriveKeypair(
+        'nose aspect organ harbor move prepare raven manage lamp consider oil front',
+      )
+      const roochAddress = kp.getPublicKey().toRoochAddress()
+      const authorizer = new PrivateKeyAuth(kp)
+
+      const account = new Account(client, roochAddress, authorizer)
+      expect(account).toBeDefined()
+
+      const tx = await account.runFunction(
+        `${defaultAddress}::entry_function::emit_vec_u8`,
+        [],
+        [
+          {
+            type: 'Raw',
+            value: arrayify('0xffff'),
+          },
+        ],
+        {
+          maxGasAmount: 2000000,
+        },
+      )
+
+      expect(tx).toBeDefined()
+    })
+
+    it('call fixed_supply_coin::faucet be ok', async () => {
+      const client = new RoochClient(LocalChain)
+
+      const kp = Ed25519Keypair.generate()
+      const roochAddress = kp.getPublicKey().toRoochAddress()
+      const authorizer = new PrivateKeyAuth(kp)
+
+      const account = new Account(client, roochAddress, authorizer)
+      expect(account).toBeDefined()
+
+      const tx = await account.runFunction(
+        `${defaultAddress}::fixed_supply_coin::faucet`,
+        [],
+        [
+          {
+            type: 'Object',
+            value: {
+              address: defaultAddress,
+              module: 'fixed_supply_coin',
+              name: 'Treasury',
+            },
+          },
+        ],
+        {
+          maxGasAmount: 200000000,
+        },
+      )
+
+      expect(tx).toBeDefined()
+
+      const fscBalance = await account.coinBalance(`${defaultAddress}::fixed_supply_coin::FSC`)
+      expect(fscBalance).toBe(BigInt(10000))
     })
   })
 

--- a/sdk/typescript/rooch-sdk/test/e2e/sdk.test.ts
+++ b/sdk/typescript/rooch-sdk/test/e2e/sdk.test.ts
@@ -12,13 +12,30 @@ import {
   LocalChain,
 } from '../../src'
 import { RoochServer } from './servers/rooch-server'
+import { RoochCli } from './cli/rooch-cli'
 
 describe('SDK', () => {
   let server: RoochServer
+  let cli: RoochCli
+  //let defaultAddress: string
 
   beforeAll(async () => {
+    // start rooch server
     server = new RoochServer()
     await server.start()
+
+    // deploy example app
+    cli = new RoochCli()
+    await cli.execute([
+      'move',
+      'publish',
+      '-p',
+      '../../../examples/entry_function_arguments/',
+      '--named-addresses',
+      'rooch_examples=default',
+    ])
+
+    //defaultAddress = await cli.defaultAccountAddress()
   })
 
   afterAll(async () => {

--- a/sdk/typescript/rooch-sdk/test/e2e/servers/rooch-server.ts
+++ b/sdk/typescript/rooch-sdk/test/e2e/servers/rooch-server.ts
@@ -2,10 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { spawn, ChildProcess } from 'child_process'
 
+export const DefaultPort = 50051
+
 export class RoochServer {
   private child: ChildProcess | undefined
 
   private ready: boolean = false
+  private port: number = DefaultPort
+
+  constructor(port: number = DefaultPort) {
+    this.port = port
+  }
 
   async start() {
     this.child = spawn('cargo', [
@@ -20,6 +27,8 @@ export class RoochServer {
       'TMP',
       '--eth-rpc-url',
       'https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
+      '--port',
+      `${this.port}`,
     ])
 
     if (this.child) {

--- a/sdk/typescript/rooch-sdk/test/e2e/servers/rooch-server.ts
+++ b/sdk/typescript/rooch-sdk/test/e2e/servers/rooch-server.ts
@@ -7,6 +7,7 @@ export const DefaultPort = 50051
 export class RoochServer {
   private child: ChildProcess | undefined
 
+  private debug: boolean = false
   private ready: boolean = false
   private port: number = DefaultPort
 
@@ -33,11 +34,15 @@ export class RoochServer {
 
     if (this.child) {
       this.child.stdout?.on('data', (data) => {
-        process.stdout.write(`${data}`)
+        if (this.debug) {
+          process.stdout.write(`${data}`)
+        }
       })
 
       this.child.stderr?.on('data', (data) => {
-        process.stderr.write(`${data}`)
+        if (this.debug) {
+          process.stdout.write(`${data}`)
+        }
       })
 
       this.child.on('close', (code) => {


### PR DESCRIPTION
## Summary

rooch-sdk callData supports Object, ObjectID and Raw types.


- Closes #issue

https://github.com/rooch-network/rooch/issues/1288