### PR TITLE
Check the Object reference count runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5053,7 +5053,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5070,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -5085,12 +5085,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5105,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5117,7 +5117,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "fail",
@@ -5131,7 +5131,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5192,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "difference",
@@ -5209,7 +5209,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5238,7 +5238,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5260,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5280,7 +5280,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
@@ -5298,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5317,7 +5317,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5331,7 +5331,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "hex",
@@ -5382,7 +5382,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "hex",
@@ -5396,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5423,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5459,7 +5459,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5496,7 +5496,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "hex",
@@ -5589,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "once_cell",
  "serde 1.0.195",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5615,7 +5615,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
@@ -5646,7 +5646,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "better_any",
@@ -5676,7 +5676,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "better_any",
  "fail",
@@ -5693,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=6ab3a7445b89e676b495370e4d21296f61f0c3f4#6ab3a7445b89e676b495370e4d21296f61f0c3f4"
+source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -8817,6 +8817,7 @@ dependencies = [
  "move-core-types",
  "move-resource-viewer",
  "move-stdlib",
+ "move-vm-types",
  "moveos",
  "moveos-stdlib",
  "moveos-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,39 +257,39 @@ opendal = "0.44.1"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-binary-format = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-bytecode-verifier = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-bytecode-utils = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-cli = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-command-line-common = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-compiler = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-core-types = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-coverage = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-disassembler = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-docgen = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-errmapgen = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-ir-compiler = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-model = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-package = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-prover = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-prover-boogie-backend = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-stackless-bytecode = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-prover-test-utils = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-resource-viewer = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-stdlib = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4", features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-#move-table-extension = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-transactional-test-runner = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-unit-test = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-vm-test-utils = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-read-write-set = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-read-write-set-dynamic = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-bytecode-source-map = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }
-move-ir-types = { git = "https://github.com/rooch-network/move", rev = "6ab3a7445b89e676b495370e4d21296f61f0c3f4" }# END MOVE DEPENDENCIES
+move-abigen = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-binary-format = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-bytecode-verifier = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-bytecode-utils = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-cli = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-command-line-common = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-compiler = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-core-types = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-coverage = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-disassembler = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-docgen = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-errmapgen = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-ir-compiler = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-model = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-package = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-prover = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-prover-boogie-backend = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-stackless-bytecode = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-prover-test-utils = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-resource-viewer = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-stdlib = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6", features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+#move-table-extension = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-transactional-test-runner = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-unit-test = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-vm-test-utils = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+read-write-set = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+read-write-set-dynamic = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-bytecode-source-map = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
+move-ir-types = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }# END MOVE DEPENDENCIES
 
 # keep this for convenient debug Move in local repo
 # [patch.'https://github.com/rooch-network/move']

--- a/crates/rooch-framework-tests/tests/cases/language/reference_test.exp
+++ b/crates/rooch-framework-tests/tests/cases/language/reference_test.exp
@@ -1,0 +1,16 @@
+processed 3 tasks
+
+task 1 'publish'. lines 3-8:
+Error: error[E07004]: invalid return of locally borrowed state
+  ┌─ /tmp/tempfile:6:9
+  │
+6 │         &1u8
+  │         ^^^^
+  │         │
+  │         Invalid return. Local variable '%#1' is still being borrowed.
+  │         It is still being borrowed by this reference
+
+
+
+task 2 'publish'. lines 11-19:
+status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/language/reference_test.move
+++ b/crates/rooch-framework-tests/tests/cases/language/reference_test.move
@@ -1,0 +1,19 @@
+//# init --addresses test=0x42
+
+//# publish
+module test::m{
+    public fun return_reference(): &u8 {
+        &1u8
+    }
+}
+
+
+//# publish
+module test::m2{
+    
+    public fun return_reference(): &u8 {
+        Self::return_reference_native()
+    }
+
+    native fun return_reference_native(): &u8;
+}

