### PR TITLE
Show display fields of object states from indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,15 +95,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.10",
  "once_cell",
  "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -539,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -698,9 +697,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "base64ct"
@@ -1267,9 +1266,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde 1.0.195",
 ]
@@ -1428,7 +1427,7 @@ name = "celestia-types"
 version = "0.1.0"
 source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=129272e8d926b4c7badf27a26dea915323dd6489#129272e8d926b4c7badf27a26dea915323dd6489"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.21.3",
  "bech32 0.9.1",
  "blockstore",
  "bytes",
@@ -1490,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1500,7 +1499,7 @@ dependencies = [
  "num-traits 0.2.16",
  "serde 1.0.195",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1771,7 +1770,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.21.3",
  "bech32 0.9.1",
  "bs58 0.5.1",
  "digest 0.10.7",
@@ -2479,7 +2478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.5",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -2585,11 +2584,10 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 dependencies = [
- "powerfmt",
  "serde 1.0.195",
 ]
 
@@ -3009,7 +3007,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be7b2ac146c1f99fe245c02d16af0696450d8e06c135db75e10eeb9e642c20d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.21.3",
  "bytes",
  "hex",
  "k256 0.13.1",
@@ -3362,7 +3360,7 @@ checksum = "00c84664b294e47fc2860d6db0db0246f79c4c724e552549631bb9505b834bee"
 dependencies = [
  "async-trait",
  "auto_impl",
- "base64 0.21.7",
+ "base64 0.21.3",
  "bytes",
  "const-hex",
  "enr",
@@ -3651,9 +3649,9 @@ checksum = "d52a7e408202050813e6f1d9addadcaafef3dca7530c7ddfb005d4081cce6779"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3801,9 +3799,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3816,9 +3814,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3826,15 +3824,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3843,9 +3841,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-locks"
@@ -3859,9 +3857,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -3870,15 +3868,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
@@ -3892,9 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4138,16 +4136,16 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.8.3",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.8.3",
  "allocator-api2",
 ]
 
@@ -4552,7 +4550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -4561,7 +4559,7 @@ version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.8.3",
  "indexmap 2.0.0",
  "is-terminal",
  "itoa",
@@ -5008,7 +5006,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.21.3",
  "pem 1.1.1",
  "ring 0.16.20",
  "serde 1.0.195",
@@ -5022,7 +5020,7 @@ version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.21.3",
  "js-sys",
  "pem 3.0.3",
  "ring 0.17.7",
@@ -5280,7 +5278,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -5454,9 +5452,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
@@ -6585,7 +6583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38ff6fec17be97b6ea1e30a4913618c8e02b2e555b5188d01668f2e4fa09507"
 dependencies = [
  "aes",
- "base64 0.21.7",
+ "base64 0.21.3",
  "bech32 0.9.1",
  "bip39",
  "bitcoin 0.30.1",
@@ -6661,12 +6659,6 @@ checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits 0.2.16",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -6855,7 +6847,7 @@ dependencies = [
  "async-compat",
  "async-trait",
  "backon",
- "base64 0.21.7",
+ "base64 0.21.3",
  "bytes",
  "chrono",
  "flagset",
@@ -6944,7 +6936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4d6a8c22fc714f0c2373e6091bf6f5e9b37b1bc0b1184874b7e0a4e303d318f"
 dependencies = [
  "dlv-list",
- "hashbrown 0.14.5",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -7207,7 +7199,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.21.3",
  "serde 1.0.195",
 ]
 
@@ -7537,12 +7529,6 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
@@ -8300,7 +8286,7 @@ checksum = "dce87f66ba6c6acef277a729f989a0eca946cb9ce6a15bcc036bda0f72d4b9fd"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.21.3",
  "chrono",
  "form_urlencoded",
  "getrandom 0.2.10",
@@ -8326,11 +8312,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.21.3",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -8355,8 +8341,6 @@ dependencies = [
  "serde 1.0.195",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -8681,7 +8665,7 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.21.3",
  "bcs",
  "celestia-rpc",
  "celestia-types",
@@ -9635,7 +9619,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.21.3",
 ]
 
 [[package]]
@@ -10492,12 +10476,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10783,27 +10767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11041,14 +11004,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "itoa",
- "num-conv",
- "powerfmt",
  "serde 1.0.195",
  "time-core",
  "time-macros",
