### PR TITLE
Add permanent area for Inscription.

### DIFF
--- a/examples/bitcoin_plants/Move.toml
+++ b/examples/bitcoin_plants/Move.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitcoin_plants"
+version = "0.0.1"
+
+[dependencies]
+MoveosStdlib = { local = "../../frameworks/moveos-stdlib" }
+RoochFramework = { local = "../../frameworks/rooch-framework" }
+BitcoinMove = { local = "../../frameworks/bitcoin-move" }
+
+[addresses]
+bitcoin_plants =  "_"
+moveos_std =  "0x2"
+rooch_framework =  "0x3"
+bitcoin_move =  "0x4"
+
+[dev-addresses]
+bitcoin_plants = "0x42"

--- a/examples/bitcoin_plants/sources/plants.move
+++ b/examples/bitcoin_plants/sources/plants.move
@@ -1,0 +1,96 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+/// A game example to show how to use the `Inscription` and `UTXO` in Rooch.
+///
+/// The game is about planting a plant from seed(Inscription),  then watering and harvesting.
+/// The full game flow and main actions are as follows:
+/// 1. Mint seed: players mint seed Inscription on Bitcoin.
+/// 2. Plant: Using the seed inscription, players plant plants on Rooch.
+/// 3. Water: Players water the plant on Rooch Layer 2 regularly. The seeds will grow, sprout, and bear fruit.    
+/// 4. Harvest:  Players harvest the fruits. The fruit is represented by Layer2's Coin or NFT.
+///
+/// In this example, you will learn how Rooch is acting as a Layer 2 to interact with Bitcoin Layer 1.
+/// The details are as follows:
+/// 1. All Bitcoin transactions are processed and tracked on Rooch. All UTXOs are represented by the `UTXO` object on Rooch.
+///     You can read all Bitcoin states. So if you have a seed Inscription on Bitcoin, you can know that.
+/// 2. After planting the plant, the plant's growth status is stored in the `Inscription` UTXO's permanently state area on Rooch .
+///     Once the seed Inscription is transferred on Bitcoin, the plant produced by this seed will also be transferred.
+/// 3. After watering the plant, the plant's growth status will be updated. The watering action will also be recorded in the `Inscription` UTXO's temporary state area.
+///     Once the seed Inscription is transferred on Bitcoin, the watering actions will be cleaned.
+/// 4. Once the plants have produced, players can harvest the fruit, the fruit will be minted as a Coin or NFT on Rooch, 
+///     which has no more relationship with the seed and the plant.
+module bitcoin_plants::plants {
+
+    use std::string;
+    use moveos_std::tx_context;
+    use moveos_std::object::{Self, Object};
+    use rooch_framework::coin::{Self, Coin, CoinInfo};
+    use rooch_framework::account_coin_store;
+    use rooch_framework::timestamp;
+    use bitcoin_move::utxo::{Self, UTXO};
+    use bitcoin_move::ord::Inscription;
+
+    const ErrorAlreadyStaked: u64 = 1;
+    const ErrorAlreadyClaimed: u64 = 2;
+
+    /// The fruit NFT.
+    struct Fruit has key, store {
+        variety: u64,
+        value: u64,
+    }
+
+    /// The plant.
+    /// Recording the plant's status and will be stored in the permanent state area of the UTXO
+    struct Plant has store {
+        /// The variety of the plant. The type variety is inferred from the seed Inscription.
+        variety: u64,
+        /// The growth value of the plant. The value will be updated by watering actions.
+        /// All status can be inferred from the growth value.
+        growth_value: u64,
+        status: u8,
+        last_watering_time: u64,
+    }
+
+    fun init() {
+        let coin_info_obj = coin::register_extend<HDC>(
+            string::utf8(b"BTC Holder Coin"),
+            string::utf8(b"HDC"),
+            DECIMALS,
+        );
+        let coin_info_holder_obj = object::new_named_object(CoinInfoHolder { coin_info: coin_info_obj });
+        // Make the coin info holder object to shared, so anyone can get mutable CoinInfoHolder object
+        object::to_shared(coin_info_holder_obj);
+    }
+
+    /// Plant with seed represented by the Inscription
+    // Parse the Inscription and store planting info and plant states in the UTXO's permanent state area.
+    public fun do_plant(seed: &mut Object<Inscription>) {
+        // Parse the Inscription, check if it is a seed Inscription.
+        // A seed inscription has protocol `bitseed` and tick name `seed`
+
+
+        // Check if the UTXO is already planted
+
+        // Store the planting info and plant status in the UTXO's permanent state area
+    }
+
+    public fun do_water(plant: &mut Object<Inscription>) {
+        // Check watering actions of this plant
+
+        // Update plant status and watering actions
+    }
+
+    public fun do_harvest(plant: &mut Object<Inscription>) {
+        // Check the plant's status.
+
+        // Harvest the plant if there are fruits
+    }
+
+    public fun is_seed(json_map: &SimpleMap<String,String>) : bool {
+        let protocol_key = string::utf8(b"p");
+        simple_map::contains_key(json_map, &protocol_key) && \
+        simple_map::borrow(json_map, &protocol_key) == &string::utf8(b"bitseed") && \
+        simple_map::borrow(json_map, &string::utf8(b"n")) == &string::utf8(b"seed")
+    }
+}

