### PR TITLE
[CLI] `rooch move` success json output

### DIFF
--- a/crates/rooch/src/commands/account/mod.rs
+++ b/crates/rooch/src/commands/account/mod.rs
@@ -8,7 +8,7 @@ use commands::{
     create::CreateCommand, list::ListCommand, nullify::NullifyCommand, switch::SwitchCommand,
     transfer::TransferCommand,
 };
-use rooch_types::error::{RoochError, RoochResult};
+use rooch_types::error::RoochResult;
 use std::path::PathBuf;
 
 pub mod commands;
@@ -34,7 +34,6 @@ impl CommandAction<String> for Account {
             AccountCommand::Balance(balance) => balance.execute_serialized().await,
             AccountCommand::Transfer(transfer) => transfer.execute_serialized().await,
         }
-        .map_err(RoochError::from)
     }
 }
 

--- a/crates/rooch/src/commands/move_cli/commands/build.rs
+++ b/crates/rooch/src/commands/move_cli/commands/build.rs
@@ -4,21 +4,21 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::*;
-
-use move_cli::base::reroot_path;
-
-use move_package::BuildConfig;
-
-use moveos_verifier::build::run_verifier;
-
+use crate::cli_types::CommandAction;
 use crate::cli_types::WalletContextOptions;
-use std::{collections::BTreeMap, path::PathBuf};
+use crate::commands::move_cli::print_serialized_success;
+use async_trait::async_trait;
+use clap::Parser;
+use move_cli::{base::reroot_path, Move};
+use moveos_verifier::build::run_verifier;
+use rooch_types::error::RoochResult;
+use serde_json::Value;
+use std::collections::BTreeMap;
 
 /// Build the package at `path`. If no path is provided defaults to current directory.
 #[derive(Parser)]
 #[clap(name = "build")]
