### PR TITLE
[statedb] Refactor StateDB and StateResolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9252,6 +9252,7 @@ dependencies = [
  "rooch-da",
  "rooch-executor",
  "rooch-framework",
+ "rooch-genesis",
  "rooch-indexer",
  "rooch-key",
  "rooch-pipeline-processor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8558,6 +8558,7 @@ dependencies = [
  "rooch-executor",
  "rooch-framework",
  "rooch-framework-tests",
+ "rooch-genesis",
  "rooch-indexer",
  "rooch-key",
  "rooch-pipeline-processor",

--- a/crates/rooch-benchmarks/Cargo.toml
+++ b/crates/rooch-benchmarks/Cargo.toml
@@ -73,6 +73,7 @@ rooch-rpc-server = { workspace = true }
 rooch-test-transaction-builder = { workspace = true }
 rooch-framework = { workspace = true }
 rooch-framework-tests = { workspace = true }
+rooch-genesis = { workspace = true }
 
 [dev-dependencies]
 

--- a/crates/rooch-benchmarks/src/tx.rs
+++ b/crates/rooch-benchmarks/src/tx.rs
@@ -28,6 +28,7 @@ use rooch_executor::actor::reader_executor::ReaderExecutorActor;
 use rooch_executor::proxy::ExecutorProxy;
 use rooch_framework::natives::default_gas_schedule;
 use rooch_framework_tests::binding_test;
+use rooch_genesis::RoochGenesis;
 use rooch_indexer::actor::indexer::IndexerActor;
 use rooch_indexer::actor::reader_indexer::IndexerReaderActor;
 use rooch_indexer::indexer_reader::IndexerReader;
@@ -118,7 +119,7 @@ lazy_static! {
 }
 
 pub fn gen_sequencer(keypair: RoochKeyPair, rooch_store: RoochStore) -> Result<SequencerActor> {
-    SequencerActor::new(keypair, rooch_store.clone(), true) // is_genesis is useless for sequencer in present
+    SequencerActor::new(keypair, rooch_store.clone())
 }
 
 //TODO reuse the rpc run_start_server function
@@ -134,7 +135,7 @@ pub async fn setup_service(
     let chain_id = RoochChainID::LOCAL;
 
     // init storage
-    let (moveos_store, rooch_store) = init_storage(datadir)?;
+    let (mut moveos_store, rooch_store) = init_storage(datadir)?;
     let (indexer_store, indexer_reader) = init_indexer(datadir)?;
 
     // init keystore
@@ -152,19 +153,25 @@ pub async fn setup_service(
     let _relayer_account = RoochAddress::from(&relayer_keypair.public());
 
     // Init executor
-    let is_genesis = moveos_store.statedb.is_genesis();
     let btc_network = Network::default().to_num();
     let data_import_mode = DataImportMode::default().to_num();
     let gas_schedule_blob =
         bcs::to_bytes(&default_gas_schedule()).expect("Failure serializing genesis gas schedule");
+
+    let genesis_ctx = chain_id.genesis_ctx(rooch_account, gas_schedule_blob);
+    let bitcoin_genesis_ctx = BitcoinGenesisContext::new(btc_network, data_import_mode);
+    let genesis: RoochGenesis = RoochGenesis::build(genesis_ctx, bitcoin_genesis_ctx)?;
+    let root = genesis.init_genesis(&mut moveos_store)?;
+
     let executor_actor = ExecutorActor::new(
-        chain_id.genesis_ctx(rooch_account, gas_schedule_blob),
-        BitcoinGenesisContext::new(btc_network, data_import_mode),
+        root.clone(),
+        genesis.clone(),
         moveos_store.clone(),
         rooch_store.clone(),
     )?;
     let reader_executor = ReaderExecutorActor::new(
-        executor_actor.genesis().clone(),
+        root.clone(),
+        genesis,
         moveos_store.clone(),
         rooch_store.clone(),
     )?
@@ -177,7 +184,7 @@ pub async fn setup_service(
 
     // Init sequencer
     info!("RPC Server sequencer address: {:?}", sequencer_account);
-    let sequencer = SequencerActor::new(sequencer_keypair, rooch_store.clone(), is_genesis)?
+    let sequencer = SequencerActor::new(sequencer_keypair, rooch_store.clone())?
         .into_actor(Some("Sequencer"), &actor_system)
         .await?;
     let sequencer_proxy = SequencerProxy::new(sequencer.into());
@@ -209,7 +216,7 @@ pub async fn setup_service(
     timers.push(proposer_timer);
 
     // Init indexer
-    let indexer_executor = IndexerActor::new(indexer_store.clone(), moveos_store.clone())?
+    let indexer_executor = IndexerActor::new(root, indexer_store.clone(), moveos_store.clone())?
         .into_actor(Some("Indexer"), &actor_system)
         .await?;
     let indexer_reader_executor = IndexerReaderActor::new(indexer_reader)?

--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -5,55 +5,40 @@ use super::messages::{
     ExecuteTransactionMessage, ExecuteTransactionResult, GetRootMessage, ResolveMessage,
     ValidateL1BlockMessage, ValidateL2TxMessage,
 };
-use accumulator::inmemory::InMemoryAccumulator;
 use anyhow::Result;
 use async_trait::async_trait;
 use coerce::actor::{context::ActorContext, message::Handler, Actor};
-use itertools::Itertools;
-use move_binary_format::errors::{Location, PartialVMError, VMResult};
 use move_core_types::account_address::AccountAddress;
-use move_core_types::identifier::{IdentStr, Identifier};
-use move_core_types::language_storage::ModuleId;
-use move_core_types::resolver::ModuleResolver;
-use move_core_types::value::MoveValue;
-use move_core_types::vm_status::{StatusCode, VMStatus};
-use moveos::gas::table::{get_gas_schedule_entries, initial_cost_schedule, MoveOSGasMeter};
+use move_core_types::vm_status::VMStatus;
+use moveos::gas::table::get_gas_schedule_entries;
 use moveos::moveos::MoveOS;
 use moveos::vm::vm_status_explainer::explain_vm_status;
-use moveos_store::transaction_store::TransactionStore;
 use moveos_store::MoveOSStore;
-use moveos_types::genesis_info::GenesisInfo;
-use moveos_types::h256::H256;
+use moveos_types::function_return_value::FunctionResult;
 use moveos_types::module_binding::MoveFunctionCaller;
-use moveos_types::move_types::FunctionId;
 use moveos_types::moveos_std::object::RootObjectEntity;
 use moveos_types::moveos_std::tx_context::TxContext;
-use moveos_types::state_resolver::MoveOSResolverProxy;
-use moveos_types::state_resolver::StateResolver;
-use moveos_types::transaction::TransactionOutput;
+use moveos_types::state_resolver::RootObjectResolver;
 use moveos_types::transaction::VerifiedMoveOSTransaction;
-use moveos_types::transaction::{
-    FunctionCall, MoveOSTransaction, TransactionExecutionInfo, VerifiedMoveAction,
-};
-use moveos_verifier::metadata::load_module_metadata;
+use moveos_types::transaction::{FunctionCall, MoveOSTransaction, VerifiedMoveAction};
 use rooch_framework::natives::gas_parameter::gas_member::FromOnChainGasSchedule;
 use rooch_genesis::RoochGenesis;
 use rooch_store::RoochStore;
 use rooch_types::address::MultiChainAddress;
-use rooch_types::bitcoin::genesis::BitcoinGenesisContext;
 use rooch_types::bitcoin::light_client::BitcoinLightClientModule;
 use rooch_types::framework::address_mapping::AddressMapping;
 use rooch_types::framework::auth_validator::{AuthValidatorCaller, TxValidateResult};
 use rooch_types::framework::ethereum_light_client::EthereumLightClientModule;
-use rooch_types::framework::genesis::GenesisContext;
 use rooch_types::framework::transaction_validator::TransactionValidator;
 use rooch_types::framework::{system_post_execute_functions, system_pre_execute_functions};
 use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::{AuthenticatorInfo, L1Block, L1BlockWithBody, RoochTransaction};
 
 pub struct ExecutorActor {
+    root: RootObjectEntity,
     genesis: RoochGenesis,
     moveos: MoveOS,
+    moveos_store: MoveOSStore,
     rooch_store: RoochStore,
 }
 
@@ -69,15 +54,14 @@ type ValidateAuthenticatorResult = Result<
 
 impl ExecutorActor {
     pub fn new(
-        genesis_ctx: GenesisContext,
-        bitcoin_genesis_ctx: BitcoinGenesisContext,
+        root: RootObjectEntity,
+        mut genesis: RoochGenesis,
         moveos_store: MoveOSStore,
         rooch_store: RoochStore,
     ) -> Result<Self> {
-        let mut genesis: RoochGenesis = RoochGenesis::build(genesis_ctx, bitcoin_genesis_ctx)?;
-
-        let gas_schedule_entries =
-            get_gas_schedule_entries(&MoveOSResolverProxy(moveos_store.clone()));
+        //TODO refactor the gas schedule loading
+        let resolver = RootObjectResolver::new(root.clone(), &moveos_store);
+        let gas_schedule_entries = get_gas_schedule_entries(&resolver);
         if let Some(gas_entries) = gas_schedule_entries {
             if let Some(gas_parameters) =
                 rooch_framework::natives::NativeGasParameters::from_on_chain_gas_schedule(
@@ -89,52 +73,20 @@ impl ExecutorActor {
         }
 
         let moveos = MoveOS::new(
-            moveos_store,
+            moveos_store.clone(),
             genesis.all_natives(),
             genesis.config.clone(),
             system_pre_execute_functions(),
             system_post_execute_functions(),
         )?;
 
-        let executor = Self {
+        Ok(Self {
+            root,
             genesis,
             moveos,
+            moveos_store,
             rooch_store,
-        };
-        executor.init_or_check_genesis()
-    }
-
-    fn init_or_check_genesis(mut self) -> Result<Self> {
-        if self.moveos().state().is_genesis() {
-            let genesis_result = self.moveos.init_genesis(
-                self.genesis.genesis_txs(),
-                self.genesis.genesis_ctx(),
-                self.genesis.bitcoin_genesis_ctx(),
-            )?;
-            let genesis_state_root = genesis_result
-                .last()
-                .expect("Genesis result must not empty")
-                .0;
-
-            //TODO should we save the genesis txs to sequencer?
-            for (mut genesis_tx, (state_root, size, genesis_tx_output)) in
-                self.genesis.genesis_txs().into_iter().zip(genesis_result)
-            {
-                let tx_hash = genesis_tx.tx_hash();
-                self.handle_tx_output(tx_hash, state_root, size, genesis_tx_output)?;
-            }
-
-            debug_assert!(
-                genesis_state_root == self.genesis.genesis_state_root(),
-                "Genesis state root mismatch"
-            );
-            let genesis_info =
-                GenesisInfo::new(self.genesis.genesis_package_hash(), genesis_state_root);
-            self.moveos().config_store().save_genesis(genesis_info)?;
-        } else {
-            self.genesis.check_genesis(self.moveos().config_store())?;
-        }
-        Ok(self)
+        })
     }
 
     pub fn get_rooch_store(&self) -> RoochStore {
@@ -158,7 +110,7 @@ impl ExecutorActor {
         multi_chain_address_sender: MultiChainAddress,
     ) -> Result<AccountAddress> {
         let resolved_sender = {
-            let address_mapping = self.moveos().as_module_binding::<AddressMapping>();
+            let address_mapping = self.as_module_binding::<AddressMapping>();
             address_mapping.resolve_or_generate(multi_chain_address_sender)?
         };
 
@@ -168,50 +120,12 @@ impl ExecutorActor {
     pub fn execute(&mut self, tx: VerifiedMoveOSTransaction) -> Result<ExecuteTransactionResult> {
         let tx_hash = tx.ctx.tx_hash();
         let (state_root, size, output) = self.moveos.execute_and_apply(tx)?;
-        self.handle_tx_output(tx_hash, state_root, size, output)
-    }
-
-    fn handle_tx_output(
-        &mut self,
-        tx_hash: H256,
-        state_root: H256,
-        size: u64,
-        output: TransactionOutput,
-    ) -> Result<ExecuteTransactionResult> {
-        if log::log_enabled!(log::Level::Debug) {
-            log::debug!(
-                "tx_hash: {}, state_root: {}, size: {}, gas_used: {}, status: {:?}",
-                tx_hash,
-                state_root,
-                size,
-                output.gas_used,
-                output.status
-            );
-        }
-        let event_hashes: Vec<_> = output.events.iter().map(|e| e.hash()).collect();
-        let event_root = InMemoryAccumulator::from_leaves(event_hashes.as_slice()).root_hash();
-
-        let transaction_info = TransactionExecutionInfo::new(
-            tx_hash,
-            state_root,
-            size,
-            event_root,
-            output.gas_used,
-            output.status.clone(),
-        );
-        self.moveos()
-            .transaction_store()
-            .save_tx_execution_info(transaction_info.clone())
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "ExecuteTransactionMessage handler save tx info failed: {:?} {}",
-                    transaction_info,
-                    e
-                )
-            })?;
+        let execution_info =
+            self.moveos_store
+                .handle_tx_output(tx_hash, state_root, size, output.clone())?;
         Ok(ExecuteTransactionResult {
             output,
-            transaction_info,
+            transaction_info: execution_info,
         })
     }
 
@@ -240,14 +154,22 @@ impl ExecutorActor {
                     )?,
                     bypass_visibility: true,
                 };
-                Ok(VerifiedMoveOSTransaction::new(ctx, action))
+                Ok(VerifiedMoveOSTransaction::new(
+                    self.root.clone(),
+                    ctx,
+                    action,
+                ))
             }
             RoochMultiChainID::Ether => {
                 let action = VerifiedMoveAction::Function {
                     call: EthereumLightClientModule::create_submit_new_block_call_bytes(block_body),
                     bypass_visibility: true,
                 };
-                Ok(VerifiedMoveOSTransaction::new(ctx, action))
+                Ok(VerifiedMoveOSTransaction::new(
+                    self.root.clone(),
+                    ctx,
+                    action,
+                ))
             }
             id => Err(anyhow::anyhow!("Chain {} not supported yet", id)),
         }
@@ -258,7 +180,7 @@ impl ExecutorActor {
 
         let authenticator = tx.authenticator_info()?;
 
-        let mut moveos_tx: MoveOSTransaction = tx.into();
+        let mut moveos_tx: MoveOSTransaction = tx.into_moveos_transaction(self.root.clone());
 
         let vm_result = self.validate_authenticator(&moveos_tx.ctx, authenticator)?;
 
@@ -286,7 +208,8 @@ impl ExecutorActor {
                 Ok(self.moveos().verify(moveos_tx)?)
             }
             Err(e) => {
-                let status_view = explain_vm_status(self.moveos.moveos_resolver(), e.clone())?;
+                let resolver = RootObjectResolver::new(self.root.clone(), &self.moveos_store);
+                let status_view = explain_vm_status(&resolver, e.clone())?;
                 log::warn!(
                     "transaction validate vm error, tx_hash: {}, error:{:?}",
                     moveos_tx.ctx.tx_hash(),
@@ -303,7 +226,7 @@ impl ExecutorActor {
         ctx: &TxContext,
         authenticator: AuthenticatorInfo,
     ) -> Result<ValidateAuthenticatorResult> {
-        let tx_validator = self.moveos().as_module_binding::<TransactionValidator>();
+        let tx_validator = self.as_module_binding::<TransactionValidator>();
         let tx_validate_function_result = tx_validator
             .validate(ctx, authenticator.clone())?
             .into_result();
@@ -313,8 +236,7 @@ impl ExecutorActor {
                 let auth_validator_option = tx_validate_result.auth_validator();
                 match auth_validator_option {
                     Some(auth_validator) => {
-                        let auth_validator_caller =
-                            AuthValidatorCaller::new(self.moveos(), auth_validator);
+                        let auth_validator_caller = AuthValidatorCaller::new(self, auth_validator);
                         let auth_validator_function_result = auth_validator_caller
                             .validate(ctx, authenticator.authenticator.payload)?
                             .into_result();
@@ -351,179 +273,6 @@ impl ExecutorActor {
             Err(vm_status) => Err(vm_status),
         };
         Ok(vm_result)
-    }
-
-    pub fn validate_gas_function(&self, tx: &MoveOSTransaction) -> VMResult<Option<bool>> {
-        let MoveOSTransaction { ctx, .. } = tx;
-
-        let gas_entries = get_gas_schedule_entries(self.moveos.moveos_resolver());
-        let cost_table = initial_cost_schedule(gas_entries);
-        let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
-        gas_meter.set_metering(false);
-
-        let verified_moveos_action = self.moveos().verify(tx.clone())?;
-        let verified_action = verified_moveos_action.action;
-
-        match verified_action {
-            VerifiedMoveAction::Function {
-                call,
-                bypass_visibility: _,
-            } => {
-                let module_id = &call.function_id.module_id;
-                let loaded_module_bytes_result =
-                    self.moveos().moveos_resolver().get_module(module_id);
-                let loaded_module_bytes = match loaded_module_bytes_result {
-                    Ok(loaded_module_bytes_opt) => match loaded_module_bytes_opt {
-                        None => {
-                            return Err(PartialVMError::new(StatusCode::RESOURCE_DOES_NOT_EXIST)
-                                .with_message(
-                                    "The name of the gas_validate_function does not exist."
-                                        .to_string(),
-                                )
-                                .finish(Location::Module(module_id.clone())));
-                        }
-                        Some(module_bytes) => module_bytes,
-                    },
-                    Err(error) => {
-                        return Err(PartialVMError::new(StatusCode::RESOURCE_DOES_NOT_EXIST)
-                            .with_message(format!(
-                                "Load module data from module_id {:} was failed {:}.",
-                                module_id.clone(),
-                                error
-                            ))
-                            .finish(Location::Module(module_id.clone())));
-                    }
-                };
-
-                let module_metadata = load_module_metadata(module_id, Ok(loaded_module_bytes))?;
-                let gas_free_function_info = {
-                    match module_metadata {
-                        None => None,
-                        Some(runtime_metadata) => Some(runtime_metadata.gas_free_function_map),
-                    }
-                };
-
-                let called_function_name = call.function_id.function_name.to_string();
-                match gas_free_function_info {
-                    None => Ok(None),
-                    Some(gas_func_info) => {
-                        let full_called_function = format!(
-                            "0x{}::{}::{}",
-                            call.function_id.module_id.address().to_hex(),
-                            call.function_id.module_id.name(),
-                            called_function_name
-                        );
-                        let gas_func_info_opt = gas_func_info.get(&full_called_function);
-
-                        if let Some(gas_func_info) = gas_func_info_opt {
-                            let gas_validate_func_name = gas_func_info.gas_validate.clone();
-
-                            let split_function = gas_validate_func_name.split("::").collect_vec();
-                            if split_function.len() != 3 {
-                                return Err(PartialVMError::new(StatusCode::VM_EXTENSION_ERROR)
-                                    .with_message(
-                                        "The name of the gas_validate_function is incorrect."
-                                            .to_string(),
-                                    )
-                                    .finish(Location::Module(call.clone().function_id.module_id)));
-                            }
-                            let real_gas_validate_func_name =
-                                split_function.get(2).unwrap().to_string();
-
-                            let gas_validate_func_call = FunctionCall::new(
-                                FunctionId::new(
-                                    call.function_id.module_id.clone(),
-                                    Identifier::new(real_gas_validate_func_name).unwrap(),
-                                ),
-                                vec![],
-                                vec![],
-                            );
-
-                            let function_execution_result =
-                                self.moveos.execute_view_function(gas_validate_func_call);
-
-                            return if function_execution_result.vm_status == VMStatus::Executed {
-                                let return_value = function_execution_result.return_values.unwrap();
-                                if !return_value.is_empty() {
-                                    let first_return_value = return_value.get(0).unwrap();
-                                    Ok(Some(
-                                        bcs::from_bytes::<bool>(first_return_value.value.as_slice())
-                                            .expect(
-                                                "the return value of gas validate function should be bool",
-                                            ),
-                                    ))
-                                } else {
-                                    return Err(PartialVMError::new(
-                                        StatusCode::VM_EXTENSION_ERROR,
-                                    )
-                                    .with_message(
-                                        "the return value of gas_validate_function is empty."
-                                            .to_string(),
-                                    )
-                                    .finish(Location::Module(call.clone().function_id.module_id)));
-                                }
-                            } else {
-                                Ok(None)
-                            };
-                        };
-
-                        Ok(None)
-                    }
-                }
-            }
-            _ => Ok(None),
-        }
-    }
-
-    pub fn get_account_balance(&self, tx: &MoveOSTransaction) -> VMResult<u128> {
-        let MoveOSTransaction { ctx, .. } = tx;
-
-        let gas_entries = get_gas_schedule_entries(self.moveos.moveos_resolver());
-        let cost_table = initial_cost_schedule(gas_entries);
-        let mut gas_meter = MoveOSGasMeter::new(cost_table, ctx.max_gas_amount);
-        gas_meter.set_metering(false);
-
-        let verified_moveos_action = self.moveos().verify(tx.clone())?;
-        let verified_action = verified_moveos_action.action;
-
-        match verified_action {
-            VerifiedMoveAction::Function {
-                call,
-                bypass_visibility: _,
-            } => {
-                let module_address = call.function_id.module_id.address();
-
-                let gas_coin_module_id = ModuleId::new(
-                    AccountAddress::from_hex_literal("0x3").unwrap(),
-                    Identifier::from(IdentStr::new("gas_coin").unwrap()),
-                );
-                let gas_balance_func_call = FunctionCall::new(
-                    FunctionId::new(gas_coin_module_id, Identifier::new("balance").unwrap()),
-                    vec![],
-                    vec![MoveValue::Address(*module_address)
-                        .simple_serialize()
-                        .unwrap()],
-                );
-
-                let function_execution_result =
-                    self.moveos.execute_view_function(gas_balance_func_call);
-
-                if function_execution_result.vm_status == VMStatus::Executed {
-                    let return_value = function_execution_result.return_values.unwrap();
-                    let first_return_value = return_value.get(0).unwrap();
-
-                    let balance = bcs::from_bytes::<move_core_types::u256::U256>(
-                        first_return_value.value.as_slice(),
-                    )
-                    .expect("the return value of gas validate function should be u128");
-
-                    Ok(balance.unchecked_as_u128())
-                } else {
-                    Ok(0)
-                }
-            }
-            _ => Ok(0),
-        }
     }
 }
 
@@ -580,6 +329,14 @@ impl Handler<GetRootMessage> for ExecutorActor {
         _msg: GetRootMessage,
         _ctx: &mut ActorContext,
     ) -> Result<RootObjectEntity> {
-        Ok(self.moveos().state().root_object())
+        Ok(self.root.clone())
+    }
+}
+
+impl MoveFunctionCaller for ExecutorActor {
+    fn call_function(&self, ctx: &TxContext, call: FunctionCall) -> Result<FunctionResult> {
+        Ok(self
+            .moveos
+            .execute_readonly_function(self.root.clone(), ctx, call))
     }
 }

--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -123,6 +123,8 @@ impl ExecutorActor {
         let execution_info =
             self.moveos_store
                 .handle_tx_output(tx_hash, state_root, size, output.clone())?;
+
+        self.root = execution_info.root_object();
         Ok(ExecuteTransactionResult {
             output,
             transaction_info: execution_info,

--- a/crates/rooch-framework-tests/src/tests/bitcoin_light_client_test.rs
+++ b/crates/rooch-framework-tests/src/tests/bitcoin_light_client_test.rs
@@ -131,7 +131,7 @@ fn check_utxo(txs: Vec<Transaction>, binding_test: &binding_test::RustBindingTes
 
     let utxo_module = binding_test.as_module_binding::<rooch_types::bitcoin::utxo::UTXOModule>();
 
-    let moveos_resolver = binding_test.executor().moveos().moveos_resolver();
+    let moveos_resolver = binding_test.resolver();
 
     for (outpoint, tx_out) in utxo_set.into_iter() {
         let outpoint: types::OutPoint = outpoint.into();

--- a/crates/rooch-framework-tests/src/tests/chain_id_test.rs
+++ b/crates/rooch-framework-tests/src/tests/chain_id_test.rs
@@ -2,19 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::binding_test;
-use moveos_types::module_binding::MoveFunctionCaller;
+use moveos_types::{module_binding::MoveFunctionCaller, state_resolver::StateResolver};
 use rooch_types::{chain_id::RoochChainID, framework::chain_id::ChainID};
 
 #[test]
 fn test_chain_id() {
     let _ = tracing_subscriber::fmt::try_init();
     let binding_test = binding_test::RustBindingTest::new().unwrap();
-    let chain_id = binding_test
-        .executor
-        .get_moveos_store()
-        .statedb
-        .get_object(&ChainID::chain_id_object_id())
-        .unwrap();
+    let resolver = binding_test.resolver();
+    let chain_id = resolver.get_object(&ChainID::chain_id_object_id()).unwrap();
     assert!(chain_id.is_some());
     let chain_id_module =
         binding_test.as_module_binding::<rooch_types::framework::chain_id::ChainIDModule>();

--- a/crates/rooch-framework-tests/src/tests/chain_id_test.rs
+++ b/crates/rooch-framework-tests/src/tests/chain_id_test.rs
@@ -13,7 +13,7 @@ fn test_chain_id() {
         .executor
         .get_moveos_store()
         .statedb
-        .get(&ChainID::chain_id_object_id())
+        .get_object(&ChainID::chain_id_object_id())
         .unwrap();
     assert!(chain_id.is_some());
     let chain_id_module =

--- a/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/native_validator_tests.rs
@@ -13,6 +13,7 @@ use crate::binding_test;
 #[test]
 fn test_validate() {
     let binding_test = binding_test::RustBindingTest::new().unwrap();
+    let root = binding_test.root().clone();
     let native_validator = binding_test
         .as_module_binding::<rooch_types::framework::native_validator::NativeValidatorModule>(
     );
@@ -24,7 +25,8 @@ fn test_validate() {
     let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
     let tx = keystore.sign_transaction(&sender, tx_data, None).unwrap();
     let auth_info = tx.authenticator_info().unwrap();
-    let move_tx: MoveOSTransaction = tx.into();
+
+    let move_tx: MoveOSTransaction = tx.into_moveos_transaction(root);
 
     native_validator
         .validate(&move_tx.ctx, auth_info.authenticator.payload)

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -321,7 +321,7 @@ mod tests {
     use moveos_store::MoveOSStore;
     use moveos_types::moveos_std::move_module::ModuleStore;
     use moveos_types::moveos_std::object::ObjectEntity;
-    use moveos_types::state_resolver::RootObjectResolver;
+    use moveos_types::state_resolver::{RootObjectResolver, StateResolver};
     use rooch_framework::natives::{all_natives, default_gas_schedule};
     use rooch_types::bitcoin::data_import_config::DataImportMode;
     use rooch_types::bitcoin::genesis::BitcoinGenesisContext;
@@ -347,7 +347,7 @@ mod tests {
             Ok(genesis) => genesis,
             Err(e) => panic!("genesis build failed: {:?}", e),
         };
-        assert_eq!(genesis.genesis_package.genesis_tx.len(), 1);
+
         let moveos_store = MoveOSStore::mock_moveos_store().unwrap();
         let mut moveos = MoveOS::new(
             moveos_store.clone(),
@@ -359,11 +359,7 @@ mod tests {
         .expect("init moveos failed");
 
         let (state_root, size, _output) = moveos
-            .init_genesis(
-                genesis.genesis_package.genesis_tx,
-                genesis.genesis_package.genesis_ctx,
-                genesis.genesis_package.bitcoin_genesis_ctx,
-            )
+            .init_genesis(genesis.genesis_package.genesis_moveos_tx)
             .expect("init genesis failed");
         let root = ObjectEntity::root_object(state_root, size);
         let resolver = RootObjectResolver::new(root, &moveos_store);

--- a/crates/rooch-indexer/src/actor/indexer.rs
+++ b/crates/rooch-indexer/src/actor/indexer.rs
@@ -13,46 +13,55 @@ use async_trait::async_trait;
 use coerce::actor::{context::ActorContext, message::Handler, Actor};
 use move_core_types::effects::Op;
 use move_core_types::language_storage::TypeTag;
+use move_core_types::resolver::MoveResolver;
 use move_resource_viewer::MoveValueAnnotator;
 use moveos_store::MoveOSStore;
-use moveos_types::moveos_std::object::ObjectID;
 use moveos_types::moveos_std::object::RawObject;
+use moveos_types::moveos_std::object::{ObjectID, RootObjectEntity};
 use moveos_types::state::{FieldChange, KeyState, MoveStructType, ObjectChange, State};
-use moveos_types::state_resolver::{MoveOSResolverProxy, StateResolver};
+use moveos_types::state_resolver::RootObjectResolver;
 use rooch_rpc_api::jsonrpc_types::{AnnotatedMoveStructView, AnnotatedMoveValueView};
 use rooch_types::bitcoin::utxo::UTXO;
 
 pub struct IndexerActor {
+    root: RootObjectEntity,
     indexer_store: IndexerStore,
-    moveos_store: MoveOSResolverProxy<MoveOSStore>,
+    moveos_store: MoveOSStore,
 }
 
 impl IndexerActor {
-    pub fn new(indexer_store: IndexerStore, moveos_store: MoveOSStore) -> Result<Self> {
+    pub fn new(
+        root: RootObjectEntity,
+        indexer_store: IndexerStore,
+        moveos_store: MoveOSStore,
+    ) -> Result<Self> {
         Ok(Self {
+            root,
             indexer_store,
-            moveos_store: MoveOSResolverProxy(moveos_store),
+            moveos_store,
         })
     }
 
-    pub fn resolve_raw_object_value_to_json(&self, raw_object: &RawObject) -> Result<String> {
-        let obj_value = MoveValueAnnotator::new(&self.moveos_store)
+    pub fn resolve_raw_object_value_to_json(
+        resolver: &dyn MoveResolver,
+        raw_object: &RawObject,
+    ) -> Result<String> {
+        let obj_value = MoveValueAnnotator::new(resolver)
             .view_resource(&raw_object.value.struct_tag, &raw_object.value.value)?;
         let obj_value_view = AnnotatedMoveStructView::from(obj_value);
         let raw_object_value_json = serde_json::to_string(&obj_value_view)?;
         Ok(raw_object_value_json)
     }
 
-    pub fn resolve_state_to_json(&self, ty_tag: &TypeTag, value: &[u8]) -> Result<String> {
-        let annotator_state =
-            MoveValueAnnotator::new(&self.moveos_store).view_value(ty_tag, value)?;
+    pub fn resolve_state_to_json(
+        resolver: &dyn MoveResolver,
+        ty_tag: &TypeTag,
+        value: &[u8],
+    ) -> Result<String> {
+        let annotator_state = MoveValueAnnotator::new(&resolver).view_value(ty_tag, value)?;
         let annotator_state_view = AnnotatedMoveValueView::from(annotator_state);
         let annotator_state_json = serde_json::to_string(&annotator_state_view)?;
         Ok(annotator_state_json)
-    }
-
-    pub fn resolve_object_state(&self, object_id: &ObjectID) -> Result<Option<State>> {
-        self.moveos_store.resolve_object_state(object_id)
     }
 
     pub fn is_utxo_object(&self, state_opt: Option<State>) -> bool {
@@ -68,8 +77,9 @@ impl IndexerActor {
         tx_order: u64,
         state_index: u64,
     ) -> Result<IndexedObjectState> {
+        let resolver = RootObjectResolver::new(self.root.clone(), &self.moveos_store);
         let raw_object = value.as_raw_object()?;
-        let obj_value_json = self.resolve_raw_object_value_to_json(&raw_object)?;
+        let obj_value_json = Self::resolve_raw_object_value_to_json(&resolver, &raw_object)?;
         let object_type = format_struct_tag(raw_object.value.struct_tag.clone());
 
         let state = IndexedObjectState::new_from_raw_object(
@@ -90,9 +100,12 @@ impl IndexerActor {
         tx_order: u64,
         state_index: u64,
     ) -> Result<IndexedFieldState> {
+        let resolver = RootObjectResolver::new(self.root.clone(), &self.moveos_store);
         let key_hex = key.to_string();
-        let key_state_json = self.resolve_state_to_json(&key.key_type, key.key.as_slice())?;
-        let state_json = self.resolve_state_to_json(&value.value_type, value.value.as_slice())?;
+        let key_state_json =
+            Self::resolve_state_to_json(&resolver, &key.key_type, key.key.as_slice())?;
+        let state_json =
+            Self::resolve_state_to_json(&resolver, &value.value_type, value.value.as_slice())?;
         let state = IndexedFieldState::new(
             object_id,
             key_hex,
@@ -213,8 +226,8 @@ impl Handler<IndexerStatesMessage> for IndexerActor {
             tx_order,
             state_change_set,
         } = msg;
-        //TODO make statedb stateless
-        self.moveos_store.0.statedb.update_root(root)?;
+
+        self.root = root;
 
         // indexer state index generator
         let mut state_index_generator = 0u64;

--- a/crates/rooch-indexer/src/tests/test_indexer.rs
+++ b/crates/rooch-indexer/src/tests/test_indexer.rs
@@ -12,7 +12,7 @@ use move_core_types::language_storage::StructTag;
 use move_core_types::vm_status::KeptVMStatus;
 use moveos_types::h256::H256;
 use moveos_types::move_types::{random_struct_tag, random_type_tag};
-use moveos_types::moveos_std::object::ObjectID;
+use moveos_types::moveos_std::object::{ObjectEntity, ObjectID};
 use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::state::MoveStructType;
 use moveos_types::transaction::{TransactionExecutionInfo, VerifiedMoveOSTransaction};
@@ -159,6 +159,7 @@ fn test_transaction_store() -> Result<()> {
     let tx_context = TxContext::new_readonly_ctx(AccountAddress::random());
     let move_action = random_verified_move_action();
     let random_moveos_tx = VerifiedMoveOSTransaction {
+        root: ObjectEntity::genesis_root_object(),
         ctx: tx_context,
         action: move_action,
         pre_execute_functions: random_function_calls(),
@@ -197,6 +198,7 @@ fn test_event_store() -> Result<()> {
     let tx_context = TxContext::new_readonly_ctx(AccountAddress::random());
     let move_action = random_verified_move_action();
     let random_moveos_tx = VerifiedMoveOSTransaction {
+        root: ObjectEntity::genesis_root_object(),
         ctx: tx_context,
         action: move_action,
         pre_execute_functions: random_function_calls(),

--- a/crates/rooch-rpc-server/Cargo.toml
+++ b/crates/rooch-rpc-server/Cargo.toml
@@ -66,3 +66,4 @@ rooch-relayer = { workspace = true }
 rooch-indexer = { workspace = true }
 rooch-da = { workspace = true }
 rooch-framework = { workspace = true }
+rooch-genesis = { workspace = true }

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -426,7 +426,9 @@ fn _build_rpc_api<M: Send + Sync + 'static>(mut rpc_module: RpcModule<M>) -> Rpc
     rpc_module
 }
 
-fn init_storage(store_config: &StoreConfig) -> Result<(RootObjectEntity, MoveOSStore, RoochStore)> {
+pub fn init_storage(
+    store_config: &StoreConfig,
+) -> Result<(RootObjectEntity, MoveOSStore, RoochStore)> {
     let (rooch_db_path, moveos_db_path) = (
         store_config.get_rooch_store_dir(),
         store_config.get_moveos_store_dir(),

--- a/crates/rooch-sequencer/src/actor/sequencer.rs
+++ b/crates/rooch-sequencer/src/actor/sequencer.rs
@@ -24,11 +24,7 @@ pub struct SequencerActor {
 }
 
 impl SequencerActor {
-    pub fn new(
-        sequencer_key: RoochKeyPair,
-        rooch_store: RoochStore,
-        _is_genesis: bool,
-    ) -> Result<Self> {
+    pub fn new(sequencer_key: RoochKeyPair, rooch_store: RoochStore) -> Result<Self> {
         let last_order_opt = rooch_store
             .get_meta_store()
             .get_sequencer_order()?

--- a/crates/rooch-types/src/transaction/rooch.rs
+++ b/crates/rooch-types/src/transaction/rooch.rs
@@ -8,6 +8,7 @@ use crate::{address::RoochAddress, chain_id::RoochChainID};
 use anyhow::Result;
 use moveos_types::gas_config::GasConfig;
 use moveos_types::h256::H256;
+use moveos_types::moveos_std::object::RootObjectEntity;
 use moveos_types::{
     moveos_std::tx_context::TxContext,
     transaction::{MoveAction, MoveOSTransaction},
@@ -189,20 +190,18 @@ impl RoochTransaction {
             Signature::new_hashed(transaction_data.tx_hash().as_bytes(), &ed25519_keypair).into();
         RoochTransaction::new(transaction_data, auth)
     }
-}
 
-impl From<RoochTransaction> for MoveOSTransaction {
-    fn from(mut tx: RoochTransaction) -> Self {
-        let tx_hash = tx.tx_hash();
-        let tx_size = tx.tx_size();
+    pub fn into_moveos_transaction(mut self, root: RootObjectEntity) -> MoveOSTransaction {
+        let tx_hash = self.tx_hash();
+        let tx_size = self.tx_size();
         let tx_ctx = TxContext::new(
-            tx.data.sender.into(),
-            tx.data.sequence_number,
-            tx.data.max_gas_amount,
+            self.data.sender.into(),
+            self.data.sequence_number,
+            self.data.max_gas_amount,
             tx_hash,
             tx_size,
         );
-        MoveOSTransaction::new(tx_ctx, tx.data.action)
+        MoveOSTransaction::new(root, tx_ctx, self.data.action)
     }
 }
 

--- a/crates/testsuite/tests/images/ord.rs
+++ b/crates/testsuite/tests/images/ord.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::time::Duration;
 
 use testcontainers::{
     core::{ContainerState, ExecCommand, WaitFor},
@@ -62,7 +61,7 @@ impl Image for Ord {
         Box::new(self.env_vars.iter())
     }
 
-    fn exec_after_start(&self, cs: ContainerState) -> Vec<ExecCommand> {
+    fn exec_after_start(&self, _cs: ContainerState) -> Vec<ExecCommand> {
         vec![ExecCommand {
             cmd: "/bin/rm -rf /data/.bitcoin/regtest/wallets/ord".to_owned(),
             ready_conditions: vec![WaitFor::Nothing],

--- a/crates/testsuite/tests/integration.rs
+++ b/crates/testsuite/tests/integration.rs
@@ -12,8 +12,7 @@ use rooch_config::{rooch_config_dir, RoochOpt, ServerOpt};
 use rooch_rpc_client::wallet_context::WalletContext;
 use rooch_rpc_server::Service;
 use serde_json::Value;
-use std::env;
-use tracing::{debug, error, info, Level};
+use tracing::{debug, error, info};
 
 use images::bitcoin::BitcoinD;
 use images::ord::Ord;
@@ -245,7 +244,7 @@ fn ord_bash_run_cmd(w: &mut World, input_tpl: String) {
     let input = eval_command_args(tpl_ctx, input_tpl);
 
     let args: Vec<&str> = input.split_whitespace().collect();
-    let cmd_name = args[0].clone();
+    let cmd_name = args[0];
 
     bitseed_args.extend(args.iter().map(|&s| s.to_string()));
 
@@ -309,7 +308,7 @@ fn ord_run_cmd(w: &mut World, input_tpl: String) {
     let input = eval_command_args(tpl_ctx, input_tpl);
 
     let args: Vec<&str> = input.split_whitespace().collect();
-    let cmd_name = args[0].clone();
+    let cmd_name = args[0];
 
     bitseed_args.extend(args.iter().map(|&s| s.to_string()));
 
@@ -371,7 +370,7 @@ fn bitcoincli_run_cmd(w: &mut World, input_tpl: String) {
     let input = eval_command_args(tpl_ctx, input_tpl);
 
     let args: Vec<&str> = input.split_whitespace().collect();
-    let cmd_name = args[0].clone();
+    let cmd_name = args[0];
 
     bitcoincli_args.extend(args.iter().map(|&s| s.to_string()));
 

--- a/frameworks/moveos-stdlib/doc/display.md
+++ b/frameworks/moveos-stdlib/doc/display.md
@@ -6,6 +6,7 @@
 
 
 -  [Resource `Display`](#0x2_display_Display)
+-  [Struct `DisplayCreate`](#0x2_display_DisplayCreate)
 -  [Function `resource_display`](#0x2_display_resource_display)
 -  [Function `object_display`](#0x2_display_object_display)
 -  [Function `set_value`](#0x2_display_set_value)
@@ -19,6 +20,7 @@
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="simple_map.md#0x2_simple_map">0x2::simple_map</a>;
 </code></pre>
@@ -33,6 +35,18 @@ Display<T> is used to define the display of the <code>T</code>
 
 
 <pre><code><b>struct</b> <a href="display.md#0x2_display_Display">Display</a>&lt;T&gt; <b>has</b> key
+</code></pre>
+
+
+
+<a name="0x2_display_DisplayCreate"></a>
+
+## Struct `DisplayCreate`
+
+Event when Display<T> created
+
+
+<pre><code><b>struct</b> <a href="display.md#0x2_display_DisplayCreate">DisplayCreate</a>&lt;T&gt; <b>has</b> drop
 </code></pre>
 
 

--- a/moveos/moveos-object-runtime/src/runtime.rs
+++ b/moveos/moveos-object-runtime/src/runtime.rs
@@ -22,15 +22,18 @@ use move_vm_types::{
 };
 use moveos_types::{
     addresses::MOVEOS_STD_ADDRESS,
+    h256::H256,
     moveos_std::{
         move_module::{ModuleStore, MoveModule},
-        object::{ModuleStoreObject, ObjectEntity, ObjectID, Root, RootObjectEntity},
+        object::{
+            ModuleStoreObject, ObjectEntity, ObjectID, Root, RootObjectEntity, GENESIS_STATE_ROOT,
+        },
     },
     state::{
         FieldChange, MoveStructState, MoveStructType, MoveType, NormalFieldChange, ObjectChange,
         State, StateChangeSet,
     },
-    state_resolver::StateResolver,
+    state_resolver::StatelessResolver,
 };
 use moveos_types::{
     moveos_std::{object, tx_context::TxContext},
@@ -57,7 +60,7 @@ const FIELD_VALUE_STRUCT_NAME: &IdentStr = ident_str!("FieldValue");
 /// extension.
 #[derive(Tid)]
 pub struct ObjectRuntimeContext<'a> {
-    resolver: &'a dyn StateResolver,
+    resolver: &'a dyn StatelessResolver,
     object_runtime: Arc<RwLock<ObjectRuntime>>,
 }
 
@@ -106,6 +109,8 @@ pub struct RuntimeObject {
     value_type: TypeTag,
     /// This is the ObjectEntity<T> value in MoveVM memory
     value: GlobalValue,
+    /// The state root of the fields
+    state_root: H256,
     fields: BTreeMap<KeyState, RuntimeField>,
 }
 
@@ -166,7 +171,7 @@ impl<'a> ObjectRuntimeContext<'a> {
     /// Create a new instance of a object runtime context. This must be passed in via an
     /// extension into VM session functions.
     pub fn new(
-        resolver: &'a dyn StateResolver,
+        resolver: &'a dyn StatelessResolver,
         object_runtime: Arc<RwLock<ObjectRuntime>>,
     ) -> Self {
         //We need to init or load the module store before verify and execute tx
@@ -184,7 +189,7 @@ impl<'a> ObjectRuntimeContext<'a> {
         self.object_runtime.clone()
     }
 
-    pub fn resolver(&self) -> &dyn StateResolver {
+    pub fn resolver(&self) -> &dyn StatelessResolver {
         self.resolver
     }
 }
@@ -259,40 +264,45 @@ impl ObjectRuntime {
     /// Initialize or load the module store Object into the ObjectRuntime.
     /// Because the module store is required when publishing genesis modules,
     /// So we can not initialize it in Move.
-    pub fn init_module_store(&mut self, resolver: &dyn StateResolver) -> PartialVMResult<()> {
+    pub fn init_module_store(&mut self, resolver: &dyn StatelessResolver) -> PartialVMResult<()> {
         let module_store_id = ModuleStore::module_store_id();
         let state = resolver
-            .resolve_object_state(&module_store_id)
+            .get_object_field_at(self.root.state_root, &module_store_id)
             .map_err(|e| {
                 partial_extension_error(format!(
                     "Failed to resolve module store object state: {:?}",
                     e
                 ))
             })?;
-        let global_value = match state {
+        let (state_root, global_value) = match state {
             Some(state) => {
-                let value = state
-                    .as_object::<ModuleStore>()
-                    .map_err(|e| {
-                        partial_extension_error(format!(
-                            "Failed to resolve module store object: {:?}",
-                            e
-                        ))
-                    })?
-                    .to_runtime_value();
+                let obj = state.into_object::<ModuleStore>().map_err(|e| {
+                    partial_extension_error(format!(
+                        "Failed to resolve module store object: {:?}",
+                        e
+                    ))
+                })?;
+                let state_root = obj.state_root();
+                let value = obj.to_runtime_value();
                 // If we load the module store object, we should cache it
-                GlobalValue::cached(value).expect("Cache the ModuleStore Object should success")
+                (
+                    state_root,
+                    GlobalValue::cached(value)
+                        .expect("Cache the ModuleStore Object should success"),
+                )
             }
             None => {
                 // If the module store object is not found, we should create a new one(before genesis).
                 // Init none GlobalValue and move value to it, make the data status is dirty
                 // The change will apart of the state change set
-                let value = ModuleStoreObject::genesis_module_store().to_runtime_value();
+                let obj = ModuleStoreObject::genesis_module_store();
+                let state_root = obj.state_root();
+                let value = obj.to_runtime_value();
                 let mut global_value = GlobalValue::none();
                 global_value
                     .move_to(value)
                     .expect("Move value to GlobalValue none should success");
-                global_value
+                (state_root, global_value)
             }
         };
         let module_store_runtime = RuntimeObject::init(
@@ -300,6 +310,7 @@ impl ObjectRuntime {
             ObjectEntity::<ModuleStore>::type_layout(),
             ObjectEntity::<ModuleStore>::type_tag(),
             global_value,
+            state_root,
         )?;
         self.root.fields.insert(
             module_store_id.to_key(),
@@ -341,7 +352,7 @@ impl ObjectRuntime {
     pub fn load_object(
         &mut self,
         layout_loader: &dyn TypeLayoutLoader,
-        resolver: &dyn StateResolver,
+        resolver: &dyn StatelessResolver,
         object_id: &ObjectID,
     ) -> PartialVMResult<(&mut RuntimeObject, Option<Option<NumBytes>>)> {
         if object_id.is_root() {
@@ -388,7 +399,7 @@ impl ObjectRuntime {
     pub fn load_module(
         &mut self,
         layout_loader: &dyn TypeLayoutLoader,
-        resolver: &dyn StateResolver,
+        resolver: &dyn StatelessResolver,
         module_id: &ModuleId,
     ) -> PartialVMResult<Option<Vec<u8>>> {
         let module_store_id = ModuleStore::module_store_id();
@@ -415,7 +426,7 @@ impl ObjectRuntime {
     pub fn publish_module(
         &mut self,
         layout_loader: &dyn TypeLayoutLoader,
-        resolver: &dyn StateResolver,
+        resolver: &dyn StatelessResolver,
         module_id: &ModuleId,
         blob: Vec<u8>,
         is_republishing: bool,
@@ -519,6 +530,7 @@ impl ObjectRuntime {
             }
         }
         let change_set = StateChangeSet {
+            state_root: root_entity.state_root(),
             global_size: root_entity.size,
             changes,
         };
@@ -707,6 +719,8 @@ impl RuntimeField {
             .expect("Move value to GlobalValue none should success");
 
         Ok(if object::is_object_entity_type(&value_type) {
+            //The object field is new, so the state_root is the genesis state root
+            let state_root = *GENESIS_STATE_ROOT;
             let object = RuntimeObject::init(
                 key.as_object_id().map_err(|e| {
                     partial_extension_error(format!("expect object id, but got {:?}, {:?}", key, e))
@@ -714,6 +728,7 @@ impl RuntimeField {
                 value_layout,
                 value_type,
                 global_value,
+                state_root,
             )?;
             RuntimeField::Object(object)
         } else {
@@ -824,13 +839,21 @@ impl RuntimeField {
 // Implementation of RuntimeObject
 
 impl RuntimeObject {
+    pub fn id(&self) -> &ObjectID {
+        &self.id
+    }
+
     pub fn load(id: ObjectID, value_layout: MoveTypeLayout, state: State) -> PartialVMResult<Self> {
+        let raw_obj = state
+            .as_raw_object()
+            .map_err(|e| partial_extension_error(format!("expect raw object, but got {:?}", e)))?;
         let value = deserialize(&value_layout, state.value.as_slice())?;
         Ok(Self {
             id,
             value_layout,
             value_type: state.value_type,
             value: GlobalValue::cached(value)?,
+            state_root: raw_obj.state_root(),
             fields: Default::default(),
         })
     }
@@ -840,12 +863,14 @@ impl RuntimeObject {
         value_layout: MoveTypeLayout,
         value_type: TypeTag,
         value: GlobalValue,
+        state_root: H256,
     ) -> PartialVMResult<Self> {
         Ok(Self {
             id,
             value_layout,
             value_type,
             value,
+            state_root,
             fields: Default::default(),
         })
     }
@@ -878,7 +903,7 @@ impl RuntimeObject {
     pub fn load_field(
         &mut self,
         layout_loader: &dyn TypeLayoutLoader,
-        resolver: &dyn StateResolver,
+        resolver: &dyn StatelessResolver,
         key: KeyState,
     ) -> PartialVMResult<(&mut RuntimeField, Option<Option<NumBytes>>)> {
         self.load_field_with_layout_fn(resolver, key, |value_type| {
@@ -893,7 +918,7 @@ impl RuntimeObject {
     pub fn load_object_field(
         &mut self,
         layout_loader: &dyn TypeLayoutLoader,
-        resolver: &dyn StateResolver,
+        resolver: &dyn StatelessResolver,
         object_id: &ObjectID,
     ) -> PartialVMResult<(&mut RuntimeObject, Option<Option<NumBytes>>)> {
         let (field, loaded) = self.load_field(layout_loader, resolver, object_id.to_key())?;
@@ -929,16 +954,21 @@ impl RuntimeObject {
 
     pub fn load_field_with_layout_fn(
         &mut self,
-        resolver: &dyn StateResolver,
+        resolver: &dyn StatelessResolver,
         key: KeyState,
         f: impl FnOnce(&TypeTag) -> PartialVMResult<MoveTypeLayout>,
     ) -> PartialVMResult<(&mut RuntimeField, Option<Option<NumBytes>>)> {
         Ok(match self.fields.entry(key.clone()) {
             Entry::Vacant(entry) => {
                 let (tv, loaded) =
-                    match resolver.resolve_table_item(&self.id, &key).map_err(|err| {
-                        partial_extension_error(format!("remote object resolver failure: {}", err))
-                    })? {
+                    match resolver
+                        .get_field_at(self.state_root, &key)
+                        .map_err(|err| {
+                            partial_extension_error(format!(
+                                "remote object resolver failure: {}",
+                                err
+                            ))
+                        })? {
                         Some(state) => {
                             let value_layout = f(&state.value_type)?;
                             let state_bytes_len = state.value.len() as u64;

--- a/moveos/moveos-object-runtime/src/runtime.rs
+++ b/moveos/moveos-object-runtime/src/runtime.rs
@@ -5,6 +5,7 @@
 
 use crate::resolved_arg::ResolvedArg;
 use better_any::{Tid, TidAble};
+use log::debug;
 use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
     effects::Op,
@@ -305,6 +306,7 @@ impl ObjectRuntime {
                 (state_root, global_value)
             }
         };
+        debug!("Init module store object with state_root: {}", state_root);
         let module_store_runtime = RuntimeObject::init(
             module_store_id.clone(),
             ObjectEntity::<ModuleStore>::type_layout(),
@@ -412,7 +414,7 @@ impl ObjectRuntime {
                 Ok(move_module.map(|m| m.byte_codes))
             }
             Err(e) => {
-                print!("load_module error: {:?}", e);
+                debug!("load_module error: {:?}", e);
                 // convert the error to StatusCode::MISSING_DATA if the module is not found
                 if e.major_status() == StatusCode::MISSING_DATA {
                     Ok(None)

--- a/moveos/moveos-store/src/state_store/statedb.rs
+++ b/moveos/moveos-store/src/state_store/statedb.rs
@@ -217,7 +217,7 @@ impl StatelessResolver for StateDBStore {
             log::trace!(
                 "get_field_at state_root: {} key: {}, result: {:?}",
                 state_root,
-                key.to_string(),
+                key,
                 result_info
             );
         }

--- a/moveos/moveos-store/src/state_store/statedb.rs
+++ b/moveos/moveos-store/src/state_store/statedb.rs
@@ -215,9 +215,9 @@ impl StatelessResolver for StateDBStore {
                 Err(e) => format!("Error({:?})", e),
             };
             log::trace!(
-                "get_field_at state_root: {} key: {:?}, result: {:?}",
+                "get_field_at state_root: {} key: {}, result: {:?}",
                 state_root,
-                key,
+                key.to_string(),
                 result_info
             );
         }

--- a/moveos/moveos-store/src/tests/test_state_store.rs
+++ b/moveos/moveos-store/src/tests/test_state_store.rs
@@ -8,9 +8,11 @@ use moveos_types::h256::H256;
 use moveos_types::move_std::string::MoveString;
 use moveos_types::moveos_std::object::ObjectID;
 use moveos_types::moveos_std::object::{ObjectEntity, GENESIS_STATE_ROOT};
+use moveos_types::moveos_std::table::TablePlaceholder;
 use moveos_types::state::{
     FieldChange, KeyState, MoveState, MoveType, ObjectChange, StateChangeSet,
 };
+use moveos_types::state_resolver::StatelessResolver;
 use moveos_types::test_utils::random_state_change_set;
 use smt::NodeReader;
 use std::str::FromStr;
@@ -23,9 +25,9 @@ fn test_statedb() {
 
     let object_id = ObjectID::random();
 
-    let mut object_change = ObjectChange::new(Op::New(
-        ObjectEntity::new_table_object(object_id.clone(), *GENESIS_STATE_ROOT, 0).into_state(),
-    ));
+    let obj = ObjectEntity::new_table_object(object_id.clone(), *GENESIS_STATE_ROOT, 0);
+
+    let mut object_change = ObjectChange::new(Op::New(obj.into_state()));
 
     let key = KeyState::new(
         MoveString::from_str("test_key").unwrap().to_bytes(),
@@ -42,17 +44,21 @@ fn test_statedb() {
         .changes
         .insert(object_id.clone(), object_change);
 
-    moveos_store
+    let (state_root, _size) = moveos_store
         .get_state_store_mut()
         .apply_change_set(state_change_set)
         .unwrap();
 
     let state = moveos_store
         .get_state_store()
-        .get_field(&object_id, &key.clone().into())
+        .get_field_at(state_root, &object_id.to_key())
         .unwrap();
     assert!(state.is_some());
-    assert_eq!(state.unwrap(), value.into());
+    let obj2 = state.unwrap().as_object::<TablePlaceholder>().unwrap();
+    //The object field size is not changed, because the size is updated in the `object.move`` Move module.
+    //assert_eq!(obj2.size, 1);
+    let value_state = moveos_store.get_field_at(obj2.state_root(), &key).unwrap();
+    assert_eq!(value_state.unwrap(), value.into());
 }
 
 #[test]

--- a/moveos/moveos-store/src/tests/test_state_store.rs
+++ b/moveos/moveos-store/src/tests/test_state_store.rs
@@ -21,10 +21,10 @@ fn test_statedb() {
 
     let mut state_change_set = StateChangeSet::default();
 
-    let table_handle = ObjectID::random();
+    let object_id = ObjectID::random();
 
     let mut object_change = ObjectChange::new(Op::New(
-        ObjectEntity::new_table_object(table_handle.clone(), *GENESIS_STATE_ROOT, 0).into_state(),
+        ObjectEntity::new_table_object(object_id.clone(), *GENESIS_STATE_ROOT, 0).into_state(),
     ));
 
     let key = KeyState::new(
@@ -40,7 +40,7 @@ fn test_statedb() {
 
     state_change_set
         .changes
-        .insert(table_handle.clone(), object_change);
+        .insert(object_id.clone(), object_change);
 
     moveos_store
         .get_state_store_mut()
@@ -49,7 +49,7 @@ fn test_statedb() {
 
     let state = moveos_store
         .get_state_store()
-        .resolve_state(&table_handle, &key.clone().into())
+        .get_field(&object_id, &key.clone().into())
         .unwrap();
     assert!(state.is_some());
     assert_eq!(state.unwrap(), value.into());

--- a/moveos/moveos-types/src/moveos_std/object.rs
+++ b/moveos/moveos-types/src/moveos_std/object.rs
@@ -402,6 +402,10 @@ impl<T> ObjectEntity<T> {
     pub fn to_frozen(&mut self) {
         self.flag |= Self::FROZEN_OBJECT_FLAG_MASK;
     }
+
+    pub fn is_genesis(&self) -> bool {
+        self.state_root() == *GENESIS_STATE_ROOT
+    }
 }
 
 impl<T> ObjectEntity<T>

--- a/moveos/moveos-types/src/state.rs
+++ b/moveos/moveos-types/src/state.rs
@@ -3,7 +3,7 @@
 
 use crate::move_std::ascii::MoveAsciiString;
 use crate::move_std::string::MoveString;
-use crate::moveos_std::object::{AnnotatedObject, ObjectEntity, RawObject};
+use crate::moveos_std::object::{AnnotatedObject, ObjectEntity, RawObject, GENESIS_STATE_ROOT};
 use crate::moveos_std::object::{ObjectID, RootObjectEntity};
 use anyhow::{bail, ensure, Result};
 use core::str;
@@ -820,7 +820,7 @@ impl FieldChange {
 }
 
 /// Global State change set.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct StateChangeSet {
     /// The state root before the changes
     pub state_root: H256,
@@ -832,6 +832,16 @@ pub struct StateChangeSet {
 impl StateChangeSet {
     pub fn root_object(&self) -> RootObjectEntity {
         ObjectEntity::root_object(self.state_root, self.global_size)
+    }
+}
+
+impl Default for StateChangeSet {
+    fn default() -> Self {
+        Self {
+            state_root: *GENESIS_STATE_ROOT,
+            global_size: 0,
+            changes: Default::default(),
+        }
     }
 }
 

--- a/moveos/moveos-types/src/state.rs
+++ b/moveos/moveos-types/src/state.rs
@@ -3,8 +3,8 @@
 
 use crate::move_std::ascii::MoveAsciiString;
 use crate::move_std::string::MoveString;
-use crate::moveos_std::object::ObjectID;
 use crate::moveos_std::object::{AnnotatedObject, ObjectEntity, RawObject};
+use crate::moveos_std::object::{ObjectID, RootObjectEntity};
 use anyhow::{bail, ensure, Result};
 use core::str;
 use move_core_types::language_storage::ModuleId;
@@ -20,6 +20,7 @@ use move_core_types::{
 };
 use move_resource_viewer::{AnnotatedMoveValue, MoveValueAnnotator};
 use move_vm_types::values::{Struct, Value};
+use primitive_types::H256;
 use serde::ser::Error;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use smt::UpdateSet;
@@ -821,9 +822,17 @@ impl FieldChange {
 /// Global State change set.
 #[derive(Clone, Debug, Default)]
 pub struct StateChangeSet {
+    /// The state root before the changes
+    pub state_root: H256,
     /// The root Object field size
     pub global_size: u64,
     pub changes: BTreeMap<ObjectID, ObjectChange>,
+}
+
+impl StateChangeSet {
+    pub fn root_object(&self) -> RootObjectEntity {
+        ObjectEntity::root_object(self.state_root, self.global_size)
+    }
 }
 
 /// A change of a single table.

--- a/moveos/moveos-types/src/transaction.rs
+++ b/moveos/moveos-types/src/transaction.rs
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::moveos_std::object::RootObjectEntity;
+use crate::moveos_std::object::{ObjectEntity, RootObjectEntity};
 use crate::{
     gas_config::GasConfig, h256, h256::H256, move_types::FunctionId,
     moveos_std::event::TransactionEvent, moveos_std::tx_context::TxContext,
@@ -398,6 +398,10 @@ impl TransactionExecutionInfo {
 
     pub fn id(&self) -> H256 {
         h256::sha3_256_of(bcs::to_bytes(self).unwrap().as_slice())
+    }
+
+    pub fn root_object(&self) -> RootObjectEntity {
+        ObjectEntity::root_object(self.state_root, self.size)
     }
 }
 

--- a/moveos/moveos-types/src/transaction.rs
+++ b/moveos/moveos-types/src/transaction.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::moveos_std::object::RootObjectEntity;
 use crate::{
     gas_config::GasConfig, h256, h256::H256, move_types::FunctionId,
     moveos_std::event::TransactionEvent, moveos_std::tx_context::TxContext,
@@ -225,6 +226,7 @@ impl Display for VerifiedMoveAction {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MoveOSTransaction {
+    pub root: RootObjectEntity,
     pub ctx: TxContext,
     pub action: MoveAction,
     /// if the pre_execute_functions is not empty, the MoveOS will call the functions before the transaction is executed.
@@ -236,7 +238,11 @@ pub struct MoveOSTransaction {
 impl MoveOSTransaction {
     /// Create a new MoveOS transaction
     /// This function only for test case usage
-    pub fn new_for_test(sender: AccountAddress, action: MoveAction) -> Self {
+    pub fn new_for_test(
+        root: RootObjectEntity,
+        sender: AccountAddress,
+        action: MoveAction,
+    ) -> Self {
         let sender_and_action = (sender, action);
         let tx_hash = h256::sha3_256_of(bcs::to_bytes(&sender_and_action).unwrap().as_slice());
         //TODO pass the sequence_number
@@ -247,13 +253,15 @@ impl MoveOSTransaction {
             tx_hash,
             1,
         );
-        Self::new(ctx, sender_and_action.1)
+
+        Self::new(root, ctx, sender_and_action.1)
     }
 
-    pub fn new(mut ctx: TxContext, action: MoveAction) -> Self {
+    pub fn new(root: RootObjectEntity, mut ctx: TxContext, action: MoveAction) -> Self {
         ctx.add(TxMeta::new_from_move_action(&action))
             .expect("add TxMeta to TxContext should success");
         Self {
+            root,
             ctx,
             action,
             pre_execute_functions: vec![],
@@ -278,6 +286,7 @@ pub struct GasStatement {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VerifiedMoveOSTransaction {
+    pub root: RootObjectEntity,
     pub ctx: TxContext,
     pub action: VerifiedMoveAction,
     pub pre_execute_functions: Vec<FunctionCall>,
@@ -285,8 +294,9 @@ pub struct VerifiedMoveOSTransaction {
 }
 
 impl VerifiedMoveOSTransaction {
-    pub fn new(ctx: TxContext, action: VerifiedMoveAction) -> Self {
+    pub fn new(root: RootObjectEntity, ctx: TxContext, action: VerifiedMoveAction) -> Self {
         Self {
+            root,
             ctx,
             action,
             pre_execute_functions: vec![],

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -515,14 +515,3 @@ impl MoveOS {
         Ok(())
     }
 }
-
-// impl MoveFunctionCaller for MoveOS {
-//     fn call_function(
-//         &self,
-//         ctx: &TxContext,
-//         function_call: FunctionCall,
-//     ) -> Result<FunctionResult> {
-//         let result = self.execute_readonly_function(ctx, function_call);
-//         Ok(result)
-//     }
-// }

--- a/moveos/moveos/src/vm/data_cache.rs
+++ b/moveos/moveos/src/vm/data_cache.rs
@@ -130,8 +130,7 @@ impl<'r, 'l, S: MoveOSResolver> TransactionCache for MoveosDataCache<'r, 'l, S> 
                 Err(PartialVMError::new(StatusCode::LINKER_ERROR)
                     .with_message(format!(
                         "Cannot find module {:?}(key:{}) in ObjectRuntime and Storage",
-                        module_id,
-                        key_state.to_string(),
+                        module_id, key_state,
                     ))
                     .finish(Location::Undefined))
             }

--- a/moveos/moveos/src/vm/data_cache.rs
+++ b/moveos/moveos/src/vm/data_cache.rs
@@ -129,8 +129,9 @@ impl<'r, 'l, S: MoveOSResolver> TransactionCache for MoveosDataCache<'r, 'l, S> 
                 let key_state = KeyState::from_module_id(module_id);
                 Err(PartialVMError::new(StatusCode::LINKER_ERROR)
                     .with_message(format!(
-                        "Cannot find module {:?}(key:{:?}) in ObjectRuntime and Storage",
-                        module_id, key_state,
+                        "Cannot find module {:?}(key:{}) in ObjectRuntime and Storage",
+                        module_id,
+                        key_state.to_string(),
                     ))
                     .finish(Location::Undefined))
             }

--- a/moveos/moveos/src/vm/moveos_vm.rs
+++ b/moveos/moveos/src/vm/moveos_vm.rs
@@ -137,7 +137,7 @@ where
         read_only: bool,
     ) -> Self {
         let root = remote.root_object();
-        let object_runtime = Arc::new(RwLock::new(ObjectRuntime::new(ctx, root)));
+        let object_runtime = Arc::new(RwLock::new(ObjectRuntime::new(ctx, root.clone())));
         Self {
             vm,
             remote,

--- a/moveos/moveos/src/vm/tx_argument_resolver.rs
+++ b/moveos/moveos/src/vm/tx_argument_resolver.rs
@@ -64,9 +64,9 @@ where
                             .with_message(format!("Invalid object id: {:?}", e))
                             .finish(location.clone())
                     })?;
-                    let state = self
+                    let object = self
                         .remote
-                        .resolve_object_state(&object_id)
+                        .get_object(&object_id)
                         .map_err(|e| {
                             PartialVMError::new(StatusCode::STORAGE_ERROR)
                                 .with_message(format!("Failed to resolve object state: {:?}", e))
@@ -77,11 +77,6 @@ where
                                 .with_message(format!("Object not found: {:?}", object_id))
                                 .finish(location.clone())
                         })?;
-                    let object = state.as_raw_object().map_err(|e| {
-                        PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT)
-                            .with_message(format!("Invalid object state: {:?}", e))
-                            .finish(location.clone())
-                    })?;
                     if let TypeTag::Struct(s) = object_type {
                         if s.as_ref() != &object.value.struct_tag {
                             return Err(PartialVMError::new(

--- a/moveos/moveos/src/vm/unit_tests/vm_arguments_tests.rs
+++ b/moveos/moveos/src/vm/unit_tests/vm_arguments_tests.rs
@@ -283,7 +283,7 @@ impl ResourceResolver for RemoteStore {
 }
 
 impl StateResolver for RemoteStore {
-    fn resolve_table_item(
+    fn get_field(
         &self,
         _handle: &ObjectID,
         _key: &KeyState,
@@ -291,7 +291,7 @@ impl StateResolver for RemoteStore {
         Ok(None)
     }
 
-    fn list_table_items(
+    fn list_fields(
         &self,
         _handle: &ObjectID,
         _cursor: Option<KeyState>,

--- a/moveos/moveos/src/vm/vm_status_explainer.rs
+++ b/moveos/moveos/src/vm/vm_status_explainer.rs
@@ -50,7 +50,7 @@ pub enum VMStatusExplainView {
     },
 }
 
-pub fn explain_vm_status<T>(module_resolver: T, vm_status: VMStatus) -> Result<VMStatusExplainView>
+pub fn explain_vm_status<T>(module_resolver: &T, vm_status: VMStatus) -> Result<VMStatusExplainView>
 where
     T: MoveResolver,
 {


### PR DESCRIPTION
## Summary

1. Make StateDB stateless.
2. ObjectRuntime load field via `state_root` and `key`.


TODO:
1. Refactor genesis build and load.