### PR TITLE
[Bitcoin] Refine inscribe inscriptions flow

### DIFF
--- a/crates/rooch-relayer/src/actor/bitcoin_relayer.rs
+++ b/crates/rooch-relayer/src/actor/bitcoin_relayer.rs
@@ -152,9 +152,10 @@ impl BitcoinRelayer {
             let block_height = block_result.header_info.height;
             let block_hash = block_result.header_info.hash;
             let time = block_result.block.header.time;
+            let tx_size = block_result.block.txdata.len();
             info!(
-                "BitcoinRelayer process block, height: {}, hash: {}, time: {}",
-                block_height, block_hash, time
+                "BitcoinRelayer process block, height: {}, hash: {}, tx_size: {}, time: {}",
+                block_height, block_hash, tx_size, time
             );
             debug!("GetBlockHeaderResult: {:?}", block_result);
 

--- a/crates/rooch-types/src/into_address.rs
+++ b/crates/rooch-types/src/into_address.rs
@@ -68,6 +68,7 @@ mod tests {
     use crate::into_address::IntoAddress;
     use bitcoin::hashes::Hash;
     use move_core_types::account_address::AccountAddress;
+    use std::str::FromStr;
 
     #[test]
     fn test_txid_into_address() {
@@ -106,6 +107,20 @@ mod tests {
         assert_eq!(
             "6ea3bf728b34c8c01ba4703e00ad688be100599b92fbdac71e6aea6ad8355552",
             txid.to_string()
+        );
+    }
+
+    #[test]
+    fn test_txid_to_address() {
+        let txid = bitcoin::Txid::from_str(
+            "207322afdcca902cb36aeb674214dc5f80f9593f12c1de57830ad33adae46a0a",
+        )
+        .unwrap();
+        let address = txid.into_address();
+        println!("{}", address);
+        assert_eq!(
+            "0a6ae4da3ad30a8357dec1123f59f9805fdc144267eb6ab32c90cadcaf227320",
+            address.to_string()
         );
     }
 }

--- a/crates/rooch-types/src/into_address.rs
+++ b/crates/rooch-types/src/into_address.rs
@@ -102,10 +102,10 @@ mod tests {
         .unwrap();
         //The txid hex string use reverse order
         let txid = bitcoin::Txid::from_byte_array(addr.into());
-        println!("{}", txid);
-        // assert_eq!(
-        //     "6ea3bf728b34c8c01ba4703e00ad688be100599b92fbdac71e6aea6ad8355552",
-        //     txid.to_string()
-        // );
+        // println!("{}", txid);
+        assert_eq!(
+            "6ea3bf728b34c8c01ba4703e00ad688be100599b92fbdac71e6aea6ad8355552",
+            txid.to_string()
+        );
     }
 }

--- a/frameworks/bitcoin-move/sources/light_client.move
+++ b/frameworks/bitcoin-move/sources/light_client.move
@@ -182,21 +182,20 @@ module bitcoin_move::light_client{
 
             idx = idx + 1;
         };
-        //If a utxo is spend seal assets, it should not seal new assets
+
+        // Transfer and inscribe may happen at the same transaction
         if(data_import_config::is_ord_mode(data_import_mode)) {
-            if (simple_multimap::length(&output_seals) == 0) {
-                let sat_points = ord::process_transaction(tx, input_utxo_values);
-                let idx = 0;
-                let protocol = type_info::type_name<Inscription>();
-                let sat_points_len = vector::length(&sat_points);
-                while (idx < sat_points_len) {
-                    let sat_point = vector::pop_back(&mut sat_points);
-                    let output_index = ord::sat_point_output_index(&sat_point);
-                    let seal_object_id = ord::sat_point_object_id(&sat_point);
-                    let utxo_seal = utxo::new_utxo_seal(protocol, seal_object_id);
-                    simple_multimap::add(&mut output_seals, output_index, utxo_seal);
-                    idx = idx + 1;
-                };
+            let sat_points = ord::process_transaction(tx, input_utxo_values);
+            let idx = 0;
+            let protocol = type_info::type_name<Inscription>();
+            let sat_points_len = vector::length(&sat_points);
+            while (idx < sat_points_len) {
+                let sat_point = vector::pop_back(&mut sat_points);
+                let output_index = ord::sat_point_output_index(&sat_point);
+                let seal_object_id = ord::sat_point_object_id(&sat_point);
+                let utxo_seal = utxo::new_utxo_seal(protocol, seal_object_id);
+                simple_multimap::add(&mut output_seals, output_index, utxo_seal);
+                idx = idx + 1;
             };
         };
 

--- a/frameworks/bitcoin-move/sources/light_client.move
+++ b/frameworks/bitcoin-move/sources/light_client.move
@@ -92,7 +92,8 @@ module bitcoin_move::light_client{
         let idx = 0;
         let coinbase_tx_idx = 0;
         let flotsams = vector::empty();
-        while(idx < vector::length(txdata)){
+        let tx_len = vector::length(txdata);
+        while(idx < tx_len){
             let tx = vector::borrow(txdata, idx);
 
             let is_coinbase = is_coinbase_tx(tx);

--- a/frameworks/bitcoin-move/sources/ord.move
+++ b/frameworks/bitcoin-move/sources/ord.move
@@ -368,9 +368,10 @@ module bitcoin_move::ord {
         let output_len = vector::length(tx_outputs);
 
         // ord has three mode for Inscribe:   SameSat,SeparateOutputs,SharedOutput,
-        //https://github.com/ordinals/ord/blob/master/src/subcommand/wallet/inscribe/batch.rs#L533
-        //TODO handle SameSat
-        let is_separate_outputs = output_len > inscriptions_len;
+        // SameSat and SharedOutput have only one output
+        // When SeparateOutputs is used, the number of output and inscription is consistent.
+        // https://github.com/ordinals/ord/blob/26fcf05a738e68ef8c9c18fcc0997ccf931d6f41/src/wallet/batch/plan.rs#L270-L307
+        let is_separate_outputs = output_len == inscriptions_len;
         let idx = 0;
         // reverse inscriptions and pop from the end
         vector::reverse(&mut inscriptions);

--- a/frameworks/bitcoin-move/sources/ord.move
+++ b/frameworks/bitcoin-move/sources/ord.move
@@ -355,13 +355,13 @@ module bitcoin_move::ord {
     }
 
     public fun process_transaction(tx: &Transaction, input_utxo_values: vector<u64>): vector<SatPoint>{
-        let output_seals = vector::empty();
+        let sat_points = vector::empty();
 
         let inscriptions = from_transaction(tx, option::some(input_utxo_values));
         let inscriptions_len = vector::length(&inscriptions);
         if(inscriptions_len == 0){
             vector::destroy_empty(inscriptions);
-            return output_seals
+            return sat_points
         };
 
         let tx_outputs = types::tx_output(tx);
@@ -398,14 +398,14 @@ module bitcoin_move::ord {
             object::transfer_extend(inscription_obj, to_address);
 
             let new_sat_point = new_sat_point((output_index as u32), offset, object_id);
-            vector::push_back(&mut output_seals, new_sat_point);
+            vector::push_back(&mut sat_points, new_sat_point);
 
             //Auto create address mapping if not exist
             bind_multichain_address(to_address, bitcoin_address_opt);
             idx = idx + 1;
         };
         vector::destroy_empty(inscriptions);
-        output_seals
+        sat_points
     }
  
     fun validate_inscription_records(tx_id: address, input_index: u64, record: vector<InscriptionRecord>): vector<InscriptionRecord>{


### PR DESCRIPTION
## Summary

1. Allow transfer and inscribe at the same transaction.
2. Confirm batch inscribe logic is correct handling.
  There are three modes for Inscribe: SameSat, SeparateOutputs, SharedOutput
   SameSat and SharedOutput mode have only one output.
   When SeparateOutputs is used, the number of output and inscription is consistent.

- Closes #issue