--- a/crates/rooch-framework-tests/tests/cases/object/borrow_two_reference.exp
+++ b/crates/rooch-framework-tests/tests/cases/object/borrow_two_reference.exp
@@ -1,0 +1,13 @@
+processed 5 tasks
+
+task 1 'publish'. lines 3-29:
+status EXECUTED
+
+task 2 'run'. lines 30-44:
+status ABORTED with code 7 in 0000000000000000000000000000000000000000000000000000000000000002::object
+
+task 3 'run'. lines 45-63:
+status EXECUTED
+
+task 4 'run'. lines 64-76:
+status ABORTED with code 7 in 0000000000000000000000000000000000000000000000000000000000000002::object

--- a/crates/rooch-framework-tests/tests/cases/object/borrow_two_reference.move
+++ b/crates/rooch-framework-tests/tests/cases/object/borrow_two_reference.move
@@ -1,0 +1,76 @@
+//# init --addresses test=0x42
+
+//# publish
+
+module test::m {
+    use moveos_std::context::{Self, Context};
+    use moveos_std::object;
+
+    struct TestStruct has key, store{
+        value: u64
+    }
+
+    fun init(ctx: &mut Context){
+        let id = context::new_named_object_uid<TestStruct>(ctx);
+        let obj = object::new(id, TestStruct{value: 0});
+        std::debug::print(&obj);
+        object::transfer(obj, context::sender(ctx));
+    }
+
+    public fun set_value(test: &mut TestStruct, value: u64){
+        test.value = value;
+    }
+
+    public fun get_value(test: &TestStruct) : u64{
+        test.value
+    }
+}
+
+// test two ref: will fail
+//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+script {
+    use moveos_std::object;
+    use moveos_std::object_id::{ObjectID};
+    use test::m::{Self, TestStruct};
+
+    fun main(obj_id: ObjectID) {
+        let object1 = object::borrow_object<TestStruct>(obj_id);
+        let object2 = object::borrow_object<TestStruct>(obj_id);
+        m::get_value(object::borrow(object1));
+        m::get_value(object::borrow(object2));
+    }
+}
+
+// test two ref in different scope: should be allowed
+//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+script {
+    use moveos_std::object;
+    use moveos_std::object_id::{ObjectID};
+    use test::m::{Self, TestStruct};
+
+    fun main(obj_id: ObjectID) {
+        {
+            let object1 = object::borrow_object<TestStruct>(obj_id);
+            m::get_value(object::borrow(object1));
+        };
+        {
+            let object2 = object::borrow_object<TestStruct>(obj_id);
+            m::get_value(object::borrow(object2));
+        };
+    }
+}
+
+// test two mut ref : will fail
+//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+script {
+    use moveos_std::object;
+    use moveos_std::object_id::{ObjectID};
+    use test::m::{Self, TestStruct};
+
+    fun main(sender: &signer, obj_id: ObjectID) {
+        let object1 = object::borrow_mut_object<TestStruct>(sender, obj_id);
+        let object2 = object::borrow_mut_object<TestStruct>(sender, obj_id);
+        m::set_value(object::borrow_mut(object1), 42);
+        m::set_value(object::borrow_mut(object2), 43);
+    }
+}

