### PR TITLE
[moveos] support object field

### DIFF
--- a/.github/workflows/check_build_test.yml
+++ b/.github/workflows/check_build_test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Execute rust tests
         run: cargo nextest run --workspace --all-features --exclude rooch-framework-tests --exclude rooch-integration-test-runner -v
       - name: Execute the framework test with 1 thread
-        run: cargo nextest run -p rooch-framework-tests -p rooch-integration-test-runner -v -j 1
+        run: cargo test run -p rooch-framework-tests -p rooch-integration-test-runner -j 1
       - name: Run CLI integration test
         # cargo-nextest does not support the CLI integration test powered by Cucumber Rust.
         # Use cargo test to run CLI integration tests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5284,7 +5284,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5301,7 +5301,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -5316,12 +5316,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5336,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "fail",
@@ -5362,7 +5362,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
@@ -5379,7 +5379,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5423,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "difference",
@@ -5440,7 +5440,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5469,7 +5469,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5491,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5511,7 +5511,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
@@ -5529,7 +5529,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5548,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5562,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5581,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5600,7 +5600,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "hex",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "hex",
@@ -5627,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5654,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5690,7 +5690,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5727,7 +5727,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5771,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "hex",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "once_cell",
  "serde 1.0.195",
@@ -5829,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5846,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
@@ -5877,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "better_any",
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "better_any",
  "fail",
