### PR TITLE
docs: fix links in Rooch's built-in library page and add dependencies at Installation page

### DIFF
--- a/docs/website/pages/build/getting-started/installation.en-US.mdx
+++ b/docs/website/pages/build/getting-started/installation.en-US.mdx
@@ -7,7 +7,7 @@
 #### Install dependencies
 
 ```shell
-sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev g++
+sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++
 ```
 
 #### Install Rust

--- a/docs/website/pages/build/getting-started/installation.zh-CN.mdx
+++ b/docs/website/pages/build/getting-started/installation.zh-CN.mdx
@@ -7,7 +7,7 @@
 #### 安装依赖
 
 ```shell
-sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev g++
+sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++
 ```
 
 #### 安装 Rust

--- a/docs/website/pages/learn/core-concepts/move-contracts/built-in-library.en-US.mdx
+++ b/docs/website/pages/learn/core-concepts/move-contracts/built-in-library.en-US.mdx
@@ -10,6 +10,6 @@ The addresses of the three libraries in Move are:
 
 ## Documentation link
 
-- [MoveStdlib](https://github.com/rooch-network/rooch/tree/frameworks/move-stdlib/doc)
-- [MoveosStdlib](https://github.com/rooch-network/rooch/edit/frameworks/moveos-stdlib/doc)
-- [RoochFramework](https://github.com/rooch-network/rooch/tree/frameworks/rooch-framework/doc)
+- [MoveStdlib](https://github.com/rooch-network/rooch/tree/main/frameworks/move-stdlib/doc)
+- [MoveosStdlib](https://github.com/rooch-network/rooch/tree/main/frameworks/moveos-stdlib/doc)
+- [RoochFramework](https://github.com/rooch-network/rooch/tree/main/frameworks/rooch-framework/doc)

--- a/docs/website/pages/learn/core-concepts/move-contracts/built-in-library.zh-CN.mdx
+++ b/docs/website/pages/learn/core-concepts/move-contracts/built-in-library.zh-CN.mdx
@@ -10,6 +10,6 @@ Rooch 当前内置了三个标准库，分别是 `MoveStdlib`、`MoveosStdlib` �
 
 ## 文档链接
 
-- [MoveStdlib](https://github.com/rooch-network/rooch/tree/frameworks/move-stdlib/doc)
-- [MoveosStdlib](https://github.com/rooch-network/rooch/edit/frameworks/moveos-stdlib/doc)
-- [RoochFramework](https://github.com/rooch-network/rooch/tree/frameworks/rooch-framework/doc)
+- [MoveStdlib](https://github.com/rooch-network/rooch/tree/main/frameworks/move-stdlib/doc)
+- [MoveosStdlib](https://github.com/rooch-network/rooch/tree/main/frameworks/moveos-stdlib/doc)
+- [RoochFramework](https://github.com/rooch-network/rooch/tree/main/frameworks/rooch-framework/doc)


### PR DESCRIPTION
1.fix links
2. I met the problem `note: ld.lld: error: unable to find library -lsqlite3` when I run `cargo build`. 
So I add the `libsqlite3-dev` to dependencies.