### PR TITLE
[CLI] Add --gas-limit option

### DIFF
--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -142,6 +142,7 @@ impl WalletContext {
         &self,
         sender: RoochAddress,
         action: MoveAction,
+        max_gas_amount: Option<u64>,
     ) -> RoochResult<RoochTransactionData> {
         let client = self.get_client().await?;
         let chain_id = client.rooch.get_chain_id().await?;
@@ -156,7 +157,7 @@ impl WalletContext {
             sender,
             sequence_number,
             chain_id,
-            GasConfig::DEFAULT_MAX_GAS_AMOUNT,
+            max_gas_amount.unwrap_or(GasConfig::DEFAULT_MAX_GAS_AMOUNT),
             action,
         );
         Ok(tx_data)
@@ -167,6 +168,7 @@ impl WalletContext {
         sender: RoochAddress,
         action: MoveAction,
         password: Option<String>,
+        max_gas_amount: Option<u64>,
     ) -> RoochResult<RoochTransaction> {
         let kp = self
             .keystore
@@ -178,7 +180,7 @@ impl WalletContext {
                 ))
             })?;
 
-        let tx_data = self.build_tx_data(sender, action).await?;
+        let tx_data = self.build_tx_data(sender, action, max_gas_amount).await?;
         let signature = Signature::new_hashed(tx_data.tx_hash().as_bytes(), &kp);
         Ok(RoochTransaction::new(
             tx_data,
@@ -203,8 +205,9 @@ impl WalletContext {
         sender: RoochAddress,
         action: MoveAction,
         password: Option<String>,
+        max_gas_amount: Option<u64>,
     ) -> RoochResult<ExecuteTransactionResponseView> {
-        let tx = self.sign(sender, action, password).await?;
+        let tx = self.sign(sender, action, password, max_gas_amount).await?;
         self.execute(tx).await
     }
 

--- a/crates/rooch/src/cli_types.rs
+++ b/crates/rooch/src/cli_types.rs
@@ -73,6 +73,11 @@ pub struct TransactionOptions {
     #[clap(long, alias = "sender-account", value_parser=ParsedAddress::parse, default_value = "default")]
     pub(crate) sender: ParsedAddress,
 
+    /// Custom the transaction's gas limit.
+    /// [default: 1_000_000_000] [alias: "gas-limit"]
+    #[clap(long, alias = "gas-limit")]
+    pub(crate) max_gas_amount: Option<u64>,
+
     /// Custom the transaction's authenticator
     /// format: `auth_validator_id:payload`, auth validator id is u64, payload is hex string
     /// example: 123:0x2abc

--- a/crates/rooch/src/commands/account/commands/nullify.rs
+++ b/crates/rooch/src/commands/account/commands/nullify.rs
@@ -49,7 +49,7 @@ impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
         // Execute the Move call as a transaction
         let mut result = if context.keystore.get_if_password_is_empty() {
             context
-                .sign_and_execute(existing_address, action, None)
+                .sign_and_execute(existing_address, action, None, None)
                 .await?
         } else {
             let password =
@@ -64,7 +64,7 @@ impl CommandAction<ExecuteTransactionResponseView> for NullifyCommand {
             }
 
             context
-                .sign_and_execute(existing_address, action, Some(password))
+                .sign_and_execute(existing_address, action, Some(password), None)
                 .await?
         };
         result = context.assert_execute_success(result)?;

--- a/moveos/moveos-types/src/gas_config.rs
+++ b/moveos/moveos-types/src/gas_config.rs
@@ -7,5 +7,5 @@ pub struct GasConfig {
 }
 
 impl GasConfig {
-    pub const DEFAULT_MAX_GAS_AMOUNT: u64 = 1000000000u64;
+    pub const DEFAULT_MAX_GAS_AMOUNT: u64 = 1_000_000_000u64;
 }


### PR DESCRIPTION
Example:
```
rooch move run --help
...
--max-gas-amount <MAX_GAS_AMOUNT>
          Custom the transaction's gas limit. [default: 1_000_000_000] [alias: "gas-limit"]
...
```

Usage:
`rooch move run --function 0xa::quick_start_counter::increase --sender-account default --gas-limit 2000000000`
or
`rooch move run --function 0xa::quick_start_counter::increase --sender-account default --max-gas-amount 2000000000`

Support:
`rooch move run`
`rooch move publish`
`rooch move framework-upgrade`
`rooch session-key create`

issue: #1257 