### PR TITLE
fix(workflow): fix da options

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -46,26 +46,22 @@ jobs:
           PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           HOST: ${{ secrets.GCP_VM_HOST }}
           USER: ${{ secrets.GCP_VM_USER }}
-          GCS_BUCKET: ${{ secrets.OPENDA_GCP_DEV_BUCKET }}
-          GCS_CREDENTIAL: ${{ secrets.OPENDA_GCP_DEV_CREDENTIAL }}
         run: |
           echo "$PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
           sudo apt update
           sudo apt install -y --no-install-recommends openssh-server
-          ssh -o StrictHostKeyChecking=no -i private_key.pem $USER@$HOST bash -c "'sleep 30' && docker ps | grep rooch | awk '{print \$1}' | xargs -r docker stop && docker ps -a | grep rooch | awk '{print \$1}' | xargs -r docker rm -f && docker pull 'ghcr.io/rooch-network/rooch:${{ steps.docker_meta.outputs.version }}' && docker run -d -v /root:/root -p 50051:50051 'ghcr.io/rooch-network/rooch:${{ steps.docker_meta.outputs.version }}' server start -n dev --eth-rpc-url https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161 --btc-rpc-url '${{secrets.BTC_TEST_RPC_URL}}' --btc-rpc-username rooch-test --btc-rpc-password '${{secrets.BTC_TEST_RPC_PWD}}' --btc-network 2 --da "{\"internal-da-server\": {\"servers\": [{\"open-da\": {\"scheme\": \"gcs\", \"config\": {\"bucket\": \"$GCS_BUCKET\", \"credential\": \"$GCS_CREDENTIAL\"}}}]}}"
+          ssh -o StrictHostKeyChecking=no -i private_key.pem $USER@$HOST bash -c "'sleep 30' && docker ps | grep rooch | awk '{print \$1}' | xargs -r docker stop && docker ps -a | grep rooch | awk '{print \$1}' | xargs -r docker rm -f && docker pull 'ghcr.io/rooch-network/rooch:${{ steps.docker_meta.outputs.version }}' && docker run -d -v /root:/root -p 50051:50051 'ghcr.io/rooch-network/rooch:${{ steps.docker_meta.outputs.version }}' server start -n dev --eth-rpc-url https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161 --btc-rpc-url '${{secrets.BTC_TEST_RPC_URL}}' --btc-rpc-username rooch-test --btc-rpc-password '${{secrets.BTC_TEST_RPC_PWD}}' --btc-network 2 --da '{"internal-da-server": {"servers": [{"open-da": {"scheme": "gcs", "config": {"bucket": "${{secrets.OPENDA_GCP_DEV_BUCKET}}", "credential": "${{secrets.OPENDA_GCP_DEV_CREDENTIAL}}"}}}]}}'"
           ssh -o StrictHostKeyChecking=no -i private_key.pem $USER@$HOST "cd /root/rooch && git pull origin main && bash scripts/check_dev_deploy_status.sh ${{ steps.docker_meta.outputs.version }} '${{ secrets.DEV_MNEMONIC_PHRASE }}'"
       - name: Deploy to GCP TESTNET VM
         env:
           PRIVATE_KEY: ${{ secrets.GCP_TESTNET_SSH_PRIVATE_KEY }}
           HOST: ${{ secrets.GCP_TESTNET_VM_HOST }}
           USER: ${{ secrets.GCP_TESTNET_VM_USER }}
-          GCS_BUCKET: ${{ secrets.OPENDA_GCP_TESTNET_BUCKET }}
-          GCS_CREDENTIAL: ${{ secrets.OPENDA_GCP_TESTNET_CREDENTIAL }}
         run: |
           echo "$PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
           sudo apt update
           sudo apt install -y --no-install-recommends openssh-server
-          ssh -o StrictHostKeyChecking=no -i private_key.pem $USER@$HOST bash -c "'sleep 30' && docker ps | grep rooch | awk '{print \$1}' | xargs -r docker stop && docker ps -a | grep rooch | awk '{print \$1}' | xargs -r docker rm -f && docker pull 'ghcr.io/rooch-network/rooch:${{ steps.docker_meta.outputs.version }}' && docker run -d -v /data:/root -p 50051:50051 'ghcr.io/rooch-network/rooch:${{ steps.docker_meta.outputs.version }}' server start -n test --btc-rpc-url '${{secrets.BTC_TEST_RPC_URL}}' --btc-rpc-username rooch-test --btc-rpc-password '${{secrets.BTC_TEST_RPC_PWD}}' --btc-network 2 --da="{\"internal-da-server\": {\"servers\": [{\"open-da\": {\"scheme\": \"gcs\", \"config\": {\"bucket\": \"$GCS_BUCKET\", \"credential\": \"$GCS_CREDENTIAL\"}}}]}}"
+          ssh -o StrictHostKeyChecking=no -i private_key.pem $USER@$HOST bash -c "'sleep 30' && docker ps | grep rooch | awk '{print \$1}' | xargs -r docker stop && docker ps -a | grep rooch | awk '{print \$1}' | xargs -r docker rm -f && docker pull 'ghcr.io/rooch-network/rooch:${{ steps.docker_meta.outputs.version }}' && docker run -d -v /data:/root -p 50051:50051 'ghcr.io/rooch-network/rooch:${{ steps.docker_meta.outputs.version }}' server start -n test --btc-rpc-url '${{secrets.BTC_TEST_RPC_URL}}' --btc-rpc-username rooch-test --btc-rpc-password '${{secrets.BTC_TEST_RPC_PWD}}' --btc-network 2 --da '{"internal-da-server": {"servers": [{"open-da": {"scheme": "gcs", "config": {"bucket": "${{secrets.OPENDA_GCP_TESTNET_BUCKET}}", "credential": "${{secrets.OPENDA_GCP_TESTNET_CREDENTIAL}}"}}}]}}'"
 


### PR DESCRIPTION
secrets replacement in GitHub actions happens before execution. It's ok to use '<da_option>' to pass json string which needs value in secrets

