### PR TITLE
[types] Unify address format to bech32

### DIFF
--- a/crates/rooch-faucet/src/web.rs
+++ b/crates/rooch-faucet/src/web.rs
@@ -26,9 +26,9 @@ use axum::{
 };
 use clap::Parser;
 use http::Method;
-use move_core_types::account_address::AccountAddress;
+
 use prometheus::{Registry, TextEncoder};
-use rooch_rpc_api::jsonrpc_types::{AccountAddressView, StructTagView};
+use rooch_rpc_api::jsonrpc_types::StructTagView;
 use rooch_rpc_client::wallet_context::WalletContext;
 use tokio::sync::RwLock;
 
@@ -99,12 +99,12 @@ impl App {
         let context = WalletContext::new(self.wallet_config_dir.clone())
             .map_err(|e| FaucetError::Wallet(e.to_string()))?;
         let client = context.get_client().await.unwrap();
-        let faucet_address: AccountAddress = context.client_config.active_address.unwrap().into();
+        let faucet_address = context.client_config.active_address.unwrap();
 
         let s = client
             .rooch
             .get_balance(
-                AccountAddressView::from(faucet_address),
+                faucet_address.into(),
                 StructTagView::from_str("0x3::gas_coin::GasCoin").unwrap(),
             )
             .await

--- a/crates/rooch-indexer/src/models/events.rs
+++ b/crates/rooch-indexer/src/models/events.rs
@@ -4,11 +4,11 @@
 use crate::types::IndexedEvent;
 use crate::{schema::events, utils};
 use diesel::prelude::*;
-use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::StructTag;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::event::EventID;
 use moveos_types::moveos_std::object::ObjectID;
+use rooch_types::address::RoochAddress;
 use rooch_types::indexer::event_filter::{IndexerEvent, IndexerEventID};
 use std::str::FromStr;
 
@@ -65,7 +65,7 @@ impl From<IndexedEvent> for StoredEvent {
 impl StoredEvent {
     pub fn try_into_indexer_event(&self) -> Result<IndexerEvent, anyhow::Error> {
         let event_handle_id = ObjectID::from_str(self.event_handle_id.as_str())?;
-        let sender = AccountAddress::from_hex_literal(self.sender.as_str())?;
+        let sender = RoochAddress::from_str(self.sender.as_str())?;
         let tx_hash = H256::from_str(self.tx_hash.as_str())?;
         let event_type = StructTag::from_str(self.event_type.as_str())?;
 

--- a/crates/rooch-indexer/src/models/states.rs
+++ b/crates/rooch-indexer/src/models/states.rs
@@ -6,9 +6,10 @@ use crate::schema::object_states;
 use crate::types::{IndexedFieldState, IndexedObjectState};
 use crate::utils;
 use diesel::prelude::*;
-use move_core_types::account_address::AccountAddress;
+use ethers::types::H256;
 use move_core_types::language_storage::{StructTag, TypeTag};
 use moveos_types::moveos_std::object::ObjectID;
+use rooch_types::address::RoochAddress;
 use rooch_types::indexer::state::{IndexerFieldState, IndexerObjectState};
 use std::str::FromStr;
 
@@ -67,10 +68,10 @@ impl From<IndexedObjectState> for StoredObjectState {
 impl StoredObjectState {
     pub fn try_into_indexer_global_state(&self) -> Result<IndexerObjectState, anyhow::Error> {
         let object_id = ObjectID::from_str(self.object_id.as_str())?;
-        let owner = AccountAddress::from_hex_literal(self.owner.as_str())?;
+        let owner = RoochAddress::from_str(self.owner.as_str())?;
 
         let object_type = StructTag::from_str(self.object_type.as_str())?;
-        let state_root = AccountAddress::from_hex_literal(self.state_root.as_str())?;
+        let state_root = H256::from_str(self.state_root.as_str())?;
 
         let state = IndexerObjectState {
             object_id,

--- a/crates/rooch-indexer/src/tests/test_indexer.rs
+++ b/crates/rooch-indexer/src/tests/test_indexer.rs
@@ -161,7 +161,7 @@ fn test_transaction_store() -> Result<()> {
     let transactions = vec![indexed_transaction];
     let _ = indexer_store.persist_transactions(transactions)?;
 
-    let filter = TransactionFilter::Sender(random_moveos_tx.ctx.sender);
+    let filter = TransactionFilter::Sender(random_moveos_tx.ctx.sender.into());
     let query_transactions =
         indexer_reader.query_transactions_with_filter(filter, None, 1, true)?;
     assert_eq!(query_transactions.len(), 1);
@@ -194,7 +194,7 @@ fn test_event_store() -> Result<()> {
     let events = vec![indexed_event];
     let _ = indexer_store.persist_events(events)?;
 
-    let filter = EventFilter::Sender(random_moveos_tx.ctx.sender);
+    let filter = EventFilter::Sender(random_moveos_tx.ctx.sender.into());
     let query_events = indexer_reader.query_events_with_filter(filter, None, 1, true)?;
     assert_eq!(query_events.len(), 1);
     Ok(())
@@ -269,7 +269,7 @@ fn test_object_type_query() -> Result<()> {
     // filter by object type and owner
     let filter = ObjectStateFilter::ObjectTypeWithOwner {
         object_type: CoinStore::<GasCoin>::struct_tag(),
-        owner,
+        owner: owner.into(),
     };
     let query_object_states =
         indexer_reader.query_object_states_with_filter(filter, None, 1, true)?;

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -139,13 +139,13 @@
     },
     {
       "name": "rooch_getBalance",
-      "description": "get account balance by AccountAddress and CoinType",
+      "description": "get account balance by RoochAddress and CoinType",
       "params": [
         {
           "name": "account_addr",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+            "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
           }
         },
         {
@@ -166,13 +166,13 @@
     },
     {
       "name": "rooch_getBalances",
-      "description": "get account balances by AccountAddress",
+      "description": "get account balances by RoochAddress",
       "params": [
         {
           "name": "account_addr",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+            "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
           }
         },
         {
@@ -745,7 +745,7 @@
             ],
             "properties": {
               "sender": {
-                "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+                "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
               }
             },
             "additionalProperties": false
@@ -1102,7 +1102,7 @@
             "$ref": "#/components/schemas/IndexerEventID"
           },
           "sender": {
-            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+            "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
           },
           "tx_hash": {
             "$ref": "#/components/schemas/primitive_types::H256"
@@ -1208,7 +1208,7 @@
             "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
           },
           "owner": {
-            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+            "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
           },
           "size": {
             "type": "integer",
@@ -1221,7 +1221,7 @@
             "minimum": 0.0
           },
           "state_root": {
-            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+            "$ref": "#/components/schemas/primitive_types::H256"
           },
           "tx_order": {
             "type": "integer",
@@ -1359,7 +1359,7 @@
             "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
           },
           "owner": {
-            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+            "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
           },
           "owner_bitcoin_address": {
             "type": [
@@ -1466,7 +1466,7 @@
             "minimum": 0.0
           },
           "txid": {
-            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+            "$ref": "#/components/schemas/primitive_types::H256"
           }
         }
       },
@@ -1799,7 +1799,7 @@
                     "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
                   },
                   "owner": {
-                    "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+                    "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
                   }
                 }
               }
@@ -1827,7 +1827,7 @@
             ],
             "properties": {
               "owner": {
-                "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+                "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
               }
             },
             "additionalProperties": false
@@ -2410,7 +2410,7 @@
             ],
             "properties": {
               "sender": {
-                "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+                "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
               }
             },
             "additionalProperties": false
@@ -2682,7 +2682,7 @@
             "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
           },
           "owner": {
-            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+            "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
           },
           "owner_bitcoin_address": {
             "type": [
@@ -2743,7 +2743,7 @@
             "description": "The txid of the UTXO",
             "allOf": [
               {
-                "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+                "$ref": "#/components/schemas/primitive_types::H256"
               }
             ]
           },
@@ -2877,6 +2877,9 @@
         "type": "string"
       },
       "rooch_types::address::BitcoinAddress": {
+        "type": "string"
+      },
+      "rooch_types::address::RoochAddress": {
         "type": "string"
       },
       "u128": {

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::account_view::BalanceInfoView;
+use crate::jsonrpc_types::address::RoochAddressView;
 use crate::jsonrpc_types::event_view::EventFilterView;
 use crate::jsonrpc_types::transaction_view::{TransactionFilterView, TransactionWithInfoView};
 use crate::jsonrpc_types::TxOptions;
 use crate::jsonrpc_types::{
-    AccessPathView, AccountAddressView, AnnotatedFunctionResultView, BalanceInfoPageView,
-    BytesView, EventOptions, EventPageView, ExecuteTransactionResponseView, FieldStateFilterView,
-    FunctionCallView, H256View, IndexerEventPageView, IndexerFieldStatePageView,
-    IndexerObjectStatePageView, ObjectStateFilterView, QueryOptions, StateOptions, StatePageView,
-    StateView, StrView, StructTagView, TransactionWithInfoPageView,
+    AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, BytesView, EventOptions,
+    EventPageView, ExecuteTransactionResponseView, FieldStateFilterView, FunctionCallView,
+    H256View, IndexerEventPageView, IndexerFieldStatePageView, IndexerObjectStatePageView,
+    ObjectStateFilterView, QueryOptions, StateOptions, StatePageView, StateView, StrView,
+    StructTagView, TransactionWithInfoPageView,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -92,19 +93,19 @@ pub trait RoochAPI {
         descending_order: Option<bool>,
     ) -> RpcResult<TransactionWithInfoPageView>;
 
-    /// get account balance by AccountAddress and CoinType
+    /// get account balance by RoochAddress and CoinType
     #[method(name = "getBalance")]
     async fn get_balance(
         &self,
-        account_addr: AccountAddressView,
+        account_addr: RoochAddressView,
         coin_type: StructTagView,
     ) -> RpcResult<BalanceInfoView>;
 
-    /// get account balances by AccountAddress
+    /// get account balances by RoochAddress
     #[method(name = "getBalances")]
     async fn get_balances(
         &self,
-        account_addr: AccountAddressView,
+        account_addr: RoochAddressView,
         cursor: Option<IndexerStateID>,
         limit: Option<StrView<usize>>,
     ) -> RpcResult<BalanceInfoPageView>;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/address.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/address.rs
@@ -3,7 +3,8 @@
 
 use crate::jsonrpc_types::StrView;
 use anyhow::Result;
-use rooch_types::address::BitcoinAddress;
+use move_core_types::account_address::AccountAddress;
+use rooch_types::address::{BitcoinAddress, RoochAddress};
 use std::str::FromStr;
 
 pub type BitcoinAddressView = StrView<BitcoinAddress>;
@@ -25,5 +26,32 @@ impl FromStr for BitcoinAddressView {
 impl From<BitcoinAddressView> for BitcoinAddress {
     fn from(value: BitcoinAddressView) -> Self {
         value.0
+    }
+}
+
+pub type RoochAddressView = StrView<RoochAddress>;
+
+impl std::fmt::Display for RoochAddressView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for RoochAddressView {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(StrView(RoochAddress::from_str(s)?))
+    }
+}
+
+impl From<RoochAddressView> for RoochAddress {
+    fn from(value: RoochAddressView) -> Self {
+        value.0
+    }
+}
+
+impl From<AccountAddress> for RoochAddressView {
+    fn from(value: AccountAddress) -> Self {
+        StrView(RoochAddress::from(value))
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/ord.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/ord.rs
@@ -3,13 +3,16 @@
 
 use crate::jsonrpc_types::address::BitcoinAddressView;
 use crate::jsonrpc_types::btc::transaction::{hex_to_txid, TxidView};
-use crate::jsonrpc_types::{AccountAddressView, BytesView, MoveStringView, StrView, StructTagView};
+use crate::jsonrpc_types::{
+    BytesView, H256View, MoveStringView, RoochAddressView, StrView, StructTagView,
+};
 use anyhow::Result;
 use bitcoin::hashes::Hash;
 use bitcoin::Txid;
-use move_core_types::account_address::AccountAddress;
+
 use moveos_types::move_std::string::MoveString;
 use moveos_types::{moveos_std::object::ObjectID, state::MoveStructType};
+use rooch_types::address::RoochAddress;
 use rooch_types::bitcoin::ord;
 use rooch_types::bitcoin::ord::{
     BitcoinInscriptionID, Inscription, InscriptionID, InscriptionState,
@@ -50,7 +53,7 @@ pub enum InscriptionFilterView {
 impl InscriptionFilterView {
     pub fn into_global_state_filter(
         filter: InscriptionFilterView,
-        resolve_address: AccountAddress,
+        resolve_address: RoochAddress,
     ) -> Result<ObjectStateFilter> {
         Ok(match filter {
             InscriptionFilterView::Owner(_owner) => ObjectStateFilter::ObjectTypeWithOwner {
@@ -73,13 +76,13 @@ impl InscriptionFilterView {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct InscriptionIDView {
-    pub txid: AccountAddressView,
+    pub txid: H256View,
     pub index: u32,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct InscriptionView {
-    pub txid: AccountAddressView,
+    pub txid: H256View,
     pub bitcoin_txid: TxidView,
     pub index: u32,
     pub offset: u64,
@@ -113,7 +116,7 @@ impl From<Inscription> for InscriptionView {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct InscriptionStateView {
     pub object_id: ObjectID,
-    pub owner: AccountAddressView,
+    pub owner: RoochAddressView,
     pub owner_bitcoin_address: Option<String>,
     pub flag: u8,
     pub value: InscriptionView,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
@@ -3,13 +3,14 @@
 
 use crate::jsonrpc_types::address::BitcoinAddressView;
 use crate::jsonrpc_types::btc::transaction::{hex_to_txid, TxidView};
-use crate::jsonrpc_types::{AccountAddressView, StructTagView};
+use crate::jsonrpc_types::{H256View, RoochAddressView, StructTagView};
 use anyhow::Result;
 use bitcoin::hashes::Hash;
 use bitcoin::Txid;
-use move_core_types::account_address::AccountAddress;
+
 use moveos_types::moveos_std::object::ObjectID;
 use moveos_types::state::MoveStructType;
+use rooch_types::address::RoochAddress;
 use rooch_types::bitcoin::utxo::{self, UTXOState, UTXO};
 use rooch_types::indexer::state::ObjectStateFilter;
 use rooch_types::into_address::IntoAddress;
@@ -44,7 +45,7 @@ pub enum UTXOFilterView {
 impl UTXOFilterView {
     pub fn into_global_state_filter(
         filter_opt: UTXOFilterView,
-        resolve_address: AccountAddress,
+        resolve_address: RoochAddress,
     ) -> Result<ObjectStateFilter> {
         Ok(match filter_opt {
             UTXOFilterView::Owner(_owner) => ObjectStateFilter::ObjectTypeWithOwner {
@@ -67,7 +68,7 @@ impl UTXOFilterView {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UTXOView {
     /// The txid of the UTXO
-    txid: AccountAddressView,
+    txid: H256View,
     /// The txid of the UTXO
     bitcoin_txid: TxidView,
     /// The vout of the UTXO
@@ -97,7 +98,7 @@ impl UTXOView {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UTXOStateView {
     pub object_id: ObjectID,
-    pub owner: AccountAddressView,
+    pub owner: RoochAddressView,
     pub owner_bitcoin_address: Option<String>,
     pub flag: u8,
     pub value: Option<UTXOView>,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::{
-    AccountAddressView, AnnotatedMoveStructView, H256View, StrView, StructTagView,
+    AnnotatedMoveStructView, H256View, RoochAddressView, StrView, StructTagView,
 };
 use moveos_types::moveos_std::event::{AnnotatedEvent, Event, EventID, TransactionEvent};
 use rooch_types::indexer::event_filter::{EventFilter, IndexerEvent, IndexerEventID};
@@ -79,9 +79,8 @@ pub struct IndexerEventView {
     pub event_type: StructTagView,
     pub event_data: StrView<Vec<u8>>,
     pub tx_hash: H256View,
-    pub sender: AccountAddressView,
+    pub sender: RoochAddressView,
     pub created_at: u64,
-
     pub decoded_event_data: Option<AnnotatedMoveStructView>,
 }
 
@@ -107,7 +106,7 @@ pub enum EventFilterView {
     /// Query by event type.
     EventType(StructTagView),
     /// Query by sender address.
-    Sender(AccountAddressView),
+    Sender(RoochAddressView),
     /// Return events emitted by the given transaction hash.
     TxHash(H256View),
     /// Return events emitted in [start_time, end_time) interval

--- a/crates/rooch-rpc-api/src/jsonrpc_types/mod.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/mod.rs
@@ -22,6 +22,7 @@ pub mod address;
 pub mod btc;
 
 pub use self::rooch_types::*;
+pub use address::*;
 pub use execute_tx_response::*;
 pub use function_return_value_view::*;
 pub use move_types::*;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
@@ -27,6 +27,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
+use super::{H256View, RoochAddressView};
+
 pub type ModuleIdView = StrView<ModuleId>;
 pub type TypeTagView = StrView<TypeTag>;
 pub type StructTagView = StrView<StructTag>;
@@ -194,9 +196,9 @@ impl From<AnnotatedMoveValue> for AnnotatedMoveValueView {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AnnotatedObjectView {
     pub id: ObjectID,
-    pub owner: AccountAddressView,
+    pub owner: RoochAddressView,
     pub flag: u8,
-    pub state_root: AccountAddressView,
+    pub state_root: H256View,
     pub size: u64,
     pub value: AnnotatedMoveStructView,
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    AccountAddressView, AnnotatedMoveValueView, BytesView, StrView, StructTagView, TypeTagView,
+    AnnotatedMoveValueView, BytesView, H256View, RoochAddressView, StrView, StructTagView,
+    TypeTagView,
 };
 use anyhow::Result;
-use move_core_types::account_address::AccountAddress;
+
 use move_core_types::effects::Op;
 use moveos_types::state::{
     AnnotatedKeyState, FieldChange, KeyState, NormalFieldChange, ObjectChange,
@@ -15,6 +16,7 @@ use moveos_types::{
     moveos_std::object::ObjectID,
     state::{AnnotatedState, State, StateChangeSet, TableTypeInfo},
 };
+use rooch_types::address::RoochAddress;
 use rooch_types::indexer::state::{
     FieldStateFilter, IndexerFieldState, IndexerObjectState, IndexerStateChangeSet,
     ObjectStateFilter, StateSyncFilter,
@@ -371,11 +373,11 @@ impl From<StateSyncFilterView> for StateSyncFilter {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct IndexerObjectStateView {
     pub object_id: ObjectID,
-    pub owner: AccountAddressView,
+    pub owner: RoochAddressView,
     pub flag: u8,
     pub value: Option<AnnotatedMoveValueView>,
     pub object_type: StructTagView,
-    pub state_root: AccountAddressView,
+    pub state_root: H256View,
     pub size: u64,
     pub tx_order: u64,
     pub state_index: u64,
@@ -417,12 +419,12 @@ pub enum ObjectStateFilterView {
     /// Query by object value type and owner.
     ObjectTypeWithOwner {
         object_type: StructTagView,
-        owner: AccountAddressView,
+        owner: RoochAddressView,
     },
     /// Query by object value type.
     ObjectType(StructTagView),
     /// Query by owner.
-    Owner(AccountAddressView),
+    Owner(RoochAddressView),
     /// Query by object id.
     ObjectId(Vec<ObjectID>),
     /// Query by multi chain address
@@ -432,7 +434,7 @@ pub enum ObjectStateFilterView {
 impl ObjectStateFilterView {
     pub fn into_object_state_filter(
         state_filter: ObjectStateFilterView,
-        resolve_address: AccountAddress,
+        resolve_address: RoochAddress,
     ) -> ObjectStateFilter {
         match state_filter {
             ObjectStateFilterView::ObjectTypeWithOwner { object_type, owner } => {

--- a/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
@@ -4,6 +4,7 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_core_types::account_address::AccountAddress;
 use moveos_types::move_std::string::MoveString;
 use schemars::gen::SchemaGenerator;
 use schemars::schema::{InstanceType, Schema, SchemaObject};
@@ -220,6 +221,13 @@ impl FromStr for H256View {
 impl From<H256View> for ethers::types::H256 {
     fn from(value: H256View) -> Self {
         value.0
+    }
+}
+
+/// In Move Struct, we use AccountAddress to represent H256
+impl From<AccountAddress> for H256View {
+    fn from(value: AccountAddress) -> Self {
+        StrView(ethers::types::H256::from(value.into_bytes()))
     }
 }
 

--- a/crates/rooch-rpc-api/src/jsonrpc_types/tests/str_view_tests.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/tests/str_view_tests.rs
@@ -116,3 +116,16 @@ fn test_account_address_view() {
     let address_result = AccountAddressView::from_str("11");
     assert!(address_result.is_err());
 }
+
+#[test]
+fn test_rooch_address_view() {
+    str_view_test_round_trip(
+        RoochAddressView::from(
+            RoochAddressView::from_str(
+                "rooch16kg65sgpy497wc4j09ds6tha6e48cg45303fnxxxua6khevfa8sqwnxk0l",
+            )
+            .unwrap(),
+        ),
+        "rooch16kg65sgpy497wc4j09ds6tha6e48cg45303fnxxxua6khevfa8sqwnxk0l",
+    );
+}

--- a/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
@@ -3,7 +3,7 @@
 
 use super::BytesView;
 use crate::jsonrpc_types::{
-    AccountAddressView, H256View, TransactionExecutionInfoView, TransactionSequenceInfoView,
+    H256View, RoochAddressView, TransactionExecutionInfoView, TransactionSequenceInfoView,
     TransactionView,
 };
 use rooch_types::indexer::transaction_filter::TransactionFilter;
@@ -78,7 +78,7 @@ impl From<TransactionWithInfo> for TransactionWithInfoView {
 #[serde(rename_all = "snake_case")]
 pub enum TransactionFilterView {
     /// Query by sender address.
-    Sender(AccountAddressView),
+    Sender(RoochAddressView),
     /// Query by multi chain original address.
     OriginalAddress(String),
     /// Query by the given transaction hash.

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -11,8 +11,8 @@ use rooch_rpc_api::jsonrpc_types::{
     account_view::BalanceInfoView, transaction_view::TransactionWithInfoView,
 };
 use rooch_rpc_api::jsonrpc_types::{
-    AccessPathView, AccountAddressView, AnnotatedFunctionResultView, BalanceInfoPageView,
-    EventOptions, EventPageView, StateOptions, StatePageView, StructTagView,
+    AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, EventOptions, EventPageView,
+    RoochAddressView, StateOptions, StatePageView, StructTagView,
 };
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, StateView};
 use rooch_rpc_api::jsonrpc_types::{TransactionWithInfoPageView, TxOptions};
@@ -183,7 +183,7 @@ impl RoochRpcClient {
 
     pub async fn get_balance(
         &self,
-        account_addr: AccountAddressView,
+        account_addr: RoochAddressView,
         coin_type: StructTagView,
     ) -> Result<BalanceInfoView> {
         Ok(self.http.get_balance(account_addr, coin_type).await?)
@@ -191,7 +191,7 @@ impl RoochRpcClient {
 
     pub async fn get_balances(
         &self,
-        account_addr: AccountAddressView,
+        account_addr: RoochAddressView,
         cursor: Option<IndexerStateID>,
         limit: Option<usize>,
     ) -> Result<BalanceInfoPageView> {

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -4,7 +4,6 @@
 use crate::client_config::{ClientConfig, DEFAULT_EXPIRATION_SECS};
 use crate::Client;
 use anyhow::{anyhow, Result};
-use move_command_line_common::address::ParsedAddress;
 use move_core_types::account_address::AccountAddress;
 use moveos_types::moveos_std::gas_schedule::GasScheduleConfig;
 use moveos_types::transaction::MoveAction;
@@ -15,6 +14,7 @@ use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_key::keystore::file_keystore::FileBasedKeystore;
 use rooch_key::keystore::Keystore;
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, KeptVMStatusView, TxOptions};
+use rooch_types::address::ParsedAddress;
 use rooch_types::address::RoochAddress;
 use rooch_types::addresses;
 use rooch_types::crypto::Signature;
@@ -71,7 +71,7 @@ impl WalletContext {
 
         //TODO support account name alias name.
         if let Some(active_address) = client_config.active_address {
-            address_mapping.insert("default".to_string(), AccountAddress::from(active_address));
+            address_mapping.insert("default".to_string(), active_address.into());
         }
 
         Ok(Self {
@@ -83,8 +83,8 @@ impl WalletContext {
         })
     }
 
-    pub fn add_address_mapping(&mut self, name: String, address: AccountAddress) {
-        self.address_mapping.insert(name, address);
+    pub fn add_address_mapping(&mut self, name: String, address: RoochAddress) {
+        self.address_mapping.insert(name, address.into());
     }
 
     pub fn address_mapping(&self) -> AddressMappingFn {
@@ -94,7 +94,7 @@ impl WalletContext {
 
     pub fn resolve_address(&self, parsed_address: ParsedAddress) -> RoochResult<AccountAddress> {
         match parsed_address {
-            ParsedAddress::Numerical(address) => Ok(address.into_inner()),
+            ParsedAddress::Numerical(address) => Ok(address.into()),
             ParsedAddress::Named(name) => {
                 self.address_mapping.get(&name).cloned().ok_or_else(|| {
                     RoochError::CommandArgumentError(format!("Unknown named address: {}", name))

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -200,12 +200,13 @@ pub async fn run_start_server(opt: &RoochOpt, server_opt: ServerOpt) -> Result<S
     }
 
     let sequencer_keypair = server_opt.sequencer_keypair.unwrap();
-    let sequencer_account: AccountAddress = RoochAddress::from(&sequencer_keypair.public()).into();
+    let sequencer_account = RoochAddress::from(&sequencer_keypair.public());
 
     let data_import_flag = opt.data_import_flag;
 
     if let RoochChainID::Builtin(builtin_chain_id) = chain_id {
         let mut network: RoochNetwork = builtin_chain_id.into();
+        let sequencer_account: AccountAddress = sequencer_account.into();
         match builtin_chain_id {
             // local and dev chain can use any sequencer account
             BuiltinChainID::Local | BuiltinChainID::Dev => {

--- a/crates/rooch-rpc-server/src/server/btc_server.rs
+++ b/crates/rooch-rpc-server/src/server/btc_server.rs
@@ -61,7 +61,7 @@ impl BtcAPIServer for BtcServer {
                     .resolve_address(multi_chain_address)
                     .await?
             }
-            _ => AccountAddress::ZERO,
+            _ => AccountAddress::ZERO.into(),
         };
 
         let global_state_filter =
@@ -116,7 +116,7 @@ impl BtcAPIServer for BtcServer {
                     .resolve_address(multi_chain_address)
                     .await?
             }
-            _ => AccountAddress::ZERO,
+            _ => AccountAddress::ZERO.into(),
         };
 
         let global_state_filter =

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -18,7 +18,6 @@ use moveos_types::{
     },
     state::{AnnotatedKeyState, AnnotatedState, KeyState},
 };
-use rooch_rpc_api::jsonrpc_types::event_view::{EventFilterView, EventView, IndexerEventView};
 use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionFilterView;
 use rooch_rpc_api::jsonrpc_types::{
     account_view::BalanceInfoView, FieldStateFilterView, IndexerEventPageView,
@@ -26,9 +25,13 @@ use rooch_rpc_api::jsonrpc_types::{
     IndexerObjectStateView, KeyStateView, ObjectStateFilterView, QueryOptions, StateKVView,
     StateOptions, TxOptions,
 };
+use rooch_rpc_api::jsonrpc_types::{
+    event_view::{EventFilterView, EventView, IndexerEventView},
+    RoochAddressView,
+};
 use rooch_rpc_api::jsonrpc_types::{transaction_view::TransactionWithInfoView, EventOptions};
 use rooch_rpc_api::jsonrpc_types::{
-    AccessPathView, AccountAddressView, BalanceInfoPageView, DisplayFieldsView, EventPageView,
+    AccessPathView, BalanceInfoPageView, DisplayFieldsView, EventPageView,
     ExecuteTransactionResponseView, FunctionCallView, H256View, StatePageView, StateView, StrView,
     StructTagView, TransactionWithInfoPageView,
 };
@@ -442,7 +445,7 @@ impl RoochAPIServer for RoochServer {
 
     async fn get_balance(
         &self,
-        account_addr: AccountAddressView,
+        account_addr: RoochAddressView,
         coin_type: StructTagView,
     ) -> RpcResult<BalanceInfoView> {
         Ok(self
@@ -452,10 +455,10 @@ impl RoochAPIServer for RoochServer {
             .map(Into::into)?)
     }
 
-    /// get account balances by AccountAddress
+    /// get account balances by RoochAddress
     async fn get_balances(
         &self,
-        account_addr: AccountAddressView,
+        account_addr: RoochAddressView,
         cursor: Option<IndexerStateID>,
         limit: Option<StrView<usize>>,
     ) -> RpcResult<BalanceInfoPageView> {
@@ -590,7 +593,7 @@ impl RoochAPIServer for RoochServer {
                     .resolve_address(multi_chain_address)
                     .await?
             }
-            _ => AccountAddress::ZERO,
+            _ => AccountAddress::ZERO.into(),
         };
         let global_state_filter =
             ObjectStateFilterView::into_object_state_filter(filter, resolve_address);

--- a/crates/rooch-rpc-server/src/service/aggregate_service.rs
+++ b/crates/rooch-rpc-server/src/service/aggregate_service.rs
@@ -3,7 +3,6 @@
 
 use crate::service::rpc_service::RpcService;
 use anyhow::Result;
-use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{StructTag, TypeTag};
 use moveos_types::access_path::AccessPath;
 use moveos_types::h256::H256;
@@ -13,7 +12,7 @@ use moveos_types::moveos_std::object::RawObject;
 use moveos_types::state::{KeyState, PlaceholderStruct};
 use rooch_rpc_api::jsonrpc_types::account_view::BalanceInfoView;
 use rooch_rpc_api::jsonrpc_types::CoinInfoView;
-use rooch_types::address::{BitcoinAddress, MultiChainAddress};
+use rooch_types::address::{BitcoinAddress, MultiChainAddress, RoochAddress};
 use rooch_types::bitcoin::ord::{Inscription, InscriptionState};
 use rooch_types::bitcoin::utxo::{UTXOState, UTXO};
 use rooch_types::framework::account_coin_store::AccountCoinStoreModule;
@@ -86,7 +85,7 @@ impl AggregateService {
 
     pub async fn get_balance(
         &self,
-        account_addr: AccountAddress,
+        account_addr: RoochAddress,
         coin_type: StructTag,
     ) -> Result<BalanceInfoView> {
         let coin_info = self
@@ -99,7 +98,8 @@ impl AggregateService {
                 anyhow::anyhow!("Can not find CoinInfo with coin_type: {}", coin_type)
             })?;
 
-        let coin_store_id = AccountCoinStoreModule::account_coin_store_id(account_addr, coin_type);
+        let coin_store_id =
+            AccountCoinStoreModule::account_coin_store_id(account_addr.into(), coin_type);
         let balance = self
             .get_coin_stores(vec![coin_store_id])
             .await?
@@ -113,7 +113,7 @@ impl AggregateService {
 
     pub async fn query_account_coin_stores(
         &self,
-        owner: AccountAddress,
+        owner: RoochAddress,
         cursor: Option<IndexerStateID>,
         limit: usize,
     ) -> Result<Vec<IndexerObjectState>> {
@@ -133,7 +133,7 @@ impl AggregateService {
 
     pub async fn get_balances(
         &self,
-        owner: AccountAddress,
+        owner: RoochAddress,
         cursor: Option<IndexerStateID>,
         limit: usize,
     ) -> Result<Vec<(Option<IndexerStateID>, BalanceInfoView)>> {

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -2,21 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag};
 use moveos_types::access_path::AccessPath;
 use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
-use moveos_types::moveos_std::account::Account;
+
 use moveos_types::moveos_std::event::{AnnotatedEvent, Event, EventID};
-use moveos_types::state::{AnnotatedState, KeyState, MoveStructType, State};
+use moveos_types::state::{AnnotatedState, KeyState, State};
 use moveos_types::state_resolver::{AnnotatedStateKV, StateKV};
 use moveos_types::transaction::{FunctionCall, TransactionExecutionInfo};
 use rooch_executor::proxy::ExecutorProxy;
 use rooch_indexer::proxy::IndexerProxy;
 use rooch_pipeline_processor::proxy::PipelineProcessorProxy;
 use rooch_sequencer::proxy::SequencerProxy;
-use rooch_types::address::MultiChainAddress;
+use rooch_types::address::{MultiChainAddress, RoochAddress};
 use rooch_types::indexer::event_filter::{EventFilter, IndexerEvent, IndexerEventID};
 use rooch_types::indexer::state::{
     FieldStateFilter, IndexerFieldState, IndexerObjectState, IndexerStateID, ObjectStateFilter,
@@ -86,19 +85,12 @@ impl RpcService {
         Ok(resp)
     }
 
-    pub async fn resolve_address(&self, mca: MultiChainAddress) -> Result<AccountAddress> {
-        self.executor.resolve_address(mca).await
+    pub async fn resolve_address(&self, mca: MultiChainAddress) -> Result<RoochAddress> {
+        self.executor.resolve_address(mca).await.map(Into::into)
     }
 
     pub async fn get_states(&self, access_path: AccessPath) -> Result<Vec<Option<State>>> {
         self.executor.get_states(access_path).await
-    }
-
-    pub async fn exists_account(&self, address: AccountAddress) -> Result<bool> {
-        let mut resp = self
-            .get_states(AccessPath::resource(address, Account::struct_tag()))
-            .await?;
-        Ok(resp.pop().flatten().is_some())
     }
 
     pub async fn exists_module(&self, module_id: ModuleId) -> Result<bool> {

--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -7,17 +7,18 @@ use crate::{
     multichain_id::{MultiChainID, RoochMultiChainID},
 };
 use anyhow::{bail, Result};
+use bech32::{Bech32m, Hrp};
 use bitcoin::bech32::segwit::encode_to_fmt_unchecked;
 use bitcoin::script::PushBytesBuf;
 use bitcoin::{
     address::Address, secp256k1::Secp256k1, Network, PrivateKey, Script, WitnessProgram,
     WitnessVersion,
 };
-
 use ethers::types::H160;
 use fastcrypto::hash::Blake2b256;
 use fastcrypto::hash::HashFunction;
 use fastcrypto::secp256k1::Secp256k1PublicKey;
+use hex::FromHex;
 use move_core_types::language_storage::TypeTag;
 use move_core_types::{
     account_address::AccountAddress,
@@ -34,6 +35,7 @@ use moveos_types::{
 };
 use nostr::secp256k1::XOnlyPublicKey;
 use nostr::Keys;
+use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::vec, prelude::*};
 use rand::{seq::SliceRandom, thread_rng};
@@ -205,9 +207,78 @@ impl MoveStructState for MultiChainAddress {
     }
 }
 
+pub static ROOCH_HRP: Lazy<Hrp> = Lazy::new(|| Hrp::parse("rooch").expect("rooch is a valid HRP"));
+
 /// Rooch address type
 #[derive(Copy, Clone, Ord, PartialOrd, PartialEq, Eq, Hash)]
 pub struct RoochAddress(pub H256);
+
+impl RoochAddress {
+    /// RoochAddress length in bytes
+    pub const LENGTH: usize = 32;
+
+    /// RoochAddress length in bech32 string length: 5 hrp + 59 data
+    pub const LENGTH_BECH32: usize = 64;
+
+    /// RoochAddress length in hex string length: 0x + 64 data
+    pub const LENGTH_HEX: usize = 66;
+
+    pub fn from_bech32(bech32: &str) -> Result<Self> {
+        let (hrp, data) = bech32::decode(bech32)?;
+        anyhow::ensure!(hrp == *ROOCH_HRP, "invalid rooch hrp");
+        anyhow::ensure!(data.len() == Self::LENGTH, "invalid rooch address length");
+        let hash = H256::from_slice(data.as_slice());
+        Ok(Self(hash))
+    }
+
+    pub fn to_bech32(&self) -> String {
+        let data = self.0.as_bytes();
+        bech32::encode::<Bech32m>(*ROOCH_HRP, data).expect("bech32 encode should success")
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.as_bytes().to_vec()
+    }
+
+    pub fn into_bytes(self) -> [u8; Self::LENGTH] {
+        self.0.to_fixed_bytes()
+    }
+
+    /// RoochAddress from_hex_literal support short hex string, such as 0x1, 0x2, 0x3
+    pub fn from_hex_literal(literal: &str) -> Result<Self> {
+        anyhow::ensure!(literal.starts_with("0x"), "Hex literal must start with 0x");
+
+        let hex_len = literal.len() - 2;
+
+        // If the string is too short, pad it
+        if hex_len < Self::LENGTH * 2 {
+            let mut hex_str = String::with_capacity(Self::LENGTH * 2);
+            for _ in 0..Self::LENGTH * 2 - hex_len {
+                hex_str.push('0');
+            }
+            hex_str.push_str(&literal[2..]);
+            RoochAddress::from_hex(hex_str)
+        } else {
+            RoochAddress::from_hex(&literal[2..])
+        }
+    }
+
+    /// RoochAddress to_hex_literal always return full hex string
+    pub fn to_hex_literal(&self) -> String {
+        format!("0x{:x}", self.0)
+    }
+
+    pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self> {
+        <[u8; Self::LENGTH]>::from_hex(hex)
+            .map_err(|_| anyhow::anyhow!("Invalid address hex string"))
+            .map(H256)
+            .map(Self)
+    }
+
+    pub fn to_hex(&self) -> String {
+        format!("{:x}", self.0)
+    }
+}
 
 impl RoochSupportedAddress for RoochAddress {
     fn random() -> Self {
@@ -253,14 +324,43 @@ impl TryFrom<MultiChainAddress> for RoochAddress {
 
 impl fmt::Display for RoochAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        //Use full address and 0x prefix for address display
-        write!(f, "0x{}", AccountAddress::from(*self))
+        //Use bech32 as default display format
+        write!(f, "{}", self.to_bech32())
+    }
+}
+
+impl fmt::LowerHex for RoochAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+
+        for byte in self.0.as_bytes() {
+            write!(f, "{:02x}", byte)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for RoochAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+
+        for byte in self.0.as_bytes() {
+            write!(f, "{:02X}", byte)?;
+        }
+
+        Ok(())
     }
 }
 
 impl fmt::Debug for RoochAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", AccountAddress::from(*self).to_hex_literal())
+        // Display the address in bech32 and hex format for debug
+        write!(f, "{}({})", self.to_bech32(), self.to_hex_literal())
     }
 }
 
@@ -268,8 +368,11 @@ impl FromStr for RoochAddress {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let address = AccountAddress::from_str(s)?;
-        Ok(Self::from(address))
+        if s.starts_with("0x") {
+            RoochAddress::from_hex_literal(s)
+        } else {
+            RoochAddress::from_bech32(s)
+        }
     }
 }
 
@@ -296,6 +399,7 @@ impl Serialize for RoochAddress {
         if serializer.is_human_readable() {
             self.to_string().serialize(serializer)
         } else {
+            //Use Move AccountAddress as default binary serialize format
             let account_address: AccountAddress = (*self).into();
             account_address.serialize(serializer)
         }
@@ -699,11 +803,62 @@ impl fmt::Display for NostrAddress {
     }
 }
 
+// Parsed Address, either a name or a numerical address
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub enum ParsedAddress {
+    Named(String),
+    Numerical(RoochAddress),
+}
+
+impl ParsedAddress {
+    pub fn into_rooch_address(
+        self,
+        mapping: &impl Fn(&str) -> Option<AccountAddress>,
+    ) -> anyhow::Result<RoochAddress> {
+        match self {
+            Self::Named(n) => mapping(n.as_str())
+                .map(Into::into)
+                .ok_or_else(|| anyhow::anyhow!("Unbound named address: '{}'", n)),
+            Self::Numerical(a) => Ok(a),
+        }
+    }
+
+    pub fn into_account_address(
+        self,
+        mapping: &impl Fn(&str) -> Option<AccountAddress>,
+    ) -> anyhow::Result<AccountAddress> {
+        self.into_rooch_address(mapping).map(AccountAddress::from)
+    }
+
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        if s.starts_with("0x") {
+            Ok(Self::Numerical(RoochAddress::from_hex_literal(s)?))
+        } else if s.starts_with(ROOCH_HRP.as_str()) && s.len() == RoochAddress::LENGTH_BECH32 {
+            Ok(Self::Numerical(RoochAddress::from_bech32(s)?))
+        } else {
+            Ok(Self::Named(s.to_string()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use bitcoin::hex::DisplayHex;
     use std::fmt::Debug;
+
+    #[test]
+    fn test_bech32() {
+        let address = RoochAddress::random();
+        let hex = address.to_hex_literal();
+        let bech32 = address.to_bech32();
+        println!("bech32: {}, hex: {}", bech32, hex);
+        assert_eq!(bech32.len(), RoochAddress::LENGTH_BECH32);
+        let address2 = RoochAddress::from_bech32(&bech32).unwrap();
+        assert_eq!(address, address2);
+        let address3 = RoochAddress::from_hex_literal(&hex).unwrap();
+        assert_eq!(address, address3);
+    }
 
     fn test_sdk_multi_chain_address(address_str: &str, expect_address_bytes: Vec<u8>) {
         let address = bitcoin::Address::from_str(address_str)
@@ -800,16 +955,21 @@ mod test {
     }
 
     fn test_rooch_address_roundtrip(rooch_address: RoochAddress) {
-        let rooch_str = rooch_address.to_string();
-        //ensure the rooch to string is hex with 0x prefix
+        let rooch_hex_str = rooch_address.to_hex_literal();
+        //ensure the rooch to_hex_literal is hex with 0x prefix
         //and is full 32 bytes output
-        assert!(rooch_str.starts_with("0x"));
-        assert_eq!(rooch_str.len(), 66);
-        let rooch_address_from_str = RoochAddress::from_str(&rooch_str).unwrap();
+        assert!(rooch_hex_str.starts_with("0x"));
+        assert_eq!(rooch_hex_str.len(), RoochAddress::LENGTH_HEX);
+        let rooch_address_from_str = RoochAddress::from_str(&rooch_hex_str).unwrap();
         assert_eq!(rooch_address, rooch_address_from_str);
 
+        let rooch_bech32_str = rooch_address.to_bech32();
+        assert_eq!(rooch_bech32_str.len(), RoochAddress::LENGTH_BECH32);
+        let rooch_address_from_bech32 = RoochAddress::from_bech32(&rooch_bech32_str).unwrap();
+        assert_eq!(rooch_address, rooch_address_from_bech32);
+
         let json_str = serde_json::to_string(&rooch_address).unwrap();
-        assert_eq!(format!("\"{}\"", rooch_str), json_str);
+        assert_eq!(format!("\"{}\"", rooch_bech32_str), json_str);
         let rooch_address_from_json: RoochAddress = serde_json::from_str(&json_str).unwrap();
         assert_eq!(rooch_address, rooch_address_from_json);
 
@@ -943,7 +1103,7 @@ mod test {
         );
         assert_eq!(
             rooch_address.to_string(),
-            "0x7fe695faf7047ccfbc85f7dccb6c405d4e9b7b44788e71a71c3891a06ce0ca12"
+            "rooch10lnft7hhq37vl0y97lwvkmzqt48fk76y0z88rfcu8zg6qm8qegfqx0rq2h"
         );
 
         Ok(())

--- a/crates/rooch-types/src/bitcoin/ord.rs
+++ b/crates/rooch-types/src/bitcoin/ord.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::types::{OutPoint, Transaction};
-use crate::address::BitcoinAddress;
+use crate::address::{BitcoinAddress, RoochAddress};
 use crate::addresses::BITCOIN_MOVE_ADDRESS;
 use crate::indexer::state::IndexerObjectState;
 use crate::into_address::IntoAddress;
@@ -231,7 +231,7 @@ impl<'a> ModuleBinding<'a> for OrdModule<'a> {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InscriptionState {
     pub object_id: ObjectID,
-    pub owner: AccountAddress,
+    pub owner: RoochAddress,
     pub owner_bitcoin_address: Option<BitcoinAddress>,
     pub flag: u8,
     pub value: Inscription,

--- a/crates/rooch-types/src/bitcoin/utxo.rs
+++ b/crates/rooch-types/src/bitcoin/utxo.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::types;
-use crate::address::BitcoinAddress;
+use crate::address::{BitcoinAddress, RoochAddress};
 use crate::addresses::BITCOIN_MOVE_ADDRESS;
 use crate::indexer::state::IndexerObjectState;
 use anyhow::Result;
@@ -93,7 +93,7 @@ pub fn derive_utxo_id(outpoint: &types::OutPoint) -> ObjectID {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UTXOState {
     pub object_id: ObjectID,
-    pub owner: AccountAddress,
+    pub owner: RoochAddress,
     pub owner_bitcoin_address: Option<BitcoinAddress>,
     pub flag: u8,
     // There is a case when rooch bitcoin relayer synchronizes the bitcoin node data and processes the `process_block`

--- a/crates/rooch-types/src/crypto.rs
+++ b/crates/rooch-types/src/crypto.rs
@@ -563,7 +563,7 @@ mod tests {
         let keypair: Ed25519KeyPair = private_key.into();
         let address: RoochAddress = keypair.public().into();
         assert_eq!(
-            address.to_string(),
+            address.to_hex_literal(),
             "0x7a1378aafadef8ce743b72e8b248295c8f61c102c94040161146ea4d51a182b6"
         );
     }

--- a/crates/rooch-types/src/function_arg.rs
+++ b/crates/rooch-types/src/function_arg.rs
@@ -1,10 +1,9 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::RoochError;
+use crate::{address::ParsedAddress, error::RoochError};
 use anyhow::{anyhow, Result};
 use move_command_line_common::{
-    address::ParsedAddress,
     parser::Parser,
     types::ParsedStructType,
     values::{ParsableValue, ValueToken},

--- a/crates/rooch-types/src/indexer/event_filter.rs
+++ b/crates/rooch-types/src/indexer/event_filter.rs
@@ -1,9 +1,9 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::indexer::Filter;
+use crate::{address::RoochAddress, indexer::Filter};
 use anyhow::Result;
-use move_core_types::account_address::AccountAddress;
+
 use move_core_types::language_storage::StructTag;
 use moveos_types::h256::H256;
 use moveos_types::move_types::struct_tag_match;
@@ -52,7 +52,7 @@ pub struct IndexerEvent {
     /// the hash of this transaction.
     pub tx_hash: H256,
     /// the account address of sender who emit the event
-    pub sender: AccountAddress,
+    pub sender: RoochAddress,
 
     /// the event created timestamp on chain
     pub created_at: u64,
@@ -64,7 +64,7 @@ pub enum EventFilter {
     /// Query by event type.
     EventType(StructTag),
     /// Query by sender address.
-    Sender(AccountAddress),
+    Sender(RoochAddress),
     /// Return events emitted by the given transaction hash.
     TxHash(H256),
     /// Return events emitted in [start_time, end_time) interval

--- a/crates/rooch-types/src/indexer/state.rs
+++ b/crates/rooch-types/src/indexer/state.rs
@@ -1,9 +1,11 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::address::RoochAddress;
 use crate::indexer::Filter;
 use anyhow::Result;
-use move_core_types::account_address::AccountAddress;
+use ethers::types::H256;
+
 use move_core_types::language_storage::{StructTag, TypeTag};
 use moveos_types::moveos_std::object::ObjectID;
 use moveos_types::state::StateChangeSet;
@@ -47,10 +49,10 @@ impl IndexerStateID {
 #[derive(Clone, Debug)]
 pub struct IndexerObjectState {
     pub object_id: ObjectID,
-    pub owner: AccountAddress,
+    pub owner: RoochAddress,
     pub flag: u8,
     pub object_type: StructTag,
-    pub state_root: AccountAddress,
+    pub state_root: H256,
     pub size: u64,
     pub tx_order: u64,
     pub state_index: u64,
@@ -82,12 +84,12 @@ pub enum ObjectStateFilter {
     /// Query by object type and owner.
     ObjectTypeWithOwner {
         object_type: StructTag,
-        owner: AccountAddress,
+        owner: RoochAddress,
     },
     /// Query by object type.
     ObjectType(StructTag),
     /// Query by owner.
-    Owner(AccountAddress),
+    Owner(RoochAddress),
     /// Query by object ids.
     ObjectId(Vec<ObjectID>),
 }

--- a/crates/rooch-types/src/indexer/transaction_filter.rs
+++ b/crates/rooch-types/src/indexer/transaction_filter.rs
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::account_address::AccountAddress;
+use crate::address::RoochAddress;
 use moveos_types::h256::H256;
 use serde::{Deserialize, Serialize};
 
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub enum TransactionFilter {
     /// Query by sender address.
-    Sender(AccountAddress),
+    Sender(RoochAddress),
     /// Query by multi chain original address.
     OriginalAddress(String),
     /// Query by the transaction hash list.

--- a/crates/rooch/src/cli_types.rs
+++ b/crates/rooch/src/cli_types.rs
@@ -3,8 +3,8 @@
 
 use async_trait::async_trait;
 use clap::Parser;
-use move_command_line_common::address::ParsedAddress;
 use rooch_rpc_client::wallet_context::WalletContext;
+use rooch_types::address::ParsedAddress;
 use rooch_types::authentication_key::AuthenticationKey;
 use rooch_types::error::{RoochError, RoochResult};
 use rooch_types::transaction::authenticator::Authenticator;

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -7,9 +7,9 @@
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
-use move_command_line_common::address::ParsedAddress;
 use move_command_line_common::types::ParsedStructType;
 use rooch_rpc_api::api::MAX_RESULT_LIMIT_USIZE;
+use rooch_types::address::ParsedAddress;
 use rooch_types::error::RoochResult;
 
 /// Show account balance, only the accounts managed by the current node are supported

--- a/crates/rooch/src/commands/account/commands/transfer.rs
+++ b/crates/rooch/src/commands/account/commands/transfer.rs
@@ -4,12 +4,12 @@
 use crate::cli_types::{CommandAction, TransactionOptions, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
-use move_command_line_common::address::ParsedAddress;
 use move_command_line_common::types::ParsedStructType;
 use move_core_types::u256::U256;
 use rooch_key::key_derive::verify_password;
 use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
+use rooch_types::address::ParsedAddress;
 use rooch_types::address::RoochAddress;
 use rooch_types::framework::transfer::TransferModule;
 use rooch_types::{

--- a/crates/rooch/src/commands/resource.rs
+++ b/crates/rooch/src/commands/resource.rs
@@ -4,10 +4,10 @@
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
-use move_command_line_common::{address::ParsedAddress, types::ParsedStructType};
+use move_command_line_common::types::ParsedStructType;
 use moveos_types::access_path::AccessPath;
 use rooch_rpc_api::jsonrpc_types::StateView;
-use rooch_types::error::RoochResult;
+use rooch_types::{address::ParsedAddress, error::RoochResult};
 
 #[derive(Debug, Parser)]
 

--- a/sdk/typescript/rooch-sdk/test/e2e/cli/rooch-cli.ts
+++ b/sdk/typescript/rooch-sdk/test/e2e/cli/rooch-cli.ts
@@ -85,7 +85,7 @@ export class RoochCli {
     const accounts = await this.execute(['account', 'list', '--json'])
     for (const account of accounts) {
       if (account.active) {
-        return account.local_account.address
+        return account.local_account.hex_address
       }
     }
 


### PR DESCRIPTION
## Summary

1. Use RoochAddress in Object Owner and Transaction Sender, output bech32 in json.
2. RPC argument supports both bech32 and hex.

- Closes #1746 

TODO:

1. The StateView directly outputs `AnnotatedState` of Move; we can not auto covert all AccountAddress to RoochAddress in Move state because we also use AccountAddress to represent h256. 