### PR TITLE
[gh-1685] draft a chain reorg operation.

### DIFF
--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -128,6 +128,7 @@ impl ExecutorActor {
             block_body,
         } = l1_block;
         match RoochMultiChainID::try_from(chain_id.id())? {
+            // TODO: wait three blocks for `submit_new_block` for bitcoin chain reorg
             RoochMultiChainID::Bitcoin => {
                 let action = VerifiedMoveAction::Function {
                     call: BitcoinModule::create_submit_new_block_call_bytes(

--- a/crates/rooch-types/src/bitcoin/mod.rs
+++ b/crates/rooch-types/src/bitcoin/mod.rs
@@ -176,6 +176,7 @@ impl<'a> BitcoinModule<'a> {
         Ok(height)
     }
 
+    // TODO: three blocks for chain reorg
     pub fn create_submit_new_block_call(block_height: u64, block: bitcoin::Block) -> FunctionCall {
         let block_hash = block.block_hash();
         let block = crate::bitcoin::types::Block::from(block);
@@ -192,6 +193,7 @@ impl<'a> BitcoinModule<'a> {
         )
     }
 
+    // TODO: three hashes for chain reorg
     pub fn create_submit_new_block_call_bytes(
         block_height: u64,
         block_hash: Vec<u8>,

--- a/frameworks/bitcoin-move/doc/bitcoin.md
+++ b/frameworks/bitcoin-move/doc/bitcoin.md
@@ -18,7 +18,8 @@
 -  [Function `get_latest_block_height`](#0x4_bitcoin_get_latest_block_height)
 
 
-<pre><code><b>use</b> <a href="">0x1::option</a>;
+<pre><code><b>use</b> <a href="">0x1::debug</a>;
+<b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::string</a>;
 <b>use</b> <a href="">0x1::vector</a>;
 <b>use</b> <a href="">0x2::bcs</a>;


### PR DESCRIPTION
## Summary

1.  Added `reorg_branchlen` and `reorg_status` props to the bitcoin block store from the bitcoin-cli api: https://developer.bitcoin.org/reference/rpc/getchaintips.html.
2. Perform a chain reorg according to this article: https://learnmeabitcoin.com/technical/blockchain/chain-reorganisation/.

Ref: https://learnmeabitcoin.com/technical/blockchain/chain-reorganisation/.

- Closes #1685