### PR TITLE
Beautify `rooch rpc request` cli output, and support `json` mode.

### DIFF
--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -19,6 +19,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::string::String;
 
+use super::HumanReadableDisplay;
+
 pub type EventPageView = PageView<EventView, u64>;
 pub type TransactionWithInfoPageView = PageView<TransactionWithInfoView, u64>;
 pub type StatePageView = PageView<StateKVView, String>;
@@ -38,6 +40,30 @@ pub struct PageView<T, C> {
     pub data: Vec<T>,
     pub next_cursor: Option<C>,
     pub has_next_page: bool,
+}
+
+impl<T, C> HumanReadableDisplay for PageView<T, C>
+where
+    T: HumanReadableDisplay,
+    C: std::fmt::Display,
+{
+    fn to_human_readable_string(&self, verbose: bool) -> String {
+        let _ = verbose;
+        format!(
+            r#"Data: 
+{}
+    
+Next cursor: 
+    {}
+    
+Has next page: {:?}"#,
+            self.data.to_human_readable_string(verbose),
+            self.next_cursor
+                .as_ref()
+                .map_or("None".to_string(), |c| c.to_string()),
+            self.has_next_page
+        )
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -412,7 +412,7 @@ impl HumanReadableDisplay for IndexerObjectStateView {
   tx_order       | {}
   state_index    | {}
 {}"#,
-            std::iter::repeat('-').take(100).collect::<String>(),
+            "-".repeat(100),
             self.object_id,
             self.object_type,
             self.owner,
@@ -420,7 +420,7 @@ impl HumanReadableDisplay for IndexerObjectStateView {
             human_readable_flag(self.flag),
             self.tx_order,
             self.state_index,
-            std::iter::repeat('-').take(100).collect::<String>(),
+            "-".repeat(100),
         )
     }
 }
@@ -542,13 +542,13 @@ impl HumanReadableDisplay for ObjectStateView {
   owner(bitcoin) | {:?}
   status         | {}
 {}"#,
-            std::iter::repeat('-').take(100).collect::<String>(),
+            "-".repeat(100),
             self.id,
             self.object_type,
             self.owner,
             self.owner_bitcoin_address,
             human_readable_flag(self.flag),
-            std::iter::repeat('-').take(100).collect::<String>(),
+            "-".repeat(100),
         )
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    AnnotatedMoveStructView, AnnotatedMoveValueView, BytesView, H256View, ObjectIDVecView,
-    RoochAddressView, RoochOrBitcoinAddressView, StrView, StructTagView, TypeTagView,
+    AnnotatedMoveStructView, AnnotatedMoveValueView, BytesView, H256View, HumanReadableDisplay,
+    ObjectIDVecView, RoochAddressView, RoochOrBitcoinAddressView, StrView, StructTagView,
+    TypeTagView,
 };
 use anyhow::Result;
 
@@ -14,7 +15,7 @@ use moveos_types::state::{
 };
 use moveos_types::state_resolver::StateKV;
 use moveos_types::{
-    moveos_std::object::{AnnotatedObject, ObjectID, RawObject},
+    moveos_std::object::{human_readable_flag, AnnotatedObject, ObjectID, RawObject},
     state::{AnnotatedState, State, StateChangeSet, TableTypeInfo},
 };
 use rooch_types::indexer::state::{
@@ -397,6 +398,33 @@ impl IndexerObjectStateView {
     }
 }
 
