### PR TITLE
chore: Optimize Link Time Optimization (LTO) and add benchmarking profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,13 +346,16 @@ inherits = "release"
 opt-level = 3
 debug = true
 overflow-checks = true
-lto = true
+lto = "thin"
 codegen-units = 1
 
 [profile.cli]
 inherits = "release"
 debug = false
 opt-level = "z"
-lto = true
+lto = "thin"
 strip = true
 codegen-units = 1
+
+[profile.bench]
+debug = true


### PR DESCRIPTION
## Summary

Switched Link Time Optimization (LTO) from 'true' to 'thin' to optimize the speed of the build while retaining the benefits of LTO. A new `bench` profile has been added to aid in performance testing and benchmarking activities