--- a/crates/rooch-framework-tests/tests/cases/object/reference.exp
+++ b/crates/rooch-framework-tests/tests/cases/object/reference.exp
@@ -1,0 +1,10 @@
+processed 4 tasks
+
+task 1 'publish'. lines 3-29:
+status EXECUTED
+
+task 2 'run'. lines 30-48:
+status EXECUTED
+
+task 3 'run'. lines 49-68:
+status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/object/reference.move
+++ b/crates/rooch-framework-tests/tests/cases/object/reference.move
@@ -1,0 +1,68 @@
+//# init --addresses test=0x42 A=0x43
+
+//# publish
+
+module test::m {
+    use moveos_std::context::{Self, Context};
+    use moveos_std::object;
+
+    struct TestStruct has key, store{
+        value: u64
+    }
+
+    fun init(ctx: &mut Context){
+        let id = context::new_named_object_uid<TestStruct>(ctx);
+        let obj = object::new(id, TestStruct{value: 0});
+        std::debug::print(&obj);
+        object::transfer(obj, context::sender(ctx));
+    }
+
+    public fun set_value(test: &mut TestStruct, value: u64){
+        test.value = value;
+    }
+
+    public fun get_value(test: &TestStruct) : u64{
+        test.value
+    }
+}
+
+// test mut ref and ref both
+//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+script {
+    use moveos_std::object::{Self, Object};
+    use test::m::{Self, TestStruct};
+
+    fun main(obj_from_arg: &mut Object<TestStruct>) {
+        let value_from_arg = m::get_value(object::borrow(obj_from_arg));
+        let object_from_ctx = object::borrow_object(object::id(obj_from_arg));
+        let value_from_ctx = m::get_value(object::borrow(object_from_ctx));
+        assert!(value_from_arg == value_from_ctx, 1);
+        m::set_value(object::borrow_mut(obj_from_arg), 42);
+        let value_from_arg = m::get_value(object::borrow(obj_from_arg));
+        let value_from_ctx = m::get_value(object::borrow(object_from_ctx));
+        assert!(value_from_arg == 42, 2);
+        assert!(value_from_arg == value_from_ctx, 3);
+    }
+}
+
+// test two mut ref
+//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+script {
+    use moveos_std::object::{Self, Object};
+    use test::m::{Self, TestStruct};
+
+    fun main(sender: &signer, obj_from_arg: &mut Object<TestStruct>) {
+        let value_from_arg = m::get_value(object::borrow(obj_from_arg));
+        let object_from_ctx = object::borrow_mut_object(sender, object::id(obj_from_arg));
+        let value_from_ctx = m::get_value(object::borrow(object_from_ctx));
+        assert!(value_from_arg == value_from_ctx, 1);
+        
+        m::set_value(object::borrow_mut(obj_from_arg), 42);
+        m::set_value(object::borrow_mut(object_from_ctx), 420);
+        
+        let value_from_arg = m::get_value(object::borrow(obj_from_arg));
+        let value_from_ctx = m::get_value(object::borrow(object_from_ctx));
+        assert!(value_from_ctx == 420, 2);
+        assert!(value_from_arg == value_from_ctx, 3);
+    }
+}