@@ -11056,17 +11017,16 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
 dependencies = [
- "num-conv",
  "time-core",
 ]
 
@@ -11142,9 +11102,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -11154,7 +11114,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -11171,9 +11131,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -11445,10 +11405,11 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -11457,9 +11418,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -11468,9 +11429,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -11998,9 +11959,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -12587,26 +12548,6 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 2.0.48",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6379,6 +6379,7 @@ dependencies = [
  "smt",
  "thiserror",
  "tiny-keccak",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -375,7 +375,11 @@ impl IndexerReader {
                 format!("{STATE_OWNER_STR} = \"{}\"", owner.to_hex_literal())
             }
             ObjectStateFilter::ObjectId(object_ids) => {
-                let object_ids_str = object_ids.into_iter().map(|obj_id| format!("\"{}\"", obj_id)).collect::<String>().join(",");
+                let object_ids_str = object_ids
+                    .into_iter()
+                    .map(|obj_id| format!("\"{}\"", obj_id))
+                    .collect::<Vec<_>>()
+                    .join(",");
                 format!("{OBJECT_ID_STR} IN ({object_ids_str})")
             }
         };

--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -374,8 +374,9 @@ impl IndexerReader {
             ObjectStateFilter::Owner(owner) => {
                 format!("{STATE_OWNER_STR} = \"{}\"", owner.to_hex_literal())
             }
-            ObjectStateFilter::ObjectId(object_id) => {
-                format!("{OBJECT_ID_STR} = \"{}\"", object_id)
+            ObjectStateFilter::ObjectId(object_ids) => {
+                let object_ids_str = object_ids.into_iter().map(|obj_id| format!("\"{}\"", obj_id)).collect::<String>().join(",");
+                format!("{OBJECT_ID_STR} IN ({object_ids_str})")
             }
         };
 

--- a/crates/rooch-indexer/src/models/states.rs
+++ b/crates/rooch-indexer/src/models/states.rs
@@ -67,7 +67,12 @@ impl StoredObjectState {
     pub fn try_into_indexer_global_state(&self) -> Result<IndexerObjectState, anyhow::Error> {
         let object_id = ObjectID::from_str(self.object_id.as_str())?;
         let owner = AccountAddress::from_hex_literal(self.owner.as_str())?;
-        let object_type = StructTag::from_str(self.object_type.as_str())?;
+        let obj_type_str = if !self.object_type.starts_with("0x") {
+            format!("0x{}", self.object_type)
+        } else {
+            self.object_type.clone()
+        };
+        let object_type = StructTag::from_str(obj_type_str.as_str())?;
         let state_root = AccountAddress::from_hex_literal(self.state_root.as_str())?;
 
         let state = IndexerObjectState {

--- a/crates/rooch-indexer/src/tests/test_indexer.rs
+++ b/crates/rooch-indexer/src/tests/test_indexer.rs
@@ -248,6 +248,12 @@ fn test_state_store() -> Result<()> {
         indexer_reader.query_object_states_with_filter(filter, None, 1, true)?;
     assert_eq!(query_object_states.len(), 0);
 
+    // test for querying batch objects with filter ObjectStateFilter::ObjectId
+    let object_ids = update_object_states.into_iter().map(|state| state.object_id).collect::<Vec<ObjectID>>();
+    let filter = ObjectStateFilter::ObjectId(object_ids);
+    let query_object_states = indexer_reader.query_object_states_with_filter(filter, None, object_ids.len(), true)?;
+    assert_eq!(query_object_states.len(), object_ids.len());
+    
     let talbe_handle = ObjectID::from_str("0x0")?;
     let filter = FieldStateFilter::ObjectId(talbe_handle);
     let query_field_states =

--- a/crates/rooch-indexer/src/tests/test_indexer.rs
+++ b/crates/rooch-indexer/src/tests/test_indexer.rs
@@ -249,11 +249,16 @@ fn test_state_store() -> Result<()> {
     assert_eq!(query_object_states.len(), 0);
 
     // test for querying batch objects with filter ObjectStateFilter::ObjectId
-    let object_ids = update_object_states.into_iter().map(|state| state.object_id).collect::<Vec<ObjectID>>();
+    let object_ids = update_object_states
+        .into_iter()
+        .map(|state| state.object_id)
+        .collect::<Vec<ObjectID>>();
+    let num_objs = object_ids.len();
     let filter = ObjectStateFilter::ObjectId(object_ids);
-    let query_object_states = indexer_reader.query_object_states_with_filter(filter, None, object_ids.len(), true)?;
-    assert_eq!(query_object_states.len(), object_ids.len());
-    
+    let query_object_states =
+        indexer_reader.query_object_states_with_filter(filter, None, num_objs, true)?;
+    assert_eq!(query_object_states.len(), num_objs);
+
     let talbe_handle = ObjectID::from_str("0x0")?;
     let filter = FieldStateFilter::ObjectId(talbe_handle);
     let query_field_states =

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -487,9 +487,9 @@
           }
         },
         {
-          "name": "descending_order",
+          "name": "query_option",
           "schema": {
-            "type": "boolean"
+            "$ref": "#/components/schemas/QueryOptions"
           }
         }
       ],
@@ -1205,6 +1205,16 @@
             "format": "uint64",
             "minimum": 0.0
           },
+          "display_fields": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DisplayFieldsView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "flag": {
             "type": "integer",
             "format": "uint8",
@@ -1849,7 +1859,10 @@
             ],
             "properties": {
               "object_id": {
-                "$ref": "#/components/schemas/ObjectID"
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectID"
+                }
               }
             },
             "additionalProperties": false
@@ -2231,6 +2244,21 @@
                 "type": "null"
               }
             ]
