### PR TITLE
[bitcoin] Define l1_tx type and split l1_tx execution from l1_block

### DIFF
--- a/crates/rooch-benchmarks/src/tx_exec.rs
+++ b/crates/rooch-benchmarks/src/tx_exec.rs
@@ -71,6 +71,7 @@ pub fn tx_exec_benchmark(c: &mut Criterion) {
                         .execute_l1_block(l1_block_with_body.clone())
                         .unwrap()
                 }
+                LedgerTxData::L1Tx(tx) => binding_test.execute_l1_tx(tx).unwrap(),
                 LedgerTxData::L2Tx(tx) => binding_test.execute(tx).unwrap(),
             }
         });

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -18,7 +18,7 @@ use moveos_types::transaction::TransactionExecutionInfo;
 use moveos_types::transaction::TransactionOutput;
 use moveos_types::transaction::VerifiedMoveOSTransaction;
 use rooch_types::address::{BitcoinAddress, MultiChainAddress};
-use rooch_types::transaction::{L1BlockWithBody, RoochTransaction};
+use rooch_types::transaction::{L1BlockWithBody, L1Transaction, RoochTransaction};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
@@ -38,6 +38,17 @@ pub struct ValidateL1BlockMessage {
 }
 
 impl Message for ValidateL1BlockMessage {
+    type Result = Result<VerifiedMoveOSTransaction>;
+}
+
+#[derive(Debug)]
+pub struct ValidateL1TxMessage {
+    pub ctx: TxContext,
+    pub l1_tx: L1Transaction,
+    pub sequencer_address: BitcoinAddress,
+}
+
+impl Message for ValidateL1TxMessage {
     type Result = Result<VerifiedMoveOSTransaction>;
 }
 

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -4,7 +4,7 @@
 use crate::actor::messages::{
     GetAnnotatedStatesByStateMessage, GetEventsByEventHandleMessage, GetEventsByEventIDsMessage,
     GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage, ListStatesMessage,
-    RefreshStateMessage, ValidateL1BlockMessage,
+    RefreshStateMessage, ValidateL1BlockMessage, ValidateL1TxMessage,
 };
 use crate::actor::reader_executor::ReaderExecutorActor;
 use crate::actor::{
@@ -38,7 +38,7 @@ use moveos_types::{
 use rooch_types::address::BitcoinAddress;
 use rooch_types::bitcoin::network::BitcoinNetwork;
 use rooch_types::framework::chain_id::ChainID;
-use rooch_types::transaction::{L1BlockWithBody, RoochTransaction};
+use rooch_types::transaction::{L1BlockWithBody, L1Transaction, RoochTransaction};
 use tokio::runtime::Handle;
 
 #[derive(Clone)]
@@ -72,6 +72,21 @@ impl ExecutorProxy {
             .send(ValidateL1BlockMessage {
                 ctx,
                 l1_block,
+                sequencer_address,
+            })
+            .await?
+    }
+
+    pub async fn validate_l1_tx(
+        &self,
+        ctx: TxContext,
+        l1_tx: L1Transaction,
+        sequencer_address: BitcoinAddress,
+    ) -> Result<VerifiedMoveOSTransaction> {
+        self.actor
+            .send(ValidateL1TxMessage {
+                ctx,
+                l1_tx,
                 sequencer_address,
             })
             .await?

--- a/crates/rooch-framework-tests/src/binding_test.rs
+++ b/crates/rooch-framework-tests/src/binding_test.rs
@@ -18,9 +18,11 @@ use rooch_db::RoochDB;
 use rooch_executor::actor::reader_executor::ReaderExecutorActor;
 use rooch_executor::actor::{executor::ExecutorActor, messages::ExecuteTransactionResult};
 use rooch_genesis::RoochGenesis;
+use rooch_types::address::BitcoinAddress;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::rooch_network::{BuiltinChainID, RoochNetwork};
-use rooch_types::transaction::{L1BlockWithBody, RoochTransaction};
+use rooch_types::transaction::{L1BlockWithBody, L1Transaction, RoochTransaction};
+use std::collections::VecDeque;
 use std::env;
 use std::path::Path;
 use std::sync::Arc;
@@ -41,6 +43,7 @@ pub struct RustBindingTest {
     //we keep the opt to ensure the temp dir is not be deleted before the test end
     opt: RoochOpt,
     sequencer: AccountAddress,
+    sequencer_bitcoin_address: BitcoinAddress,
     kp: RoochKeyPair,
     pub executor: ExecutorActor,
     pub reader_executor: ReaderExecutorActor,
@@ -79,6 +82,7 @@ impl RustBindingTest {
             opt,
             root,
             sequencer: sequencer.to_rooch_address().into(),
+            sequencer_bitcoin_address: sequencer,
             kp,
             executor,
             reader_executor,
@@ -119,30 +123,84 @@ impl RustBindingTest {
     }
 
     pub fn execute_l1_block(&mut self, l1_block: L1BlockWithBody) -> Result<()> {
-        let sequence_number = self.get_account_sequence_number(self.sequencer)?;
-        let ctx = self.create_bt_blk_tx_ctx(sequence_number, l1_block.clone());
-        let verified_tx: VerifiedMoveOSTransaction =
+        let ctx = self.create_l1_block_ctx(&l1_block)?;
+        let verified_tx: VerifiedMoveOSTransaction = self.executor.validate_l1_block(
+            ctx,
+            l1_block.clone(),
+            self.sequencer_bitcoin_address.clone(),
+        )?;
+        self.execute_verified_tx(verified_tx)?;
+
+        if l1_block.block.chain_id.is_bitcoin() {
+            let block =
+                bcs::from_bytes::<rooch_types::bitcoin::types::Block>(&l1_block.block_body)?;
+            let mut l1_txs = block
+                .txdata
+                .iter()
+                .map(|tx| {
+                    L1Transaction::new(
+                        l1_block.block.chain_id,
+                        l1_block.block.block_hash.clone(),
+                        tx.id.to_vec(),
+                    )
+                })
+                .collect::<VecDeque<_>>();
+            let coinbase_tx = l1_txs.pop_front().expect("coinbase tx should exist");
+            l1_txs.push_back(coinbase_tx);
+            for tx in &block.txdata[1..] {
+                let l1_tx = L1Transaction::new(
+                    l1_block.block.chain_id,
+                    l1_block.block.block_hash.clone(),
+                    tx.id.to_vec(),
+                );
+                self.execute_l1_tx(l1_tx)?;
+            }
+            let coinbase_tx = L1Transaction::new(
+                l1_block.block.chain_id,
+                l1_block.block.block_hash.clone(),
+                block.txdata[0].id.to_vec(),
+            );
+            self.execute_l1_tx(coinbase_tx)?;
+        }
+        Ok(())
+    }
+
+    pub fn execute_l1_tx(&mut self, l1_tx: L1Transaction) -> Result<()> {
+        let ctx = self.create_l1_tx_ctx(l1_tx.clone())?;
+        let verified_tx =
             self.executor
-                .validate_l1_block(ctx, l1_block, self.kp.public().bitcoin_address()?)?;
+                .validate_l1_tx(ctx, l1_tx, self.sequencer_bitcoin_address.clone())?;
         self.execute_verified_tx(verified_tx)
     }
 
-    pub fn create_bt_blk_tx_ctx(
-        &mut self,
-        sequence_number: u64,
-        l1_block: L1BlockWithBody,
-    ) -> TxContext {
+    pub fn create_l1_block_ctx(&self, l1_block: &L1BlockWithBody) -> Result<TxContext> {
+        let sequence_number = self.get_account_sequence_number(self.sequencer)?;
         let max_gas_amount = GasScheduleConfig::INITIAL_MAX_GAS_AMOUNT * 1000;
         let tx_hash = l1_block.block.tx_hash();
         let tx_size = l1_block.block.tx_size();
 
-        TxContext::new(
+        Ok(TxContext::new(
             self.sequencer,
             sequence_number,
             max_gas_amount,
             tx_hash,
             tx_size,
-        )
+        ))
+    }
+
+    pub fn create_l1_tx_ctx(&self, l1_tx: L1Transaction) -> Result<TxContext> {
+        let sequence_number = self.get_account_sequence_number(self.sequencer)?;
+        let max_gas_amount = GasScheduleConfig::INITIAL_MAX_GAS_AMOUNT * 1000;
+        let tx_hash = l1_tx.tx_hash();
+        let tx_size = l1_tx.tx_size();
+
+        Ok(TxContext::new(
+            self.sequencer,
+            sequence_number,
+            max_gas_amount,
+            tx_hash,
+            tx_size,
+        ))
     }
 
     pub fn execute_as_result(&mut self, tx: RoochTransaction) -> Result<ExecuteTransactionResult> {

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -1662,6 +1662,34 @@
           {
             "type": "object",
             "required": [
+              "block_hash",
+              "chain_id",
+              "txid",
+              "type"
+            ],
+            "properties": {
+              "block_hash": {
+                "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
+              },
+              "chain_id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "txid": {
+                "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "l1_tx"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
               "action",
               "action_type",
               "raw",

--- a/crates/rooch-pipeline-processor/src/actor/messages.rs
+++ b/crates/rooch-pipeline-processor/src/actor/messages.rs
@@ -6,7 +6,7 @@ use coerce::actor::message::Message;
 use moveos_types::moveos_std::tx_context::TxContext;
 use rooch_types::{
     address::BitcoinAddress,
-    transaction::{ExecuteTransactionResponse, L1BlockWithBody, RoochTransaction},
+    transaction::{ExecuteTransactionResponse, L1BlockWithBody, L1Transaction, RoochTransaction},
 };
 
 #[derive(Clone)]
@@ -26,5 +26,16 @@ pub struct ExecuteL1BlockMessage {
 }
 
 impl Message for ExecuteL1BlockMessage {
+    type Result = Result<ExecuteTransactionResponse>;
+}
+
+#[derive(Clone)]
+pub struct ExecuteL1TxMessage {
+    pub ctx: TxContext,
+    pub tx: L1Transaction,
+    pub sequencer_address: BitcoinAddress,
+}
+
+impl Message for ExecuteL1TxMessage {
     type Result = Result<ExecuteTransactionResponse>;
 }

--- a/crates/rooch-pipeline-processor/src/proxy/mod.rs
+++ b/crates/rooch-pipeline-processor/src/proxy/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::actor::{
-    messages::{ExecuteL1BlockMessage, ExecuteL2TxMessage},
+    messages::{ExecuteL1BlockMessage, ExecuteL1TxMessage, ExecuteL2TxMessage},
     processor::PipelineProcessorActor,
 };
 use anyhow::Result;
@@ -10,7 +10,9 @@ use coerce::actor::ActorRef;
 use moveos_types::moveos_std::tx_context::TxContext;
 use rooch_types::{
     address::BitcoinAddress,
-    transaction::{rooch::RoochTransaction, ExecuteTransactionResponse, L1BlockWithBody},
+    transaction::{
+        rooch::RoochTransaction, ExecuteTransactionResponse, L1BlockWithBody, L1Transaction,
+    },
 };
 
 #[derive(Clone)]
@@ -35,6 +37,21 @@ impl PipelineProcessorProxy {
     ) -> Result<ExecuteTransactionResponse> {
         self.actor
             .send(ExecuteL1BlockMessage {
+                ctx,
+                tx,
+                sequencer_address,
+            })
+            .await?
+    }
+
+    pub async fn execute_l1_tx(
+        &self,
+        ctx: TxContext,
+        tx: L1Transaction,
+        sequencer_address: BitcoinAddress,
+    ) -> Result<ExecuteTransactionResponse> {
+        self.actor
+            .send(ExecuteL1TxMessage {
                 ctx,
                 tx,
                 sequencer_address,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
@@ -7,7 +7,9 @@ use crate::jsonrpc_types::{
     TransactionView,
 };
 use rooch_types::indexer::transaction::TransactionFilter;
-use rooch_types::transaction::{L1Block, LedgerTransaction, LedgerTxData, TransactionWithInfo};
+use rooch_types::transaction::{
+    L1Block, L1Transaction, LedgerTransaction, LedgerTxData, TransactionWithInfo,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -29,9 +31,27 @@ impl From<L1Block> for L1BlockView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct L1TransactionView {
+    pub chain_id: u64,
+    pub block_hash: BytesView,
+    pub txid: BytesView,
+}
+
+impl From<L1Transaction> for L1TransactionView {
+    fn from(tx: L1Transaction) -> Self {
+        Self {
+            chain_id: tx.chain_id.id(),
+            block_hash: tx.block_hash.into(),
+            txid: tx.txid.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LedgerTxDataView {
     L1Block(L1BlockView),
+    L1Tx(L1TransactionView),
     L2Tx(TransactionView),
 }
 
@@ -42,6 +62,7 @@ impl LedgerTxDataView {
     ) -> Self {
         match data {
             LedgerTxData::L1Block(block) => LedgerTxDataView::L1Block(block.into()),
+            LedgerTxData::L1Tx(tx) => LedgerTxDataView::L1Tx(tx.into()),
             LedgerTxData::L2Tx(tx) => LedgerTxDataView::L2Tx(
                 TransactionView::new_from_rooch_transaction(tx, sender_bitcoin_address),
             ),

--- a/crates/rooch-types/src/bitcoin/pending_block.rs
+++ b/crates/rooch-types/src/bitcoin/pending_block.rs
@@ -1,0 +1,95 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::addresses::BITCOIN_MOVE_ADDRESS;
+use anyhow::Result;
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use moveos_types::{
+    module_binding::{ModuleBinding, MoveFunctionCaller},
+    move_std::option::MoveOption,
+    moveos_std::tx_context::TxContext,
+    state::MoveStructState,
+    state::MoveStructType,
+};
+use serde::{Deserialize, Serialize};
+
+pub const MODULE_NAME: &IdentStr = ident_str!("pending_block");
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingTxs {
+    pub block_hash: AccountAddress,
+    pub txs: Vec<AccountAddress>,
+}
+
+impl MoveStructType for PendingTxs {
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("PendingTxs");
+    const ADDRESS: AccountAddress = BITCOIN_MOVE_ADDRESS;
+}
+
+impl MoveStructState for PendingTxs {
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            move_core_types::value::MoveTypeLayout::Address,
+            move_core_types::value::MoveTypeLayout::Vector(Box::new(
+                move_core_types::value::MoveTypeLayout::Address,
+            )),
+        ])
+    }
+}
+
+/// Rust bindings for BitcoinMove bitcoin module
+pub struct PendingBlockModule<'a> {
+    caller: &'a dyn MoveFunctionCaller,
+}
+
+impl<'a> PendingBlockModule<'a> {
+    pub const GET_READY_PENDING_TXS_FUNCTION_NAME: &'static IdentStr =
+        ident_str!("get_ready_pending_txs");
+    pub const GET_LATEST_BLOCK_HEIGHT_FUNCTION_NAME: &'static IdentStr =
+        ident_str!("get_latest_block_height");
+
+    pub fn get_ready_pending_txs(&self) -> Result<Option<PendingTxs>> {
+        let call =
+            Self::create_function_call(Self::GET_READY_PENDING_TXS_FUNCTION_NAME, vec![], vec![]);
+        let ctx = TxContext::new_readonly_ctx(AccountAddress::ZERO);
+        let pending_txs_opt =
+            self.caller
+                .call_function(&ctx, call)?
+                .into_result()
+                .map(|mut values| {
+                    let value = values.pop().expect("should have one return value");
+                    bcs::from_bytes::<MoveOption<PendingTxs>>(&value.value)
+                        .expect("should be a valid MoveOption<PendingTxs>")
+                })?;
+        Ok(pending_txs_opt.into())
+    }
+
+    pub fn get_latest_block_height(&self) -> Result<Option<u64>> {
+        let call =
+            Self::create_function_call(Self::GET_LATEST_BLOCK_HEIGHT_FUNCTION_NAME, vec![], vec![]);
+        let ctx = TxContext::new_readonly_ctx(AccountAddress::ZERO);
+        let height = self
+            .caller
+            .call_function(&ctx, call)?
+            .into_result()
+            .map(|mut values| {
+                let value = values.pop().expect("should have one return value");
+                bcs::from_bytes::<MoveOption<u64>>(&value.value)
+                    .expect("should be a valid MoveOption<u64>")
+            })?;
+        Ok(height.into())
+    }
+}
+
+impl<'a> ModuleBinding<'a> for PendingBlockModule<'a> {
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const MODULE_ADDRESS: AccountAddress = BITCOIN_MOVE_ADDRESS;
+
+    fn new(caller: &'a impl MoveFunctionCaller) -> Self
+    where
+        Self: Sized,
+    {
+        Self { caller }
+    }
+}

--- a/crates/rooch-types/src/framework/auth_validator.rs
+++ b/crates/rooch-types/src/framework/auth_validator.rs
@@ -175,7 +175,7 @@ impl MoveStructState for TxValidateResult {
 }
 
 impl TxValidateResult {
-    pub fn new_l1_block(sequencer_address: BitcoinAddress) -> Self {
+    pub fn new_l1_block_or_tx(sequencer_address: BitcoinAddress) -> Self {
         Self {
             auth_validator_id: BuiltinAuthValidator::Bitcoin.flag().into(),
             auth_validator: MoveOption::none(),

--- a/crates/rooch-types/src/indexer/transaction.rs
+++ b/crates/rooch-types/src/indexer/transaction.rs
@@ -44,6 +44,7 @@ impl IndexerTransaction {
         let status = serde_json::to_string(&execution_info.status)?;
         let (auth_validator_id, authenticator_payload) = match &transaction.data {
             LedgerTxData::L1Block(_block) => (0, vec![]),
+            LedgerTxData::L1Tx(_tx) => (0, vec![]),
             LedgerTxData::L2Tx(tx) => (
                 tx.authenticator().auth_validator_id,
                 tx.authenticator().payload.clone(),

--- a/crates/rooch-types/src/transaction/mod.rs
+++ b/crates/rooch-types/src/transaction/mod.rs
@@ -18,7 +18,9 @@ pub mod rooch;
 
 use crate::indexer::transaction::IndexerTransaction;
 pub use authenticator::Authenticator;
-pub use ledger_transaction::{L1Block, L1BlockWithBody, LedgerTransaction, LedgerTxData};
+pub use ledger_transaction::{
+    L1Block, L1BlockWithBody, L1Transaction, LedgerTransaction, LedgerTxData,
+};
 pub use rooch::{RoochTransaction, RoochTransactionData};
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/frameworks/bitcoin-move/doc/pending_block.md
+++ b/frameworks/bitcoin-move/doc/pending_block.md
@@ -11,6 +11,7 @@ PendingStore is used to store the pending blocks and txs, and handle the reorg
 -  [Resource `PendingStore`](#0x4_pending_block_PendingStore)
 -  [Struct `InprocessBlock`](#0x4_pending_block_InprocessBlock)
 -  [Struct `ReorgEvent`](#0x4_pending_block_ReorgEvent)
+-  [Struct `PendingTxs`](#0x4_pending_block_PendingTxs)
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x4_pending_block_genesis_init)
 -  [Function `new_pending_block_id`](#0x4_pending_block_new_pending_block_id)
@@ -23,6 +24,8 @@ PendingStore is used to store the pending blocks and txs, and handle the reorg
 -  [Function `inprocess_block_tx`](#0x4_pending_block_inprocess_block_tx)
 -  [Function `inprocess_block_header`](#0x4_pending_block_inprocess_block_header)
 -  [Function `inprocess_block_height`](#0x4_pending_block_inprocess_block_height)
+-  [Function `get_ready_pending_txs`](#0x4_pending_block_get_ready_pending_txs)
+-  [Function `get_latest_block_height`](#0x4_pending_block_get_latest_block_height)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -89,6 +92,17 @@ This is a hot potato struct, can not be store and drop
 
 
 <pre><code><b>struct</b> <a href="pending_block.md#0x4_pending_block_ReorgEvent">ReorgEvent</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<a name="0x4_pending_block_PendingTxs"></a>
+
+## Struct `PendingTxs`
+
+
+
+<pre><code><b>struct</b> <a href="pending_block.md#0x4_pending_block_PendingTxs">PendingTxs</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -287,4 +301,27 @@ This is a hot potato struct, can not be store and drop
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="pending_block.md#0x4_pending_block_inprocess_block_height">inprocess_block_height</a>(inprocess_block: &<a href="pending_block.md#0x4_pending_block_InprocessBlock">pending_block::InprocessBlock</a>): u64
+</code></pre>
+
+
+
+<a name="0x4_pending_block_get_ready_pending_txs"></a>
+
+## Function `get_ready_pending_txs`
+
+Get the pending txs which are ready to be processed
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pending_block.md#0x4_pending_block_get_ready_pending_txs">get_ready_pending_txs</a>(): <a href="_Option">option::Option</a>&lt;<a href="pending_block.md#0x4_pending_block_PendingTxs">pending_block::PendingTxs</a>&gt;
+</code></pre>
+
+
+
+<a name="0x4_pending_block_get_latest_block_height"></a>
+
+## Function `get_latest_block_height`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pending_block.md#0x4_pending_block_get_latest_block_height">get_latest_block_height</a>(): <a href="_Option">option::Option</a>&lt;u64&gt;
 </code></pre>

--- a/frameworks/bitcoin-move/sources/pending_block.move
+++ b/frameworks/bitcoin-move/sources/pending_block.move
@@ -73,10 +73,23 @@ module bitcoin_move::pending_block{
         }
     }
 
+    fun borrow_store(): &PendingStore {
+        let obj_id = object::named_object_id<PendingStore>();
+        let store_obj = object::borrow_object(obj_id);
+        object::borrow(store_obj)
+    }
+
     fun borrow_mut_store(): &mut PendingStore {
         let obj_id = object::named_object_id<PendingStore>();
         let store_obj = object::borrow_mut_object_extend(obj_id);
         object::borrow_mut(store_obj)
+    }
+
+    fun borrow_pending_block(block_hash: address): &Object<PendingBlock>{
+        let block_id = new_pending_block_id(block_hash);
+        let block_obj_id = object::custom_object_id<PendingBlockID, PendingBlock>(block_id);
+        assert!(object::exists_object(block_obj_id), ErrorPendingBlockNotFound);
+        object::borrow_object(block_obj_id)
     }
 
     fun borrow_mut_pending_block(block_hash: address): &mut Object<PendingBlock>{
@@ -234,4 +247,40 @@ module bitcoin_move::pending_block{
         let block_obj = object::borrow(&inprocess_block.block_obj);
         block_obj.block_height
     }
+
+    // ============== Pending Block Query ==============
+
+    struct PendingTxs has copy, drop, store{
+        block_hash: address,
+        txs: vector<address>,
+    }
+
+    /// Get the pending txs which are ready to be processed
+    public fun get_ready_pending_txs(): Option<PendingTxs>{
+        let store = borrow_store();
+        if(option::is_none(&store.latest_block_height)){
+            return option::none()
+        };
+        let latest_block_height = *option::borrow(&store.latest_block_height);
+        let ready_block_height = latest_block_height - store.reorg_pending_blocks;
+        if(!simple_map::contains_key(&store.pending_blocks, &ready_block_height)){
+            return option::none()
+        };
+        let block_hash = *simple_map::borrow(&store.pending_blocks, &ready_block_height);
+        let block_obj = borrow_pending_block(block_hash);
+        let tx_ids: vector<address> = *object::borrow_field(block_obj, TX_IDS_KEY);
+        let unprocessed_tx_ids : vector<address> = vector::filter(tx_ids, |txid| {
+            object::contains_field(block_obj, *txid)
+        });
+        let pending_txs = PendingTxs{
+            block_hash: block_hash,
+            txs: unprocessed_tx_ids,
+        };
+        option::some(pending_txs)
+    }
+
+    public fun get_latest_block_height(): Option<u64>{
+        let store = borrow_store();
+        store.latest_block_height
+    } 
 }


### PR DESCRIPTION
## Summary

Part of #1797, follow #1901

TODO

1. Load ready l1 tx from the contract and resolve reorg.
2. Add more tests for reorg.