@@ -5924,7 +5924,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
+source = "git+https://github.com/rooch-network/move?rev=18dadfba4cfec0eff8caafdc3ec22c3f08da552d#18dadfba4cfec0eff8caafdc3ec22c3f08da552d"
 dependencies = [
  "bcs",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5284,7 +5284,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5301,7 +5301,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -5316,12 +5316,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5336,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "fail",
@@ -5362,7 +5362,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
@@ -5379,7 +5379,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5423,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "difference",
@@ -5440,7 +5440,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5469,7 +5469,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5491,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5511,7 +5511,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
@@ -5529,7 +5529,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5548,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5562,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5581,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5600,7 +5600,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "hex",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "hex",
@@ -5627,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5654,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5690,7 +5690,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5727,7 +5727,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5771,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "hex",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "once_cell",
  "serde 1.0.195",
@@ -5829,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5846,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
@@ -5877,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "better_any",
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "better_any",
  "fail",
@@ -5924,7 +5924,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/rooch-network/move?rev=ef13deb11509f6628434f128e04cc34ce28406d6#ef13deb11509f6628434f128e04cc34ce28406d6"
+source = "git+https://github.com/rooch-network/move?rev=31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a#31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a"
 dependencies = [
  "bcs",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,39 +265,39 @@ opendal = "0.44.1"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-binary-format = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-bytecode-verifier = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-bytecode-utils = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-cli = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-command-line-common = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-compiler = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-core-types = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-coverage = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-disassembler = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-docgen = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-errmapgen = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-ir-compiler = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-model = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-package = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-prover = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-prover-boogie-backend = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-stackless-bytecode = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-prover-test-utils = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-resource-viewer = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-stdlib = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a", features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-#move-table-extension = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-transactional-test-runner = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-unit-test = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a", features = ["stacktrace", "debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-read-write-set = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-read-write-set-dynamic = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-bytecode-source-map = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
-move-ir-types = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }# END MOVE DEPENDENCIES
+move-abigen = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-binary-format = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-bytecode-verifier = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-bytecode-utils = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-cli = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-command-line-common = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-compiler = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-core-types = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-coverage = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-disassembler = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-docgen = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-errmapgen = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-ir-compiler = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-model = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-package = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-prover = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-prover-boogie-backend = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-stackless-bytecode = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-prover-test-utils = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-resource-viewer = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-stdlib = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d", features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+#move-table-extension = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-transactional-test-runner = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-unit-test = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d", features = ["stacktrace", "debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+read-write-set = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+read-write-set-dynamic = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-bytecode-source-map = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }
+move-ir-types = { git = "https://github.com/rooch-network/move", rev = "18dadfba4cfec0eff8caafdc3ec22c3f08da552d" }# END MOVE DEPENDENCIES
 
 # keep this for convenient debug Move in local repo
 # [patch.'https://github.com/rooch-network/move']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,39 +265,39 @@ opendal = "0.44.1"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-binary-format = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-bytecode-verifier = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-bytecode-utils = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-cli = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-command-line-common = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-compiler = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-core-types = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-coverage = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-disassembler = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-docgen = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-errmapgen = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-ir-compiler = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-model = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-package = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-prover = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-prover-boogie-backend = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-stackless-bytecode = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-prover-test-utils = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-resource-viewer = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-stdlib = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6", features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-#move-table-extension = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-transactional-test-runner = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-unit-test = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6", features = ["stacktrace", "debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-read-write-set = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-read-write-set-dynamic = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-bytecode-source-map = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }
-move-ir-types = { git = "https://github.com/rooch-network/move", rev = "ef13deb11509f6628434f128e04cc34ce28406d6" }# END MOVE DEPENDENCIES
+move-abigen = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-binary-format = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-bytecode-verifier = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-bytecode-utils = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-cli = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-command-line-common = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-compiler = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-core-types = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-coverage = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-disassembler = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-docgen = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-errmapgen = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-ir-compiler = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-model = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-package = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-prover = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-prover-boogie-backend = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-stackless-bytecode = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-prover-test-utils = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-resource-viewer = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-stdlib = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a", features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+#move-table-extension = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-transactional-test-runner = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-unit-test = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a", features = ["stacktrace", "debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+read-write-set = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+read-write-set-dynamic = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-bytecode-source-map = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }
+move-ir-types = { git = "https://github.com/rooch-network/move", rev = "31a8ba7864ae6b83560c32fdc8f1cfaafab8e04a" }# END MOVE DEPENDENCIES
 
 # keep this for convenient debug Move in local repo
 # [patch.'https://github.com/rooch-network/move']

--- a/crates/rooch-framework-tests/src/tests/chain_id_test.rs
+++ b/crates/rooch-framework-tests/src/tests/chain_id_test.rs
@@ -13,7 +13,7 @@ fn test_chain_id() {
         .executor
         .get_moveos_store()
         .statedb
-        .get(ChainID::chain_id_object_id())
+        .get(&ChainID::chain_id_object_id())
         .unwrap();
     assert!(chain_id.is_some());
     let chain_id_module =

--- a/crates/rooch-framework-tests/tests/cases/coin_store/coin_store.move
+++ b/crates/rooch-framework-tests/tests/cases/coin_store/coin_store.move
@@ -20,7 +20,7 @@ script {
 //# run rooch_framework::gas_coin::faucet_entry --signers test 
 
 //Transfer via coin store
-//# run --signers test --args @0xd073508b9582eff4e01078dc2e62489c15bbef91b6a2e568ac8fb33f0cf54daa
+//# run --signers test --args object:0xd073508b9582eff4e01078dc2e62489c15bbef91b6a2e568ac8fb33f0cf54daa
 script {
     use moveos_std::object::{Object};
     

--- a/crates/rooch-framework-tests/tests/cases/object/basic.exp
+++ b/crates/rooch-framework-tests/tests/cases/object/basic.exp
@@ -7,13 +7,13 @@ task 2 'run'. lines 38-38:
 status EXECUTED
 
 task 3 'view_object'. lines 40-42:
-ObjectEntity { id: ObjectID(8f684aa792b9b1058aeccd3941849e9662132d81c974b826a9c6bddae8880bd6), owner: 0000000000000000000000000000000000000000000000000000000000000043, flag: 0, state_root: 5350415253455f4d45524b4c455f504c414345484f4c4445525f484153480000, size: 0, value: AnnotatedMoveStruct { abilities: [Store, Key, ], type_: StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("S"), type_params: [] }, value: [(Identifier("v"), U8(1))] } }
+ObjectEntity { id: 0x8f684aa792b9b1058aeccd3941849e9662132d81c974b826a9c6bddae8880bd6, owner: 0000000000000000000000000000000000000000000000000000000000000043, flag: 0, state_root: 5350415253455f4d45524b4c455f504c414345484f4c4445525f484153480000, size: 0, value: AnnotatedMoveStruct { abilities: [Store, Key, ], type_: StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("S"), type_params: [] }, value: [(Identifier("v"), U8(1))] } }
 
 task 4 'run'. lines 43-43:
 status EXECUTED
 
 task 5 'view_object'. lines 45-47:
-ObjectEntity { id: ObjectID(8f684aa792b9b1058aeccd3941849e9662132d81c974b826a9c6bddae8880bd6), owner: 0000000000000000000000000000000000000000000000000000000000000043, flag: 0, state_root: 5350415253455f4d45524b4c455f504c414345484f4c4445525f484153480000, size: 0, value: AnnotatedMoveStruct { abilities: [Store, Key, ], type_: StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("S"), type_params: [] }, value: [(Identifier("v"), U8(2))] } }
+ObjectEntity { id: 0x8f684aa792b9b1058aeccd3941849e9662132d81c974b826a9c6bddae8880bd6, owner: 0000000000000000000000000000000000000000000000000000000000000043, flag: 0, state_root: 5350415253455f4d45524b4c455f504c414345484f4c4445525f484153480000, size: 0, value: AnnotatedMoveStruct { abilities: [Store, Key, ], type_: StructTag { address: 0000000000000000000000000000000000000000000000000000000000000042, module: Identifier("m"), name: Identifier("S"), type_params: [] }, value: [(Identifier("v"), U8(2))] } }
 
 task 6 'run'. lines 48-50:
 status EXECUTED

--- a/crates/rooch-framework-tests/tests/cases/object/borrow_two_reference.move
+++ b/crates/rooch-framework-tests/tests/cases/object/borrow_two_reference.move
@@ -26,7 +26,7 @@ module test::m {
 }
 
 // test two ref: will fail
-//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+//# run --signers test --args object_id:0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
 script {
     use moveos_std::object;
     use moveos_std::object::ObjectID;
@@ -41,7 +41,7 @@ script {
 }
 
 // test two ref in different scope: should be allowed
-//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+//# run --signers test --args object_id:0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
 script {
     use moveos_std::object;
     use moveos_std::object::ObjectID;
@@ -60,7 +60,7 @@ script {
 }
 
 // test two mut ref : will fail
-//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+//# run --signers test --args object_id:0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
 script {
     use moveos_std::object;
     use moveos_std::object::ObjectID;

--- a/crates/rooch-framework-tests/tests/cases/object/object_args.move
+++ b/crates/rooch-framework-tests/tests/cases/object/object_args.move
@@ -26,7 +26,7 @@ module test::m {
 }
 
 // test one mut ref: expect success
-//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+//# run --signers test --args object_id:0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
 script {
     use moveos_std::object::{Object};
     use test::m::{TestStruct};
@@ -36,7 +36,7 @@ script {
 }
 
 // test mut ref and ref both: expect failure
-//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+//# run --signers test --args object_id:0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
 script {
     use moveos_std::object::{Self, Object};
     use test::m::{TestStruct};
@@ -47,7 +47,7 @@ script {
 }
 
 // test two mut ref: expect failure
-//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+//# run --signers test --args object_id:0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
 script {
     use moveos_std::object::{Self, Object};
     use test::m::{TestStruct};
@@ -59,7 +59,7 @@ script {
 
 
 // test two repeat mut ref: expect failure
-//# run --signers test --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c --args @0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
+//# run --signers test --args object_id:0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c --args object_id:0xdbac1380a14940361115d51f5d89871c502556428d4eed8d44cd66abd5e0700c
 script {
     use moveos_std::object::{Object};
     use test::m::{TestStruct};

--- a/crates/rooch-framework-tests/tests/cases/table/basic.move
+++ b/crates/rooch-framework-tests/tests/cases/table/basic.move
@@ -53,7 +53,7 @@ script {
     }
 }
 
-//# run --signers test --args @0xf3c06966c440fb4c80181943f9beaefc170c38a9aeafac0265b58030d086cfe5
+//# run --signers test --args object:0xf3c06966c440fb4c80181943f9beaefc170c38a9aeafac0265b58030d086cfe5
 
 script {
     use std::string;

--- a/crates/rooch-framework-tests/tests/cases/timestamp/timestamp_test.move
+++ b/crates/rooch-framework-tests/tests/cases/timestamp/timestamp_test.move
@@ -10,7 +10,7 @@ script {
 }
 
 //Timestamp object as argument.
-//# run --signers test --args @0x711ab0301fd517b135b88f57e84f254c94758998a602596be8ae7ba56a0d14b3
+//# run --signers test --args object:0x711ab0301fd517b135b88f57e84f254c94758998a602596be8ae7ba56a0d14b3
 script {
     use moveos_std::object::{Self, Object};
     use rooch_framework::timestamp::{Self, Timestamp};

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -350,7 +350,7 @@ mod tests {
         let module_store_state = moveos
             .moveos_store()
             .get_state_store()
-            .get(ModuleStore::module_store_id())
+            .get(&ModuleStore::module_store_id())
             .unwrap();
         assert!(module_store_state.is_some());
         let _module_store_obj = module_store_state
@@ -360,7 +360,7 @@ mod tests {
         let chain_id_state = moveos
             .moveos_store()
             .get_state_store()
-            .get(rooch_types::framework::chain_id::ChainID::chain_id_object_id())
+            .get(&rooch_types::framework::chain_id::ChainID::chain_id_object_id())
             .unwrap();
         assert!(chain_id_state.is_some());
     }

--- a/crates/rooch-indexer/src/actor/indexer.rs
+++ b/crates/rooch-indexer/src/actor/indexer.rs
@@ -18,8 +18,8 @@ use move_core_types::language_storage::TypeTag;
 use move_resource_viewer::MoveValueAnnotator;
 use moveos_store::MoveOSStore;
 use moveos_types::moveos_std::object::ObjectID;
-use moveos_types::moveos_std::object::{self, RawObject};
-use moveos_types::state::{KeyState, MoveStructType, SplitStateChangeSet, State};
+use moveos_types::moveos_std::object::RawObject;
+use moveos_types::state::{KeyState, MoveState, MoveStructType, SplitStateChangeSet, State};
 use moveos_types::state_resolver::{MoveOSResolverProxy, StateResolver};
 use rooch_rpc_api::jsonrpc_types::{AnnotatedMoveStructView, AnnotatedMoveValueView};
 use rooch_types::bitcoin::utxo::UTXO;
@@ -141,7 +141,7 @@ impl Handler<IndexerStatesMessage> for IndexerActor {
 
         for (table_handle, table_change) in state_change_set.changes.clone() {
             // handle global object
-            if table_handle == object::GLOBAL_OBJECT_STORAGE_HANDLE {
+            if table_handle == ObjectID::root() {
                 for (key, op) in table_change.entries.into_iter() {
                     match op {
                         Op::Modify(value) => {
@@ -165,7 +165,7 @@ impl Handler<IndexerStatesMessage> for IndexerActor {
                             }
                         }
                         Op::Delete => {
-                            let table_handle = ObjectID::from_bytes(key.key.as_slice())?;
+                            let table_handle = ObjectID::from_bytes(key.key)?;
                             remove_global_states.push(table_handle.to_string());
                         }
                         Op::New(value) => {
@@ -199,7 +199,7 @@ impl Handler<IndexerStatesMessage> for IndexerActor {
                             let state = self.new_table_state(
                                 key,
                                 value,
-                                table_handle,
+                                table_handle.clone(),
                                 tx_order,
                                 state_index_generator,
                             )?;
@@ -221,7 +221,7 @@ impl Handler<IndexerStatesMessage> for IndexerActor {
                             let state = self.new_table_state(
                                 key,
                                 value,
-                                table_handle,
+                                table_handle.clone(),
                                 tx_order,
                                 state_index_generator,
                             )?;

--- a/crates/rooch-integration-test-runner/src/lib.rs
+++ b/crates/rooch-integration-test-runner/src/lib.rs
@@ -282,7 +282,7 @@ impl<'a> MoveOSTestAdapter<'a> for MoveOSTestRunner<'a> {
             MoveOSSubcommands::ViewObject { object_id } => {
                 let resoler = self.moveos.moveos_resolver();
                 let object = resoler
-                    .get_annotated_object(object_id)?
+                    .get_annotated_object(object_id.clone())?
                     .ok_or_else(|| anyhow::anyhow!("Object with id {} not found", object_id))?;
                 //TODO should we bring the AnnotatedObjectView from jsonrpc to test adapter for better json output formatting?
                 Ok(Some(format!("{:?}", object)))

--- a/crates/rooch-integration-test-runner/tests/cases/call_args_test.exp
+++ b/crates/rooch-integration-test-runner/tests/cases/call_args_test.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
-task 1 'run'. lines 4-22:
+task 1 'run'. lines 4-20:
 status EXECUTED
 
-task 2 'run'. lines 23-58:
+task 2 'run'. lines 21-56:
 status EXECUTED

--- a/crates/rooch-integration-test-runner/tests/cases/call_args_test.move
+++ b/crates/rooch-integration-test-runner/tests/cases/call_args_test.move
@@ -1,7 +1,7 @@
 //# init --addresses tester=0x42
 
 //call function use move value style argument
-//# run --signers tester --args 1u8 1u16 1u32 1u64 1u128 1u256 @0x42 b"hello" @0x711ab0301fd517b135b88f57e84f254c94758998a602596be8ae7ba56a0d14b3 @0x711ab0301fd517b135b88f57e84f254c94758998a602596be8ae7ba56a0d14b3
+//# run --signers tester --args 1u8 1u16 1u32 1u64 1u128 1u256 @0x42 b"hello"
 script {
     
     fun main(
@@ -13,8 +13,6 @@ script {
         _v_u256: u256,
         _v_address: address,
         _v_string: std::string::String,
-        _v_object_id: moveos_std::object::ObjectID,
-        _v_object: &moveos_std::object::Object<rooch_framework::timestamp::Timestamp>,
         ) {
     }
 }

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -1761,7 +1761,15 @@
         }
       },
       "ObjectID": {
-        "$ref": "#/components/schemas/Hex"
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/Hex"
+          }
+        }
       },
       "OpView_for_StateView": {
         "oneOf": [

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -1761,15 +1761,7 @@
         }
       },
       "ObjectID": {
-        "type": "object",
-        "required": [
-          "value"
-        ],
-        "properties": {
-          "value": {
-            "$ref": "#/components/schemas/Hex"
-          }
-        }
+        "$ref": "#/components/schemas/Hex"
       },
       "OpView_for_StateView": {
         "oneOf": [

--- a/crates/rooch-rpc-server/src/service/aggregate_service.rs
+++ b/crates/rooch-rpc-server/src/service/aggregate_service.rs
@@ -149,7 +149,7 @@ impl AggregateService {
                     .collect::<Result<Vec<_>>>()?;
 
                 let coin_stores = self
-                    .get_coin_stores(coin_store_ids.iter().map(|(_, v)| *v).collect())
+                    .get_coin_stores(coin_store_ids.iter().map(|(_, v)| v.clone()).collect())
                     .await?;
 
                 let coin_types = coin_stores
@@ -275,7 +275,10 @@ impl AggregateService {
     }
 
     pub async fn pack_uxtos(&self, states: Vec<IndexerGlobalState>) -> Result<Vec<UTXOState>> {
-        let table_handles = states.iter().map(|m| m.object_id).collect::<Vec<_>>();
+        let table_handles = states
+            .iter()
+            .map(|m| m.object_id.clone())
+            .collect::<Vec<_>>();
         let owners = states.iter().map(|m| m.owner).collect::<Vec<_>>();
         let owner_keys = states
             .iter()
@@ -353,7 +356,10 @@ impl AggregateService {
         &self,
         states: Vec<IndexerGlobalState>,
     ) -> Result<Vec<InscriptionState>> {
-        let table_handles = states.iter().map(|m| m.object_id).collect::<Vec<_>>();
+        let table_handles = states
+            .iter()
+            .map(|m| m.object_id.clone())
+            .collect::<Vec<_>>();
         let owners = states.iter().map(|m| m.owner).collect::<Vec<_>>();
         let owner_keys = states
             .iter()

--- a/crates/rooch-types/src/bitcoin/brc20.rs
+++ b/crates/rooch-types/src/bitcoin/brc20.rs
@@ -83,7 +83,7 @@ impl<'a> BRC20Module<'a> {
             Self::GET_TICK_INFO_FUNCTION_NAME,
             vec![],
             vec![
-                MoveValue::Address(BRC20Store::object_id().into()),
+                BRC20Store::object_id().to_move_value(),
                 MoveValue::vector_u8(MoveString::from(tick).to_bytes()),
             ],
         );
@@ -105,7 +105,7 @@ impl<'a> BRC20Module<'a> {
             Self::GET_BALANCE_FUNCTION_NAME,
             vec![],
             vec![
-                MoveValue::Address(BRC20Store::object_id().into()),
+                BRC20Store::object_id().to_move_value(),
                 MoveValue::vector_u8(MoveString::from(tick).to_bytes()),
                 MoveValue::Address(addr),
             ],

--- a/crates/rooch-types/src/bitcoin/light_client.rs
+++ b/crates/rooch-types/src/bitcoin/light_client.rs
@@ -110,7 +110,7 @@ impl<'a> BitcoinLightClientModule<'a> {
             Self::GET_BLOCK_FUNCTION_NAME,
             vec![],
             vec![
-                MoveValue::Address(BitcoinBlockStore::object_id().into()),
+                BitcoinBlockStore::object_id().to_move_value(),
                 MoveValue::Address(block_hash.into_address()),
             ],
         );
@@ -132,7 +132,7 @@ impl<'a> BitcoinLightClientModule<'a> {
             Self::GET_BLOCK_BY_HEIGHT_FUNCTION_NAME,
             vec![],
             vec![
-                MoveValue::Address(BitcoinBlockStore::object_id().into()),
+                BitcoinBlockStore::object_id().to_move_value(),
                 MoveValue::U64(block_height),
             ],
         );
@@ -154,7 +154,7 @@ impl<'a> BitcoinLightClientModule<'a> {
             Self::GET_BLOCK_HEIGHT_FUNCTION_NAME,
             vec![],
             vec![
-                MoveValue::Address(BitcoinBlockStore::object_id().into()),
+                BitcoinBlockStore::object_id().to_move_value(),
                 MoveValue::Address(block_hash.into_address()),
             ],
         );
@@ -175,7 +175,7 @@ impl<'a> BitcoinLightClientModule<'a> {
         let call = Self::create_function_call(
             Self::GET_LATEST_BLOCK_HEIGHT_FUNCTION_NAME,
             vec![],
-            vec![MoveValue::Address(BitcoinBlockStore::object_id().into())],
+            vec![BitcoinBlockStore::object_id().to_move_value()],
         );
         let ctx = TxContext::new_readonly_ctx(AccountAddress::ZERO);
         let height = self
@@ -195,7 +195,7 @@ impl<'a> BitcoinLightClientModule<'a> {
             Self::GET_UTXO_FUNCTION_NAME,
             vec![],
             vec![
-                MoveValue::Address(BitcoinUTXOStore::object_id().into()),
+                BitcoinUTXOStore::object_id().to_move_value(),
                 MoveValue::Address(tx_id.into_address()),
                 MoveValue::U32(vout),
             ],
@@ -218,8 +218,8 @@ impl<'a> BitcoinLightClientModule<'a> {
             Self::REMAINING_TX_COUNT_FUNCTION_NAME,
             vec![],
             vec![
-                MoveValue::Address(BitcoinBlockStore::object_id().into()),
-                MoveValue::Address(BitcoinUTXOStore::object_id().into()),
+                BitcoinBlockStore::object_id().to_move_value(),
+                BitcoinUTXOStore::object_id().to_move_value(),
             ],
         );
         let ctx = TxContext::new_readonly_ctx(AccountAddress::ZERO);
@@ -241,7 +241,7 @@ impl<'a> BitcoinLightClientModule<'a> {
             Self::SUBMIT_NEW_BLOCK_ENTRY_FUNCTION_NAME,
             vec![],
             vec![
-                MoveValue::Address(BitcoinBlockStore::object_id().into()),
+                BitcoinBlockStore::object_id().to_move_value(),
                 MoveValue::U64(block_height),
                 MoveValue::Address(block_hash.into_address()),
                 MoveValue::vector_u8(
@@ -256,8 +256,8 @@ impl<'a> BitcoinLightClientModule<'a> {
             Self::PROCESS_UTXOS_ENTRY_FUNCTION_NAME,
             vec![],
             vec![
-                MoveValue::Address(BitcoinBlockStore::object_id().into()),
-                MoveValue::Address(BitcoinUTXOStore::object_id().into()),
+                BitcoinBlockStore::object_id().to_move_value(),
+                BitcoinUTXOStore::object_id().to_move_value(),
                 MoveValue::U64(batch_size),
             ],
         )
@@ -273,5 +273,16 @@ impl<'a> ModuleBinding<'a> for BitcoinLightClientModule<'a> {
         Self: Sized,
     {
         Self { caller }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_object_id() {
+        let bitcoin_store_object_id = BitcoinBlockStore::object_id();
+        println!("bitcoin_store_object_id: {:?}", bitcoin_store_object_id);
     }
 }

--- a/crates/rooch-types/src/bitcoin/light_client.rs
+++ b/crates/rooch-types/src/bitcoin/light_client.rs
@@ -275,14 +275,3 @@ impl<'a> ModuleBinding<'a> for BitcoinLightClientModule<'a> {
         Self { caller }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_object_id() {
-        let bitcoin_store_object_id = BitcoinBlockStore::object_id();
-        println!("bitcoin_store_object_id: {:?}", bitcoin_store_object_id);
-    }
-}

--- a/crates/rooch-types/src/framework/address_mapping.rs
+++ b/crates/rooch-types/src/framework/address_mapping.rs
@@ -98,15 +98,17 @@ impl<'a> AddressMapping<'a> {
                 let value2 = values.get(2).ok_or(anyhow::anyhow!(
                     "Address mapping handle expected return value"
                 ))?;
-                let address_mapping_handle = ObjectID::from_bytes(&value0.value).map_err(|e| {
+                let address_mapping_handle =
+                    ObjectID::from_bytes(value0.value.clone()).map_err(|e| {
+                        anyhow::anyhow!("Address mapping handle convert error {}", e.to_string())
+                    })?;
+                let mapping_handle = ObjectID::from_bytes(value1.value.clone()).map_err(|e| {
                     anyhow::anyhow!("Address mapping handle convert error {}", e.to_string())
                 })?;
-                let mapping_handle = ObjectID::from_bytes(&value1.value).map_err(|e| {
-                    anyhow::anyhow!("Address mapping handle convert error {}", e.to_string())
-                })?;
-                let reverse_mapping_handle = ObjectID::from_bytes(&value2.value).map_err(|e| {
-                    anyhow::anyhow!("Address mapping handle convert error {}", e.to_string())
-                })?;
+                let reverse_mapping_handle =
+                    ObjectID::from_bytes(value2.value.clone()).map_err(|e| {
+                        anyhow::anyhow!("Address mapping handle convert error {}", e.to_string())
+                    })?;
                 Ok((
                     address_mapping_handle,
                     mapping_handle,

--- a/crates/rooch-types/src/function_arg.rs
+++ b/crates/rooch-types/src/function_arg.rs
@@ -19,6 +19,7 @@ use move_core_types::{
 use moveos_types::{
     move_types::FunctionId,
     moveos_std::object::{self, ObjectID},
+    state::MoveState,
 };
 use std::{
     fmt::{Display, Formatter},
@@ -296,7 +297,7 @@ impl FunctionArg {
             FunctionArg::Bool(arg) => MoveValue::Bool(arg),
             FunctionArg::ObjectID(parsed_object_id) | FunctionArg::Object(parsed_object_id) => {
                 let object_id = parsed_object_id.into_object_id(mapping)?;
-                MoveValue::Address(object_id.into())
+                object_id.to_move_value()
             }
             FunctionArg::String(arg) => MoveValue::vector_u8(arg.as_bytes().to_vec()),
             FunctionArg::U8(arg) => MoveValue::U8(arg),

--- a/crates/rooch-types/src/test_utils.rs
+++ b/crates/rooch-types/src/test_utils.rs
@@ -16,7 +16,7 @@ use moveos_types::moveos_std::account::Account;
 use moveos_types::moveos_std::event::{Event, EventID};
 use moveos_types::moveos_std::move_module::ModuleStore;
 use moveos_types::moveos_std::object::ObjectID;
-use moveos_types::moveos_std::object::{self, ObjectEntity, GENESIS_STATE_ROOT};
+use moveos_types::moveos_std::object::{ObjectEntity, GENESIS_STATE_ROOT};
 use moveos_types::moveos_std::table::TablePlaceholder;
 use moveos_types::state::{KeyState, State, StateChangeSet, TableChange};
 use moveos_types::transaction::{FunctionCall, MoveAction, ScriptCall, VerifiedMoveAction};
@@ -336,7 +336,7 @@ pub fn random_state_change_set() -> StateChangeSet {
     // generate global table
     state_change_set
         .changes
-        .insert(object::GLOBAL_OBJECT_STORAGE_HANDLE, random_table_change());
+        .insert(ObjectID::root(), random_table_change());
 
     state_change_set
 }

--- a/crates/rooch/src/commands/abi/commands/export_rooch_types.rs
+++ b/crates/rooch/src/commands/abi/commands/export_rooch_types.rs
@@ -9,9 +9,9 @@ use move_core_types::{
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
 };
-use moveos_types::move_std::ascii::MoveAsciiString;
 use moveos_types::move_std::string::MoveString;
 use moveos_types::transaction::MoveAction;
+use moveos_types::{move_std::ascii::MoveAsciiString, moveos_std::object::ObjectID};
 use rooch_types::error::RoochResult;
 use rooch_types::transaction::rooch::RoochTransaction;
 use serde_reflection::{Samples, Tracer, TracerConfig};
@@ -67,10 +67,20 @@ fn convert_enum(yaml_value: &mut Value) {
 }
 
 fn export_rooch_types_yaml(file_path: &String) -> RoochResult<()> {
-    let mut tracer = Tracer::new(TracerConfig::default());
+    let mut tracer = Tracer::new(
+        TracerConfig::default()
+            .record_samples_for_structs(true)
+            .record_samples_for_newtype_structs(true),
+    );
 
     // Predefine StructTag to prevent recursive definitions from reporting errors.
     let mut samples = Samples::new();
+
+    tracer
+        .trace_value(&mut samples, &ObjectID::random())
+        .unwrap();
+    tracer.trace_type::<ObjectID>(&samples).unwrap();
+
     let example_struct_tag = StructTag {
         address: AccountAddress::random(),
         module: Identifier::new("Module").unwrap(),

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -188,7 +188,7 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function default::entry_function::emit_vec_u8 --args "vector<u8>:2,3,4" "
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      Then cmd: "move run --function default::entry_function::emit_vec_object_id --args "vector<address>:0x1324,0x41234,0x1234" "
+      Then cmd: "move run --function default::entry_function::emit_vec_object_id --args "vector<object_id>:0x1324,0x41234,0x1234" "
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function default::entry_function::emit_mix --args 3u8 --args "vector<object_id>:0x2342,0x3132" "
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"

--- a/moveos/moveos-object-runtime/src/resolved_arg.rs
+++ b/moveos/moveos-object-runtime/src/resolved_arg.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::{account_address::AccountAddress, value::MoveValue};
-use moveos_types::moveos_std::{
-    object::ObjectID,
-    object::{ObjectEntity, RawData},
+use moveos_types::{
+    moveos_std::object::{ObjectEntity, ObjectID, RawData},
+    state::MoveState,
 };
 
 #[derive(Debug, Clone)]

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/account.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/account.md
@@ -29,6 +29,7 @@
 -  [Function `account_move_resource_from`](#0x2_account_account_move_resource_from)
 -  [Function `account_exists_resource`](#0x2_account_account_exists_resource)
 -  [Function `transfer`](#0x2_account_transfer)
+-  [Function `borrow_account`](#0x2_account_borrow_account)
 -  [Function `borrow_resource`](#0x2_account_borrow_resource)
 -  [Function `borrow_mut_resource`](#0x2_account_borrow_mut_resource)
 -  [Function `move_resource_to`](#0x2_account_move_resource_to)
@@ -56,7 +57,7 @@ Account is part of the StorageAbstraction
 It is also used to store the account's resources
 
 
-<pre><code><b>struct</b> <a href="account.md#0x2_account_Account">Account</a> <b>has</b> store, key
+<pre><code><b>struct</b> <a href="account.md#0x2_account_Account">Account</a> <b>has</b> key
 </code></pre>
 
 
@@ -447,6 +448,17 @@ Create a new account object space
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x2_account_transfer">transfer</a>(obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;<a href="account.md#0x2_account_Account">account::Account</a>&gt;, <a href="account.md#0x2_account">account</a>: <b>address</b>)
+</code></pre>
+
+
+
+<a name="0x2_account_borrow_account"></a>
+
+## Function `borrow_account`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_borrow_account">borrow_account</a>(<a href="account.md#0x2_account">account</a>: <b>address</b>): &<a href="object.md#0x2_object_Object">object::Object</a>&lt;<a href="account.md#0x2_account_Account">account::Account</a>&gt;
 </code></pre>
 
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
@@ -14,6 +14,7 @@ For more details, please refer to https://rooch.network/docs/developer-guides/ob
 -  [Resource `Box`](#0x2_object_Box)
 -  [Struct `TestStructID`](#0x2_object_TestStructID)
 -  [Constants](#@Constants_0)
+-  [Function `has_parent`](#0x2_object_has_parent)
 -  [Function `address_to_object_id`](#0x2_object_address_to_object_id)
 -  [Function `named_object_id`](#0x2_object_named_object_id)
 -  [Function `account_named_object_id`](#0x2_object_account_named_object_id)
@@ -55,7 +56,6 @@ For more details, please refer to https://rooch.network/docs/developer-guides/ob
 -  [Function `as_ref`](#0x2_object_as_ref)
 -  [Function `as_mut_ref`](#0x2_object_as_mut_ref)
 -  [Function `mut_entity_as_object`](#0x2_object_mut_entity_as_object)
--  [Function `global_object_storage_handle`](#0x2_object_global_object_storage_handle)
 -  [Function `add_to_global`](#0x2_object_add_to_global)
 -  [Function `borrow_root_object`](#0x2_object_borrow_root_object)
 -  [Function `borrow_from_global`](#0x2_object_borrow_from_global)
@@ -205,6 +205,16 @@ The Object or dynamic field already exists
 
 
 
+<a name="0x2_object_ErrorChildObjectTooDeep"></a>
+
+The child object level is too deep
+
+
+<pre><code><b>const</b> <a href="object.md#0x2_object_ErrorChildObjectTooDeep">ErrorChildObjectTooDeep</a>: u64 = 11;
+</code></pre>
+
+
+
 <a name="0x2_object_ErrorFieldsNotEmpty"></a>
 
 The dynamic fields is not empty
@@ -289,15 +299,6 @@ Can not take out the object which is bound to the account
 
 
 
-<a name="0x2_object_GlobalObjectStorageHandleID"></a>
-
-
-
-<pre><code><b>const</b> <a href="object.md#0x2_object_GlobalObjectStorageHandleID">GlobalObjectStorageHandleID</a>: <b>address</b> = 0x0;
-</code></pre>
-
-
-
 <a name="0x2_object_SHARED_OBJECT_FLAG_MASK"></a>
 
 
@@ -321,6 +322,17 @@ Can not take out the object which is bound to the account
 
 
 <pre><code><b>const</b> <a href="object.md#0x2_object_SYSTEM_OWNER_ADDRESS">SYSTEM_OWNER_ADDRESS</a>: <b>address</b> = 0x0;
+</code></pre>
+
+
+
+<a name="0x2_object_has_parent"></a>
+
+## Function `has_parent`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_has_parent">has_parent</a>(object_id: &<a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): bool
 </code></pre>
 
 
@@ -811,18 +823,6 @@ This function is for the module of <code>T</code> to extend the <code>transfer</
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_mut_entity_as_object">mut_entity_as_object</a>&lt;T: key&gt;(object_entity: &<b>mut</b> <a href="object.md#0x2_object_ObjectEntity">object::ObjectEntity</a>&lt;T&gt;): <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;
-</code></pre>
-
-
-
-<a name="0x2_object_global_object_storage_handle"></a>
-
-## Function `global_object_storage_handle`
-
-The global object storage's object id should be <code>0x0</code>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_global_object_storage_handle">global_object_storage_handle</a>(): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
 </code></pre>
 
 

--- a/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
+++ b/moveos/moveos-stdlib/moveos-stdlib/doc/object.md
@@ -15,6 +15,9 @@ For more details, please refer to https://rooch.network/docs/developer-guides/ob
 -  [Struct `TestStructID`](#0x2_object_TestStructID)
 -  [Constants](#@Constants_0)
 -  [Function `has_parent`](#0x2_object_has_parent)
+-  [Function `parent_id`](#0x2_object_parent_id)
+-  [Function `is_parent`](#0x2_object_is_parent)
+-  [Function `is_root`](#0x2_object_is_root)
 -  [Function `address_to_object_id`](#0x2_object_address_to_object_id)
 -  [Function `named_object_id`](#0x2_object_named_object_id)
 -  [Function `account_named_object_id`](#0x2_object_account_named_object_id)
@@ -56,33 +59,22 @@ For more details, please refer to https://rooch.network/docs/developer-guides/ob
 -  [Function `as_ref`](#0x2_object_as_ref)
 -  [Function `as_mut_ref`](#0x2_object_as_mut_ref)
 -  [Function `mut_entity_as_object`](#0x2_object_mut_entity_as_object)
--  [Function `add_to_global`](#0x2_object_add_to_global)
--  [Function `borrow_root_object`](#0x2_object_borrow_root_object)
--  [Function `borrow_from_global`](#0x2_object_borrow_from_global)
--  [Function `borrow_mut_root_object`](#0x2_object_borrow_mut_root_object)
--  [Function `borrow_mut_from_global`](#0x2_object_borrow_mut_from_global)
--  [Function `remove_from_global`](#0x2_object_remove_from_global)
--  [Function `contains_global`](#0x2_object_contains_global)
 -  [Function `add_field`](#0x2_object_add_field)
+-  [Function `add_object_field`](#0x2_object_add_object_field)
 -  [Function `add_field_internal`](#0x2_object_add_field_internal)
 -  [Function `borrow_field`](#0x2_object_borrow_field)
--  [Function `borrow_field_internal`](#0x2_object_borrow_field_internal)
+-  [Function `borrow_object_field`](#0x2_object_borrow_object_field)
 -  [Function `borrow_field_with_default`](#0x2_object_borrow_field_with_default)
--  [Function `borrow_field_with_default_internal`](#0x2_object_borrow_field_with_default_internal)
 -  [Function `borrow_mut_field`](#0x2_object_borrow_mut_field)
--  [Function `borrow_mut_field_internal`](#0x2_object_borrow_mut_field_internal)
+-  [Function `borrow_mut_object_field`](#0x2_object_borrow_mut_object_field)
 -  [Function `borrow_mut_field_with_default`](#0x2_object_borrow_mut_field_with_default)
--  [Function `borrow_mut_field_with_default_internal`](#0x2_object_borrow_mut_field_with_default_internal)
 -  [Function `upsert_field`](#0x2_object_upsert_field)
--  [Function `upsert_field_internal`](#0x2_object_upsert_field_internal)
 -  [Function `remove_field`](#0x2_object_remove_field)
--  [Function `remove_field_internal`](#0x2_object_remove_field_internal)
+-  [Function `remove_object_field`](#0x2_object_remove_object_field)
 -  [Function `contains_field`](#0x2_object_contains_field)
+-  [Function `contains_object_field`](#0x2_object_contains_object_field)
 -  [Function `contains_field_with_type`](#0x2_object_contains_field_with_type)
--  [Function `contains_field_internal`](#0x2_object_contains_field_internal)
--  [Function `contains_field_with_value_type_internal`](#0x2_object_contains_field_with_value_type_internal)
 -  [Function `field_size`](#0x2_object_field_size)
--  [Function `field_size_internal`](#0x2_object_field_size_internal)
 
 
 <pre><code><b>use</b> <a href="">0x1::hash</a>;
@@ -290,6 +282,26 @@ Can not take out the object which is bound to the account
 
 
 
+<a name="0x2_object_ErrorParentNotMatch"></a>
+
+The parent object is not match
+
+
+<pre><code><b>const</b> <a href="object.md#0x2_object_ErrorParentNotMatch">ErrorParentNotMatch</a>: u64 = 13;
+</code></pre>
+
+
+
+<a name="0x2_object_ErrorWithoutParent"></a>
+
+The object has no parent
+
+
+<pre><code><b>const</b> <a href="object.md#0x2_object_ErrorWithoutParent">ErrorWithoutParent</a>: u64 = 12;
+</code></pre>
+
+
+
 <a name="0x2_object_FROZEN_OBJECT_FLAG_MASK"></a>
 
 
@@ -330,9 +342,45 @@ Can not take out the object which is bound to the account
 
 ## Function `has_parent`
 
+Check if the object_id has parent
+The object_id has parent means the object_id is not the root object_id
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_has_parent">has_parent</a>(object_id: &<a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): bool
+</code></pre>
+
+
+
+<a name="0x2_object_parent_id"></a>
+
+## Function `parent_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_parent_id">parent_id</a>(object_id: &<a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
+</code></pre>
+
+
+
+<a name="0x2_object_is_parent"></a>
+
+## Function `is_parent`
+
+Check if the <code>parent</code> is the parent of the <code>child</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_is_parent">is_parent</a>(parent: &<a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, child: &<a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): bool
+</code></pre>
+
+
+
+<a name="0x2_object_is_root"></a>
+
+## Function `is_root`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_is_root">is_root</a>(object_id: &<a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): bool
 </code></pre>
 
 
@@ -827,83 +875,6 @@ This function is for the module of <code>T</code> to extend the <code>transfer</
 
 
 
-<a name="0x2_object_add_to_global"></a>
-
-## Function `add_to_global`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_add_to_global">add_to_global</a>&lt;T: key&gt;(obj: <a href="object.md#0x2_object_ObjectEntity">object::ObjectEntity</a>&lt;T&gt;)
-</code></pre>
-
-
-
-<a name="0x2_object_borrow_root_object"></a>
-
-## Function `borrow_root_object`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_borrow_root_object">borrow_root_object</a>(): &<a href="object.md#0x2_object_ObjectEntity">object::ObjectEntity</a>&lt;<a href="object.md#0x2_object_Root">object::Root</a>&gt;
-</code></pre>
-
-
-
-<a name="0x2_object_borrow_from_global"></a>
-
-## Function `borrow_from_global`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_borrow_from_global">borrow_from_global</a>&lt;T: key&gt;(object_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): &<a href="object.md#0x2_object_ObjectEntity">object::ObjectEntity</a>&lt;T&gt;
-</code></pre>
-
-
-
-<a name="0x2_object_borrow_mut_root_object"></a>
-
-## Function `borrow_mut_root_object`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_borrow_mut_root_object">borrow_mut_root_object</a>(): &<b>mut</b> <a href="object.md#0x2_object_ObjectEntity">object::ObjectEntity</a>&lt;<a href="object.md#0x2_object_Root">object::Root</a>&gt;
-</code></pre>
-
-
-
-<a name="0x2_object_borrow_mut_from_global"></a>
-
-## Function `borrow_mut_from_global`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_borrow_mut_from_global">borrow_mut_from_global</a>&lt;T: key&gt;(object_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): &<b>mut</b> <a href="object.md#0x2_object_ObjectEntity">object::ObjectEntity</a>&lt;T&gt;
-</code></pre>
-
-
-
-<a name="0x2_object_remove_from_global"></a>
-
-## Function `remove_from_global`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_remove_from_global">remove_from_global</a>&lt;T: key&gt;(object_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): <a href="object.md#0x2_object_ObjectEntity">object::ObjectEntity</a>&lt;T&gt;
-</code></pre>
-
-
-
-<a name="0x2_object_contains_global"></a>
-
-## Function `contains_global`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_contains_global">contains_global</a>(object_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): bool
-</code></pre>
-
-
-
 <a name="0x2_object_add_field"></a>
 
 ## Function `add_field`
@@ -915,6 +886,20 @@ object, and cannot be discovered from it.
 
 <pre><code>#[private_generics(#[T])]
 <b>public</b> <b>fun</b> <a href="object.md#0x2_object_add_field">add_field</a>&lt;T: key, K: <b>copy</b>, drop, V: store&gt;(obj: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, key: K, val: V)
+</code></pre>
+
+
+
+<a name="0x2_object_add_object_field"></a>
+
+## Function `add_object_field`
+
+Add a object field to the object. return the child object
+The parent object must be a shared object
+
+
+<pre><code>#[private_generics(#[T], #[V])]
+<b>public</b> <b>fun</b> <a href="object.md#0x2_object_add_object_field">add_object_field</a>&lt;T: key, V: key&gt;(obj: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, v: V): <a href="object.md#0x2_object_Object">object::Object</a>&lt;V&gt;
 </code></pre>
 
 
@@ -946,15 +931,14 @@ Aborts if there is no field for <code>key</code>.
 
 
 
-<a name="0x2_object_borrow_field_internal"></a>
+<a name="0x2_object_borrow_object_field"></a>
 
-## Function `borrow_field_internal`
+## Function `borrow_object_field`
 
-Acquire an immutable reference to the value which <code>key</code> maps to.
-Aborts if there is no field for <code>key</code>.
+Borrow the child object by <code>key</code>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_borrow_field_internal">borrow_field_internal</a>&lt;K: <b>copy</b>, drop, V&gt;(obj_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, key: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_object_field">borrow_object_field</a>&lt;T: key, V: key&gt;(obj: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, key: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): &<a href="object.md#0x2_object_Object">object::Object</a>&lt;V&gt;
 </code></pre>
 
 
@@ -968,19 +952,6 @@ Returns specified default value if there is no field for <code>key</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_field_with_default">borrow_field_with_default</a>&lt;T: key, K: <b>copy</b>, drop, V: store&gt;(obj: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, key: K, default: &V): &V
-</code></pre>
-
-
-
-<a name="0x2_object_borrow_field_with_default_internal"></a>
-
-## Function `borrow_field_with_default_internal`
-
-Acquire an immutable reference to the value which <code>key</code> maps to.
-Returns specified default value if there is no field for <code>key</code>.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_borrow_field_with_default_internal">borrow_field_with_default_internal</a>&lt;K: <b>copy</b>, drop, V&gt;(obj_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, key: K, default: &V): &V
 </code></pre>
 
 
@@ -999,15 +970,15 @@ Aborts if there is no field for <code>key</code>.
 
 
 
-<a name="0x2_object_borrow_mut_field_internal"></a>
+<a name="0x2_object_borrow_mut_object_field"></a>
 
-## Function `borrow_mut_field_internal`
+## Function `borrow_mut_object_field`
 
-Acquire a mutable reference to the value which <code>key</code> maps to.
-Aborts if there is no field for <code>key</code>.
+Borrow the child object by <code>key</code>
+Because the parent object must be a shared object, so we do not require the #[private_generics(T)] here
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_borrow_mut_field_internal">borrow_mut_field_internal</a>&lt;K: <b>copy</b>, drop, V&gt;(obj_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, key: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_borrow_mut_object_field">borrow_mut_object_field</a>&lt;T: key, V: key&gt;(obj: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, key: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;V&gt;
 </code></pre>
 
 
@@ -1026,19 +997,6 @@ Insert the pair (<code>key</code>, <code>default</code>) first if there is no fi
 
 
 
-<a name="0x2_object_borrow_mut_field_with_default_internal"></a>
-
-## Function `borrow_mut_field_with_default_internal`
-
-Acquire a mutable reference to the value which <code>key</code> maps to.
-Insert the pair (<code>key</code>, <code>default</code>) first if there is no field for <code>key</code>.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_borrow_mut_field_with_default_internal">borrow_mut_field_with_default_internal</a>&lt;T: key, K: <b>copy</b>, drop, V: drop&gt;(obj_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, key: K, default: V): &<b>mut</b> V
-</code></pre>
-
-
-
 <a name="0x2_object_upsert_field"></a>
 
 ## Function `upsert_field`
@@ -1049,19 +1007,6 @@ update the value of the field for <code>key</code> to <code>value</code> otherwi
 
 <pre><code>#[private_generics(#[T])]
 <b>public</b> <b>fun</b> <a href="object.md#0x2_object_upsert_field">upsert_field</a>&lt;T: key, K: <b>copy</b>, drop, V: drop, store&gt;(obj: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, key: K, value: V)
-</code></pre>
-
-
-
-<a name="0x2_object_upsert_field_internal"></a>
-
-## Function `upsert_field_internal`
-
-Insert the pair (<code>key</code>, <code>value</code>) if there is no field for <code>key</code>.
-update the value of the field for <code>key</code> to <code>value</code> otherwise
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_upsert_field_internal">upsert_field_internal</a>&lt;T: key, K: <b>copy</b>, drop, V: drop&gt;(obj_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, key: K, value: V)
 </code></pre>
 
 
@@ -1080,15 +1025,14 @@ Aborts if there is no field for <code>key</code>.
 
 
 
-<a name="0x2_object_remove_field_internal"></a>
+<a name="0x2_object_remove_object_field"></a>
 
-## Function `remove_field_internal`
-
-Remove from <code><a href="object.md#0x2_object">object</a></code> and return the value which <code>key</code> maps to.
-Aborts if there is no field for <code>key</code>.
+## Function `remove_object_field`
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_remove_field_internal">remove_field_internal</a>&lt;T: key, K: <b>copy</b>, drop, V&gt;(obj_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, key: K): V
+
+<pre><code>#[private_generics(#[T])]
+<b>public</b> <b>fun</b> <a href="object.md#0x2_object_remove_object_field">remove_object_field</a>&lt;T: key, V: key&gt;(obj: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, child: <a href="object.md#0x2_object_Object">object::Object</a>&lt;V&gt;): V
 </code></pre>
 
 
@@ -1105,6 +1049,18 @@ Returns true if <code><a href="object.md#0x2_object">object</a></code> contains 
 
 
 
+<a name="0x2_object_contains_object_field"></a>
+
+## Function `contains_object_field`
+
+Returns true if <code><a href="object.md#0x2_object">object</a></code> contains an Object field for <code>key</code> and the value type is <code>V</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_contains_object_field">contains_object_field</a>&lt;T: key, V: key&gt;(obj: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;, key: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): bool
+</code></pre>
+
+
+
 <a name="0x2_object_contains_field_with_type"></a>
 
 ## Function `contains_field_with_type`
@@ -1117,30 +1073,6 @@ Returns true if <code><a href="object.md#0x2_object">object</a></code> contains 
 
 
 
-<a name="0x2_object_contains_field_internal"></a>
-
-## Function `contains_field_internal`
-
-Returns true if <code><a href="object.md#0x2_object">object</a></code> contains an field for <code>key</code>.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_contains_field_internal">contains_field_internal</a>&lt;K: <b>copy</b>, drop&gt;(obj_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, key: K): bool
-</code></pre>
-
-
-
-<a name="0x2_object_contains_field_with_value_type_internal"></a>
-
-## Function `contains_field_with_value_type_internal`
-
-Returns true if <code><a href="object.md#0x2_object">object</a></code> contains an field for <code>key</code> and the value type is <code>V</code>.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_contains_field_with_value_type_internal">contains_field_with_value_type_internal</a>&lt;K: <b>copy</b>, drop, V: store&gt;(obj_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, key: K): bool
-</code></pre>
-
-
-
 <a name="0x2_object_field_size"></a>
 
 ## Function `field_size`
@@ -1149,15 +1081,4 @@ Returns the size of the object fields, the number of key-value pairs
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_field_size">field_size</a>&lt;T: key&gt;(obj: &<a href="object.md#0x2_object_Object">object::Object</a>&lt;T&gt;): u64
-</code></pre>
-
-
-
-<a name="0x2_object_field_size_internal"></a>
-
-## Function `field_size_internal`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_field_size_internal">field_size_internal</a>&lt;T: key&gt;(object_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>): u64
 </code></pre>

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/object.move
@@ -36,7 +36,10 @@ module moveos_std::object {
     const ErrorTypeMismatch: u64 = 10;
     /// The child object level is too deep
     const ErrorChildObjectTooDeep: u64 = 11;
-    const ErrorNoParent: u64 = 12;
+    /// The object has no parent 
+    const ErrorWithoutParent: u64 = 12;
+    /// The parent object is not match
+    const ErrorParentNotMatch: u64 = 13;
 
     const SYSTEM_OWNER_ADDRESS: address = @0x0;
     
@@ -59,9 +62,26 @@ module moveos_std::object {
 
     public fun parent_id(object_id: &ObjectID): ObjectID {
         let path = object_id.path;
-        assert!(!vector::is_empty(&path), ErrorNoParent);
+        assert!(!vector::is_empty(&path), ErrorWithoutParent);
         vector::pop_back(&mut path);
         ObjectID{path: path}
+    }
+
+    /// Check if the `parent` is the parent of the `child`
+    public fun is_parent(parent: &ObjectID, child: &ObjectID): bool {
+        let parent_path = parent.path;
+        let child_path = child.path;
+        let parent_len = vector::length(&parent_path);
+        let child_len = vector::length(&child_path);
+        if (parent_len >= child_len) {
+            return false
+        };
+        vector::pop_back(&mut child_path);
+        parent_path == child_path
+    }
+
+    public fun is_root(object_id: &ObjectID): bool {
+        vector::is_empty(&object_id.path)
     }
 
     /// Generate a new ObjectID from an address
@@ -161,18 +181,6 @@ module moveos_std::object {
         new_with_id(id, value)
     }
 
-    #[private_generics(PT)]
-    /// Create a new object with parent, the parent must be a shared object
-    fun new_with_parent<PT: key, T: key>(parent: &mut Object<PT>, value: T): Object<T> {
-        assert!(is_shared(parent), ErrorObjectNotShared);
-        // Currently, the child object level is limited to 2
-        assert!(vector::length(&parent.id.path) < 2, ErrorChildObjectTooDeep);
-        let id = derive_child_object_id(&parent.id);
-        let obj_entity = new_internal(id, value);
-        add_field_internal<PT, ObjectID, ObjectEntity<T>>(parent.id, id, obj_entity);
-        Object{id}
-    }
-
     fun derive_child_object_id(parent: &ObjectID): ObjectID{
         let path = parent.path;
         vector::push_back(&mut path, tx_context::fresh_address());
@@ -180,9 +188,7 @@ module moveos_std::object {
     }
 
     public(friend) fun new_with_id<T: key>(id: ObjectID, value: T): Object<T> {
-        let obj_entity = new_internal(id, value);
-        add_to_global(obj_entity);
-        Object{id}
+        add_object_field_internal<Root, T>(root_object_id(), id, value)
     }
 
     fun new_internal<T: key>(id: ObjectID, value: T): ObjectEntity<T> {
@@ -274,8 +280,6 @@ module moveos_std::object {
         (owner, mut_entity_as_object(object_entity))
     }
 
-    // // #[private_generics(T)]
-    // TODO Need to tighter restrictions ?
     /// Borrow mut Shared Object by object_id
     public fun borrow_mut_object_shared<T: key>(object_id: ObjectID): &mut Object<T> {
         let obj = borrow_mut_object_internal<T>(object_id);
@@ -289,26 +293,23 @@ module moveos_std::object {
     /// This function is only can be called by the module of `T`.
     /// The caller must ensure that the dynamic fields are empty before delete the Object
     public fun remove<T: key>(self: Object<T>) : T {
-        let Object{id} = self; 
-        let object_entity = remove_from_global<T>(id);
-        let ObjectEntity{id:_, owner:_, flag:_, value, state_root:_, size} = object_entity;
-        // Need to ensure that the Fields is empty before delete the Object
-        assert!(size == 0, ErrorFieldsNotEmpty);
-        value
+        remove_object_field_internal<Root, T>(root_object_id(), self, true)
     }
 
     /// Remove the object from the global storage, and return the object value
     /// Do not check if the dynamic fields are empty 
     public(friend) fun remove_unchecked<T: key>(self: Object<T>) : T {
-        let Object{id} = self; 
-        let object_entity = remove_from_global<T>(id);
-        let ObjectEntity{id:_, owner:_, flag:_, value, state_root:_, size:_} = object_entity;
-        value
+        remove_object_field_internal<Root, T>(root_object_id(), self, false)
     }
 
     /// Directly drop the Object
     fun drop<T: key>(self: Object<T>) {
         let Object{id:_} = self;
+    }
+
+    fun drop_entity<T: key>(entity: ObjectEntity<T>):T{
+        let ObjectEntity{id:_,owner:_,flag:_,state_root:_,size:_, value } = entity;
+        value
     }
 
     /// Make the Object shared, Any one can get the &mut Object<T> from shared object
@@ -449,45 +450,65 @@ module moveos_std::object {
         ObjectID{path: vector::empty()}
     }
 
-    public(friend) fun add_to_global<T: key>(obj: ObjectEntity<T>) {
-        add_field_internal<Root, ObjectID, ObjectEntity<T>>(root_object_id(), obj.id, obj);
+    fun borrow_from_global<T: key>(object_id: ObjectID): &ObjectEntity<T> {
+        let parent_id = if(has_parent(&object_id)){
+            parent_id(&object_id)
+        }else{
+            //root object
+            object_id
+        };
+        borrow_field_internal<ObjectID, ObjectEntity<T>>(parent_id, object_id)
     }
 
-    public(friend) fun borrow_root_object(): &ObjectEntity<Root>{
-        borrow_from_global<Root>(root_object_id())
-    }
-
-    public(friend) fun borrow_from_global<T: key>(object_id: ObjectID): &ObjectEntity<T> {
-        borrow_field_internal<ObjectID, ObjectEntity<T>>(root_object_id(), object_id)
-    }
-
-    public(friend) fun borrow_mut_root_object(): &mut ObjectEntity<Root>{
-        borrow_mut_from_global<Root>(root_object_id())
-    }
-
-    public(friend) fun borrow_mut_from_global<T: key>(object_id: ObjectID): &mut ObjectEntity<T> {
-        let object_entity = borrow_mut_field_internal<ObjectID, ObjectEntity<T>>(root_object_id(), object_id);
+    fun borrow_mut_from_global<T: key>(object_id: ObjectID): &mut ObjectEntity<T> {
+        let parent_id = if(has_parent(&object_id)){
+            parent_id(&object_id)
+        }else{
+            //root object
+            object_id
+        };
+        let object_entity = borrow_mut_field_internal<ObjectID, ObjectEntity<T>>(parent_id, object_id);
         assert!(!is_frozen_internal(object_entity), ErrorObjectFrozen);
         object_entity
     }
 
-    public(friend) fun remove_from_global<T: key>(object_id: ObjectID): ObjectEntity<T> {
+    fun remove_from_global<T: key>(object_id: ObjectID): ObjectEntity<T> {
+        // Currently, we only support to remove the object from the root object
+        // If we want to remove the child object, we need to call the `remove_object_field` function
         remove_field_internal<Root, ObjectID, ObjectEntity<T>>(root_object_id(), object_id)
     }
 
-    public(friend) fun contains_global(object_id: ObjectID): bool {
-        contains_field_internal(root_object_id(), object_id)
+    fun contains_global(object_id: ObjectID): bool {
+        contains_field_internal(parent_id(&object_id), object_id)
     }
 
 
     // === Object Raw Dynamic Fields ===
 
-     #[private_generics(T)]
+    #[private_generics(T)]
     /// Add a dynamic filed to the object. Aborts if an field for this
     /// key already exists. The field itself is not stored in the
     /// object, and cannot be discovered from it.
     public fun add_field<T: key, K: copy + drop, V: store>(obj: &mut Object<T>, key: K, val: V) {
         add_field_internal<T,K,V>(obj.id, key, val)
+    }
+
+    #[private_generics(T, V)]
+    /// Add a object field to the object. return the child object
+    /// The parent object must be a shared object
+    public fun add_object_field<T: key, V: key>(obj: &mut Object<T>, v: V): Object<V> {
+        // Only shared object can add child object
+        assert!(is_shared(obj), ErrorObjectNotShared);
+        // Currently, the child object level is limited to 2
+        assert!(vector::length(&obj.id.path) < 2, ErrorChildObjectTooDeep);
+        let child_id = derive_child_object_id(&obj.id);
+        add_object_field_internal<T, V>(obj.id, child_id, v)
+    }
+
+    fun add_object_field_internal<T: key, V: key>(parent_id: ObjectID, child_id: ObjectID, v: V): Object<V> {
+        let child_entity = new_internal(child_id, v);
+        add_field_internal<T, ObjectID, ObjectEntity<V>>(parent_id, child_id, child_entity);
+        Object{id: child_id} 
     }
 
      /// Add a new field to the object. Aborts if an field for this
@@ -505,9 +526,20 @@ module moveos_std::object {
         borrow_field_internal<K, V>(obj.id, key)
     }
 
-     /// Acquire an immutable reference to the value which `key` maps to.
+    /// Borrow the child object by `key`
+    public fun borrow_object_field<T: key, V: key>(obj: &Object<T>, key: ObjectID): &Object<V> {
+        borrow_object_field_internal<T, V>(obj.id, key)
+    }
+
+    fun borrow_object_field_internal<T: key, V: key>(parent_id: ObjectID, key: ObjectID): &Object<V> {
+        assert!(is_parent(&parent_id, &key), ErrorParentNotMatch);
+        let object_entity = borrow_field_internal<ObjectID, ObjectEntity<V>>(parent_id, key);
+        as_ref(object_entity)
+    }
+
+    /// Acquire an immutable reference to the value which `key` maps to.
     /// Aborts if there is no field for `key`.
-    public(friend) fun borrow_field_internal<K: copy + drop, V>(obj_id: ObjectID, key: K): &V {
+    fun borrow_field_internal<K: copy + drop, V>(obj_id: ObjectID, key: K): &V {
         &borrow_box<K, V, Box<V>>(obj_id, key).val
     }
 
@@ -519,7 +551,7 @@ module moveos_std::object {
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Returns specified default value if there is no field for `key`.
-    public(friend) fun borrow_field_with_default_internal<K: copy + drop, V>(obj_id: ObjectID, key: K, default: &V): &V {
+    fun borrow_field_with_default_internal<K: copy + drop, V>(obj_id: ObjectID, key: K, default: &V): &V {
          if (!contains_field_internal<K>(obj_id, key)) {
             default
         } else {
@@ -534,9 +566,17 @@ module moveos_std::object {
         borrow_mut_field_internal<K, V>(obj.id, key)
     }
 
+    /// Borrow the child object by `key`
+    /// Because the parent object must be a shared object, so we do not require the #[private_generics(T)] here
+    public fun borrow_mut_object_field<T: key, V: key>(obj: &mut Object<T>, key: ObjectID): &mut Object<V> {
+        assert!(is_parent(&obj.id, &key), ErrorParentNotMatch);
+        let object_entity = borrow_mut_field_internal<ObjectID, ObjectEntity<V>>(obj.id, key);
+        as_mut_ref(object_entity)
+    }
+
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no field for `key`.
-    public(friend) fun borrow_mut_field_internal<K: copy + drop, V>(obj_id: ObjectID, key: K): &mut V {
+    fun borrow_mut_field_internal<K: copy + drop, V>(obj_id: ObjectID, key: K): &mut V {
         &mut borrow_box_mut<K, V, Box<V>>(obj_id, key).val
     }
 
@@ -549,7 +589,7 @@ module moveos_std::object {
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Insert the pair (`key`, `default`) first if there is no field for `key`.
-    public(friend) fun borrow_mut_field_with_default_internal<T: key, K: copy + drop, V: drop>(obj_id: ObjectID, key: K, default: V): &mut V {
+    fun borrow_mut_field_with_default_internal<T: key, K: copy + drop, V: drop>(obj_id: ObjectID, key: K, default: V): &mut V {
         if (!contains_field_internal<K>(obj_id, copy key)) {
             add_field_internal<T, K, V>(obj_id, key, default)
         };
@@ -565,7 +605,7 @@ module moveos_std::object {
 
     /// Insert the pair (`key`, `value`) if there is no field for `key`.
     /// update the value of the field for `key` to `value` otherwise
-    public(friend) fun upsert_field_internal<T: key, K: copy + drop, V: drop>(obj_id: ObjectID, key: K, value: V) {
+    fun upsert_field_internal<T: key, K: copy + drop, V: drop>(obj_id: ObjectID, key: K, value: V) {
         if (!contains_field_internal<K>(obj_id, copy key)) {
             add_field_internal<T, K, V>(obj_id, key, value)
         } else {
@@ -581,9 +621,26 @@ module moveos_std::object {
         remove_field_internal<T, K, V>(obj.id, key)
     }
 
+    #[private_generics(T)]
+    public fun remove_object_field<T: key, V: key>(obj: &mut Object<T>, child: Object<V>): V {
+        remove_object_field_internal<T, V>(obj.id, child, true) 
+    }
+
+    fun remove_object_field_internal<T: key, V: key>(parent_id: ObjectID, child: Object<V>, check_size: bool): V {
+        let Object{id:child_id} = child;
+        assert!(is_parent(&parent_id, &child_id), ErrorParentNotMatch);
+        let object_entity = remove_field_internal<T, ObjectID, ObjectEntity<V>>(parent_id, child_id);
+        let ObjectEntity{id:_, owner:_, flag:_, value, state_root:_, size:size} = object_entity;
+        if(check_size){
+            // Need to ensure that the Fields is empty before delete the Object
+            assert!(size == 0, ErrorFieldsNotEmpty);
+        };
+        value
+    }
+
     /// Remove from `object` and return the value which `key` maps to.
     /// Aborts if there is no field for `key`.
-    public(friend) fun remove_field_internal<T: key, K: copy + drop, V>(obj_id: ObjectID, key: K): V {
+    fun remove_field_internal<T: key, K: copy + drop, V>(obj_id: ObjectID, key: K): V {
         let Box { val } = remove_box<K, V, Box<V>>(obj_id, key);
         let object_entity = borrow_mut_from_global<T>(obj_id);
         object_entity.size = object_entity.size - 1;
@@ -595,18 +652,27 @@ module moveos_std::object {
         contains_field_internal<K>(obj.id, key)
     }
 
+    /// Returns true if `object` contains an Object field for `key` and the value type is `V`.
+    public fun contains_object_field<T: key, V: key>(obj: &Object<T>, key: ObjectID): bool {
+        if(is_parent(&obj.id, &key)){
+            contains_field_with_value_type_internal<ObjectID, ObjectEntity<V>>(obj.id, key)
+        }else{
+            false
+        }
+    }
+
     /// Returns true if `object` contains an field for `key` and the value type is `V`.
     public fun contains_field_with_type<T: key, K: copy + drop, V: store>(obj: &Object<T>, key: K): bool {
         contains_field_with_value_type_internal<K, V>(obj.id, key)
     }
 
     /// Returns true if `object` contains an field for `key`.
-    public(friend) fun contains_field_internal<K: copy + drop>(obj_id: ObjectID, key: K): bool {
+    fun contains_field_internal<K: copy + drop>(obj_id: ObjectID, key: K): bool {
         contains_box<K>(obj_id, key)
     }
 
     /// Returns true if `object` contains an field for `key` and the value type is `V`.
-    public(friend) fun contains_field_with_value_type_internal<K: copy + drop, V: store>(obj_id: ObjectID, key: K): bool {
+    fun contains_field_with_value_type_internal<K: copy + drop, V>(obj_id: ObjectID, key: K): bool {
         contains_box_with_value_type<K, V>(obj_id, key)
     }
 
@@ -615,7 +681,7 @@ module moveos_std::object {
         field_size_internal<T>(obj.id)
     }
 
-    public(friend) fun field_size_internal<T: key>(object_id: ObjectID): u64 {
+    fun field_size_internal<T: key>(object_id: ObjectID): u64 {
         let object_entity = borrow_from_global<T>(object_id);
         object_entity.size
     }
@@ -697,7 +763,7 @@ module moveos_std::object {
         to_shared_internal(&mut obj_enitty);
         assert!(is_shared_internal(&obj_enitty), 1002);
         assert!(!is_frozen_internal(&obj_enitty), 1003);
-        add_to_global(obj_enitty);
+        let TestStruct{count:_} = drop_entity(obj_enitty);
     }
 
     #[test]
@@ -709,7 +775,7 @@ module moveos_std::object {
         to_frozen_internal(&mut obj_enitty);
         assert!(!is_shared_internal(&obj_enitty), 1002);
         assert!(is_frozen_internal(&obj_enitty), 1003);
-        add_to_global(obj_enitty);
+        let TestStruct{count:_} = drop_entity(obj_enitty);
         
     }
 
@@ -725,7 +791,7 @@ module moveos_std::object {
         to_frozen_internal(&mut obj_enitty);
         assert!(is_shared_internal(&obj_enitty), 1002);
         assert!(is_frozen_internal(&obj_enitty), 1003);
-        add_to_global(obj_enitty);
+        let TestStruct{count:_} = drop_entity(obj_enitty);
     }
 
     #[test]
@@ -887,16 +953,13 @@ module moveos_std::object {
         };
     }
 
-    //#[test]
+    #[test_only]
     fun test_new_with_parent(){
         let parent = new(TestStruct{count: 1});
         let parent_id = id(&parent);
         to_shared(parent);
         let parent = borrow_mut_object_shared<TestStruct>(parent_id);
-        let child = new_with_parent(parent, TestStruct{count: 2});
-        abort 42
-        //TODO support remove children object
-        //let TestStruct{count:_} = remove(child);
-        //let TestStruct{count:_} = remove(parent);
+        let child = add_object_field(parent, TestStruct{count: 2});
+        let TestStruct{count:_} = remove_object_field(parent, child);
     }
 }

--- a/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
+++ b/moveos/moveos-stdlib/moveos-stdlib/sources/table.move
@@ -251,11 +251,4 @@ module moveos_std::table {
         destroy_empty(t);
     }
 
-    #[test]
-    fun test_table_object(){
-        let t = new<u64, u8>();
-        let _t_obj_entity = object::borrow_from_global<TablePlaceholder>(object::id(&t.handle));
-        drop_unchecked(t);
-    }
-
 }

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/object.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/object.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::raw_table;
-use crate::natives::{helpers::make_module_natives, moveos_stdlib::raw_table::NativeTableContext};
+use crate::natives::{
+    helpers::make_module_natives, helpers::make_native,
+    moveos_stdlib::raw_table::NativeTableContext,
+};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{gas_algebra::InternalGas, vm_status::StatusCode};
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
@@ -180,11 +183,11 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
     let natives = [
         (
             "as_ref_inner",
-            make_native_as_ref_inner(gas_params.as_ref_inner),
+            make_native(gas_params.as_ref_inner, native_as_ref_inner),
         ),
         (
             "as_mut_ref_inner",
-            make_native_as_mut_ref_inner(gas_params.as_mut_ref_inner),
+            make_native(gas_params.as_mut_ref_inner, native_as_mut_ref_inner),
         ),
         (
             "add_box",

--- a/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
+++ b/moveos/moveos-stdlib/src/natives/moveos_stdlib/raw_table/mod.rs
@@ -289,16 +289,16 @@ impl TableData {
         // _context: &NativeContext,
         handle: ObjectID,
     ) -> PartialVMResult<&mut Table> {
-        match self.tables.entry(handle) {
+        match self.tables.entry(handle.clone()) {
             Entry::Vacant(e) => {
+                if log::log_enabled!(log::Level::Trace) {
+                    log::trace!("[RawTable] creating table {}", handle);
+                }
                 let table = Table {
                     handle,
                     content: Default::default(),
                     size_increment: 0,
                 };
-                if log::log_enabled!(log::Level::Trace) {
-                    log::trace!("[RawTable] creating table {}", handle);
-                }
                 Ok(e.insert(table))
             }
             Entry::Occupied(e) => Ok(e.into_mut()),
@@ -316,13 +316,15 @@ impl TableData {
     }
 
     pub fn load_object(&mut self, object_id: &ObjectID) -> VMResult<()> {
-        self.object_reference.entry(*object_id).or_insert_with(|| {
-            //TODO we should load the ObjectEntity<T> from the resolver
-            //Then cache the Object<T>
-            let object_id_value = object_id.to_runtime_value();
-            GlobalValue::cached(Value::struct_(Struct::pack(vec![object_id_value])))
-                .expect("Failed to cache the Struct")
-        });
+        self.object_reference
+            .entry(object_id.clone())
+            .or_insert_with(|| {
+                //TODO we should load the ObjectEntity<T> from the resolver
+                //Then cache the Object<T>
+                let object_id_value = object_id.to_runtime_value();
+                GlobalValue::cached(Value::struct_(Struct::pack(vec![object_id_value])))
+                    .expect("Failed to cache the Struct")
+            });
         Ok(())
     }
 
@@ -352,7 +354,7 @@ impl TableData {
                 let ref_value = self.borrow_object(object_id)?;
                 //We cache the object reference in the object_ref_in_args
                 //Ensure the reference count and the object can not be borrowed in Move
-                self.object_ref_in_args.insert(*object_id, ref_value);
+                self.object_ref_in_args.insert(object_id.clone(), ref_value);
             }
         }
         Ok(())
@@ -516,7 +518,7 @@ fn native_add_box(
 
     let val = args.pop_back().unwrap();
     let key = args.pop_back().unwrap();
-    let handle = get_table_handle(&mut args)?;
+    let handle = get_object_id(&mut args)?;
 
     let table = table_data.get_or_create_table(handle)?;
     let (tv, loaded, _, key_bytes_len) =
@@ -566,7 +568,7 @@ fn native_borrow_box(
     let mut table_data = table_context.table_data.write();
 
     let key = args.pop_back().unwrap();
-    let handle = get_table_handle(&mut args)?;
+    let handle = get_object_id(&mut args)?;
     let table = table_data.get_or_create_table(handle)?;
     let (tv, loaded, table_key, key_bytes_len) =
         get_table_runtime_value(context, table_context, table, &ty_args[0], key)?;
@@ -578,13 +580,14 @@ fn native_borrow_box(
     if tv.exists()? {
         match tv.borrow_global(value_type.clone()) {
             Ok(ref_val) => Ok(NativeResult::ok(cost, smallvec![ref_val])),
-            Err(_) => {
+            Err(err) => {
                 if log::log_enabled!(log::Level::Debug) {
                     log::warn!(
-                        "[RawTable] borrow_box type mismatch: handle: {:?}, value_type: {:?} key:{:?}.",
+                        "[RawTable] borrow_box type mismatch: handle: {:?}, value_type: {:?} key:{:?}, err: {:?}",
                         &table.handle,
                         value_type.to_canonical_string(),
-                        table_key
+                        table_key,
+                    err
                     );
                 }
                 Ok(NativeResult::err(cost, E_TYPE_MISMATCH))
@@ -633,8 +636,8 @@ fn native_contains_box(
     let mut table_data = table_context.table_data.write();
 
     let key = args.pop_back().unwrap();
-    let handle = get_table_handle(&mut args)?;
-    let table = table_data.get_or_create_table(handle)?;
+    let handle = get_object_id(&mut args)?;
+    let table = table_data.get_or_create_table(handle.clone())?;
     let (tv, loaded, table_key, key_bytes_len) =
         get_table_runtime_value(context, table_context, table, &ty_args[0], key)?;
 
@@ -680,8 +683,8 @@ fn native_contains_box_with_value_type(
     let mut table_data = table_context.table_data.write();
 
     let key = args.pop_back().unwrap();
-    let handle = get_table_handle(&mut args)?;
-    let table = table_data.get_or_create_table(handle)?;
+    let handle = get_object_id(&mut args)?;
+    let table = table_data.get_or_create_table(handle.clone())?;
     let (tv, loaded, table_key, key_bytes_len) =
         get_table_runtime_value(context, table_context, table, &ty_args[0], key)?;
 
@@ -740,7 +743,7 @@ fn native_remove_box(
     let mut table_data = table_context.table_data.write();
 
     let key = args.pop_back().unwrap();
-    let handle = get_table_handle(&mut args)?;
+    let handle = get_object_id(&mut args)?;
     let table = table_data.get_or_create_table(handle)?;
 
     let (tv, loaded, _, key_bytes_len) =
@@ -777,9 +780,12 @@ pub fn make_native_remove_box(
 // =========================================================================================
 // Helpers
 
-fn get_table_handle(args: &mut VecDeque<Value>) -> PartialVMResult<ObjectID> {
+fn get_object_id(args: &mut VecDeque<Value>) -> PartialVMResult<ObjectID> {
     let handle = args.pop_back().unwrap();
     ObjectID::from_runtime_value(handle).map_err(|e| {
+        if log::log_enabled!(log::Level::Debug) {
+            log::warn!("[RawTable] get_object_id: {:?}", e);
+        }
         PartialVMError::new(StatusCode::TYPE_RESOLUTION_FAILURE).with_message(e.to_string())
     })
 }

--- a/moveos/moveos-store/src/event_store/mod.rs
+++ b/moveos/moveos-store/src/event_store/mod.rs
@@ -63,7 +63,7 @@ impl EventDBStore {
 
     fn get_or_create_event_handle(&self, event_handle_type: &StructTag) -> Result<EventHandle> {
         let event_handle_id = EventHandle::derive_event_handle_id(event_handle_type);
-        let event_handle = self.get_event_handle(event_handle_id)?;
+        let event_handle = self.get_event_handle(event_handle_id.clone())?;
         if let Some(event_handle) = event_handle {
             return Ok(event_handle);
         }
@@ -74,7 +74,7 @@ impl EventDBStore {
 
     fn save_event_handle(&self, event_handle: EventHandle) -> Result<()> {
         self.event_handle_store
-            .put_all(vec![(event_handle.id, event_handle)])
+            .put_all(vec![(event_handle.id.clone(), event_handle)])
     }
 
     pub fn save_events(&self, tx_events: Vec<TransactionEvent>) -> Result<Vec<EventID>> {
@@ -96,15 +96,15 @@ impl EventDBStore {
                 let handle = event_handles
                     .get_mut(&tx_event.event_type)
                     .expect("Event handle must exist");
-                let event_id = EventID::new(handle.id, handle.count);
+                let event_id = EventID::new(handle.id.clone(), handle.count);
                 let event = Event::new(
-                    event_id,
+                    event_id.clone(),
                     tx_event.event_type,
                     tx_event.event_data,
                     tx_event.event_index,
                 );
                 handle.count += 1;
-                event_ids.push(event_id);
+                event_ids.push(event_id.clone());
                 ((event_id.event_handle_id, event_id.event_seq), event)
             })
             .collect::<Vec<_>>();
@@ -112,7 +112,7 @@ impl EventDBStore {
         self.event_handle_store.put_all(
             event_handles
                 .into_values()
-                .map(|handle| (handle.id, handle))
+                .map(|handle| (handle.id.clone(), handle))
                 .collect::<Vec<_>>(),
         )?;
         Ok(event_ids)
@@ -141,12 +141,14 @@ impl EventDBStore {
         limit: u64,
         descending_order: bool,
     ) -> Result<Vec<Event>> {
-        let event_handle = self.get_event_handle(*event_handle_id)?.ok_or_else(|| {
-            anyhow!(
-                "Can not find event handle by id: {}",
-                event_handle_id.to_string()
-            )
-        })?;
+        let event_handle = self
+            .get_event_handle(event_handle_id.clone())?
+            .ok_or_else(|| {
+                anyhow!(
+                    "Can not find event handle by id: {}",
+                    event_handle_id.to_string()
+                )
+            })?;
         let last_seq = event_handle.count;
 
         let ids = if descending_order {
@@ -166,7 +168,7 @@ impl EventDBStore {
 
         let event_ids = ids
             .into_iter()
-            .map(|v| (EventID::new(*event_handle_id, v)))
+            .map(|v| (EventID::new(event_handle_id.clone(), v)))
             .collect::<Vec<_>>();
         Ok(self
             .multi_get_events(event_ids)?

--- a/moveos/moveos-store/src/tests/test_store.rs
+++ b/moveos/moveos-store/src/tests/test_store.rs
@@ -113,13 +113,19 @@ fn test_event_store() {
 
     let event_ids = store.save_events(tx_events.clone()).unwrap();
     assert_eq!(event_ids.len(), 2);
-    let event0 = store.get_event(event_ids[0]).unwrap().unwrap();
+    let event0 = store
+        .get_event(event_ids.get(0).cloned().unwrap())
+        .unwrap()
+        .unwrap();
     assert_eq!(event0.event_type, tx_events[0].event_type);
     assert_eq!(event0.event_data, tx_events[0].event_data);
     assert_eq!(event0.event_index, tx_events[0].event_index);
     assert_eq!(event0.event_id.event_seq, 0);
 
-    let event1 = store.get_event(event_ids[1]).unwrap().unwrap();
+    let event1 = store
+        .get_event(event_ids.get(1).cloned().unwrap())
+        .unwrap()
+        .unwrap();
     assert_eq!(event1.event_type, tx_events[1].event_type);
     assert_eq!(event1.event_data, tx_events[1].event_data);
     assert_eq!(event1.event_index, tx_events[1].event_index);

--- a/moveos/moveos-types/src/access_path.rs
+++ b/moveos/moveos-types/src/access_path.rs
@@ -7,7 +7,7 @@ use crate::state::KeyState;
 use crate::{
     move_types::{random_identity, random_struct_tag},
     moveos_std::object::ObjectID,
-    state_resolver::{self, module_id_to_key, resource_tag_to_key},
+    state_resolver::{module_id_to_key, resource_tag_to_key},
 };
 use anyhow::Result;
 use move_core_types::language_storage::ModuleId;
@@ -256,7 +256,7 @@ impl AccessPath {
         match self.0 {
             Path::Table { table_handle, keys } => (table_handle, keys),
             Path::Object { object_ids } => {
-                let table_handle = state_resolver::GLOBAL_OBJECT_STORAGE_HANDLE;
+                let table_handle = ObjectID::root().clone();
                 let keys = Some(
                     object_ids
                         .iter()

--- a/moveos/moveos-types/src/moveos_std/any.rs
+++ b/moveos/moveos-types/src/moveos_std/any.rs
@@ -88,7 +88,7 @@ pub trait AnyTrait {
                 T::type_tag().to_canonical_string()
             );
         }
-        T::from_bytes(&data)
+        T::from_bytes(data)
     }
 }
 

--- a/moveos/moveos-types/src/moveos_std/event.rs
+++ b/moveos/moveos-types/src/moveos_std/event.rs
@@ -81,7 +81,7 @@ impl<'a> ModuleBinding<'a> for EventModule<'a> {
 /// the Unique ID is a combination of event handle id and event seq number.
 /// the ID is local to this particular fullnode and will be different from other fullnode.
 #[derive(
-    Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize, JsonSchema,
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize, JsonSchema,
 )]
 pub struct EventID {
     /// each event handle corresponds to a unique event handle id. event handler id equal to guid.

--- a/moveos/moveos-types/src/moveos_std/object.rs
+++ b/moveos/moveos-types/src/moveos_std/object.rs
@@ -2,16 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::table::TablePlaceholder;
+use crate::h256;
 use crate::moveos_std::account::Account;
 use crate::moveos_std::move_module::ModuleStore;
 use crate::state::KeyState;
-use crate::state::MoveType;
 use crate::{
     addresses::MOVEOS_STD_ADDRESS,
     state::{MoveState, MoveStructState, MoveStructType, State},
 };
-use crate::{h256, state_resolver};
-use anyhow::{bail, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Result};
 use fastcrypto::encoding::Hex;
 use move_core_types::language_storage::ModuleId;
 use move_core_types::{
@@ -23,6 +22,8 @@ use move_core_types::{
 };
 use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
 use move_vm_types::values::Struct;
+use move_vm_types::values::VMValueCast;
+use move_vm_types::values::Value;
 use once_cell::sync::Lazy;
 use primitive_types::H256;
 use schemars::JsonSchema;
@@ -34,50 +35,29 @@ pub const MODULE_NAME: &IdentStr = ident_str!("object");
 pub static MODULE_ID: Lazy<ModuleId> =
     Lazy::new(|| ModuleId::new(MOVEOS_STD_ADDRESS, MODULE_NAME.to_owned()));
 pub const OBJECT_ENTITY_STRUCT_NAME: &IdentStr = ident_str!("ObjectEntity");
-//TODO rename to ROOT_OBJECT_ID
-pub const GLOBAL_OBJECT_STORAGE_HANDLE: ObjectID = state_resolver::GLOBAL_OBJECT_STORAGE_HANDLE;
 
 // New table's state_root should be the place holder hash.
 pub static GENESIS_STATE_ROOT: Lazy<H256> = Lazy::new(|| *SPARSE_MERKLE_PLACEHOLDER_HASH);
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Hash, JsonSchema)]
-pub struct ObjectID(#[schemars(with = "Hex")] AccountAddress);
+#[derive(Eq, PartialEq, Clone, PartialOrd, Ord, Hash, JsonSchema)]
+pub struct ObjectID(#[schemars(with = "Hex")] Vec<AccountAddress>);
 
 impl ObjectID {
-    pub const LENGTH: usize = h256::LENGTH;
-
     /// Creates a new ObjectID
-    pub const fn new(obj_id: [u8; Self::LENGTH]) -> Self {
-        Self(AccountAddress::new(obj_id))
+    pub fn new(obj_id: [u8; AccountAddress::LENGTH]) -> Self {
+        Self(vec![AccountAddress::new(obj_id)])
     }
 
     pub fn root() -> Self {
-        GLOBAL_OBJECT_STORAGE_HANDLE
+        Self(vec![])
     }
 
     pub fn random() -> Self {
         Self::new(h256::H256::random().into())
     }
 
-    /// Hex address: 0x0
-    pub const ZERO: Self = Self::new([0u8; Self::LENGTH]);
-
-    /// Hex address: 0x1
-    pub const ONE: Self = Self::get_hex_object_id_one();
-
-    /// Hex address: 0x2
-    pub const TWO: Self = Self::get_hex_object_id_two();
-
-    const fn get_hex_object_id_one() -> Self {
-        let mut addr = [0u8; AccountAddress::LENGTH];
-        addr[AccountAddress::LENGTH - 1] = 1u8;
-        Self::new(addr)
-    }
-
-    const fn get_hex_object_id_two() -> Self {
-        let mut addr = [0u8; AccountAddress::LENGTH];
-        addr[AccountAddress::LENGTH - 1] = 2u8;
-        Self::new(addr)
+    pub fn zero() -> Self {
+        Self::new([0u8; AccountAddress::LENGTH])
     }
 
     /// Create an ObjectID from transaction hash digest and `creation_num`.
@@ -89,33 +69,48 @@ impl ObjectID {
         Self::new(h256::sha3_256_of(&buffer).into())
     }
 
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
-        <[u8; Self::LENGTH]>::try_from(bytes.as_ref())
-            .map_err(|_| anyhow::anyhow!("Invalid ObjectID bytes, length:{}", bytes.as_ref().len()))
-            .map(ObjectID::from)
-    }
-
-    pub fn from_key(key: KeyState) -> Result<Self> {
-        if key.key_type != Self::type_tag() {
-            return Err(anyhow::anyhow!("Invalid ObjectID type"));
-        }
-        Self::from_bytes(key.key)
-    }
-
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-
     pub fn to_key(&self) -> KeyState {
         let key_type = TypeTag::Struct(Box::new(Self::struct_tag()));
+        //We should use the bcs::to_bytes(ObjectID) as the key
         KeyState::new(self.to_bytes(), key_type)
+    }
+
+    pub fn to_hex(&self) -> String {
+        let bytes: Vec<u8> = self.0.iter().flat_map(|addr| addr.to_vec()).collect();
+        hex::encode(bytes)
+    }
+
+    pub fn from_hex_literal(literal: &str) -> Result<Self> {
+        let literal = literal.strip_prefix("0x").unwrap_or(literal);
+        let hex_len = literal.len();
+        // If the string is too short, pad it
+        if hex_len < AccountAddress::LENGTH * 2 {
+            let mut hex_str = String::with_capacity(AccountAddress::LENGTH * 2);
+            for _ in 0..AccountAddress::LENGTH * 2 - hex_len {
+                hex_str.push('0');
+            }
+            hex_str.push_str(literal);
+            Self::from_hex(hex_str.as_str())
+        } else {
+            Self::from_hex(literal)
+        }
+    }
+
+    pub fn from_hex(hex: &str) -> Result<Self> {
+        let bytes = hex::decode(hex)?;
+        Self::from_bytes(bytes)
     }
 }
 
 impl std::fmt::Display for ObjectID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // The AccountAddress display has no prefix, so we add it here
-        write!(f, "0x{}", self.0)
+        write!(f, "0x{}", self.to_hex())
+    }
+}
+
+impl std::fmt::Debug for ObjectID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{}", self.to_hex())
     }
 }
 
@@ -127,7 +122,9 @@ impl MoveStructType for ObjectID {
 
 impl MoveStructState for ObjectID {
     fn struct_layout() -> MoveStructLayout {
-        MoveStructLayout::new(vec![MoveTypeLayout::Address])
+        MoveStructLayout::new(vec![MoveTypeLayout::Vector(Box::new(
+            MoveTypeLayout::Address,
+        ))])
     }
 
     fn from_runtime_value_struct(value: Struct) -> Result<Self>
@@ -135,16 +132,15 @@ impl MoveStructState for ObjectID {
         Self: Sized,
     {
         let mut fields = value.unpack()?;
-        let address = AccountAddress::from_runtime_value(
-            fields
-                .next()
-                .ok_or_else(|| anyhow::anyhow!("Invalid ObjectID"))?,
-        )?;
-        Ok(ObjectID(address))
+        let vector = fields
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Invalid ObjectID"))?;
+        let path = vector.cast()?;
+        Ok(ObjectID(path))
     }
 
     fn to_runtime_value_struct(&self) -> Struct {
-        Struct::pack(vec![self.0.to_runtime_value()])
+        Struct::pack(vec![Value::vector_address(self.0.clone())])
     }
 }
 
@@ -164,7 +160,7 @@ impl<'de> Deserialize<'de> for ObjectID {
             let s = String::deserialize(deserializer)?;
             Ok(ObjectID::from_str(s.as_str()).map_err(serde::de::Error::custom)?)
         } else {
-            Ok(ObjectID(AccountAddress::deserialize(deserializer)?))
+            Ok(ObjectID(Vec::<AccountAddress>::deserialize(deserializer)?))
         }
     }
 }
@@ -192,30 +188,27 @@ impl TryFrom<AnnotatedMoveStruct> for ObjectID {
             .value
             .pop()
             .ok_or_else(|| anyhow::anyhow!("Invalid ObjectID"))?;
-        debug_assert!(field_name.as_str() == "id");
-        let account_address = match field_value {
-            AnnotatedMoveValue::Address(account_address) => account_address,
+        debug_assert!(field_name.as_str() == "path");
+        let path = match field_value {
+            AnnotatedMoveValue::Vector(t, vector) => {
+                debug_assert!(t == TypeTag::Address);
+                vector
+                    .into_iter()
+                    .map(|annotated_move_value| match annotated_move_value {
+                        AnnotatedMoveValue::Address(addr) => Ok(addr),
+                        _ => Err(anyhow::anyhow!("Invalid ObjectID")),
+                    })
+                    .collect::<Result<Vec<AccountAddress>>>()?
+            }
             _ => return Err(anyhow::anyhow!("Invalid ObjectID")),
         };
-        Ok(ObjectID(account_address))
-    }
-}
-
-impl From<[u8; ObjectID::LENGTH]> for ObjectID {
-    fn from(bytes: [u8; ObjectID::LENGTH]) -> Self {
-        Self::new(bytes)
+        Ok(ObjectID(path))
     }
 }
 
 impl From<AccountAddress> for ObjectID {
     fn from(address: AccountAddress) -> Self {
-        ObjectID(address)
-    }
-}
-
-impl From<ObjectID> for AccountAddress {
-    fn from(object_id: ObjectID) -> Self {
-        AccountAddress::new(object_id.0.into())
+        ObjectID(vec![address])
     }
 }
 
@@ -229,9 +222,7 @@ impl FromStr for ObjectID {
                 .map_err(|_e| anyhow::anyhow!("Named ObjectID must be a valid struct tag:{}", s))?;
             Ok(named_object_id(&struct_tag))
         } else {
-            let address = AccountAddress::from_hex_literal(s)
-                .map_err(|_e| anyhow::anyhow!("Invalid ObjectID:{}|", s))?;
-            Ok(ObjectID::from(address))
+            ObjectID::from_hex_literal(s)
         }
     }
 }
@@ -377,7 +368,7 @@ where
 
     pub fn to_raw(&self) -> RawObject {
         RawObject {
-            id: self.id,
+            id: self.id.clone(),
             owner: self.owner,
             flag: self.flag,
             value: RawData {
@@ -490,7 +481,7 @@ where
 pub type RawObject = ObjectEntity<RawData>;
 pub type RootObjectEntity = ObjectEntity<Root>;
 
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub struct RawData {
     pub struct_tag: StructTag,
     pub value: Vec<u8>,
@@ -501,27 +492,63 @@ impl RawObject {
     const MODULE_NAME: &'static IdentStr = MODULE_NAME;
     const STRUCT_NAME: &'static IdentStr = OBJECT_ENTITY_STRUCT_NAME;
 
+    //This function is from bcs module,
+    //find a better way to parse the vec.
+    fn parse_length(bytes: &[u8]) -> Result<(usize, usize)> {
+        let mut value: u64 = 0;
+        let mut iter = bytes.iter();
+        let mut used_bytes: usize = 0;
+        for shift in (0..32).step_by(7) {
+            let byte = *iter
+                .next()
+                .ok_or_else(|| anyhow!("Invalid bytes, NonCanonicalUleb128Encoding"))?;
+            used_bytes += 1;
+            let digit = byte & 0x7f;
+            value |= u64::from(digit) << shift;
+            // If the highest bit of `byte` is 0, return the final value.
+            if digit == byte {
+                if shift > 0 && digit == 0 {
+                    // We only accept canonical ULEB128 encodings, therefore the
+                    // heaviest (and last) base-128 digit must be non-zero.
+                    bail!("Invalid bytes, NonCanonicalUleb128Encoding");
+                }
+                // Decoded integer must not overflow.
+                return Ok((
+                    used_bytes,
+                    u32::try_from(value).map_err(|_| {
+                        anyhow!("Invalid bytes, IntegerOverflowDuringUleb128Decoding")
+                    })? as usize,
+                ));
+            }
+        }
+        // Decoded integer must not overflow.
+        bail!("Invalid bytes, IntegerOverflowDuringUleb128Decoding")
+    }
+
     pub fn from_bytes(bytes: &[u8], struct_tag: StructTag) -> Result<Self> {
+        let (path_len_bytes, path_len) = Self::parse_length(bytes)?;
+        let object_id_len = path_len_bytes + path_len * AccountAddress::LENGTH;
+
         ensure!(
-            bytes.len() > ObjectID::LENGTH + AccountAddress::LENGTH + AccountAddress::LENGTH,
+            bytes.len() > object_id_len + AccountAddress::LENGTH + 1 + AccountAddress::LENGTH + 8,
             "Invalid bytes length"
         );
 
-        let id: ObjectID = bcs::from_bytes(&bytes[..ObjectID::LENGTH])?;
+        let id: ObjectID = bcs::from_bytes(&bytes[..object_id_len])?;
         let owner: AccountAddress =
-            bcs::from_bytes(&bytes[ObjectID::LENGTH..ObjectID::LENGTH + AccountAddress::LENGTH])?;
-        let flag = bytes[ObjectID::LENGTH + AccountAddress::LENGTH
-            ..ObjectID::LENGTH + AccountAddress::LENGTH + 1][0];
+            bcs::from_bytes(&bytes[object_id_len..object_id_len + AccountAddress::LENGTH])?;
+        let flag = bytes
+            [object_id_len + AccountAddress::LENGTH..object_id_len + AccountAddress::LENGTH + 1][0];
         let state_root: AccountAddress = bcs::from_bytes(
-            &bytes[ObjectID::LENGTH + AccountAddress::LENGTH + 1
-                ..ObjectID::LENGTH + AccountAddress::LENGTH + 1 + AccountAddress::LENGTH],
+            &bytes[object_id_len + AccountAddress::LENGTH + 1
+                ..object_id_len + AccountAddress::LENGTH + 1 + AccountAddress::LENGTH],
         )?;
         let size: u64 = bcs::from_bytes(
-            &bytes[ObjectID::LENGTH + AccountAddress::LENGTH + 1 + AccountAddress::LENGTH
-                ..ObjectID::LENGTH + AccountAddress::LENGTH + 1 + AccountAddress::LENGTH + 8],
+            &bytes[object_id_len + AccountAddress::LENGTH + 1 + AccountAddress::LENGTH
+                ..object_id_len + AccountAddress::LENGTH + 1 + AccountAddress::LENGTH + 8],
         )?;
         let value = bytes
-            [ObjectID::LENGTH + AccountAddress::LENGTH + 1 + AccountAddress::LENGTH + 8..]
+            [object_id_len + AccountAddress::LENGTH + 1 + AccountAddress::LENGTH + 8..]
             .to_vec();
         Ok(RawObject {
             id,
@@ -670,7 +697,7 @@ impl AnnotatedObject {
 }
 
 /// In Move, Object<T> is like a pointer to ObjectEntity<T>
-#[derive(Debug, Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Object<T> {
     pub id: ObjectID,
     pub ty: std::marker::PhantomData<T>,
@@ -705,6 +732,7 @@ mod tests {
     use move_vm_types::values::Value;
 
     use super::*;
+    use anyhow::Ok;
 
     #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize)]
     struct TestStruct {
@@ -727,7 +755,7 @@ mod tests {
     fn test_object_serialize() -> Result<()> {
         //let struct_type = TestStruct::struct_tag();
         let object_value = TestStruct { count: 1 };
-        let object_id = ObjectID::new(crate::h256::H256::random().into());
+        let object_id = ObjectID::random();
         let object = ObjectEntity::new(
             object_id,
             AccountAddress::random(),
@@ -737,8 +765,9 @@ mod tests {
             object_value,
         );
 
-        let raw_object: RawObject =
-            RawObject::from_bytes(&object.to_bytes()?, TestStruct::struct_tag())?;
+        let bytes = bcs::to_bytes(&object)?;
+
+        let raw_object: RawObject = RawObject::from_bytes(&bytes, TestStruct::struct_tag())?;
 
         let object2 = bcs::from_bytes::<ObjectEntity<TestStruct>>(&raw_object.to_bytes()).unwrap();
         assert_eq!(object, object2);
@@ -784,8 +813,7 @@ mod tests {
     fn test_address_to_object_id() {
         let address = AccountAddress::random();
         let object_id = ObjectID::from(address);
-        let address2 = AccountAddress::from(object_id);
-        assert_eq!(address, address2);
+        assert_eq!(address, object_id.0[0]);
     }
 
     #[test]
@@ -823,15 +851,14 @@ mod tests {
         assert_eq!(object_id, object_id_from_json);
 
         let bytes = bcs::to_bytes(&object_id).unwrap();
-        assert!(bytes.len() == 32);
+
         let object_id_from_bytes = bcs::from_bytes(&bytes).unwrap();
         assert_eq!(object_id, object_id_from_bytes);
     }
 
     #[test]
     fn test_object_id() {
-        test_object_id_roundtrip(ObjectID::ZERO);
-        test_object_id_roundtrip(ObjectID::ONE);
+        test_object_id_roundtrip(ObjectID::zero());
         test_object_id_roundtrip(ObjectID::new(crate::h256::H256::random().into()));
     }
 
@@ -903,5 +930,14 @@ mod tests {
         let runtime_value = object_id.to_runtime_value();
         let object_id2 = ObjectID::from_runtime_value(runtime_value).unwrap();
         assert_eq!(object_id, object_id2);
+    }
+
+    #[test]
+    fn test_root_object_id() {
+        let root_object_id = ObjectID::root();
+        let bytes = root_object_id.to_bytes();
+        assert!(bytes.is_empty());
+        let key = root_object_id.to_key();
+        println!("key: {:?}", key);
     }
 }

--- a/moveos/moveos-types/src/state.rs
+++ b/moveos/moveos-types/src/state.rs
@@ -194,11 +194,11 @@ pub trait MoveState: MoveType + DeserializeOwned + Serialize {
         let self_layout = Self::type_layout();
         type_layout_match(&self_layout, other_type_layout)
     }
-    fn from_bytes(bytes: &[u8]) -> Result<Self>
+    fn from_bytes<T: AsRef<Vec<u8>>>(bytes: T) -> Result<Self>
     where
         Self: Sized,
     {
-        bcs::from_bytes(bytes)
+        bcs::from_bytes(bytes.as_ref())
             .map_err(|e| anyhow::anyhow!("Deserialize the MoveState error: {:?}", e))
     }
     fn to_bytes(&self) -> Vec<u8> {
@@ -479,7 +479,7 @@ pub trait MoveStructState: MoveState + MoveStructType + DeserializeOwned + Seria
                     Self::type_tag()
                 )
             })?;
-        Self::from_bytes(&blob)
+        Self::from_bytes(blob)
     }
 }
 
@@ -751,17 +751,17 @@ impl SplitStateChangeSet {
     }
 
     pub fn add_new_table(&mut self, table_handle: ObjectID) {
-        let table_change_set = self.get_or_insert_table_change_set(table_handle);
+        let table_change_set = self.get_or_insert_table_change_set(table_handle.clone());
         table_change_set.new_tables.insert(table_handle);
     }
 
     pub fn add_table_change(&mut self, table_handle: ObjectID, table_change: TableChange) {
-        let table_change_set = self.get_or_insert_table_change_set(table_handle);
+        let table_change_set = self.get_or_insert_table_change_set(table_handle.clone());
         table_change_set.changes.insert(table_handle, table_change);
     }
 
     pub fn add_remove_table(&mut self, table_handle: ObjectID) {
-        let table_change_set = self.get_or_insert_table_change_set(table_handle);
+        let table_change_set = self.get_or_insert_table_change_set(table_handle.clone());
         table_change_set.removed_tables.insert(table_handle);
     }
 }

--- a/moveos/moveos-types/src/state_resolver.rs
+++ b/moveos/moveos-types/src/state_resolver.rs
@@ -22,14 +22,12 @@ use move_core_types::{
 };
 use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue, MoveValueAnnotator};
 
-pub const GLOBAL_OBJECT_STORAGE_HANDLE: ObjectID = ObjectID::ZERO;
-
 pub type StateKV = (KeyState, State);
 pub type AnnotatedStateKV = (AnnotatedKeyState, AnnotatedState);
 
 /// A global state resolver which needs to be provided by the environment.
 /// This allows to lookup data in remote storage.
-/// If the handle is GLOBAL_OBJECT_STORAGE_HANDLE, it will get the data from the global state tree,
+/// If the handle is ObjectID::root(), it will get the data from the global state tree,
 /// otherwise it will get the data from the table state tree.
 /// The key can be an ObjectID or an arbitrary key of a table.
 pub trait StateResolver {
@@ -48,7 +46,7 @@ pub trait StateResolver {
 
     // get object data from global state tree.
     fn resolve_object_state(&self, object: &ObjectID) -> Result<Option<State>, anyhow::Error> {
-        self.resolve_table_item(&GLOBAL_OBJECT_STORAGE_HANDLE, &object.to_key())
+        self.resolve_table_item(&ObjectID::root(), &object.to_key())
     }
 }
 

--- a/moveos/moveos-types/src/transaction.rs
+++ b/moveos/moveos-types/src/transaction.rs
@@ -309,8 +309,8 @@ impl TransactionOutput {
             .events
             .clone()
             .into_iter()
-            .enumerate()
-            .map(|(index, event)| Event::new_with_event_id(event_ids[index], event))
+            .zip(event_ids)
+            .map(|(event, event_id)| Event::new_with_event_id(event_id, event))
             .collect::<Vec<_>>();
 
         TransactionOutput {

--- a/moveos/moveos/src/vm/tx_argument_resolver.rs
+++ b/moveos/moveos/src/vm/tx_argument_resolver.rs
@@ -15,6 +15,7 @@ use moveos_object_runtime::resolved_arg::ResolvedArg;
 use moveos_types::{
     move_std::{ascii::MoveAsciiString, string::MoveString},
     moveos_std::object::ObjectID,
+    state::MoveState,
 };
 use moveos_types::{
     moveos_std::object::Object,

--- a/sdk/typescript/rooch-sdk/src/account/account.ts
+++ b/sdk/typescript/rooch-sdk/src/account/account.ts
@@ -264,7 +264,35 @@ export class Account implements IAccount {
     const state = await this.client.getStates(accessPath)
     if (state) {
       const stateView = state as any
-      const tableId = stateView[0].value
+      //TODO decode the SessionKeys struct
+      //Return stateView example
+      // [
+      //   {
+      //     "value": "0x01870b722363e5b32c8cf65be3791e45901d6a01cdc12f15c9ea94bc6a606b6e9a",
+      //     "value_type": "0x3::session_key::SessionKeys",
+      //     "decoded_value": {
+      //       "abilities": 12,
+      //       "type": "0x3::session_key::SessionKeys",
+      //       "value": {
+      //         "keys": {
+      //           "abilities": 4,
+      //           "type": "0x2::table::Table<vector<u8>, 0x3::session_key::SessionKey>",
+      //           "value": {
+      //             "handle": {
+      //               "abilities": 12,
+      //               "type": "0x2::object::Object<0x2::table::TablePlaceholder>",
+      //               "value": {
+      //                 "id": "0x870b722363e5b32c8cf65be3791e45901d6a01cdc12f15c9ea94bc6a606b6e9a"
+      //               }
+      //             }
+      //           }
+      //         }
+      //       }
+      //     },
+      //     "display_fields": null
+      //   }
+      // ]
+      const tableId = stateView[0].decoded_value.value.keys.value.handle.value.id
 
       const accessPath = `/table/${tableId}`
       const pageView = await this.client.listStates({

--- a/sdk/typescript/rooch-sdk/src/types/rooch.ts
+++ b/sdk/typescript/rooch-sdk/src/types/rooch.ts
@@ -18,6 +18,7 @@ export type AuthenticationKey = string
 export type MultiEd25519PublicKey = string
 export type MultiEd25519Signature = string
 export type EventKey = string
+export type ObjectID = string
 
 export type ModuleId = string | { address: AccountAddress; name: Identifier }
 export type FunctionId =

--- a/sdk/typescript/rooch-sdk/tools/serdegen/rooch_types.yml
+++ b/sdk/typescript/rooch-sdk/tools/serdegen/rooch_types.yml
@@ -1,23 +1,80 @@
----
-Identifier:
-  NEWTYPESTRUCT: STR
 AccountAddress:
   NEWTYPESTRUCT:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 32
-ModuleId:
+Authenticator:
   STRUCT:
-    - address:
-        TYPENAME: AccountAddress
-    - name:
-        TYPENAME: Identifier
+    - auth_validator_id: U64
+    - payload:
+        SEQ: U8
+FunctionCall:
+  STRUCT:
+    - function_id:
+        TYPENAME: FunctionId
+    - ty_args:
+        SEQ:
+          TYPENAME: TypeTag
+    - args:
+        SEQ:
+          SEQ: U8
 FunctionId:
   STRUCT:
     - module_id:
         TYPENAME: ModuleId
     - function_name:
         TYPENAME: Identifier
+Identifier:
+  NEWTYPESTRUCT: STR
+ModuleId:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - name:
+        TYPENAME: Identifier
+MoveAction:
+  ENUM:
+    0:
+      Script:
+        NEWTYPE:
+          TYPENAME: ScriptCall
+    1:
+      Function:
+        NEWTYPE:
+          TYPENAME: FunctionCall
+    2:
+      ModuleBundle:
+        NEWTYPE:
+          SEQ:
+            SEQ: U8
+ObjectID:
+  NEWTYPESTRUCT:
+    SEQ:
+      TYPENAME: AccountAddress
+RoochTransaction:
+  STRUCT:
+    - data:
+        TYPENAME: RoochTransactionData
+    - authenticator:
+        TYPENAME: Authenticator
+RoochTransactionData:
+  STRUCT:
+    - sender:
+        TYPENAME: AccountAddress
+    - sequence_number: U64
+    - chain_id: U64
+    - max_gas_amount: U64
+    - action:
+        TYPENAME: MoveAction
+ScriptCall:
+  STRUCT:
+    - code: BYTES
+    - ty_args:
+        SEQ:
+          TYPENAME: TypeTag
+    - args:
+        SEQ:
+          SEQ: U8
 StructTag:
   STRUCT:
     - address:
@@ -57,38 +114,3 @@ TypeTag:
       u32: UNIT
     10:
       u256: UNIT
-ScriptCall:
-  STRUCT:
-    - code: BYTES
-    - ty_args:
-        SEQ:
-          TYPENAME: TypeTag
-    - args:
-        SEQ: BYTES
-FunctionCall:
-  STRUCT:
-    - function_id:
-        TYPENAME: FunctionId
-    - ty_args:
-        SEQ:
-          TYPENAME: TypeTag
-    - args:
-        SEQ: BYTES
-Bundle:
-  NEWTYPESTRUCT:
-    SEQ: BYTES
-
-MoveAction:
-  ENUM:
-    0:
-      Script:
-        NEWTYPE:
-          TYPENAME: ScriptCall
-    1:
-      Function:
-        NEWTYPE:
-          TYPENAME: FunctionCall
-    2:
-      ModuleBundle:
-        NEWTYPE:
-          TYPENAME: Bundle


### PR DESCRIPTION
## Summary

1. Make ObjectID to a path. ObjectID{address} => ObjectID{vector<address>}.
2. Add `add_object_field`,`borrow_object_field`,`borrow_mut_object_field`,`remove_object_field` to object module.
3. Refactor account module.
4. `object::borrow_object,` and `object::borrow_mut_object` also support child objects, but `object::remove` does not support removing child objects.

TODO: add more tests and examples. 

Part of #1423 