### PR TITLE
[indexer] Indexer support child object

### DIFF
--- a/crates/rooch-indexer/src/tests/test_indexer.rs
+++ b/crates/rooch-indexer/src/tests/test_indexer.rs
@@ -276,14 +276,8 @@ fn test_state_store() -> Result<()> {
     // test state sync
     let state_change_set = random_state_change_set();
     let mut split_state_change_set = SplitStateChangeSet::default();
-    for table_handle in state_change_set.new_tables {
-        split_state_change_set.add_new_table(table_handle);
-    }
     for (table_handle, table_change) in state_change_set.changes.clone() {
         split_state_change_set.add_table_change(table_handle, table_change);
-    }
-    for table_handle in state_change_set.removed_tables.clone() {
-        split_state_change_set.add_remove_table(table_handle);
     }
 
     let mut indexed_table_change_sets = vec![];

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -2185,9 +2185,7 @@
       "StateChangeSetView": {
         "type": "object",
         "required": [
-          "changes",
-          "new_tables",
-          "removed_tables"
+          "changes"
         ],
         "properties": {
           "changes": {
@@ -2195,20 +2193,6 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/TableChangeView"
             }
-          },
-          "new_tables": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ObjectID"
-            },
-            "uniqueItems": true
-          },
-          "removed_tables": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ObjectID"
-            },
-            "uniqueItems": true
           }
         }
       },