--- a/crates/rooch-framework-tests/tests/cases/object/reference.move
+++ b/crates/rooch-framework-tests/tests/cases/object/reference.move
@@ -34,12 +34,12 @@ script {
 
     fun main(obj_from_arg: &mut Object<TestStruct>) {
         let value_from_arg = m::get_value(object::borrow(obj_from_arg));
-        let object_from_ctx = object::borrow_object(object::id(obj_from_arg));
-        let value_from_ctx = m::get_value(object::borrow(object_from_ctx));
+        let obj_from_store = object::borrow_object(object::id(obj_from_arg));
+        let value_from_ctx = m::get_value(object::borrow(obj_from_store));
         assert!(value_from_arg == value_from_ctx, 1);
         m::set_value(object::borrow_mut(obj_from_arg), 42);
         let value_from_arg = m::get_value(object::borrow(obj_from_arg));
-        let value_from_ctx = m::get_value(object::borrow(object_from_ctx));
+        let value_from_ctx = m::get_value(object::borrow(obj_from_store));
         assert!(value_from_arg == 42, 2);
         assert!(value_from_arg == value_from_ctx, 3);
     }
@@ -53,15 +53,15 @@ script {
 
     fun main(sender: &signer, obj_from_arg: &mut Object<TestStruct>) {
         let value_from_arg = m::get_value(object::borrow(obj_from_arg));
-        let object_from_ctx = object::borrow_mut_object(sender, object::id(obj_from_arg));
-        let value_from_ctx = m::get_value(object::borrow(object_from_ctx));
+        let obj_from_store = object::borrow_mut_object(sender, object::id(obj_from_arg));
+        let value_from_ctx = m::get_value(object::borrow(obj_from_store));
         assert!(value_from_arg == value_from_ctx, 1);
         
         m::set_value(object::borrow_mut(obj_from_arg), 42);
-        m::set_value(object::borrow_mut(object_from_ctx), 420);
+        m::set_value(object::borrow_mut(obj_from_store), 420);
         
         let value_from_arg = m::get_value(object::borrow(obj_from_arg));
-        let value_from_ctx = m::get_value(object::borrow(object_from_ctx));
+        let value_from_ctx = m::get_value(object::borrow(obj_from_store));
         assert!(value_from_ctx == 420, 2);
         assert!(value_from_arg == value_from_ctx, 3);
     }

--- a/crates/rooch-types/Cargo.toml
+++ b/crates/rooch-types/Cargo.toml
@@ -43,6 +43,7 @@ sha3 = { workspace = true }
 bs58 = { workspace = true, features = ["check"] }
 
 move-core-types = { workspace = true }
+move-vm-types = { workspace = true }
 move-stdlib = { workspace = true }
 move-command-line-common = { workspace = true }
 move-binary-format = { workspace = true }

--- a/crates/rooch-types/src/multichain_id.rs
+++ b/crates/rooch-types/src/multichain_id.rs
@@ -170,6 +170,14 @@ impl MoveState for RoochMultiChainID {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::U64
     }
+
+    fn to_runtime_value(&self) -> move_vm_types::values::Value {
+        move_vm_types::values::Value::u64(*self as u64)
+    }
+
+    fn from_runtime_value(value: move_vm_types::values::Value) -> anyhow::Result<Self> {
+        RoochMultiChainID::try_from(value.value_as::<u64>()?)
+    }
 }
 
 impl RoochMultiChainID {

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
@@ -143,6 +143,15 @@ Developers only need to use Object<T> related APIs and do not need to know the O
 
 
 
+<a name="0x2_object_ErrorObjectAlreadyBorrowed"></a>
+
+
+
+<pre><code><b>const</b> <a href="object.md#0x2_object_ErrorObjectAlreadyBorrowed">ErrorObjectAlreadyBorrowed</a>: u64 = 7;
+</code></pre>
+
+
+
 <a name="0x2_object_ErrorObjectAlreadyExist"></a>
 
 

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
@@ -25,11 +25,11 @@ module moveos_std::object {
     const ErrorObjectAlreadyExist: u64 = 1;
     const ErrorObjectFrozen: u64 = 2;
     const ErrorInvalidOwnerAddress:u64 = 3;
-
     const ErrorObjectOwnerNotMatch: u64 = 4;
     const ErrorObjectNotShared: u64 = 5;
     ///Can not take out the object which is bound to the account
     const ErrorObjectIsBound: u64 = 6;
+    const ErrorObjectAlreadyBorrowed: u64 = 7;
 
     const SYSTEM_OWNER_ADDRESS: address = @0x0;
     

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/object.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/object.rs
@@ -1,22 +1,21 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::errors::PartialVMResult;
-use move_core_types::gas_algebra::InternalGas;
+use crate::natives::{helpers::make_module_natives, moveos_stdlib::raw_table::NativeTableContext};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{gas_algebra::InternalGas, vm_status::StatusCode};
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
 use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
-    values::{GlobalValue, Struct, Value},
+    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
 };
 use moveos_types::{
-    moveos_std::object::Object,
+    moveos_std::{object::Object, object_id::ObjectID},
     state::{MoveState, PlaceholderStruct},
 };
 use smallvec::smallvec;
 use std::{collections::VecDeque, sync::Arc};
 
-use crate::natives::helpers::make_module_natives;
+const ERROR_OBJECT_ALREADY_BORROWED: u64 = 7;
 
 #[derive(Debug, Clone)]
 pub struct AsRefGasParameters {
@@ -98,11 +97,9 @@ pub fn make_native_as_mut_ref_inner(gas_params: AsMutRefGasParameters) -> Native
 
 fn borrow_object_reference(
     context: &mut NativeContext,
-    object_id: Value,
+    object_id_value: Value,
     ref_type: &Type,
 ) -> PartialVMResult<Value> {
-    let gv = GlobalValue::cached(Value::struct_(Struct::pack(vec![object_id])))?;
-
     let type_tag = context.type_to_type_tag(ref_type)?;
     let type_layout = context
         .get_type_layout(&type_tag)
@@ -113,7 +110,20 @@ fn borrow_object_reference(
         "Expected a struct type with layout same as Object<T>"
     );
 
-    //TODO should we keep the GlobalValue in Context?
+    let object_id = ObjectID::from_runtime_value(object_id_value)
+        .map_err(|_e| partial_extension_error("Invalid object id argument"))?;
+    let table_context = context.extensions_mut().get_mut::<NativeTableContext>();
+
+    let data = table_context.table_data();
+    let mut table_data = data.write();
+    let gv = table_data.get_or_create_object_reference(object_id)?;
+
+    if gv.reference_count() >= 2 {
+        return Err(PartialVMError::new(StatusCode::ABORTED)
+            .with_sub_status(ERROR_OBJECT_ALREADY_BORROWED)
+            .with_message(format!("Object {} already borrowed", object_id)));
+    }
+
     gv.borrow_global()
 }
 
@@ -145,4 +155,8 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
     ];
 
     make_module_natives(natives)
+}
+
+fn partial_extension_error(msg: impl ToString) -> PartialVMError {
+    PartialVMError::new(StatusCode::VM_EXTENSION_ERROR).with_message(msg.to_string())
 }

--- a/moveos/moveos-types/src/state.rs
+++ b/moveos/moveos-types/src/state.rs
@@ -16,7 +16,7 @@ use move_core_types::{
     value::{MoveStructLayout, MoveTypeLayout, MoveValue},
 };
 use move_resource_viewer::{AnnotatedMoveValue, MoveValueAnnotator};
-use move_vm_types::values::Value;
+use move_vm_types::values::{Struct, Value};
 use serde::ser::Error;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use smt::UpdateSet;
@@ -205,27 +205,10 @@ pub trait MoveState: MoveType + DeserializeOwned + Serialize {
     }
 
     /// Convert the MoveState to MoveRuntime Value
-    fn to_runtime_value(&self) -> Value {
-        let blob = self.to_bytes();
-        Value::simple_deserialize(&blob, &Self::type_layout())
-            .expect("Deserialize the Move Runtime Value from MoveState bytes should success")
-    }
+    fn to_runtime_value(&self) -> Value;
 
     /// Convert the MoveState from MoveRuntime Value
-    fn from_runtime_value(value: Value) -> Result<Self>
-    where
-        Self: Sized,
-    {
-        let blob = value
-            .simple_serialize(&Self::type_layout())
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Serilaize the MoveState to bytes error: {:?}",
-                    Self::type_tag()
-                )
-            })?;
-        Self::from_bytes(&blob)
-    }
+    fn from_runtime_value(value: Value) -> Result<Self>;
 }
 
 impl MoveType for u8 {
@@ -237,6 +220,14 @@ impl MoveType for u8 {
 impl MoveState for u8 {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::U8
+    }
+
+    fn to_runtime_value(&self) -> Value {
+        Value::u8(*self)
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        Ok(value.value_as::<u8>()?)
     }
 }
 
@@ -250,6 +241,14 @@ impl MoveState for u16 {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::U16
     }
+
+    fn to_runtime_value(&self) -> Value {
+        Value::u16(*self)
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        Ok(value.value_as::<u16>()?)
+    }
 }
 
 impl MoveType for u32 {
@@ -260,6 +259,14 @@ impl MoveType for u32 {
 impl MoveState for u32 {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::U32
+    }
+
+    fn to_runtime_value(&self) -> Value {
+        Value::u32(*self)
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        Ok(value.value_as::<u32>()?)
     }
 }
 
@@ -273,6 +280,14 @@ impl MoveState for u64 {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::U64
     }
+
+    fn to_runtime_value(&self) -> Value {
+        Value::u64(*self)
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        Ok(value.value_as::<u64>()?)
+    }
 }
 
 impl MoveType for u128 {
@@ -284,6 +299,14 @@ impl MoveType for u128 {
 impl MoveState for u128 {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::U128
+    }
+
+    fn to_runtime_value(&self) -> Value {
+        Value::u128(*self)
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        Ok(value.value_as::<u128>()?)
     }
 }
 
@@ -297,6 +320,14 @@ impl MoveState for U256 {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::U256
     }
+
+    fn to_runtime_value(&self) -> Value {
+        Value::u256(*self)
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        Ok(value.value_as::<U256>()?)
+    }
 }
 
 impl MoveType for bool {
@@ -309,6 +340,14 @@ impl MoveState for bool {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::Bool
     }
+
+    fn to_runtime_value(&self) -> Value {
+        Value::bool(*self)
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        Ok(value.value_as::<bool>()?)
+    }
 }
 
 impl MoveType for AccountAddress {
@@ -320,6 +359,14 @@ impl MoveType for AccountAddress {
 impl MoveState for AccountAddress {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::Address
+    }
+
+    fn to_runtime_value(&self) -> Value {
+        Value::address(*self)
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        Ok(value.value_as::<AccountAddress>()?)
     }
 }
 
@@ -339,6 +386,15 @@ where
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::Struct(Self::struct_layout())
     }
