### PR TITLE
ci(bench): refine bcs serialized size bench by passing function as put values

### DIFF
--- a/crates/rooch-benchmarks/benches/bench_utils.rs
+++ b/crates/rooch-benchmarks/benches/bench_utils.rs
@@ -1,38 +1,67 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use serde::Serialize;
+
 use rooch_benchmarks::helper::profiled;
 use rooch_types::transaction::L1Block;
 
-pub fn l1_block_encode_size_benchmark(c: &mut Criterion) {
-    let l1_block = L1Block::default();
-    c.bench_function("l1_block_encode_siz", |b| {
-        b.iter(|| {
-            let _ = l1_block.encode().len() as u64;
-        })
-    });
+pub struct BcsSerializeSizeFunContainer<T: ?Sized + Serialize> {
+    pub func: fn(&T) -> u64,
+    pub name: &'static str,
 }
 
-pub fn l1_block_serialized_size_benchmark(c: &mut Criterion) {
+pub fn serialized_size<T>(value: &T) -> u64
+where
+    T: ?Sized + Serialize,
+{
+    bcs::serialized_size(value).unwrap() as u64
+}
+
+pub fn encode_size<T>(value: &T) -> u64
+where
+    T: ?Sized + Serialize,
+{
+    bcs::to_bytes(value)
+        .expect("encode transaction should success")
+        .len() as u64
+}
+
+pub fn bcs_serialized_size_benchmark(c: &mut Criterion) {
     let l1_block = L1Block::default();
-    c.bench_function("l1_block_serialized_size", |b| {
-        b.iter(|| {
-            let _ = bcs::serialized_size(&l1_block).unwrap() as u64;
-        })
-    });
+    let mut group = c.benchmark_group("bcs_serialized_size");
+
+    let funcs = vec![
+        BcsSerializeSizeFunContainer {
+            func: serialized_size,
+            name: "serialized_size",
+        },
+        BcsSerializeSizeFunContainer {
+            func: encode_size,
+            name: "encode_size",
+        },
+    ];
+    for func in funcs.iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(func.name),
+            &func.func,
+            |b, &func| {
+                b.iter(|| {
+                    let _ = func(&l1_block);
+                })
+            },
+        );
+    }
+    group.finish();
 }
 
 criterion_group! {
-    name = l1_block_encode_size_bench;
-    config = profiled(None);
-    targets = l1_block_encode_size_benchmark
+    name = bcs_serialized_size_bench;
+    config = profiled(None).warm_up_time(Duration::from_millis(10));
+    targets = bcs_serialized_size_benchmark
 }
 
-criterion_group! {
-    name = l1_block_serialized_size_bench;
-    config = profiled(None);
-    targets = l1_block_serialized_size_benchmark
-}
-
-criterion_main!(l1_block_encode_size_bench, l1_block_serialized_size_bench);
+criterion_main!(bcs_serialized_size_bench);


### PR DESCRIPTION
## Summary

This commit refines the benchmarks for 'bcs serialized size' by making the benchmark function take function values as inputs. This is done by redefining the benchmark function to take a vector of function containers as parameter, which allows different evaluation functions to be passed in as arguments. It provides a more flexible way to perform benchmarks and measure different aspects of the encoding and serializing processes:

```
bcs_serialized_size/serialized_size
                        time:   [5.4677 ns 5.4749 ns 5.4862 ns]
                        change: [-0.9429% -0.4567% +0.0422%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
bcs_serialized_size/encode_size
                        time:   [33.733 ns 33.749 ns 33.763 ns]
                        change: [-1.1451% -1.0485% -0.9064%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
  ```

- Closes #issue