### PR TITLE
[statedb] Refactor smt raw store

### DIFF
--- a/moveos/moveos-store/src/state_store/mod.rs
+++ b/moveos/moveos-store/src/state_store/mod.rs
@@ -6,8 +6,9 @@ pub mod statedb;
 use crate::STATE_NODE_PREFIX_NAME;
 use anyhow::Result;
 use moveos_types::h256::H256;
-use raw_store::derive_store;
-use raw_store::{CodecKVStore, CodecWriteBatch};
+use raw_store::rocks::batch::WriteBatch;
+use raw_store::CodecKVStore;
+use raw_store::{derive_store, WriteOp};
 use smt::NodeReader;
 use std::collections::BTreeMap;
 
@@ -15,17 +16,22 @@ derive_store!(NodeDBStore, H256, Vec<u8>, STATE_NODE_PREFIX_NAME);
 
 impl NodeDBStore {
     pub fn put(&self, key: H256, node: Vec<u8>) -> Result<()> {
-        self.kv_put(key, node)
+        self.put_raw(key.as_bytes().to_vec(), node)
     }
 
     pub fn write_nodes(&self, nodes: BTreeMap<H256, Vec<u8>>) -> Result<()> {
-        let batch = CodecWriteBatch::new_puts(nodes.into_iter().collect());
-        self.write_batch_sync(batch)
+        let batch = WriteBatch::new_with_rows(
+            nodes
+                .into_iter()
+                .map(|(k, v)| (k.0.to_vec(), WriteOp::Value(v)))
+                .collect(),
+        );
+        self.write_batch_raw(batch)
     }
 }
 
 impl NodeReader for NodeDBStore {
     fn get(&self, hash: &H256) -> Result<Option<Vec<u8>>> {
-        self.kv_get(*hash)
+        self.get_raw(hash.as_bytes())
     }
 }

--- a/moveos/moveos-store/src/tests/test_store.rs
+++ b/moveos/moveos-store/src/tests/test_store.rs
@@ -32,7 +32,7 @@ fn test_reopen() {
         )
         .unwrap();
         assert_eq!(
-            db.get(DEFAULT_PREFIX_NAME, bcs::to_bytes(&key).unwrap())
+            db.get(DEFAULT_PREFIX_NAME, bcs::to_bytes(&key).unwrap().as_slice())
                 .unwrap(),
             Some(bcs::to_bytes(&value).unwrap())
         );
@@ -40,7 +40,7 @@ fn test_reopen() {
     {
         let db = RocksDB::new(tmpdir.path(), cfs, RocksdbConfig::default(), None).unwrap();
         assert_eq!(
-            db.get(DEFAULT_PREFIX_NAME, bcs::to_bytes(&key).unwrap())
+            db.get(DEFAULT_PREFIX_NAME, bcs::to_bytes(&key).unwrap().as_slice())
                 .unwrap(),
             Some(bcs::to_bytes(&value).unwrap())
         );
@@ -69,7 +69,7 @@ fn test_open_read_only() {
     );
     assert!(result.is_err());
     let result = db
-        .get(DEFAULT_PREFIX_NAME, bcs::to_bytes(&key).unwrap())
+        .get(DEFAULT_PREFIX_NAME, bcs::to_bytes(&key).unwrap().as_slice())
         .unwrap();
     assert_eq!(result, Some(bcs::to_bytes(&value).unwrap()));
 }

--- a/moveos/raw-store/src/rocks/mod.rs
+++ b/moveos/raw-store/src/rocks/mod.rs
@@ -353,10 +353,10 @@ where
 }
 
 impl DBStore for RocksDB {
-    fn get(&self, prefix_name: &str, key: Vec<u8>) -> Result<Option<Vec<u8>>> {
+    fn get(&self, prefix_name: &str, key: &[u8]) -> Result<Option<Vec<u8>>> {
         record_metrics("db", prefix_name, "get", self.metrics.as_ref()).call(|| {
             let cf_handle = self.get_cf_handle(prefix_name);
-            let result = self.db.get_cf(&cf_handle, key.as_slice())?;
+            let result = self.db.get_cf(&cf_handle, key)?;
             Ok(result)
         })
     }
@@ -377,7 +377,7 @@ impl DBStore for RocksDB {
         })
     }
 
-    fn contains_key(&self, prefix_name: &str, key: Vec<u8>) -> Result<bool> {
+    fn contains_key(&self, prefix_name: &str, key: &[u8]) -> Result<bool> {
         record_metrics("db", prefix_name, "contains_key", self.metrics.as_ref()).call(|| match self
             .get(prefix_name, key)
         {

--- a/moveos/raw-store/src/traits.rs
+++ b/moveos/raw-store/src/traits.rs
@@ -9,7 +9,7 @@ pub trait KVStore: Send + Sync {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
     fn multiple_get(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>>;
     fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<()>;
-    fn contains_key(&self, key: Vec<u8>) -> Result<bool>;
+    fn contains_key(&self, key: &[u8]) -> Result<bool>;
     fn remove(&self, key: Vec<u8>) -> Result<()>;
     fn write_batch(&self, batch: WriteBatch) -> Result<()>;
     fn get_len(&self) -> Result<u64>;
@@ -19,9 +19,9 @@ pub trait KVStore: Send + Sync {
 }
 
 pub trait DBStore: Send + Sync {
-    fn get(&self, prefix_name: &str, key: Vec<u8>) -> Result<Option<Vec<u8>>>;
+    fn get(&self, prefix_name: &str, key: &[u8]) -> Result<Option<Vec<u8>>>;
     fn put(&self, prefix_name: &str, key: Vec<u8>, value: Vec<u8>) -> Result<()>;
-    fn contains_key(&self, prefix_name: &str, key: Vec<u8>) -> Result<bool>;
+    fn contains_key(&self, prefix_name: &str, key: &[u8]) -> Result<bool>;
     fn remove(&self, prefix_name: &str, key: Vec<u8>) -> Result<()>;
     fn write_batch(&self, prefix_name: &str, batch: WriteBatch) -> Result<()>;
     fn get_len(&self) -> Result<u64>;

--- a/moveos/smt/src/jellyfish_merkle/tree_cache/tree_cache_test.rs
+++ b/moveos/smt/src/jellyfish_merkle/tree_cache/tree_cache_test.rs
@@ -7,10 +7,9 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::jellyfish_merkle::mock_tree_store::{MockTestStore, TestKey, TestValue};
-
 use super::super::{node_type::Node, NodeKey};
 use super::*;
+use crate::jellyfish_merkle::mock_tree_store::{MockTestStore, TestKey, TestValue};
 
 fn random_leaf_with_key() -> (Node<TestKey, TestValue>, NodeKey) {
     let node = Node::new_leaf(TestKey::random(), TestValue::random());

--- a/moveos/smt/src/smt_object.rs
+++ b/moveos/smt/src/smt_object.rs
@@ -168,12 +168,16 @@ impl<T> AsRef<T> for SMTObject<T> {
     }
 }
 
+// Because we use expect in the From impl, so make it only available in test.
+#[cfg(test)]
 impl<T> From<T> for SMTObject<T>
 where
     T: EncodeToObject,
 {
     fn from(origin: T) -> SMTObject<T> {
-        origin.into_object().expect("encode to object failed")
+        origin
+            .into_object()
+            .expect("Failed to convert origin to SMTObject")
     }
 }
 


### PR DESCRIPTION
## Summary

Refactor smt node store directly using raw store API, eliminate unnecessary `bcs::to_bytes.`


The SMTObject can not eliminate, because the `State` is `Vec<u8> + TypeTag`.