+          }
+        }
+      },
+      "QueryOptions": {
+        "type": "object",
+        "properties": {
+          "descending": {
+            "description": "If true, return query items in descending order.",
+            "default": false,
+            "type": "boolean"
+          },
+          "showDisplay": {
+            "description": "If true, result with display rendered is returned",
+            "default": false,
+            "type": "boolean"
           }
         }
       },

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -2252,7 +2252,7 @@
         "properties": {
           "descending": {
             "description": "If true, return query items in descending order.",
-            "default": false,
+            "default": true,
             "type": "boolean"
           },
           "showDisplay": {

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -411,9 +411,9 @@
           }
         },
         {
-          "name": "descending_order",
+          "name": "query_option",
           "schema": {
-            "type": "boolean"
+            "$ref": "#/components/schemas/QueryOptions"
           }
         }
       ],
@@ -449,9 +449,9 @@
           }
         },
         {
-          "name": "descending_order",
+          "name": "query_option",
           "schema": {
-            "type": "boolean"
+            "$ref": "#/components/schemas/QueryOptions"
           }
         }
       ],
@@ -525,9 +525,9 @@
           }
         },
         {
-          "name": "descending_order",
+          "name": "query_option",
           "schema": {
-            "type": "boolean"
+            "$ref": "#/components/schemas/QueryOptions"
           }
         }
       ],

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -9,8 +9,8 @@ use crate::jsonrpc_types::{
     AccessPathView, AccountAddressView, AnnotatedFunctionResultView, BalanceInfoPageView,
     BytesView, EventOptions, EventPageView, ExecuteTransactionResponseView, FieldStateFilterView,
     FunctionCallView, H256View, IndexerEventPageView, IndexerFieldStatePageView,
-    IndexerObjectStatePageView, ObjectStateFilterView, StateOptions, StatePageView, StateView,
-    StrView, StructTagView, TransactionWithInfoPageView,
+    IndexerObjectStatePageView, ObjectStateFilterView, QueryOptions, StateOptions, StatePageView,
+    StateView, StrView, StructTagView, TransactionWithInfoPageView,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -139,7 +139,7 @@ pub trait RoochAPI {
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerStateID>,
         limit: Option<StrView<usize>>,
-        descending_order: Option<bool>,
+        query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerObjectStatePageView>;
 
     /// Query the Object field states indexer by state filter

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -117,7 +117,7 @@ pub trait RoochAPI {
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<StrView<u64>>,
         limit: Option<StrView<usize>>,
-        descending_order: Option<bool>,
+        query_option: Option<QueryOptions>,
     ) -> RpcResult<TransactionWithInfoPageView>;
 
     /// Query the events indexer by event filter
@@ -128,7 +128,7 @@ pub trait RoochAPI {
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerEventID>,
         limit: Option<StrView<usize>>,
-        descending_order: Option<bool>,
+        query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerEventPageView>;
 
     /// Query the object states indexer by state filter
@@ -150,6 +150,6 @@ pub trait RoochAPI {
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerStateID>,
         limit: Option<StrView<usize>>,
-        descending_order: Option<bool>,
+        query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerFieldStatePageView>;
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/ord.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/ord.rs
@@ -63,7 +63,9 @@ impl InscriptionFilterView {
                 let obj_id = ord::derive_inscription_id(&inscription_id);
                 ObjectStateFilter::ObjectId(vec![obj_id])
             }
-            InscriptionFilterView::ObjectId(object_id) => ObjectStateFilter::ObjectId(vec![object_id]),
+            InscriptionFilterView::ObjectId(object_id) => {
+                ObjectStateFilter::ObjectId(vec![object_id])
+            }
             InscriptionFilterView::All => ObjectStateFilter::ObjectType(Inscription::struct_tag()),
         })
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/ord.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/ord.rs
@@ -61,9 +61,9 @@ impl InscriptionFilterView {
                 let txid = hex_to_txid(txid.as_str())?;
                 let inscription_id = InscriptionID::new(txid.into_address(), index);
                 let obj_id = ord::derive_inscription_id(&inscription_id);
-                ObjectStateFilter::ObjectId(obj_id)
+                ObjectStateFilter::ObjectId(vec![obj_id])
             }
-            InscriptionFilterView::ObjectId(object_id) => ObjectStateFilter::ObjectId(object_id),
+            InscriptionFilterView::ObjectId(object_id) => ObjectStateFilter::ObjectId(vec![object_id]),
             InscriptionFilterView::All => ObjectStateFilter::ObjectType(Inscription::struct_tag()),
         })
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
@@ -56,9 +56,9 @@ impl UTXOFilterView {
                 let outpoint =
                     rooch_types::bitcoin::types::OutPoint::new(txid.into_address(), vout);
                 let utxo_id = utxo::derive_utxo_id(&outpoint);
-                ObjectStateFilter::ObjectId(utxo_id)
+                ObjectStateFilter::ObjectId(vec![utxo_id])
             }