+impl HumanReadableDisplay for IndexerObjectStateView {
+    fn to_human_readable_string(&self, verbose: bool) -> String {
+        let _ = verbose; // TODO: implement verbose string
+
+        format!(
+            r#"{}
+  objectId       | {}
+  type           | {}
+  owner          | {}
+  owner(bitcoin) | {:?}
+  status         | {}
+  tx_order       | {}
+  state_index    | {}
+{}"#,
+            std::iter::repeat('-').take(100).collect::<String>(),
+            self.object_id,
+            self.object_type,
+            self.owner,
+            self.owner_bitcoin_address,
+            human_readable_flag(self.flag),
+            self.tx_order,
+            self.state_index,
+            std::iter::repeat('-').take(100).collect::<String>(),
+        )
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ObjectStateFilterView {
@@ -499,5 +527,41 @@ impl ObjectStateView {
     pub fn with_owner_bitcoin_address(mut self, owner_bitcoin_address: Option<String>) -> Self {
         self.owner_bitcoin_address = owner_bitcoin_address;
         self
+    }
+}
+
+impl HumanReadableDisplay for ObjectStateView {
+    fn to_human_readable_string(&self, verbose: bool) -> String {
+        let _ = verbose; // TODO: implement verbose string
+
+        format!(
+            r#"{}
+  objectId       | {}
+  type           | {}
+  owner          | {}
+  owner(bitcoin) | {:?}
+  status         | {}
+{}"#,
+            std::iter::repeat('-').take(100).collect::<String>(),
+            self.id,
+            self.object_type,
+            self.owner,
+            self.owner_bitcoin_address,
+            human_readable_flag(self.flag),
+            std::iter::repeat('-').take(100).collect::<String>(),
+        )
+    }
+}
+
+impl<T> HumanReadableDisplay for Vec<T>
+where
+    T: HumanReadableDisplay,
+{
+    fn to_human_readable_string(&self, verbose: bool) -> String {
+        let _ = verbose;
+        self.iter()
+            .map(|s| s.to_human_readable_string(verbose))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
@@ -264,3 +264,18 @@ impl std::fmt::Display for MoveStringView {
         // write!(f, "0x{}", hex::encode(&self.0))
     }
 }
+
+/// This trait is used to convert a struct to a human readable string
+/// `verbose`: if true, the human readable string will be more detailed
+pub trait HumanReadableDisplay {
+    fn to_human_readable_string(&self, verbose: bool) -> String;
+}
+
+impl<T> HumanReadableDisplay for StrView<T>
+where
+    T: HumanReadableDisplay,
+{
+    fn to_human_readable_string(&self, verbose: bool) -> String {
+        self.0.to_human_readable_string(verbose)
+    }
+}

--- a/crates/rooch/src/commands/rpc/commands/request.rs
+++ b/crates/rooch/src/commands/rpc/commands/request.rs
@@ -6,6 +6,10 @@ use async_trait::async_trait;
 use clap::Parser;
 use rooch_types::error::RoochResult;
 
+use rooch_rpc_api::jsonrpc_types::{
+    HumanReadableDisplay, IndexerObjectStatePageView, ObjectStateView,
+};
+
 /// Send a RPC request
 #[derive(Debug, Parser)]
 pub struct RequestCommand {
@@ -23,6 +27,10 @@ pub struct RequestCommand {
 
     #[clap(flatten)]
     pub(crate) context_options: WalletContextOptions,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
 }
 
 #[async_trait]
@@ -44,5 +52,35 @@ impl CommandAction<serde_json::Value> for RequestCommand {
             None => vec![],
         };
         Ok(client.request(self.method.as_str(), params).await?)
+    }
+
+    /// Executes the command, and serializes it to the common JSON output type
+    async fn execute_serialized(self) -> RoochResult<String> {
+        let method = self.method.clone();
+        match self.execute().await {
+            Ok(result) => {
+                if method == "rooch_getObjectStates" {
+                    let view =
+                        serde_json::from_value::<Vec<Option<ObjectStateView>>>(result.clone())?
+                            .into_iter()
+                            .flatten()
+                            .collect::<Vec<_>>();
+                    return Ok(view.to_human_readable_string(false));
+                } else if method == "rooch_queryObjectStates" {
+                    Ok(
+                        serde_json::from_value::<IndexerObjectStatePageView>(result.clone())?
+                            .to_human_readable_string(false),
+                    )
+                } else {
+                    // TODO: handle other rpc methods.
+                    let output = serde_json::to_string_pretty(&result).unwrap();
+                    if output == "null" {
+                        return Ok("".to_string());
+                    }
+                    Ok(output)
+                }
+            }
+            Err(e) => Err(e),
+        }
     }
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -7,24 +7,24 @@ Feature: Rooch CLI integration tests
     @serial
     Scenario: rooch rpc test
       Given a server for rooch_rpc_test
-      Then cmd: "rpc request --method rooch_getStates --params '["/resource/0x3/0x3::account_coin_store::AutoAcceptCoins",{"decode":true}]'"
+      Then cmd: "rpc request --method rooch_getStates --params '["/resource/0x3/0x3::account_coin_store::AutoAcceptCoins",{"decode":true}]' --json"
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x3::account_coin_store::AutoAcceptCoins'"
-      Then cmd: "rpc request --method rooch_getStates --params '["/object/0x3",{"decode":true}]'"
+      Then cmd: "rpc request --method rooch_getStates --params '["/object/0x3",{"decode":true}]' --json"
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x2::object::ObjectEntity<0x2::account::Account>'"
-      Then cmd: "rpc request --method rooch_listStates --params '["/resource/0x3", null, null, {"decode":true}]"
+      Then cmd: "rpc request --method rooch_listStates --params '["/resource/0x3", null, null, {"decode":true}] --json"
       Then assert: "'{{$.rpc[-1]}}' contains '0x3::account_coin_store::AutoAcceptCoins'"
-      Then cmd: "rpc request --method rooch_getStates --params '["/object/0x5921974509dbe44ab84328a625f4a6580a5f89dff3e4e2dec448cb2b1c7f5b9",{"decode":true}]'"
+      Then cmd: "rpc request --method rooch_getStates --params '["/object/0x5921974509dbe44ab84328a625f4a6580a5f89dff3e4e2dec448cb2b1c7f5b9",{"decode":true}]' --json"
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x2::object::ObjectEntity<0x2::object::Timestamp>'"
       Then assert: "{{$.rpc[-1][0].decoded_value.value.value.value.milliseconds}} == 0"
-      Then cmd: "rpc request --method rooch_getStates --params '["/object/0x2::object::Timestamp",{"decode":true}]'"
+      Then cmd: "rpc request --method rooch_getStates --params '["/object/0x2::object::Timestamp",{"decode":true}]' --json"
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x2::object::ObjectEntity<0x2::object::Timestamp>'"
-      Then cmd: "rpc request --method rooch_getObjectStates --params '["0x5921974509dbe44ab84328a625f4a6580a5f89dff3e4e2dec448cb2b1c7f5b9", {"decode":false}]'"
-      Then cmd: "rpc request --method rooch_getObjectStates --params '["0x5921974509dbe44ab84328a625f4a6580a5f89dff3e4e2dec448cb2b1c7f5b9", {"decode":true}]'"
+      Then cmd: "rpc request --method rooch_getObjectStates --params '["0x5921974509dbe44ab84328a625f4a6580a5f89dff3e4e2dec448cb2b1c7f5b9", {"decode":false}]' --json"
+      Then cmd: "rpc request --method rooch_getObjectStates --params '["0x5921974509dbe44ab84328a625f4a6580a5f89dff3e4e2dec448cb2b1c7f5b9", {"decode":true}]' --json"
       Then assert: "{{$.rpc[-1][0].object_type}} == '0x2::object::Timestamp'"
       Then assert: "{{$.rpc[-1][0].value}} == {{$.rpc[-2][0].value}}'
-      Then cmd: "rpc request --method rooch_getFieldStates --params '["0x2214495c6abca5dd5a2bf0f2a28a74541ff10c89818a1244af24c4874325ebdb", ["0x41022214495c6abca5dd5a2bf0f2a28a74541ff10c89818a1244af24c4874325ebdb8238d4e7553801ebf92b4311e16bbeb26eec676fd5bcbb31dcc59610148d90c8070000000000000000000000000000000000000000000000000000000000000002066f626a656374084f626a656374494400"], {"decode": true, "showDisplay": true}]'"
+      Then cmd: "rpc request --method rooch_getFieldStates --params '["0x2214495c6abca5dd5a2bf0f2a28a74541ff10c89818a1244af24c4874325ebdb", ["0x41022214495c6abca5dd5a2bf0f2a28a74541ff10c89818a1244af24c4874325ebdb8238d4e7553801ebf92b4311e16bbeb26eec676fd5bcbb31dcc59610148d90c8070000000000000000000000000000000000000000000000000000000000000002066f626a656374084f626a656374494400"], {"decode": true, "showDisplay": true}]' --json"
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x2::object::ObjectEntity<0x2::module_store::Package>'"
-      Then cmd: "rpc request --method rooch_listFieldStates --params '["0x2214495c6abca5dd5a2bf0f2a28a74541ff10c89818a1244af24c4874325ebdb", null, "2", {"decode": false, "showDisplay": false}]'"
+      Then cmd: "rpc request --method rooch_listFieldStates --params '["0x2214495c6abca5dd5a2bf0f2a28a74541ff10c89818a1244af24c4874325ebdb", null, "2", {"decode": false, "showDisplay": false}]' --json"
       Then assert: "{{$.rpc[-1].has_next_page}} == true"
       Then stop the server 
     
@@ -37,7 +37,7 @@ Feature: Rooch CLI integration tests
       # use bitcoin_address
       Then cmd: "account nullify -a {{$.account[-1].account0.bitcoin_address}}"
 
-      Then cmd: "rpc request --method rooch_getBalance --params '["{{$.address_mapping.default}}", "0x3::gas_coin::GasCoin"]'"
+      Then cmd: "rpc request --method rooch_getBalance --params '["{{$.address_mapping.default}}", "0x3::gas_coin::GasCoin"]' --json"
       Then assert: "'{{$.rpc[-1].coin_type}}' == '0x3::gas_coin::GasCoin'"
       Then assert: "'{{$.rpc[-1].balance}}' == '0'"
 
@@ -45,7 +45,7 @@ Feature: Rooch CLI integration tests
       Then cmd: "move run --function rooch_framework::gas_coin::faucet_entry --args u256:10000000000"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
-      Then cmd: "rpc request --method rooch_getStates --params '["/object/0x5921974509dbe44ab84328a625f4a6580a5f89dff3e4e2dec448cb2b1c7f5b9",{"decode":true}]'"
+      Then cmd: "rpc request --method rooch_getStates --params '["/object/0x5921974509dbe44ab84328a625f4a6580a5f89dff3e4e2dec448cb2b1c7f5b9",{"decode":true}]' --json"
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x2::object::ObjectEntity<0x2::object::Timestamp>'"
       # ensure the tx_timestamp update the global timestamp
       Then assert: "{{$.rpc[-1][0].decoded_value.value.value.value.milliseconds}} != 0"
@@ -62,7 +62,7 @@ Feature: Rooch CLI integration tests
       # account balance
       Then cmd: "account balance"
       Then cmd: "account balance --coin-type rooch_framework::gas_coin::GasCoin"
-      Then cmd: "rpc request --method rooch_getBalance --params '["{{$.address_mapping.default}}", "0x3::gas_coin::GasCoin"]'"
+      Then cmd: "rpc request --method rooch_getBalance --params '["{{$.address_mapping.default}}", "0x3::gas_coin::GasCoin"]' --json"
       Then assert: "'{{$.rpc[-1].balance}}' != '0'"
 
       Then stop the server
@@ -123,29 +123,29 @@ Feature: Rooch CLI integration tests
     Then sleep: "5"
 
     # genesis tx does not write indexer
-    Then cmd: "rpc request --method rooch_queryTransactions --params '[{"tx_order_range":{"from_order":0,"to_order":2}}, null, "1", {"descending": true,"showDisplay":false}]'"
+    Then cmd: "rpc request --method rooch_queryTransactions --params '[{"tx_order_range":{"from_order":0,"to_order":2}}, null, "1", {"descending": true,"showDisplay":false}]' --json"
     Then assert: "{{$.rpc[-1].data[0].transaction.sequence_info.tx_order}} == 1"
     Then assert: "{{$.rpc[-1].next_cursor}} == 1"
     Then assert: "{{$.rpc[-1].has_next_page}} == true"
-    Then cmd: "rpc request --method rooch_queryTransactions --params '[{"tx_order_range":{"from_order":0,"to_order":2}}, "1", "1", {"descending": true,"showDisplay":false}]'"
+    Then cmd: "rpc request --method rooch_queryTransactions --params '[{"tx_order_range":{"from_order":0,"to_order":2}}, "1", "1", {"descending": true,"showDisplay":false}]' --json"
     Then assert: "{{$.rpc[-1].data[0].transaction.sequence_info.tx_order}} == 0"
     Then assert: "{{$.rpc[-1].next_cursor}} == 0"
     Then assert: "{{$.rpc[-1].has_next_page}} == false"
-    Then cmd: "rpc request --method rooch_queryEvents --params '[{"tx_order_range":{"from_order":0, "to_order":2}}, null, "20", {"descending": true,"showDisplay":false}]'"
+    Then cmd: "rpc request --method rooch_queryEvents --params '[{"tx_order_range":{"from_order":0, "to_order":2}}, null, "20", {"descending": true,"showDisplay":false}]' --json"
     Then assert: "{{$.rpc[-1].data[0].indexer_event_id.tx_order}} == 1"
     Then assert: "{{$.rpc[-1].next_cursor.tx_order}} == 0"
     Then assert: "{{$.rpc[-1].has_next_page}} == false"
 
     # Sync states
-    Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x3::coin::CoinInfo"}, null, "10", {"descending": true,"showDisplay":false}]'"
+    Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x3::coin::CoinInfo"}, null, "10", {"descending": true,"showDisplay":false}]' --json"
     Then assert: "{{$.rpc[-1].data[0].tx_order}} == 1"
     Then assert: "{{$.rpc[-1].data[0].object_type}} == 0x3::coin::CoinInfo<0x3::gas_coin::GasCoin>"
     Then assert: "{{$.rpc[-1].has_next_page}} == false"
 
-    Then cmd: "rpc request --method rooch_listFieldStates --params '["{{$.address_mapping.default}}", null, "10", {"descending": true,"showDisplay":false}]'"
+    Then cmd: "rpc request --method rooch_listFieldStates --params '["{{$.address_mapping.default}}", null, "10", {"descending": true,"showDisplay":false}]' --json"
     Then assert: "{{$.rpc[-1].has_next_page}} == false"
 
-#    Then cmd: "rpc request --method rooch_syncStates --params '[null, null, "2", false]'"
+#    Then cmd: "rpc request --method rooch_syncStates --params '[null, null, "2", false]' --json"
 #    Then assert: "{{$.rpc[-1].data[0].tx_order}} == 0"
 #    Then assert: "{{$.rpc[-1].next_cursor.state_index}} == 1"
 #    Then assert: "{{$.rpc[-1].has_next_page}} == true"
@@ -254,7 +254,7 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       
       Then cmd: "account list --json"
-      Then cmd: "rpc request --method rooch_getBalance --params '["{{$.account[-1].default.bitcoin_address}}", "{{$.account[-1].default.hex_address}}::fixed_supply_coin::FSC"]'"
+      Then cmd: "rpc request --method rooch_getBalance --params '["{{$.account[-1].default.bitcoin_address}}", "{{$.account[-1].default.hex_address}}::fixed_supply_coin::FSC"]' --json"
       Then assert: "'{{$.rpc[-1].coin_type}}' == '{{$.address_mapping.default}}::fixed_supply_coin::FSC'"
       Then assert: "'{{$.rpc[-1].balance}}' != '0'"
 
@@ -276,7 +276,7 @@ Feature: Rooch CLI integration tests
     #Then cmd: "move run --function default::my_coin::faucet --args object:default::my_coin::Treasury"
     #Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
-    #Then cmd: "rpc request --method rooch_getBalance --params '["{{$.address_mapping.default}}", "{{$.address_mapping.default}}::my_coin::MyCoin"]'"
+    #Then cmd: "rpc request --method rooch_getBalance --params '["{{$.address_mapping.default}}", "{{$.address_mapping.default}}::my_coin::MyCoin"]' --json"
     #Then assert: "'{{$.rpc[-1].coin_type}}' == '{{$.address_mapping.default}}::my_coin::MyCoin'"
     #Then assert: "'{{$.rpc[-1].balance}}' != '0'"
     Then stop the server
@@ -303,7 +303,7 @@ Feature: Rooch CLI integration tests
       # because the indexer is async update, so sleep 2 seconds to wait indexer update.
       Then sleep: "2"
 
-      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"{{$.address_mapping.default}}::child_object::Child"}, null, "10", {"descending": true,"showDisplay":false}]'"
+      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"{{$.address_mapping.default}}::child_object::Child"}, null, "10", {"descending": true,"showDisplay":false}]' --json"
       Then assert: "{{$.rpc[-1].data[0].object_id}} == {{$.event[-1].data[0].decoded_event_data.value.id}}"
 
       Then cmd: "move run --function default::third_party_module_for_child_object::update_child_age --args object:{{$.event[-1].data[0].decoded_event_data.value.id}} --args u64:10"
