### PR TITLE
feat(tx): cache data_hash for RoochTransaction

### DIFF
--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -115,7 +115,7 @@ impl ExecutorActor {
                 .0;
 
             //TODO should we save the genesis txs to sequencer?
-            for (genesis_tx, (state_root, size, genesis_tx_output)) in
+            for (mut genesis_tx, (state_root, size, genesis_tx_output)) in
                 self.genesis.genesis_txs().into_iter().zip(genesis_result)
             {
                 let tx_hash = genesis_tx.tx_hash();

--- a/crates/rooch-indexer/src/types.rs
+++ b/crates/rooch-indexer/src/types.rs
@@ -53,7 +53,7 @@ pub struct IndexedTransaction {
 
 impl IndexedTransaction {
     pub fn new(
-        transaction: LedgerTransaction,
+        mut transaction: LedgerTransaction,
         execution_info: TransactionExecutionInfo,
         moveos_tx: VerifiedMoveOSTransaction,
     ) -> Result<Self> {
@@ -133,7 +133,7 @@ pub struct IndexedEvent {
 impl IndexedEvent {
     pub fn new(
         event: Event,
-        transaction: LedgerTransaction,
+        mut transaction: LedgerTransaction,
         moveos_tx: VerifiedMoveOSTransaction,
     ) -> Self {
         IndexedEvent {

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -127,7 +127,8 @@ impl RoochAPIServer for RoochServer {
 
     async fn send_raw_transaction(&self, payload: BytesView) -> RpcResult<H256View> {
         info!("send_raw_transaction payload: {:?}", payload);
-        let tx = bcs::from_bytes::<RoochTransaction>(&payload.0).map_err(anyhow::Error::from)?;
+        let mut tx =
+            bcs::from_bytes::<RoochTransaction>(&payload.0).map_err(anyhow::Error::from)?;
         info!("send_raw_transaction tx: {:?}", tx);
 
         let hash = tx.tx_hash();

--- a/crates/rooch-sequencer/src/actor/sequencer.rs
+++ b/crates/rooch-sequencer/src/actor/sequencer.rs
@@ -42,7 +42,7 @@ impl SequencerActor {
         })
     }
 
-    pub fn sequence(&mut self, tx_data: LedgerTxData) -> Result<LedgerTransaction> {
+    pub fn sequence(&mut self, mut tx_data: LedgerTxData) -> Result<LedgerTransaction> {
         let tx_order = if self.last_order == 0 {
             let last_order_opt = self
                 .rooch_store

--- a/crates/rooch-store/src/transaction_store/mod.rs
+++ b/crates/rooch-store/src/transaction_store/mod.rs
@@ -59,7 +59,7 @@ impl TransactionDBStore {
         }
     }
 
-    pub fn save_transaction(&mut self, transaction: LedgerTransaction) -> Result<()> {
+    pub fn save_transaction(&mut self, mut transaction: LedgerTransaction) -> Result<()> {
         let tx_hash = transaction.tx_hash();
         let tx_order = transaction.sequence_info.tx_order;
         self.tx_store.kv_put(tx_hash, transaction)?;

--- a/crates/rooch-types/src/transaction/ledger_transaction.rs
+++ b/crates/rooch-types/src/transaction/ledger_transaction.rs
@@ -24,7 +24,7 @@ impl L1Block {
     }
 
     pub fn tx_size(&self) -> u64 {
-        bcs::serialized_size(self).expect("serialize size should success") as u64
+        bcs::serialized_size(self).expect("serialize transaction size should success") as u64
     }
 }
 
@@ -41,7 +41,7 @@ pub enum LedgerTxData {
 }
 
 impl LedgerTxData {
-    pub fn tx_hash(&self) -> H256 {
+    pub fn tx_hash(&mut self) -> H256 {
         match self {
             LedgerTxData::L1Block(block) => block.tx_hash(),
             LedgerTxData::L2Tx(tx) => tx.tx_hash(),
@@ -87,7 +87,7 @@ impl LedgerTransaction {
         }
     }
 
-    pub fn tx_hash(&self) -> H256 {
+    pub fn tx_hash(&mut self) -> H256 {
         self.data.tx_hash()
     }
 

--- a/crates/rooch-types/src/transaction/rooch.rs
+++ b/crates/rooch-types/src/transaction/rooch.rs
@@ -76,6 +76,7 @@ pub struct RoochTransaction {
     data: RoochTransactionData,
     authenticator: Authenticator,
 
+    #[serde(skip_serializing, skip_deserializing)]
     data_hash: Option<H256>,
 }
 


### PR DESCRIPTION
## Summary

### pros.

1. saving redundant calculation

### cons.

1. change struct of RoochTransaction, the result of serilization changed
2. mut tx

### other approach

1. outside cache with limit @jolestar 
