### PR TITLE
ci(bench): add bench code files into ci lint checking

### DIFF
--- a/crates/rooch-benchmarks/benches/bench_tx_query.rs
+++ b/crates/rooch-benchmarks/benches/bench_tx_query.rs
@@ -32,7 +32,7 @@ pub fn transaction_query_benchmark(c: &mut Criterion) {
         let _ = rt.block_on(async { rpc_service.execute_tx(tx).await.unwrap() });
     }
 
-    let mut tx_orders = (1..500).cycle().map(|v| v);
+    let mut tx_orders = (1..500).cycle();
     c.bench_function("get_transactions_by_order", |b| {
         b.to_async(Runtime::new().unwrap()).iter(|| {
             rooch_server.get_transactions_by_order(

--- a/crates/rooch-benchmarks/benches/bench_tx_sequence.rs
+++ b/crates/rooch-benchmarks/benches/bench_tx_sequence.rs
@@ -12,17 +12,18 @@ use rooch_types::transaction::LedgerTxData;
 use std::time::Duration;
 
 pub fn tx_sequence_benchmark(c: &mut Criterion) {
-    let mut binding_test = binding_test::RustBindingTest::new().unwrap();
+    let binding_test = binding_test::RustBindingTest::new().unwrap();
     let keystore = InMemKeystore::new_insecure_for_tests(10);
 
     let rooch_account = keystore.addresses()[0];
     let rooch_key_pair = keystore
-        .get_key_pairs(&rooch_account, None)?
+        .get_key_pairs(&rooch_account, None)
+        .unwrap()
         .pop()
         .expect("key pair should have value");
     let sequencer_keypair = rooch_key_pair.copy();
     let mut sequencer =
-        gen_sequencer(sequencer_keypair, binding_test.executor().get_rooch_store())?;
+        gen_sequencer(sequencer_keypair, binding_test.executor().get_rooch_store()).unwrap();
 
     let mut test_transaction_builder = TestTransactionBuilder::new(rooch_account.into());
     let tx_cnt = 100;

--- a/crates/rooch-benchmarks/src/tx.rs
+++ b/crates/rooch-benchmarks/src/tx.rs
@@ -62,7 +62,7 @@ use std::time::Duration;
 use std::{env, fs};
 use tracing::info;
 
-pub const EXAMPLE_SIMPLE_BLOG_PACKAGE_NAME: &'static str = "simple_blog";
+pub const EXAMPLE_SIMPLE_BLOG_PACKAGE_NAME: &str = "simple_blog";
 pub const EXAMPLE_SIMPLE_BLOG_NAMED_ADDRESS: &str = "simple_blog";
 
 #[derive(PartialEq, Eq)]
@@ -319,7 +319,7 @@ pub fn create_l2_tx(
 pub fn find_block_height(dir: String) -> Result<Vec<u64>> {
     let mut block_heights = Vec::new();
 
-    for entry in fs::read_dir(&dir)? {
+    for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.is_file() && path.extension().unwrap_or_default() == "hex" {
@@ -387,8 +387,7 @@ pub fn tx_exec_benchmark(c: &mut Criterion) {
         let btc_blk_dir = env::var("ROOCH_BENCH_BTC_BLK_DIR").unwrap();
 
         let heights = find_block_height(btc_blk_dir.clone()).unwrap();
-        let mut cnt = 0;
-        for height in heights {
+        for (cnt, height) in heights.into_iter().enumerate() {
             if cnt >= tx_cnt {
                 break;
             }
@@ -401,7 +400,6 @@ pub fn tx_exec_benchmark(c: &mut Criterion) {
                 .validate_l1_block(ctx, l1_block.clone())
                 .unwrap();
             transactions.push(move_tx);
-            cnt += 1;
         }
     }
 

--- a/crates/rooch-test-transaction-builder/src/lib.rs
+++ b/crates/rooch-test-transaction-builder/src/lib.rs
@@ -80,23 +80,19 @@ impl TestTransactionBuilder {
     }
 
     pub fn call_article_create(&self) -> MoveAction {
-        let mut args = vec![];
-        args.push(
+        let args = vec![
             bcs::to_bytes(&random_string_with_size(20)).expect("serialize title should success"),
-        );
-        args.push(bcs::to_bytes(&random_string()).expect("serialize body should success"));
+            bcs::to_bytes(&random_string()).expect("serialize body should success"),
+        ];
 
         self.new_function_call("simple_blog", "create_article", args, vec![])
     }
 
     pub fn call_article_create_with_size(&self, len: usize) -> MoveAction {
-        let mut args = vec![];
-        args.push(
+        let args = vec![
             bcs::to_bytes(&random_string_with_size(20)).expect("serialize title should success"),
-        );
-        args.push(
             bcs::to_bytes(&random_string_with_size(len)).expect("serialize body should success"),
-        );
+        ];
 
         self.new_function_call("simple_blog", "create_article", args, vec![])
     }
@@ -135,13 +131,10 @@ impl TestTransactionBuilder {
         let mut config = BuildConfig::default();
 
         // Parse named addresses from context and update config
-        match named_address_key {
-            Some(key) => {
-                let mut named_addresses = BTreeMap::<String, AccountAddress>::new();
-                named_addresses.insert(key, self.sender);
-                config.additional_named_addresses = named_addresses;
-            }
-            None => {}
+        if let Some(key) = named_address_key {
+            let mut named_addresses = BTreeMap::<String, AccountAddress>::new();
+            named_addresses.insert(key, self.sender);
+            config.additional_named_addresses = named_addresses;
         };
         let config_cloned = config.clone();
 

--- a/scripts/pr.sh
+++ b/scripts/pr.sh
@@ -91,6 +91,7 @@ MOVE_TEST_CRATES="\
 if [ ! -z "$CHECK" ]; then
   cargo fmt -- --check
   cargo clippy --all-targets --all-features --tests --benches -- -D warnings
+  cargo clippy -p rooch-benchmarks --all-features --tests --benches -- -D warnings
 fi
 
 cargo build


### PR DESCRIPTION
## Summary

for origin one, the --benches arguments cannot cover rooch-benchmarks may caused by

```
[lib]
bench = false
```

setting in rooch-benchmarks/Cargo.toml

I add the checking manually and fix clippy warnings