-            UTXOFilterView::ObjectId(object_id) => ObjectStateFilter::ObjectId(object_id),
+            UTXOFilterView::ObjectId(object_id) => ObjectStateFilter::ObjectId(vec![object_id]),
             UTXOFilterView::All => ObjectStateFilter::ObjectType(UTXO::struct_tag()),
         })
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rpc_options.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rpc_options.rs
@@ -65,7 +65,7 @@ impl TxOptions {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct QueryOptions {
     /// If true, return query items in descending order.
@@ -75,10 +75,6 @@ pub struct QueryOptions {
 }
 
 impl QueryOptions {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn descending(mut self, descending: bool) -> Self {
         self.descending = descending;
         self
@@ -87,5 +83,14 @@ impl QueryOptions {
     pub fn show_display(mut self, show_display: bool) -> Self {
         self.show_display = show_display;
         self
+    }
+}
+
+impl Default for QueryOptions {
+    fn default() -> Self {
+        Self {
+            descending: true,
+            show_display: false,
+        }
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rpc_options.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rpc_options.rs
@@ -64,3 +64,28 @@ impl TxOptions {
         self
     }
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct QueryOptions {
+    /// If true, return query items in descending order.
+    pub descending: bool,
+    /// If true, result with display rendered is returned
+    pub show_display: bool,
+}
+
+impl QueryOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn descending(mut self, descending: bool) -> Self {
+        self.descending = descending;
+        self
+    }
+
+    pub fn show_display(mut self, show_display: bool) -> Self {
+        self.show_display = show_display;
+        self
+    }
+}

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -417,7 +417,7 @@ pub enum ObjectStateFilterView {
     /// Query by owner.
     Owner(AccountAddressView),
     /// Query by object id.
-    ObjectId(ObjectID),
+    ObjectId(Vec<ObjectID>),
     /// Query by multi chain address
     MultiChainAddress { multichain_id: u64, address: String },
 }
@@ -438,7 +438,7 @@ impl ObjectStateFilterView {
                 ObjectStateFilter::ObjectType(object_type.into())
             }
             ObjectStateFilterView::Owner(owner) => ObjectStateFilter::Owner(owner.into()),
-            ObjectStateFilterView::ObjectId(object_id) => ObjectStateFilter::ObjectId(object_id),
+            ObjectStateFilterView::ObjectId(object_ids) => ObjectStateFilter::ObjectId(object_ids),
             ObjectStateFilterView::MultiChainAddress {
                 multichain_id: _,
                 address: _,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -381,6 +381,7 @@ pub struct IndexerObjectStateView {
     pub state_index: u64,
     pub created_at: u64,
     pub updated_at: u64,
+    pub display_fields: Option<DisplayFieldsView>,
 }
 
 impl IndexerObjectStateView {
@@ -400,7 +401,13 @@ impl IndexerObjectStateView {
             state_index: state.state_index,
             created_at: state.created_at,
             updated_at: state.updated_at,
+            display_fields: None,
         }
+    }
+
+    pub fn with_display_fields(mut self, display_fields: Option<DisplayFieldsView>) -> Self {
+        self.display_fields = display_fields;
+        self
     }
 }
 

--- a/crates/rooch-types/src/indexer/state.rs
+++ b/crates/rooch-types/src/indexer/state.rs
@@ -96,7 +96,7 @@ impl ObjectStateFilter {
             ObjectStateFilter::ObjectType(object_type) => object_type == &item.object_type,
             ObjectStateFilter::Owner(owner) => owner == &item.owner,
             ObjectStateFilter::ObjectId(object_ids) => {
-                object_ids.len() == 1 && object_ids[0] == item.object_id,
+                object_ids.len() == 1 && object_ids[0] == item.object_id
             }
         })
     }

--- a/crates/rooch-types/src/indexer/state.rs
+++ b/crates/rooch-types/src/indexer/state.rs
@@ -83,8 +83,8 @@ pub enum ObjectStateFilter {
     ObjectType(StructTag),
     /// Query by owner.
     Owner(AccountAddress),
-    /// Query by object id.
-    ObjectId(ObjectID),
+    /// Query by object ids.
+    ObjectId(Vec<ObjectID>),
 }
 
 impl ObjectStateFilter {
@@ -95,7 +95,9 @@ impl ObjectStateFilter {
             }
             ObjectStateFilter::ObjectType(object_type) => object_type == &item.object_type,
             ObjectStateFilter::Owner(owner) => owner == &item.owner,
-            ObjectStateFilter::ObjectId(object_id) => object_id == &item.object_id,
+            ObjectStateFilter::ObjectId(object_ids) => {
+                object_ids.len() == 1 && object_ids[0] == item.object_id,
+            }
         })
     }
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -108,26 +108,26 @@ Feature: Rooch CLI integration tests
     # because the indexer is async update, so sleep 5 seconds to wait indexer update.
     Then sleep: "5"
     
-    Then cmd: "rpc request --method rooch_queryTransactions --params '[{"tx_order_range":{"from_order":0,"to_order":2}}, null, "1", true]'"
+    Then cmd: "rpc request --method rooch_queryTransactions --params '[{"tx_order_range":{"from_order":0,"to_order":2}}, null, "1", {"descending": true,"showDisplay":false}]'"
     Then assert: "{{$.rpc[-1].data[0].transaction.sequence_info.tx_order}} == 1"
     Then assert: "{{$.rpc[-1].next_cursor}} == 1"
     Then assert: "{{$.rpc[-1].has_next_page}} == true"
-    Then cmd: "rpc request --method rooch_queryTransactions --params '[{"tx_order_range":{"from_order":0,"to_order":2}}, "1", "1", true]'"
+    Then cmd: "rpc request --method rooch_queryTransactions --params '[{"tx_order_range":{"from_order":0,"to_order":2}}, "1", "1", {"descending": true,"showDisplay":false}]'"
     Then assert: "{{$.rpc[-1].data[0].transaction.sequence_info.tx_order}} == 0"
     Then assert: "{{$.rpc[-1].next_cursor}} == 0"
     Then assert: "{{$.rpc[-1].has_next_page}} == false"
-    Then cmd: "rpc request --method rooch_queryEvents --params '[{"tx_order_range":{"from_order":0, "to_order":2}}, null, "10", true]'"
+    Then cmd: "rpc request --method rooch_queryEvents --params '[{"tx_order_range":{"from_order":0, "to_order":2}}, null, "10", {"descending": true,"showDisplay":false}]'"
     Then assert: "{{$.rpc[-1].data[0].indexer_event_id.tx_order}} == 1"
     Then assert: "{{$.rpc[-1].next_cursor.tx_order}} == 0"
     Then assert: "{{$.rpc[-1].has_next_page}} == false"
 
     # Sync states
-    Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x3::coin::CoinInfo"}, null, "10", true]'"
+    Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x3::coin::CoinInfo"}, null, "10", {"descending": true,"showDisplay":false}]'"
     Then assert: "{{$.rpc[-1].data[0].tx_order}} == 0"
     Then assert: "{{$.rpc[-1].data[0].object_type}} == 0x3::coin::CoinInfo"
     Then assert: "{{$.rpc[-1].has_next_page}} == false"
 
-    Then cmd: "rpc request --method rooch_queryFieldStates --params '[{"object_id":"0x3"}, null, "10", true]'"
+    Then cmd: "rpc request --method rooch_queryFieldStates --params '[{"object_id":"0x3"}, null, "10", {"descending": true,"showDisplay":false}]'"
     Then assert: "{{$.rpc[-1].has_next_page}} == false"
 
 #    Then cmd: "rpc request --method rooch_syncStates --params '[null, null, "2", false]'"
@@ -288,7 +288,7 @@ Feature: Rooch CLI integration tests
       # because the indexer is async update, so sleep 2 seconds to wait indexer update.
       Then sleep: "2"
 
-      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"{{$.address_mapping.default}}::child_object::Child"}, null, "10", true]'"
+      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"{{$.address_mapping.default}}::child_object::Child"}, null, "10", {"descending": true,"showDisplay":false}]'"
       Then assert: "{{$.rpc[-1].data[0].object_id}} == {{$.event[-1].data[0].decoded_event_data.value.id}}"
 
       Then cmd: "move run --function default::third_party_module_for_child_object::update_child_age --args object:{{$.event[-1].data[0].decoded_event_data.value.id}} --args u64:10"