@@ -331,17 +331,17 @@ Feature: Rooch CLI integration tests
       Then cmd: "state --access-path /object/{{$.event[-1].data[0].decoded_event_data.value.id}}"
       Then assert: "{{$.state[-1][0].decoded_value.value.value.type}} == '{{$.address_mapping.default}}::display::ObjectType'"
 
-      Then cmd: "rpc request --method rooch_getStates --params '["/object/{{$.event[-1].data[0].decoded_event_data.value.id}}", {"decode": false, "showDisplay": true}]'"
+      Then cmd: "rpc request --method rooch_getStates --params '["/object/{{$.event[-1].data[0].decoded_event_data.value.id}}", {"decode": false, "showDisplay": true}]' --json"
       Then assert: "{{$.rpc[-1][0].display_fields.fields.name}}  == test_object"
 
       # because the indexer is async update, so sleep 2 seconds to wait indexer update.
       Then sleep: "2"
 
-      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"{{$.address_mapping.default}}::display::ObjectType"}, null, "10", {"descending": false,"showDisplay":true}]'"
+      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"{{$.address_mapping.default}}::display::ObjectType"}, null, "10", {"descending": false,"showDisplay":true}]' --json"
       Then assert: "{{$.rpc[-1].data[0].object_id}} == {{$.event[-1].data[0].decoded_event_data.value.id}}"
       Then assert: "{{$.rpc[-1].data[0].display_fields.fields.name}} == test_object"
 