+
+    fn to_runtime_value(&self) -> Value {
+        Value::struct_(S::to_runtime_value_struct(self))
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        let s = value.value_as::<Struct>()?;
+        S::from_runtime_value_struct(s)
+    }
 }
 
 impl<S> MoveType for Vec<S>
@@ -356,6 +412,19 @@ where
 {
     fn type_layout() -> MoveTypeLayout {
         MoveTypeLayout::Vector(Box::new(S::type_layout()))
+    }
+
+    fn to_runtime_value(&self) -> Value {
+        let values: Vec<Value> = self.iter().map(MoveState::to_runtime_value).collect();
+        Value::vector_for_testing_only(values)
+    }
+
+    fn from_runtime_value(value: Value) -> Result<Self> {
+        let values = value.value_as::<Vec<Value>>()?;
+        values
+            .into_iter()
+            .map(MoveState::from_runtime_value)
+            .collect()
     }
 }
 
@@ -377,6 +446,29 @@ impl MoveStructType for PlaceholderStruct {
 /// It is like the `MoveResource` in move_core_types
 pub trait MoveStructState: MoveState + MoveStructType + DeserializeOwned + Serialize {
     fn struct_layout() -> MoveStructLayout;
+
+    /// Convert the MoveState to MoveRuntime Value
+    fn to_runtime_value_struct(&self) -> Struct {
+        let blob = self.to_bytes();
+        Struct::simple_deserialize(&blob, &Self::struct_layout())
+            .expect("Deserialize the Move Runtime Value from MoveState bytes should success")
+    }
+
+    /// Convert the MoveState from MoveRuntime Value
+    fn from_runtime_value_struct(value: Struct) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let blob = value
+            .simple_serialize(&Self::struct_layout())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Serilaize the MoveState to bytes error: {:?}",
+                    Self::type_tag()
+                )
+            })?;
+        Self::from_bytes(&blob)
+    }
 }
 
 impl<T> From<T> for State


### PR DESCRIPTION
## Summary

Check the Object reference count runtime

1. Count the Object reference count and forbid two references from the same object.
2. Refactor the `to_runtime_value` and `from_runtime_value` trait

TODO:
1. Increment the reference count when passing Object reference from the arguments.