### PR TITLE
deploy both release and prerelease to testnet seed

### DIFF
--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -10,7 +10,7 @@ jobs:
   deploy-rooch-testnet:
     name: deploy rooch testnet
     runs-on: self-hosted
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release' && (github.event.release.prerelease == true || github.event.release.prerelease == false) }}
     steps:
       - name: Extract version
         id: extract-version


### PR DESCRIPTION
Under https://docs.github.com/en/rest/releases/releases#create-a-release there is

```
prerelease boolean
true to identify the release as a prerelease. false to identify the release as a full release.
Default: false
```