-      Then cmd: "rpc request --method rooch_getObjectStates --params '["{{$.event[-1].data[0].decoded_event_data.value.id}}", {"decode": false, "showDisplay": true}]'"
+      Then cmd: "rpc request --method rooch_getObjectStates --params '["{{$.event[-1].data[0].decoded_event_data.value.id}}", {"decode": false, "showDisplay": true}]' --json"
       Then assert: "{{$.rpc[-1][0].display_fields.fields.name}} == test_object"
 
       
@@ -392,7 +392,7 @@ Feature: Rooch CLI integration tests
       Then sleep: "10" # wait rooch sync and index
 
       # query utxos
-      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type_with_owner":{"object_type":"0x4::utxo::UTXO","owner":"{{$.account[-1].default.bitcoin_address}}"}},null, null, null]'"
+      Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type_with_owner":{"object_type":"0x4::utxo::UTXO","owner":"{{$.account[-1].default.bitcoin_address}}"}},null, null, null]' --json"
       Then assert: "{{$.rpc[-1].data[0].owner}} == {{$.account[-1].default.address}}"
 
       # release servers

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -11,7 +11,7 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x3::account_coin_store::AutoAcceptCoins'"
       Then cmd: "rpc request --method rooch_getStates --params '["/object/0x3",{"decode":true}]' --json"
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x2::object::ObjectEntity<0x2::account::Account>'"
-      Then cmd: "rpc request --method rooch_listStates --params '["/resource/0x3", null, null, {"decode":true}] --json"
+      Then cmd: "rpc request --method rooch_listStates --params '["/resource/0x3", null, null, {"decode":true}]' --json"
       Then assert: "'{{$.rpc[-1]}}' contains '0x3::account_coin_store::AutoAcceptCoins'"
       Then cmd: "rpc request --method rooch_getStates --params '["/object/0x5921974509dbe44ab84328a625f4a6580a5f89dff3e4e2dec448cb2b1c7f5b9",{"decode":true}]' --json"
       Then assert: "{{$.rpc[-1][0].value_type}} == '0x2::object::ObjectEntity<0x2::object::Timestamp>'"

