### PR TITLE
ci: add pure mem filesystem for bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8031,6 +8031,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml 0.9.25",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",

--- a/crates/rooch-benchmarks/Cargo.toml
+++ b/crates/rooch-benchmarks/Cargo.toml
@@ -35,6 +35,7 @@ hyper = { workspace = true }
 log = { workspace = true }
 lazy_static = { workspace = true }
 rpassword = { workspace = true }
+tempfile = { workspace = true }
 
 criterion = { workspace = true }
 #criterion-cpu-time = { workspace = true }

--- a/crates/rooch-benchmarks/benches/bench_tx_write.rs
+++ b/crates/rooch-benchmarks/benches/bench_tx_write.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use moveos_config::temp_dir;
-use rooch_benchmarks::tx::{create_publish_transaction, create_transaction, setup_service};
+use rooch_benchmarks::tx::{
+    create_publish_transaction, create_transaction, setup_service, temp_dir,
+};
 use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_key::keystore::memory_keystore::InMemKeystore;
 use rooch_test_transaction_builder::TestTransactionBuilder;

--- a/crates/rooch-benchmarks/src/tx.rs
+++ b/crates/rooch-benchmarks/src/tx.rs
@@ -40,7 +40,10 @@ use rooch_types::bitcoin::genesis::BitcoinGenesisContext;
 use rooch_types::bitcoin::network::Network;
 use rooch_types::chain_id::RoochChainID;
 use rooch_types::transaction::TypedTransaction;
+use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
+use tempfile::TempDir;
 use tracing::info;
 
 pub const EXAMPLE_SIMPLE_BLOG_PACKAGE_NAME: &'static str = "simple_blog";
@@ -229,4 +232,15 @@ pub fn create_transaction(
     let rooch_tx =
         keystore.sign_transaction(&test_transaction_builder.sender.into(), tx_data, None)?;
     Ok(TypedTransaction::Rooch(rooch_tx))
+}
+
+pub fn temp_dir() -> DataDirPath {
+    match std::env::var("PUREMEM") {
+        Ok(pure_mem) => {
+            let temp_dir = TempDir::new_in(pure_mem)
+                .expect("Failed to create temp dir in provided memory fs path");
+            DataDirPath::TempPath(Arc::from(temp_dir))
+        }
+        Err(_) => moveos_config::temp_dir(),
+    }
 }


### PR DESCRIPTION
## Summary

no significant improvement found:

```
 RUST_LOG=error PUREMEM=/Volumes/RAMDisk/rtmp cargo bench --bench bench_tx_write
...
 execute_tx              time:   [5.1027 ms 5.6767 ms 5.9972 ms]
                         change: [-13.073% -0.8050% +12.977%] (p = 0.91 > 0.05)
                         No change in performance detected.
```

- Closes #1395 