@@ -321,8 +321,8 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.wallet[-1].total}} == 5000000000"
 
       # query utxos and inscriptions
-      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x4::utxo::UTXO"}, null, "2", true]'"
-      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x4::ord::Inscription"}, null, "2", true]'"
+      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x4::utxo::UTXO"}, null, "2", {"descending": true,"showDisplay":false}]'"
+      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x4::ord::Inscription"}, null, "2", {"descending": true,"showDisplay":false}]'"
 
       # release servers
       Then stop the server

--- a/moveos/moveos-types/Cargo.toml
+++ b/moveos/moveos-types/Cargo.toml
@@ -30,6 +30,7 @@ tiny-keccak = { workspace = true, features = ["keccak", "sha3"] }
 fastcrypto = { workspace = true }
 proptest = { optional = true, workspace = true }
 proptest-derive = { optional = true, workspace = true }
+tracing = { workspace = true }
 
 move-core-types = { workspace = true }
 move-vm-types = { workspace = true }

--- a/moveos/moveos-types/src/moveos_std/display.rs
+++ b/moveos/moveos-types/src/moveos_std/display.rs
@@ -21,6 +21,17 @@ use serde::{Deserialize, Serialize};
 
 pub const MODULE_NAME: &IdentStr = ident_str!("display");
 