--- a/moveos/moveos-types/src/moveos_std/object.rs
+++ b/moveos/moveos-types/src/moveos_std/object.rs
@@ -49,13 +49,13 @@ pub static GENESIS_STATE_ROOT: Lazy<H256> = Lazy::new(|| *SPARSE_MERKLE_PLACEHOL
 pub fn human_readable_flag(flag: u8) -> String {
     let mut status = vec![];
     if flag & SHARED_OBJECT_FLAG_MASK == SHARED_OBJECT_FLAG_MASK {
-        status.push(format!("{}", "SHARED"));
+        status.push("SHARED".to_string());
     }
     if flag & FROZEN_OBJECT_FLAG_MASK == FROZEN_OBJECT_FLAG_MASK {
-        status.push(format!("{}", "FROZEN"));
+        status.push("FROZEN".to_string());
     }
     if flag & BOUND_OBJECT_FLAG_MASK == BOUND_OBJECT_FLAG_MASK {
-        status.push(format!("{}", "BOUND"));
+        status.push("BOUND".to_string());
     }
 
     status.join(",")

--- a/moveos/moveos-types/src/moveos_std/object.rs
+++ b/moveos/moveos-types/src/moveos_std/object.rs
@@ -41,9 +41,25 @@ pub const SYSTEM_OWNER_ADDRESS: AccountAddress = AccountAddress::ZERO;
 
 pub const SHARED_OBJECT_FLAG_MASK: u8 = 1;
 pub const FROZEN_OBJECT_FLAG_MASK: u8 = 1 << 1;
+pub const BOUND_OBJECT_FLAG_MASK: u8 = 1 << 2;
 
 // New table's state_root should be the place holder hash.
 pub static GENESIS_STATE_ROOT: Lazy<H256> = Lazy::new(|| *SPARSE_MERKLE_PLACEHOLDER_HASH);
+
+pub fn human_readable_flag(flag: u8) -> String {
+    let mut status = vec![];
+    if flag & SHARED_OBJECT_FLAG_MASK == SHARED_OBJECT_FLAG_MASK {
+        status.push(format!("{}", "SHARED"));
+    }
+    if flag & FROZEN_OBJECT_FLAG_MASK == FROZEN_OBJECT_FLAG_MASK {
+        status.push(format!("{}", "FROZEN"));
+    }
+    if flag & BOUND_OBJECT_FLAG_MASK == BOUND_OBJECT_FLAG_MASK {
+        status.push(format!("{}", "BOUND"));
+    }
+
+    status.join(",")
+}
 
 #[derive(Eq, PartialEq, Clone, PartialOrd, Ord, Hash, JsonSchema)]
 pub struct ObjectID(#[schemars(with = "Hex")] Vec<AccountAddress>);

--- a/moveos/moveos-types/src/moveos_std/object.rs
+++ b/moveos/moveos-types/src/moveos_std/object.rs
@@ -47,15 +47,19 @@ pub const BOUND_OBJECT_FLAG_MASK: u8 = 1 << 2;
 pub static GENESIS_STATE_ROOT: Lazy<H256> = Lazy::new(|| *SPARSE_MERKLE_PLACEHOLDER_HASH);
 
 pub fn human_readable_flag(flag: u8) -> String {
+    if flag == 0 {
+        return "UserOwned".to_string();
+    };
+
     let mut status = vec![];
     if flag & SHARED_OBJECT_FLAG_MASK == SHARED_OBJECT_FLAG_MASK {
-        status.push("SHARED".to_string());
+        status.push("Shared".to_string());
     }
     if flag & FROZEN_OBJECT_FLAG_MASK == FROZEN_OBJECT_FLAG_MASK {
-        status.push("FROZEN".to_string());
+        status.push("Frozen".to_string());
     }
     if flag & BOUND_OBJECT_FLAG_MASK == BOUND_OBJECT_FLAG_MASK {
-        status.push("BOUND".to_string());
+        status.push("Bound".to_string());
     }
 
     status.join(",")


### PR DESCRIPTION
## Summary

Beautify `rooch rpc request` cli output in default. And output json format with `--json` option. For now, only method `rooch_getObjectStates` and `rooch_queryObjectStates` output are beautified.

Part of #1803

TODO:

- [ ] Beautify other rpc methods.