-pub struct Build {
+pub struct BuildCommand {
     /// Named addresses for the move binary
     ///
     /// Example: alice=0x1234, bob=default, alice2=alice
@@ -29,10 +29,21 @@ pub struct Build {
 
     #[clap(flatten)]
     config_options: WalletContextOptions,
+
+    #[clap(flatten)]
+    move_args: Move,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
 }
 
-impl Build {
-    pub async fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
+#[async_trait]
+impl CommandAction<Option<Value>> for BuildCommand {
+    async fn execute(self) -> RoochResult<Option<Value>> {
+        let path = self.move_args.package_path;
+        let config = self.move_args.build_config;
+
         let context = self.config_options.build()?;
 
         let mut config = config;
@@ -46,7 +57,7 @@ impl Build {
                 config.dev_mode = true;
             }
             config.download_deps_for_package(&rerooted_path, &mut std::io::stdout())?;
-            return Ok(());
+            return print_serialized_success(self.json);
         }
 
         let config_cloned = config.clone();
@@ -55,6 +66,6 @@ impl Build {
 
         run_verifier(rerooted_path, config_cloned, &mut package)?;
 
-        Ok(())
+        print_serialized_success(self.json)
     }
 }

--- a/crates/rooch/src/commands/move_cli/commands/coverage.rs
+++ b/crates/rooch/src/commands/move_cli/commands/coverage.rs
@@ -1,0 +1,40 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use crate::commands::move_cli::serialized_success;
+use async_trait::async_trait;
+use clap::Parser;
+use move_cli::{base::coverage::Coverage, Move};
+use rooch_types::error::RoochResult;
+use serde_json::Value;
+
+/// Inspect test coverage for this package. A previous test run with the `--coverage` flag must
+/// have previously been run.
+#[derive(Parser)]
+#[clap(name = "coverage")]
+pub struct CoverageCommand {
+    #[clap(flatten)]
+    pub coverage: Coverage,
+
+    #[clap(flatten)]
+    move_args: Move,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
+}
+
+#[async_trait]
+impl CommandAction<Option<Value>> for CoverageCommand {
+    async fn execute(self) -> RoochResult<Option<Value>> {
+        let path = self.move_args.package_path;
+        let config = self.move_args.build_config;
+        self.coverage.execute(path, config)?;
+
+        serialized_success(self.json)
+    }
+}

--- a/crates/rooch/src/commands/move_cli/commands/disassemble.rs
+++ b/crates/rooch/src/commands/move_cli/commands/disassemble.rs
@@ -1,0 +1,39 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use crate::commands::move_cli::serialized_success;
+use async_trait::async_trait;
+use clap::Parser;
+use move_cli::{base::disassemble::Disassemble, Move};
+use rooch_types::error::RoochResult;
+use serde_json::Value;
+
+/// Disassemble the Move bytecode pointed to
+#[derive(Parser)]
+#[clap(name = "disassemble")]
+pub struct DisassembleCommand {
+    #[clap(flatten)]
+    pub disassemble: Disassemble,
+
+    #[clap(flatten)]
+    move_args: Move,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
+}
+
+#[async_trait]
+impl CommandAction<Option<Value>> for DisassembleCommand {
+    async fn execute(self) -> RoochResult<Option<Value>> {
+        let path = self.move_args.package_path;
+        let config = self.move_args.build_config;
+        self.disassemble.execute(path, config)?;
+
+        serialized_success(self.json)
+    }
+}

--- a/crates/rooch/src/commands/move_cli/commands/docgen.rs
+++ b/crates/rooch/src/commands/move_cli/commands/docgen.rs
@@ -1,0 +1,39 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use crate::commands::move_cli::serialized_success;
+use async_trait::async_trait;
+use clap::Parser;
+use move_cli::{base::docgen::Docgen, Move};
+use rooch_types::error::RoochResult;
+use serde_json::Value;
+
+/// Generate javadoc style documentation for Move packages
+#[derive(Parser)]
+#[clap(name = "docgen")]
+pub struct DocgenCommand {
+    #[clap(flatten)]
+    pub docgen: Docgen,
+
+    #[clap(flatten)]
+    move_args: Move,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
+}
+
+#[async_trait]
+impl CommandAction<Option<Value>> for DocgenCommand {
+    async fn execute(self) -> RoochResult<Option<Value>> {
+        let path = self.move_args.package_path;
+        let config = self.move_args.build_config;
+        self.docgen.execute(path, config)?;
+
+        serialized_success(self.json)
+    }
+}

--- a/crates/rooch/src/commands/move_cli/commands/errmap.rs
+++ b/crates/rooch/src/commands/move_cli/commands/errmap.rs
@@ -1,0 +1,81 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use crate::commands::move_cli::print_serialized_success;
+use async_trait::async_trait;
+use clap::Parser;
+use move_cli::{base::errmap::Errmap, base::reroot_path, Move};
+use move_package::ModelConfig;
+use rooch_types::error::{RoochError, RoochResult};
+use serde_json::Value;
+
+/// Generate error map for the package and its dependencies at `path` for use by the Move
+/// explanation tool.
+#[derive(Parser)]
+#[clap(name = "errmap")]
+pub struct ErrmapCommand {
+    #[clap(flatten)]
+    pub errmap: Errmap,
+
+    #[clap(flatten)]
+    move_args: Move,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
+}
+
+#[async_trait]
+impl CommandAction<Option<Value>> for ErrmapCommand {
+    async fn execute(self) -> RoochResult<Option<Value>> {
+        let error_prefix: Option<String>;
+        match self.errmap.error_prefix {
+            Some(prefix) => {
+                if prefix == "Error" {
+                    error_prefix = Some("Error".to_owned());
+                } else if prefix == "E" {
+                    error_prefix = Some("E".to_owned());
+                } else {
+                    return Err(RoochError::CommandArgumentError(
+                                "Invalid error prefix. Use --error-prefix \"E\" for move-stdlib, --error-prefix \"Error\" for moveos-stdlib and rooch-framework, etc.".to_owned(),
+                            ));
+                }
+            }
+            None => {
+                return Err(RoochError::CommandArgumentError(
+                            "Error prefix not provided. Use --error-prefix \"E\" for move-stdlib, --error-prefix \"Error\" for moveos-stdlib and rooch-framework, etc.".to_owned(),
+                        ));
+            }
+        }
+
+        let path = self.move_args.package_path;
+        let config = self.move_args.build_config;
+
+        let rerooted_path = reroot_path(path)?;
+        let output_file = self.errmap.output_file;
+        let mut errmap_options = move_errmapgen::ErrmapOptions::default();
+        if let Some(err_prefix) = error_prefix {
+            errmap_options.error_prefix = err_prefix;
+        }
+        errmap_options.output_file = output_file
+            .with_extension(move_command_line_common::files::MOVE_ERROR_DESC_EXTENSION)
+            .to_string_lossy()
+            .to_string();
+        let model = config.move_model_for_package(
+            &rerooted_path,
+            ModelConfig {
+                all_files_as_targets: true,
+                target_filter: None,
+            },
+        )?;
+        let mut errmap_gen = move_errmapgen::ErrmapGen::new(&model, &errmap_options);
+        errmap_gen.gen();
+        errmap_gen.save_result();
+
+        print_serialized_success(self.json)
+    }
+}

--- a/crates/rooch/src/commands/move_cli/commands/info.rs
+++ b/crates/rooch/src/commands/move_cli/commands/info.rs
@@ -1,0 +1,44 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use async_trait::async_trait;
+use clap::Parser;
+use move_cli::{base::reroot_path, Move};
+use rooch_types::error::RoochResult;
+use serde_json::{json, Value};
+
+/// Print address information.
+#[derive(Parser)]
+#[clap(name = "info")]
+pub struct InfoCommand {
+    #[clap(flatten)]
+    move_args: Move,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
+}
+
+#[async_trait]
+impl CommandAction<Option<Value>> for InfoCommand {
+    async fn execute(self) -> RoochResult<Option<Value>> {
+        let path = self.move_args.package_path;
+        let config = self.move_args.build_config;
+        let rerooted_path = reroot_path(path)?;
+
+        let resolved_graph =
+            config.resolution_graph_for_package(&rerooted_path, &mut std::io::stdout())?;
+
+        if self.json {
+            let json_result = json!({ "Result": "Success" });
+            Ok(Some(json_result))
+        } else {
+            resolved_graph.print_info()?;
+            Ok(None)
+        }
+    }
+}

--- a/crates/rooch/src/commands/move_cli/commands/mod.rs
+++ b/crates/rooch/src/commands/move_cli/commands/mod.rs
@@ -2,10 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod build;
+pub mod coverage;
+pub mod disassemble;
+pub mod docgen;
+pub mod errmap;
 pub mod explain;
 pub mod framework_upgrade;
+pub mod info;
 pub mod integration_test;
 pub mod new;
+pub mod prove;
 pub mod publish;
 pub mod run_function;
 pub mod run_view_function;

--- a/crates/rooch/src/commands/move_cli/commands/prove.rs
+++ b/crates/rooch/src/commands/move_cli/commands/prove.rs
@@ -1,0 +1,40 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use crate::commands::move_cli::serialized_success;
+use async_trait::async_trait;
+use clap::Parser;
+use move_cli::{base::prove::Prove, Move};
+use rooch_types::error::RoochResult;
+use serde_json::Value;
+
+/// Inspect test coverage for this package. A previous test run with the `--coverage` flag must
+/// have previously been run.
+#[derive(Parser)]
+#[clap(name = "coverage")]
+pub struct ProveCommand {
+    #[clap(flatten)]
+    pub prove: Prove,
+
+    #[clap(flatten)]
+    move_args: Move,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
+}
+
+#[async_trait]
+impl CommandAction<Option<Value>> for ProveCommand {
+    async fn execute(self) -> RoochResult<Option<Value>> {
+        let path = self.move_args.package_path;
+        let config = self.move_args.build_config;
+        self.prove.execute(path, config)?;
+
+        serialized_success(self.json)
+    }
+}

--- a/crates/rooch/src/commands/move_cli/commands/unit_test.rs
+++ b/crates/rooch/src/commands/move_cli/commands/unit_test.rs
@@ -1,13 +1,14 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli_types::WalletContextOptions;
+use crate::cli_types::{CommandAction, WalletContextOptions};
+use crate::commands::move_cli::serialized_success;
+use async_trait::async_trait;
 use clap::Parser;
 use codespan_reporting::diagnostic::Severity;
-use move_cli::base::test;
+use move_cli::{base::test, Move};
 use move_command_line_common::address::NumericalAddress;
 use move_command_line_common::parser::NumberFormat;
-use move_package::BuildConfig;
 use move_unit_test::extensions::set_extension_hook;
 use move_vm_runtime::native_extensions::NativeContextExtensions;
 use moveos_config::DataDirPath;
@@ -25,12 +26,14 @@ use moveos_verifier::metadata::run_extended_checks;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use rooch_genesis::FrameworksGasParameters;
+use rooch_types::error::{RoochError, RoochResult};
+use serde_json::Value;
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 use termcolor::Buffer;
 
 #[derive(Parser)]
 #[group(skip)]
-pub struct Test {
+pub struct TestCommand {
     #[clap(flatten)]
     pub test: test::Test,
 
@@ -44,22 +47,30 @@ pub struct Test {
 
     #[clap(flatten)]
     config_options: WalletContextOptions,
+
+    #[clap(flatten)]
+    move_args: Move,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
 }
 
-impl Test {
-    pub async fn execute(
-        self,
-        path: Option<PathBuf>,
-        build_config: BuildConfig,
-    ) -> anyhow::Result<()> {
+#[async_trait]
+impl CommandAction<Option<Value>> for TestCommand {
+    async fn execute(self) -> RoochResult<Option<Value>> {
         let context = self.config_options.build()?;
 
-        let mut build_config = build_config;
+        let mut build_config = self.move_args.build_config;
         build_config
             .additional_named_addresses
             .extend(context.parse_and_resolve_addresses(self.named_addresses)?);
 
-        let root_path = path.clone().unwrap_or_else(|| PathBuf::from("."));
+        let root_path = self
+            .move_args
+            .package_path
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("."));
 
         build_config.dev_mode = true;
 
@@ -89,7 +100,9 @@ impl Test {
             let buffer_output = String::from_utf8_lossy(buffer.as_slice()).to_string();
             eprintln!("{}", buffer_output);
             if global_env.has_errors() {
-                return Err(anyhow::Error::msg("extended checks failed"));
+                return Err(RoochError::from(anyhow::Error::msg(
+                    "extended checks failed",
+                )));
             }
         }
 
@@ -98,8 +111,14 @@ impl Test {
         let gas_parameter = FrameworksGasParameters::initial();
         let natives = gas_parameter.all_natives();
         set_extension_hook(Box::new(new_moveos_natives_runtime));
-        self.test
-            .execute(path, build_config, natives, Some(cost_table))
+        self.test.execute(
+            self.move_args.package_path,
+            build_config,
+            natives,
+            Some(cost_table),
+        )?;
+
+        serialized_success(self.json)
     }
 }
 

--- a/crates/rooch/src/commands/move_cli/mod.rs
+++ b/crates/rooch/src/commands/move_cli/mod.rs
@@ -16,6 +16,7 @@ use move_cli::{
     Move,
 };
 use rooch_types::error::{RoochError, RoochResult};
+use serde_json::json;
 
 use crate::commands::move_cli::commands::explain::Explain;
 use crate::CommandAction;
@@ -54,23 +55,25 @@ pub enum MoveCommand {
 impl CommandAction<String> for MoveCli {
     async fn execute(self) -> RoochResult<String> {
         let move_args = self.move_args;
+        let json_result = json!({ "Result": "Success" });
+        let move_success = serde_json::to_string_pretty(&json_result).unwrap();
         match self.cmd {
             MoveCommand::Build(c) => c
                 .execute(move_args.package_path, move_args.build_config)
                 .await
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::Coverage(c) => c
                 .execute(move_args.package_path, move_args.build_config)
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::Disassemble(c) => c
                 .execute(move_args.package_path, move_args.build_config)
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::Docgen(c) => c
                 .execute(move_args.package_path, move_args.build_config)
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::Errmap(mut c) => {
                 match c.error_prefix {
@@ -93,26 +96,26 @@ impl CommandAction<String> for MoveCli {
                 }
 
                 c.execute(move_args.package_path, move_args.build_config)
-                    .map(|_| "Success".to_owned())
+                    .map(|_| move_success)
                     .map_err(RoochError::from)
             }
             MoveCommand::Info(c) => c
                 .execute(move_args.package_path, move_args.build_config)
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::New(c) => c
                 .execute(move_args.package_path)
                 .await
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::Prove(c) => c
                 .execute(move_args.package_path, move_args.build_config)
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::Test(c) => c
                 .execute(move_args.package_path, move_args.build_config)
                 .await
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::Publish(c) => c.execute_serialized().await,
             MoveCommand::Run(c) => c.execute_serialized().await,
@@ -120,12 +123,12 @@ impl CommandAction<String> for MoveCli {
             MoveCommand::IntegrationTest(c) => c
                 .execute(move_args)
                 .await
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::Explain(c) => c
                 .execute()
                 .await
-                .map(|_| "Success".to_owned())
+                .map(|_| move_success)
                 .map_err(RoochError::from),
             MoveCommand::FrameworkUpgrade(c) => c.execute_serialized().await,
         }


### PR DESCRIPTION
-  #1803
```
{
  "Result": "Success"
}
```
Just enable "success" in the JSON output.