+pub fn get_display_id_from_object_struct_tag(struct_tag: StructTag) -> ObjectID {
+    let object_type_tag = TypeTag::from(struct_tag);
+    let display_struct_tag = StructTag {
+        address: MOVEOS_STD_ADDRESS,
+        name: ident_str!("Display").to_owned(),
+        module: MODULE_NAME.to_owned(),
+        type_params: vec![object_type_tag],
+    };
+    object::named_object_id(&display_struct_tag)
+}
+
 pub fn get_object_display_id(value_type: TypeTag) -> ObjectID {
     let object_tag = StructTag {
         address: MOVEOS_STD_ADDRESS,
@@ -28,14 +39,7 @@ pub fn get_object_display_id(value_type: TypeTag) -> ObjectID {
         module: ident_str!("object").to_owned(),
         type_params: vec![value_type],
     };
-    let object_type = TypeTag::from(object_tag);
-    let struct_tag = StructTag {
-        address: MOVEOS_STD_ADDRESS,
-        name: ident_str!("Display").to_owned(),
-        module: MODULE_NAME.to_owned(),
-        type_params: vec![object_type],
-    };
-    object::named_object_id(&struct_tag)
+    get_display_id_from_object_struct_tag(object_tag)
 }
 
 pub fn get_resource_display_id(value_type: TypeTag) -> ObjectID {

--- a/moveos/moveos-types/src/moveos_std/display.rs
+++ b/moveos/moveos-types/src/moveos_std/display.rs
@@ -120,7 +120,6 @@ fn get_value_from_move_struct(move_value: &AnnotatedMoveValue, var_name: &str) -
         }
     }
 
