### PR TITLE
Support child object query and add child object example

### DIFF
--- a/crates/rooch-relayer/src/lib.rs
+++ b/crates/rooch-relayer/src/lib.rs
@@ -36,6 +36,6 @@ impl TxSubmiter for Client {
         self.rooch.get_sequence_number(address).await
     }
     async fn submit_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponseView> {
-        self.rooch.execute_tx(tx).await
+        self.rooch.execute_tx(tx, None).await
     }
 }

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -7,7 +7,6 @@ use moveos_types::h256::H256;
 use moveos_types::moveos_std::account::Account;
 use moveos_types::{access_path::AccessPath, state::State, transaction::FunctionCall};
 use rooch_rpc_api::api::rooch_api::RoochAPIClient;
-use rooch_rpc_api::jsonrpc_types::TransactionWithInfoPageView;
 use rooch_rpc_api::jsonrpc_types::{
     account_view::BalanceInfoView, transaction_view::TransactionWithInfoView,
 };
@@ -16,6 +15,7 @@ use rooch_rpc_api::jsonrpc_types::{
     EventOptions, EventPageView, StateOptions, StatePageView, StructTagView,
 };
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, StateView};
+use rooch_rpc_api::jsonrpc_types::{TransactionWithInfoPageView, TxOptions};
 use rooch_types::{address::RoochAddress, transaction::rooch::RoochTransaction};
 use std::sync::Arc;
 
@@ -36,10 +36,14 @@ impl RoochRpcClient {
         Ok(self.http.get_chain_id().await?.0)
     }
 
-    pub async fn execute_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponseView> {
+    pub async fn execute_tx(
+        &self,
+        tx: RoochTransaction,
+        tx_option: Option<TxOptions>,
+    ) -> Result<ExecuteTransactionResponseView> {
         let tx_payload = bcs::to_bytes(&tx)?;
         self.http
-            .execute_raw_transaction(tx_payload.into(), None)
+            .execute_raw_transaction(tx_payload.into(), tx_option)
             .await
             .map_err(|e| anyhow::anyhow!(e))
     }

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -14,7 +14,7 @@ use rooch_config::{rooch_config_dir, ROOCH_CLIENT_CONFIG, ROOCH_SERVER_CONFIG};
 use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_key::keystore::file_keystore::FileBasedKeystore;
 use rooch_key::keystore::Keystore;
-use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, KeptVMStatusView};
+use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, KeptVMStatusView, TxOptions};
 use rooch_types::address::RoochAddress;
 use rooch_types::addresses;
 use rooch_types::crypto::Signature;
@@ -193,7 +193,7 @@ impl WalletContext {
         let client = self.get_client().await?;
         client
             .rooch
-            .execute_tx(tx)
+            .execute_tx(tx, Some(TxOptions { with_output: true }))
             .await
             .map_err(|e| RoochError::TransactionError(e.to_string()))
     }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -295,3 +295,18 @@ Feature: Rooch CLI integration tests
     Then assert: "'{{$.rpc[-1].balance}}' != '0'"
     Then stop the server
   
+  @serial
+  Scenario: basic_object example
+      Given a server for basic_object
+      Then cmd: "account create"
+      Then cmd: "move publish -p ../../examples/basic_object  --named-addresses basic_object=default"
+      Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
+      Then cmd: "move run --function default::third_party_module_for_child_object::create_child --args string:alice"
+      Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
+      
+      Then cmd: "event get-events-by-event-handle -t default::child_object::NewChildEvent"
+      Then cmd: "state --access-path /object/{{$.event[-1].data[0].decoded_event_data.value.id}}"
+      Then assert: "{{$.state[-1][0].decoded_value.value.value.value.name}} == alice"
+      
+      Then stop the server
+  

--- a/examples/basic_object/README.md
+++ b/examples/basic_object/README.md
@@ -1,6 +1,5 @@
 # A Basic Object Example
 
-TODO
 
-1. A Show different between `T: key+store` + `T: key` 
-2. Show different code style between use ObjectRef<T> as argument of entry function or borrow it from context.
+1. `basic_object.move` A simple object example to show the difference between `T: key+store` and `T: key`, how to define custom transfer rules.
+2. `child_object.move` A simple object example to show how to define a child object and how to use it.

