### PR TITLE
ci: fix link error in bench

### DIFF
--- a/crates/rooch-benchmarks/benches/bench_tx_write.rs
+++ b/crates/rooch-benchmarks/benches/bench_tx_write.rs
@@ -3,7 +3,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use moveos_config::temp_dir;
-use rooch_benchmarks::tx::{create_transaction, setup_service};
+use rooch_benchmarks::tx::{create_publish_transaction, create_transaction, setup_service};
 use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_key::keystore::memory_keystore::InMemKeystore;
 use rooch_test_transaction_builder::TestTransactionBuilder;
@@ -22,7 +22,10 @@ pub fn transaction_write_benchmark(c: &mut Criterion) {
     let default_account = keystore.addresses()[0];
     let mut test_transaction_builder = TestTransactionBuilder::new(default_account.into());
 
-    let transactions: Vec<_> = (0..10000)
+    let tx = create_publish_transaction(&test_transaction_builder, &keystore).unwrap();
+    let _publish_result = rt.block_on(async { rpc_service.execute_tx(tx).await.unwrap() });
+
+    let transactions: Vec<_> = (0..1000)
         .map(|n| create_transaction(&mut test_transaction_builder, &keystore, n).unwrap())
         .collect();
     let mut transactions_iter = transactions.into_iter().cycle();


### PR DESCRIPTION
## Summary

after fix link error, the execution process working as expect:

```
RUST_LOG=error cargo bench --bench bench_tx_write
   Compiling rooch-benchmarks v0.1.0 (/Users/templex/rooch/bodhi/rooch/crates/rooch-benchmarks)
    Finished bench [optimized + debuginfo] target(s) in 13.62s
     Running benches/bench_tx_write.rs (/Users/templex/rooch/bodhi/rooch/target/release/deps/bench_tx_write-624c3ac78421ba7f)
INCLUDING DEPENDENCY MoveStdlib
INCLUDING DEPENDENCY MoveosStdlib
INCLUDING DEPENDENCY RoochFramework
BUILDING simple_blog
execute_tx              time:   [5.5210 ms 6.0733 ms 6.3923 ms]
                        change: [-12.752% -2.5564% +8.6448%] (p = 0.66 > 0.05)
                        No change in performance detected.
```

the avg TPS is about ~150 in tx_write_bench