-    println!(">>>>>> {:?}....{:?}", parts, current_value);
     match current_value {
         AnnotatedMoveValue::Vector(_, _) | AnnotatedMoveValue::Bytes(_) => {
             anyhow::bail!(
@@ -148,14 +147,7 @@ fn parse_template(template: &str, move_value: &AnnotatedMoveValue) -> Result<Str
             '}' if !escaped => {
                 in_braces = false;
                 let value = get_value_from_move_struct(move_value, &var_name)?;
-                println!(
-                    "#### {:?}, {:?}, {:?}",
-                    var_name,
-                    value.clone(),
-                    output.clone()
-                );
                 output = output.replace(&format!("{{{}}}", var_name), &value);
-                println!("####> {:?}", output.clone());
             }
             _ if !escaped => {
                 if in_braces {
@@ -178,13 +170,11 @@ pub struct RawDisplay {
 impl RawDisplay {
     /// Render the display with given MoveStruct instance.
     pub fn render(&self, annotated_obj: &AnnotatedMoveValue) -> BTreeMap<String, String> {
-        println!(">>>>>> AnnotatedMoveValue: {:?}", annotated_obj);
-        println!(">>>>> template: {:?}", self.to_btree_map());
         let fields = self.to_btree_map().into_iter().map(|entry| {
             match parse_template(&entry.1, annotated_obj) {
                 Ok(value) => (entry.0, value),
                 Err(err) => {
-                    println!("Display template render error: {:?}", err);
+                    tracing::debug!("Display template render error: {:?}", err);
                     entry // TODO: handle render error
                 }
             }

--- a/moveos/moveos-types/src/moveos_std/display.rs
+++ b/moveos/moveos-types/src/moveos_std/display.rs
@@ -21,6 +21,12 @@ use serde::{Deserialize, Serialize};
 
 pub const MODULE_NAME: &IdentStr = ident_str!("display");
 
+pub fn is_display_struct(struct_tag: &StructTag) -> bool {
+    struct_tag.address == MOVEOS_STD_ADDRESS
+        && struct_tag.module == MODULE_NAME.to_owned()
+        && struct_tag.name == ident_str!("Display").to_owned()
+}
+
 pub fn get_display_id_from_object_struct_tag(struct_tag: StructTag) -> ObjectID {
     let object_type_tag = TypeTag::from(struct_tag);
     let display_struct_tag = StructTag {
@@ -163,7 +169,7 @@ fn parse_template(template: &str, move_value: &AnnotatedMoveValue) -> Result<Str
 /// Display struct in rust, binding for moveos_std::display::Display
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize)]
 pub struct RawDisplay {
-    pub fields: SimpleMap<MoveString, MoveString>,
+    pub sample_map: SimpleMap<MoveString, MoveString>,
 }
 
 impl RawDisplay {
@@ -183,7 +189,7 @@ impl RawDisplay {
 
     pub fn to_btree_map(&self) -> BTreeMap<String, String> {
         let mut btree_map = BTreeMap::new();
-        for element in &self.fields.data {
+        for element in &self.sample_map.data {
             btree_map.insert(element.key.to_string(), element.value.to_string());
         }
         btree_map


### PR DESCRIPTION
## Summary

1. Unify `QueryOptions` parameter for `query_object_states`, `query_transactions`, `query_events`, `query_field_states`. This may break clients which called these apis.
2. `query_object_states` support return display fields of objects.

@wow-sven 