--- a/examples/basic_object/sources/basic_object.move
+++ b/examples/basic_object/sources/basic_object.move
@@ -1,0 +1,69 @@
+module basic_object::pub_transfer{
+    use moveos_std::object::{Self, Object};
+
+    /// A object are transferable by anyone using `object::tansfer`
+    struct PubTransfer has key,store{
+        value: u64,
+    }
+
+    public fun new(value: u64) : Object<PubTransfer>{
+        object::new(PubTransfer{value}) 
+    }
+
+}
+
+module basic_object::custom_transfer{
+    use moveos_std::object::{Self, Object};
+
+    const ErrorInvalidTransfer: u64 = 1;
+
+    /// A object support custom transfer rule
+    struct CustomTransfer has key{
+        value: u64,
+    }
+
+    public fun new(value: u64) : Object<CustomTransfer>{
+        object::new(CustomTransfer{value}) 
+    }
+
+    fun custom_transfer_role(obj: &Object<CustomTransfer>) {
+        assert!(object::borrow(obj).value > 10, ErrorInvalidTransfer);
+    }
+
+    public fun transfer(obj: Object<CustomTransfer>, new_owner: address) {
+        custom_transfer_role(&obj);
+        //We use `object::transfer_extend` to extend the transfer rule
+        object::transfer_extend(obj, new_owner);
+    }
+}
+
+module basic_object::third_party_module{
+    use moveos_std::object;
+    use moveos_std::tx_context;
+
+    public fun create_and_pub_transfer(value: u64){
+        let obj = basic_object::pub_transfer::new(value);
+        object::transfer(obj, tx_context::sender());
+    }
+
+    public fun create_and_custom_transfer(value: u64){
+        let obj = basic_object::custom_transfer::new(value);
+        //We can not use `object::transfer` here, because the `T` of `object::transfer<T: key+store>` require the object to be `store`
+        //And we also can not use `object::transfer_extend` here, because the `T` of `object::transfer_extend<T: key>` require `#[private_generics(T)]`
+        //We only can use `object::transfer_extend` in the module where the object is defined
+        //object::transfer(obj, tx_context::sender());
+        basic_object::custom_transfer::transfer(obj, tx_context::sender());
+    }
+
+    #[test]
+    fun test_transfer_success(){
+        create_and_pub_transfer(100);
+        create_and_custom_transfer(100);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = basic_object::custom_transfer::ErrorInvalidTransfer, location = basic_object::custom_transfer)]
+    fun test_transfer_fail(){
+        create_and_custom_transfer(5);
+    }
+}

