### PR TITLE
fix the check build test workflow

### DIFF
--- a/kube/runner/runner.yaml
+++ b/kube/runner/runner.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        cloud.google.com/gke-nodepool: ci-pool
+        cloud.google.com/gke-nodepool: ci-pool-200g
       image: nada9527/actions-runner-dind:v2.311.0-ubuntu-22.04-8e48463
       repository: rooch-network/rooch
       ephemeral: true


### PR DESCRIPTION
It turns out the reason was the runner disk size, now fixed.