### PR TITLE
[keystore] Use the BIP86 as the private key derivation path purpose

### DIFF
--- a/crates/rooch-key/src/keystore/memory_keystore.rs
+++ b/crates/rooch-key/src/keystore/memory_keystore.rs
@@ -41,15 +41,6 @@ impl AccountKeystore for InMemKeystore {
         self.keystore.get_key_pair(address, password)
     }
 
-    // fn update_address_encryption_data(
-    //     &mut self,
-    //     address: &RoochAddress,
-    //     encryption: EncryptionData,
-    // ) -> Result<(), anyhow::Error> {
-    //     self.keystore
-    //         .update_address_encryption_data(address, encryption)
-    // }
-
     fn nullify(&mut self, address: &RoochAddress) -> Result<(), anyhow::Error> {
         self.keystore.nullify(address)
     }


### PR DESCRIPTION
## Summary

Use the BIP86 as the private key derivation path purpose. follow #1674 