@@ -2327,8 +2311,7 @@
       "TableChangeView": {
         "type": "object",
         "required": [
-          "entries",
-          "size_increment"
+          "entries"
         ],
         "properties": {
           "entries": {
@@ -2336,10 +2319,6 @@
             "items": {
               "$ref": "#/components/schemas/DynamicFieldView"
             }
-          },
-          "size_increment": {
-            "type": "integer",
-            "format": "int64"
           }
         }
       },

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -209,16 +209,12 @@ impl From<TableTypeInfoView> for TableTypeInfo {
 
 #[derive(Default, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct StateChangeSetView {
-    pub new_tables: BTreeSet<ObjectID>,
-    pub removed_tables: BTreeSet<ObjectID>,
     pub changes: BTreeMap<ObjectID, TableChangeView>,
 }
 
 impl From<StateChangeSet> for StateChangeSetView {
     fn from(table_change_set: StateChangeSet) -> Self {
         Self {
-            new_tables: table_change_set.new_tables,
-            removed_tables: table_change_set.removed_tables,
             changes: table_change_set
                 .changes
                 .into_iter()
@@ -272,7 +268,6 @@ impl DynamicFieldView {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct TableChangeView {
     pub entries: Vec<DynamicFieldView>,
-    pub size_increment: i64,
 }
 
 impl From<TableChange> for TableChangeView {
@@ -283,7 +278,6 @@ impl From<TableChange> for TableChangeView {
                 .into_iter()
                 .map(|(k, v)| DynamicFieldView::new(k.into(), v.into()))
                 .collect::<Vec<_>>(),
-            size_increment: table_change.size_increment,
         }
     }
 }
@@ -296,7 +290,6 @@ impl From<TableChangeView> for TableChange {
                 .into_iter()
                 .map(|kv| (kv.k.into(), kv.v.into()))
                 .collect(),
-            size_increment: table_change.size_increment,
         }
     }
 }
@@ -304,8 +297,6 @@ impl From<TableChangeView> for TableChange {
 impl From<StateChangeSetView> for StateChangeSet {
     fn from(table_change_set: StateChangeSetView) -> Self {
         Self {
-            new_tables: table_change_set.new_tables,
-            removed_tables: table_change_set.removed_tables,
             changes: table_change_set
                 .changes
                 .into_iter()

--- a/crates/rooch-types/src/test_utils.rs
+++ b/crates/rooch-types/src/test_utils.rs
@@ -296,18 +296,7 @@ pub fn random_table_change() -> TableChange {
 pub fn random_state_change_set() -> StateChangeSet {
     let mut state_change_set = StateChangeSet::default();
 
-    // generate new tables
     let mut rng = thread_rng();
-    for _n in 0..rng.gen_range(1..=5) {
-        let handle = ObjectID::from(AccountAddress::random());
-        state_change_set.new_tables.insert(handle);
-    }
-
-    // generate remove tables
-    for _n in 0..rng.gen_range(1..=5) {
-        let handle = ObjectID::from(AccountAddress::random());
-        state_change_set.removed_tables.insert(handle);
-    }
 
     // generate change tables
     for _n in 0..rng.gen_range(1..=5) {

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -314,6 +314,12 @@ Feature: Rooch CLI integration tests
       Then cmd: "state --access-path /object/{{$.event[-1].data[0].decoded_event_data.value.id}}"
       Then assert: "{{$.state[-1][0].decoded_value.value.value.value.name}} == bob"
 
+      Then cmd: "rpc request --method rooch_queryGlobalStates --params '[{"object_type":"{{$.address_mapping.default}}::child_object::Child"}, null, "10", true]'"
+      Then assert: "{{$.rpc[-1].data[0].object_id}} == {{$.event[-1].data[0].decoded_event_data.value.id}}"
+
+      #TODO fix child dynamic field
+      #Then cmd: "move run --function default::third_party_module_for_child_object::update_child_age --args object:{{$.event[-1].data[0].decoded_event_data.value.id}} --args u64:10"
+      
       Then cmd: "move run --function default::third_party_module_for_child_object::remove_child_via_id --args object_id:{{$.event[-1].data[0].decoded_event_data.value.id}}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 

--- a/examples/basic_object/sources/child_object.move
+++ b/examples/basic_object/sources/child_object.move
@@ -41,6 +41,7 @@ module basic_object::child_object{
     }
 
     public fun remove_child(child: Object<Child>){
+        remove_child_property<u64>(&mut child, std::string::utf8(b"age"));
         let parent_obj = borrow_mut_parent();
         let id = object::id(&child);
         let Child{ sequencer, name:_ } = object::remove_object_field(parent_obj, child);
@@ -52,9 +53,41 @@ module basic_object::child_object{
         child.name = name;
     }
 
+    public fun update_age(child: &mut Object<Child>, age: u64){
+        update_child_property(child, std::string::utf8(b"age"), age);
+    }
+
+    public fun get_age(child: &Object<Child>) : u64{
+        *get_child_property(child, std::string::utf8(b"age"))
+    }
+
+    fun update_child_property<V: store + drop>(child: &mut Object<Child>, property: String, value: V){
+        object::upsert_field(child, property, value);
+    }
+
+    fun get_child_property<V: store + drop>(child: &Object<Child>, property: String): &V{
+        object::borrow_field(child, property)
+    }
+
+    fun remove_child_property<V: store + drop>(child: &mut Object<Child>, property: String){
+        if(object::contains_field(child, property)){
+            let _v:V = object::remove_field(child, property);
+        }
+    }
+
     #[test_only]
     public fun init_for_testing(){
         init();
+    }
+
+    #[test]
+    fun test_child(){
+        init();
+        let child = new_child(std::string::utf8(b"Alice"));
+        update_name(&mut child, std::string::utf8(b"Bob"));
+        update_age(&mut child,11);
+        assert!(get_age(&child) == 11, 1000);
+        remove_child(child);
     }
 }
 
@@ -76,6 +109,10 @@ module basic_object::third_party_module_for_child_object{
     public entry fun update_child_name_via_id(sender: &signer, child_id: ObjectID, name: String){
         let child = object::borrow_mut_object<Child>(sender, child_id);
         child_object::update_name(child, name);
+    }
+
+    public entry fun update_child_age(child: &mut Object<Child>, age: u64){
+        child_object::update_age(child, age);
     }
 
     public entry fun remove_child_via_id(sender: &signer, child_id: ObjectID){

--- a/moveos/moveos-store/src/tests/test_state_store.rs
+++ b/moveos/moveos-store/src/tests/test_state_store.rs
@@ -155,7 +155,6 @@ fn test_statedb_state_root() -> Result<()> {
         .get_state_store_mut()
         .apply_change_set(random_state_change_set())?;
     assert_ne!(state_root, new_state_root);
-    assert_ne!(size, new_size);
     Ok(())
 }
 

--- a/moveos/moveos/src/vm/data_cache.rs
+++ b/moveos/moveos/src/vm/data_cache.rs
@@ -247,10 +247,10 @@ pub fn into_change_set(
             .with_message("TableData is referenced more than once".to_owned())
     })?;
     let data = table_data.into_inner();
-    let (tx_context, new_tables, removed_tables, tables) = data.into_inner();
+    let (tx_context, tables) = data.into_inner();
     let mut changes = BTreeMap::new();
     for (handle, table) in tables {
-        let (_, content, size_increment) = table.into_inner();
+        let (_, content) = table.into_inner();
         let mut entries = BTreeMap::new();
         for (key, table_value) in content {
             let (value_layout, value_type, op) = match table_value.into_effect() {
@@ -284,25 +284,10 @@ pub fn into_change_set(
             }
         }
         if !entries.is_empty() {
-            changes.insert(
-                handle,
-                TableChange {
-                    entries,
-                    size_increment,
-                },
-            );
-        } else {
-            debug_assert!(size_increment == 0);
+            changes.insert(handle, TableChange { entries });
         }
     }
-    Ok((
-        tx_context,
-        StateChangeSet {
-            new_tables,
-            removed_tables,
-            changes,
-        },
-    ))
+    Ok((tx_context, StateChangeSet { changes }))
 }
 
 // Unbox a value of `moveos_std::raw_table::Box<V>` to V and serialize it.


### PR DESCRIPTION
## Summary

Follow #1466 

The indexer supports the child object and puts all children in the global states table.

TODO:
1. Refactor the ChangeSet to fix the child object dynamic field bug.
2. Rename global_states table to object_states table, and table_states table to field_states table.