--- a/examples/bitcoin_plants/sources/plants.move
+++ b/examples/bitcoin_plants/sources/plants.move
@@ -74,7 +74,6 @@ module bitcoin_plants::plants {
 
         // Check if the Inscription is already planted
         assert!(!ord::contains_permanent_state<Plant>(seed), ErrorAlreadyPlanted);
-
         // TODO: init the Plant from seed attributes
         let plant = Plant {
             variety: 0,
@@ -162,8 +161,12 @@ module bitcoin_plants::plants {
     #[test_only]
     use std::option;
 
+    #[test_only]
+    use rooch_framework::genesis;
+
     #[test]
     fun test() {
+        genesis::init_for_test();
         let inscription_obj = ord::new_inscription_object_for_test(
             @0x3232423,
             0,
@@ -195,7 +198,7 @@ module bitcoin_plants::plants {
 
         let plant = ord::remove_permanent_state<Plant>(&mut inscription_obj);
         let Plant { variety: _, growth_value: _, health: _, last_watering_time: _, pickable_fruits: _, picked_fruits: _ } = plant;
-        
+        ord::destroy_permanent_area(&mut inscription_obj);
         ord::drop_inscription_object_for_test(inscription_obj);
     }
 }

--- a/frameworks/bitcoin-move/doc/ord.md
+++ b/frameworks/bitcoin-move/doc/ord.md
@@ -48,6 +48,12 @@
 -  [Function `borrow_permanent_state`](#0x4_ord_borrow_permanent_state)
 -  [Function `borrow_mut_permanent_state`](#0x4_ord_borrow_mut_permanent_state)
 -  [Function `remove_permanent_state`](#0x4_ord_remove_permanent_state)
+-  [Function `add_temp_state`](#0x4_ord_add_temp_state)
+-  [Function `contains_temp_state`](#0x4_ord_contains_temp_state)
+-  [Function `borrow_temp_state`](#0x4_ord_borrow_temp_state)
+-  [Function `borrow_mut_temp_state`](#0x4_ord_borrow_mut_temp_state)
+-  [Function `remove_temp_state`](#0x4_ord_remove_temp_state)
+-  [Function `drop_temp_area`](#0x4_ord_drop_temp_area)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -151,6 +157,15 @@
 <a name="@Constants_0"></a>
 
 ## Constants
+
+
+<a name="0x4_ord_TEMPORARY_AREA"></a>
+
+
+
+<pre><code><b>const</b> <a href="ord.md#0x4_ord_TEMPORARY_AREA">TEMPORARY_AREA</a>: <a href="">vector</a>&lt;u8&gt; = [116, 101, 109, 112, 111, 114, 97, 114, 121, 95, 97, 114, 101, 97];
+</code></pre>
+
 
 
 <a name="0x4_ord_COIN_VALUE"></a>
@@ -579,4 +594,74 @@ Block Rewards
 
 <pre><code>#[private_generics(#[S])]
 <b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_remove_permanent_state">remove_permanent_state</a>&lt;S: store&gt;(inscription: &<b>mut</b> <a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;): S
+</code></pre>
+
+
+
+<a name="0x4_ord_add_temp_state"></a>
+
+## Function `add_temp_state`
+
+
+
+<pre><code>#[private_generics(#[S])]
+<b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_add_temp_state">add_temp_state</a>&lt;S: drop, store&gt;(inscription: &<b>mut</b> <a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;, state: S)
+</code></pre>
+
+
+
+<a name="0x4_ord_contains_temp_state"></a>
+
+## Function `contains_temp_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_contains_temp_state">contains_temp_state</a>&lt;S: drop, store&gt;(inscription: &<a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;): bool
+</code></pre>
+
+
+
+<a name="0x4_ord_borrow_temp_state"></a>
+
+## Function `borrow_temp_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_borrow_temp_state">borrow_temp_state</a>&lt;S: drop, store&gt;(inscription: &<a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;): &S
+</code></pre>
+
+
+
+<a name="0x4_ord_borrow_mut_temp_state"></a>
+
+## Function `borrow_mut_temp_state`
+
+
+
+<pre><code>#[private_generics(#[S])]
+<b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_borrow_mut_temp_state">borrow_mut_temp_state</a>&lt;S: drop, store&gt;(inscription: &<b>mut</b> <a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;): &<b>mut</b> S
+</code></pre>
+
+
+
+<a name="0x4_ord_remove_temp_state"></a>
+
+## Function `remove_temp_state`
+
+
+
+<pre><code>#[private_generics(#[S])]
+<b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_remove_temp_state">remove_temp_state</a>&lt;S: drop, store&gt;(inscription: &<b>mut</b> <a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;): S
+</code></pre>
+
+
+
+<a name="0x4_ord_drop_temp_area"></a>
+
+## Function `drop_temp_area`
+
+Drop the bag, whether it's empty or not
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ord.md#0x4_ord_drop_temp_area">drop_temp_area</a>(inscription: &<b>mut</b> <a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;)
 </code></pre>

--- a/frameworks/bitcoin-move/doc/ord.md
+++ b/frameworks/bitcoin-move/doc/ord.md
@@ -43,11 +43,17 @@
 -  [Function `from_transaction_bytes`](#0x4_ord_from_transaction_bytes)
 -  [Function `subsidy_by_height`](#0x4_ord_subsidy_by_height)
 -  [Function `bind_multichain_address`](#0x4_ord_bind_multichain_address)
+-  [Function `add_permanent_state`](#0x4_ord_add_permanent_state)
+-  [Function `contains_permanent_state`](#0x4_ord_contains_permanent_state)
+-  [Function `borrow_permanent_state`](#0x4_ord_borrow_permanent_state)
+-  [Function `borrow_mut_permanent_state`](#0x4_ord_borrow_mut_permanent_state)
+-  [Function `remove_permanent_state`](#0x4_ord_remove_permanent_state)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::string</a>;
 <b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="">0x2::bag</a>;
 <b>use</b> <a href="">0x2::bcs</a>;
 <b>use</b> <a href="">0x2::event</a>;
 <b>use</b> <a href="">0x2::json</a>;
@@ -55,6 +61,7 @@
 <b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="">0x2::simple_map</a>;
 <b>use</b> <a href="">0x2::table_vec</a>;
+<b>use</b> <a href="">0x2::type_info</a>;
 <b>use</b> <a href="">0x3::address_mapping</a>;
 <b>use</b> <a href="">0x3::bitcoin_address</a>;
 <b>use</b> <a href="">0x3::multichain_address</a>;
@@ -161,6 +168,15 @@ How many satoshis are in "one bitcoin".
 
 
 <pre><code><b>const</b> <a href="ord.md#0x4_ord_FIRST_POST_SUBSIDY_EPOCH">FIRST_POST_SUBSIDY_EPOCH</a>: u32 = 33;
+</code></pre>
+
+
+
+<a name="0x4_ord_PERMANENT_AREA"></a>
+
+
+
+<pre><code><b>const</b> <a href="ord.md#0x4_ord_PERMANENT_AREA">PERMANENT_AREA</a>: <a href="">vector</a>&lt;u8&gt; = [112, 101, 114, 109, 97, 110, 101, 110, 116, 95, 97, 114, 101, 97];
 </code></pre>
 
 
@@ -505,4 +521,62 @@ Block Rewards
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ord.md#0x4_ord_bind_multichain_address">bind_multichain_address</a>(rooch_address: <b>address</b>, bitcoin_address_opt: <a href="_Option">option::Option</a>&lt;<a href="_BitcoinAddress">bitcoin_address::BitcoinAddress</a>&gt;)
+</code></pre>
+
+
+
+<a name="0x4_ord_add_permanent_state"></a>
+
+## Function `add_permanent_state`
+
+
+
+<pre><code>#[private_generics(#[S])]
+<b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_add_permanent_state">add_permanent_state</a>&lt;S: store&gt;(inscription: &<b>mut</b> <a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;, state: S)
+</code></pre>
+
+
+
+<a name="0x4_ord_contains_permanent_state"></a>
+
+## Function `contains_permanent_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_contains_permanent_state">contains_permanent_state</a>&lt;S: store&gt;(inscription: &<a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;): bool
+</code></pre>
+
+
+
+<a name="0x4_ord_borrow_permanent_state"></a>
+
+## Function `borrow_permanent_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_borrow_permanent_state">borrow_permanent_state</a>&lt;S: store&gt;(inscription: &<a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;): &S
+</code></pre>
+
+
+
+<a name="0x4_ord_borrow_mut_permanent_state"></a>
+
+## Function `borrow_mut_permanent_state`
+
+
+
+<pre><code>#[private_generics(#[S])]
+<b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_borrow_mut_permanent_state">borrow_mut_permanent_state</a>&lt;S: store&gt;(inscription: &<b>mut</b> <a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;): &<b>mut</b> S
+</code></pre>
+
+
+
+<a name="0x4_ord_remove_permanent_state"></a>
+
+## Function `remove_permanent_state`
+
+
+
+<pre><code>#[private_generics(#[S])]
+<b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_remove_permanent_state">remove_permanent_state</a>&lt;S: store&gt;(inscription: &<b>mut</b> <a href="_Object">object::Object</a>&lt;<a href="ord.md#0x4_ord_Inscription">ord::Inscription</a>&gt;): S
 </code></pre>

--- a/frameworks/bitcoin-move/doc/utxo.md
+++ b/frameworks/bitcoin-move/doc/utxo.md
@@ -10,7 +10,6 @@
 -  [Resource `BitcoinUTXOStore`](#0x4_utxo_BitcoinUTXOStore)
 -  [Struct `CreatingUTXOEvent`](#0x4_utxo_CreatingUTXOEvent)
 -  [Struct `RemovingUTXOEvent`](#0x4_utxo_RemovingUTXOEvent)
--  [Struct `TempState`](#0x4_utxo_TempState)
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x4_utxo_genesis_init)
 -  [Function `borrow_utxo_store`](#0x4_utxo_borrow_utxo_store)
@@ -106,17 +105,6 @@ Event for remove UTXO
 
 
 <pre><code><b>struct</b> <a href="utxo.md#0x4_utxo_RemovingUTXOEvent">RemovingUTXOEvent</a> <b>has</b> drop, store
-</code></pre>
-
-
-
-<a name="0x4_utxo_TempState"></a>
-
-## Struct `TempState`
-
-
-
-<pre><code><b>struct</b> <a href="utxo.md#0x4_utxo_TempState">TempState</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/frameworks/bitcoin-move/sources/ord.move
+++ b/frameworks/bitcoin-move/sources/ord.move
@@ -29,6 +29,7 @@ module bitcoin_move::ord {
     const FIRST_POST_SUBSIDY_EPOCH: u32 = 33;
 
     const PERMANENT_AREA: vector<u8> = b"permanent_area";
+    const TEMPORARY_AREA: vector<u8> = b"temporary_area";
 
     /// How many satoshis are in "one bitcoin".
     const COIN_VALUE: u64 = 100_000_000;
@@ -213,6 +214,8 @@ module bitcoin_move::ord {
             let seal_object_id = *vector::borrow(&mut seals, j);
             let (origin_owner, inscription_obj) = object::take_object_extend<Inscription>(seal_object_id);
             let inscription = object::borrow_mut(&mut inscription_obj);
+            // drop the temporary area if inscription is transferred.
+            drop_temporary_area(&mut inscription_obj);
 
             let (is_match, new_sat_point) = match_utxo_and_generate_sat_point(inscription.offset, seal_object_id, tx, input_utxo_values, input_index);
             if(is_match){
@@ -669,10 +672,68 @@ module bitcoin_move::ord {
     }
 
     // TODO: remove #[test_only]?
+    /// Destroy permanent area if it's empty. Aborts if it's not empty.
     #[test_only]
     public fun destroy_permanent_area(inscription: &mut Object<Inscription>){
-        let bag: Bag = object::remove_field(inscription, PERMANENT_AREA);
-        bag::destroy_empty(bag);
+        if object::contains_field(inscription, PERMANENT_AREA) {
+            let bag = object::remove_field(inscription, PERMANENT_AREA);
+            bag::destroy_empty(bag);
+        }
+    }
+
+
+    // ==== Temporary Area ===
+
+    #[private_generics(S)]
+    public fun add_temp_state<S: store + drop>(inscription: &mut Object<Inscription>, state: S){
+        if(object::contains_field(inscription, TEMPORARY_AREA)){
+            let bag = object::borrow_mut_field(inscription, TEMPORARY_AREA);
+            let name = type_info::type_name<S>();
+            bag::add_dropable(bag, name, state);
+        }else{
+            let bag = bag::new_dropable();
+            let name = type_info::type_name<S>();
+            bag::add_dropable(&mut bag, name, state);
+            object::add_field(inscription, TEMPORARY_AREA, bag);
+        }
+    }
+
+    public fun contains_temp_state<S: store + drop>(inscription: &Object<Inscription>) : bool {
+        if(object::contains_field(inscription, TEMPORARY_AREA)){
+            let bag = object::borrow_field(inscription, TEMPORARY_AREA);
+            let name = type_info::type_name<S>();
+            bag::contains(bag, name)
+        }else{
+            false
+        }
+    }
+
+    public fun borrow_temp_state<S: store + drop>(inscription: &Object<Inscription>) : &S {
+        let bag = object::borrow_field(inscription, TEMPORARY_AREA);
+        let name = type_info::type_name<S>();
+        bag::borrow(bag, name)
+    }
+
+    #[private_generics(S)]
+    public fun borrow_mut_temp_state<S: store + drop>(inscription: &mut Object<Inscription>) : &mut S {
+        let bag = object::borrow_mut_field(inscription, TEMPORARY_AREA);
+        let name = type_info::type_name<S>();
+        bag::borrow_mut(bag, name)
+    }
+
+    #[private_generics(S)]
+    public fun remove_temp_state<S: store + drop>(inscription: &mut Object<Inscription>) : S {
+        let bag = object::borrow_mut_field(inscription, TEMPORARY_AREA);
+        let name = type_info::type_name<S>();
+        bag::remove(bag, name)
+    }
+
+    /// Drop the bag, whether it's empty or not
+    public(friend) fun drop_temporary_area(inscription: &mut Object<Inscription>){
+        if object::contains_field(inscription, TEMPORARY_AREA) {
+            let bag = object::remove_field(inscription, TEMPORARY_AREA);
+            bag::drop(bag);
+        }
     }
 
     #[test_only]
@@ -760,5 +821,80 @@ module bitcoin_move::ord {
         let PermanentState { value: _ } = state;
         destroy_permanent_area(&mut inscription_obj);
         drop_inscription_object_for_test(inscription_obj);
+    }
+
+    #[test_only]
+    struct TempState has store, copy, drop {
+        value: u64,
+    }
+
+    #[test]
+    fun test_temp_state(){
+        // genesis_init();
+        let txid = @0x77dfc2fe598419b00641c296181a96cf16943697f573480b023b77cce82ada21;
+        let inscription_obj = new_inscription_object_for_test(
+            txid,
+            0,
+            0,
+            0,
+            vector[],
+            option::none(),
+            option::none(),
+            vector[],
+            option::none(),
+            option::none(),
+            option::none(),
+        );
+        add_temp_state(&mut inscription_obj, TempState{value: 10});
+        assert!(contains_temp_state<TempState>(&inscription_obj), 1);
+        assert!(borrow_temp_state<TempState>(&inscription_obj).value == 10, 2);
+        {
+            let state = borrow_mut_temp_state<TempState>(&mut inscription_obj);
+            state.value = 20;
+        };
+        let state = remove_temp_state<TempState>(&mut inscription_obj);
+        assert!(state.value == 20, 1);
+        assert!(!contains_temp_state<TempState>(&inscription_obj), 3);
+
+        drop_temporary_area(&mut inscription_obj);
+        drop_inscription_object_for_test(inscription_obj);
+    }
+
+    #[test_only]
+    fun mock_inscription_transferring_along_utxo(inscription_obj: Object<Inscription>, to: address) {
+        drop_temporary_area(&mut inscription_obj);
+        object::transfer_extend(inscription_obj, to);
+    }
+
+    // If the inscription is transferred, the permanent area will be kept and the temporary area will be dropped.
+    #[test]
+    fun test_transfer() {
+        let txid = @0x77dfc2fe598419b00641c296181a96cf16943697f573480b023b77cce82ada21;
+        let inscription_obj = new_inscription_object_for_test(
+            txid,
+            0,
+            0,
+            0,
+            vector[],
+            option::none(),
+            option::none(),
+            vector[],
+            option::none(),
+            option::none(),
+            option::none(),
+        );
+
+        add_temp_state(&mut inscription_obj, TempState{value: 10});
+        add_permanent_state(&mut inscription_obj, PermanentState{value: 10});
+        let object_id = object::id(&inscription_obj);
+
+        let to_address = @0x42;
+        {
+            mock_inscription_transferring_along_utxo(inscription_obj, to_address);
+        }
+
+        let inscription_obj = object::borrow_object<Inscription>(object_id);
+        assert!(!contains_temp_state<TempState>(&inscription_obj), 1);
+        assert!(contains_permanent_state<PermanentState>(&inscription_obj), 2);
     }
 }

--- a/frameworks/bitcoin-move/sources/ord.move
+++ b/frameworks/bitcoin-move/sources/ord.move
@@ -173,6 +173,17 @@ module bitcoin_move::ord {
         json::to_map(record.body)
     }
 
+    public fun parse_inscription_body(inscription: &Inscription) : SimpleMap<String,String> {
+        if (vector::is_empty(&inscription.body) || option::is_none(&inscription.content_type)) {
+            return simple_map::new()
+        };
+        let content_type = option::destroy_some(inscription.content_type);
+        if(content_type != string::utf8(b"text/plain;charset=utf-8") || content_type != string::utf8(b"text/plain") || content_type != string::utf8(b"application/json")){
+            return simple_map::new()
+        };
+        json::to_map(inscription.body)
+    }
+
     public fun exists_inscription(txid: address, index: u32): bool{
         let id = InscriptionID{
             txid: txid,

--- a/frameworks/bitcoin-move/sources/ord.move
+++ b/frameworks/bitcoin-move/sources/ord.move
@@ -13,7 +13,7 @@ module bitcoin_move::ord {
     use moveos_std::json;
     use moveos_std::table_vec::{Self, TableVec};
     use moveos_std::type_info;
-    use moveos_std::bag::{Self, Bag};
+    use moveos_std::bag;
     use rooch_framework::address_mapping;
     use rooch_framework::multichain_address;
     use rooch_framework::bitcoin_address::BitcoinAddress;

--- a/frameworks/bitcoin-move/sources/utxo.move
+++ b/frameworks/bitcoin-move/sources/utxo.move
@@ -283,6 +283,7 @@ module bitcoin_move::utxo{
         simple_multimap::drop(seals);
     }
 
+    #[test_only]
     struct TempState has store, copy, drop {
         value: u64,
     }


### PR DESCRIPTION
## Summary

1. Add permanent_area for `bitcoin_move::ord::Inscription`
2. Add an incomplete example `bitcoin_plants`(#1214 ) which use the permanent area.