--- a/examples/basic_object/sources/child_object.move
+++ b/examples/basic_object/sources/child_object.move
@@ -1,0 +1,92 @@
+module basic_object::child_object{
+    use std::string::String;
+    use moveos_std::object::{Self, Object, ObjectID};
+
+    struct Parent has key{
+        sequencer: u64,
+    }
+    struct Child has key,store{
+        sequencer: u64,
+        name: String,
+    }
+
+    struct NewChildEvent has copy, drop{
+        id: ObjectID,
+        sequencer: u64,
+    }
+
+    struct ChildRemovedEvent has copy, drop{
+        id: ObjectID,
+        sequencer: u64,
+    }
+
+    fun init(){
+        let parent = object::new_named_object(Parent{sequencer:0});
+        object::to_shared(parent);
+    }
+
+    fun borrow_mut_parent() : &mut Object<Parent> {
+        let parent_obj_id = object::named_object_id<Parent>();
+        object::borrow_mut_object_shared<Parent>(parent_obj_id)
+    }
+
+    public fun new_child(name: String): Object<Child> {
+        let parent_obj = borrow_mut_parent();
+        let new_sequencer = object::borrow(parent_obj).sequencer + 1;
+        let child = object::add_object_field(parent_obj, Child{sequencer:new_sequencer, name:name});
+        let id = object::id(&child);
+        object::borrow_mut(parent_obj).sequencer = new_sequencer;
+        moveos_std::event::emit(NewChildEvent{id:id, sequencer:new_sequencer});
+        child
+    }
+
+    public fun remove_child(child: Object<Child>){
+        let parent_obj = borrow_mut_parent();
+        let id = object::id(&child);
+        let Child{ sequencer, name:_ } = object::remove_object_field(parent_obj, child);
+        moveos_std::event::emit(ChildRemovedEvent{id:id, sequencer:sequencer});
+    }
+
+    public fun update_name(child: &mut Object<Child>, name: String){
+        let child = object::borrow_mut(child);
+        child.name = name;
+    }
+
+    #[test_only]
+    public fun init_for_testing(){
+        init();
+    }
+}
+
+module basic_object::third_party_module_for_child_object{
+    use std::string::String;
+    use moveos_std::tx_context;
+    use moveos_std::object::{Self, Object, ObjectID};
+    use basic_object::child_object::{Self, Child};
+
+    public entry fun create_child(name: String){
+        let child = child_object::new_child(name);
+        object::transfer(child, tx_context::sender());
+    }
+
+    public entry fun update_child_name(child: &mut Object<Child>, name: String){
+        child_object::update_name(child, name);
+    }
+
+    public entry fun update_child_name_via_id(sender: &signer, child_id: ObjectID, name: String){
+        let child = object::borrow_mut_object<Child>(sender, child_id);
+        child_object::update_name(child, name);
+    }
+
+    public entry fun remove_child_via_id(sender: &signer, child_id: ObjectID){
+        let child = object::take_object<Child>(sender, child_id);
+        child_object::remove_child(child);
+    }
+
+    #[test]
+    fun test_create_child(){
+        child_object::init_for_testing();
+        create_child(std::string::utf8(b"Alice"));
+    }
+}
+

--- a/examples/basic_object/sources/public_object.move
+++ b/examples/basic_object/sources/public_object.move
@@ -1,3 +1,0 @@
-module basic_object::public_object{
-    
-}

--- a/moveos/moveos-types/src/moveos_std/object.rs
+++ b/moveos/moveos-types/src/moveos_std/object.rs
@@ -69,6 +69,25 @@ impl ObjectID {
         Self::new(h256::sha3_256_of(&buffer).into())
     }
 
+    /// Get the parent ObjectID of the current ObjectID
+    pub fn parent(&self) -> Option<Self> {
+        if self.0.is_empty() {
+            None
+        } else {
+            let mut parent = self.0.clone();
+            parent.pop();
+            Some(Self(parent))
+        }
+    }
+
+    pub fn is_root(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn has_parent(&self) -> bool {
+        !self.is_root()
+    }
+
     pub fn to_key(&self) -> KeyState {
         let key_type = TypeTag::Struct(Box::new(Self::struct_tag()));
         //We should use the bcs::to_bytes(ObjectID) as the key

--- a/moveos/moveos-types/src/state_resolver.rs
+++ b/moveos/moveos-types/src/state_resolver.rs
@@ -161,10 +161,10 @@ pub fn module_id_to_key(module_id: &ModuleId) -> KeyState {
 pub trait StateReader: StateResolver {
     /// Get states by AccessPath
     fn get_states(&self, path: AccessPath) -> Result<Vec<Option<State>>> {
-        let (handle, keys) = path.into_table_query();
-        let keys = keys.ok_or_else(|| anyhow::anyhow!("AccessPath invalid path"))?;
-        keys.into_iter()
-            .map(|key| self.resolve_table_item(&handle, &key))
+        let query = path.into_state_query().into_fields_query()?;
+        query
+            .into_iter()
+            .map(|(object_id, key)| self.resolve_table_item(&object_id, &key))
             .collect()
     }
 
@@ -175,8 +175,8 @@ pub trait StateReader: StateResolver {
         cursor: Option<KeyState>,
         limit: usize,
     ) -> Result<Vec<StateKV>> {
-        let (handle, _keys) = path.into_table_query();
-        self.list_table_items(&handle, cursor, limit)
+        let query = path.into_state_query().into_list_query()?;
+        self.list_table_items(&query, cursor, limit)
     }
 }
 


### PR DESCRIPTION
## Summary

1. AccessPath supports child objects.
2. Add a child object example.

Follow #1456 

Part of #1423 