### PR TITLE
[vm]Use system address to execute L1 block and L1 tx

### DIFF
--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -315,8 +315,8 @@ impl BaseConfig {
     pub fn data_dir(&self) -> &Path {
         self.data_dir.as_path()
     }
-    pub fn base_data_dir(&self) -> DataDirPath {
-        self.base_data_dir.clone()
+    pub fn base_data_dir(&self) -> &Path {
+        self.base_data_dir.path()
     }
 }
 

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -10,14 +10,13 @@ use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::event::{AnnotatedEvent, Event, EventID};
 use moveos_types::moveos_std::object::RootObjectEntity;
-use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::state::{AnnotatedState, KeyState, State};
 use moveos_types::state_resolver::{AnnotatedStateKV, StateKV};
 use moveos_types::transaction::FunctionCall;
 use moveos_types::transaction::TransactionExecutionInfo;
 use moveos_types::transaction::TransactionOutput;
 use moveos_types::transaction::VerifiedMoveOSTransaction;
-use rooch_types::address::{BitcoinAddress, MultiChainAddress};
+use rooch_types::address::MultiChainAddress;
 use rooch_types::transaction::{L1BlockWithBody, L1Transaction, RoochTransaction};
 use serde::{Deserialize, Serialize};
 
@@ -32,9 +31,7 @@ impl Message for ValidateL2TxMessage {
 
 #[derive(Debug)]
 pub struct ValidateL1BlockMessage {
-    pub ctx: TxContext,
     pub l1_block: L1BlockWithBody,
-    pub sequencer_address: BitcoinAddress,
 }
 
 impl Message for ValidateL1BlockMessage {
@@ -43,9 +40,7 @@ impl Message for ValidateL1BlockMessage {
 
 #[derive(Debug)]
 pub struct ValidateL1TxMessage {
-    pub ctx: TxContext,
     pub l1_tx: L1Transaction,
-    pub sequencer_address: BitcoinAddress,
 }
 
 impl Message for ValidateL1TxMessage {

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -35,7 +35,6 @@ use moveos_types::{
     moveos_std::event::AnnotatedEvent,
     state::{AnnotatedState, State},
 };
-use rooch_types::address::BitcoinAddress;
 use rooch_types::bitcoin::network::BitcoinNetwork;
 use rooch_types::framework::chain_id::ChainID;
 use rooch_types::transaction::{L1BlockWithBody, L1Transaction, RoochTransaction};
@@ -64,32 +63,13 @@ impl ExecutorProxy {
 
     pub async fn validate_l1_block(
         &self,
-        ctx: TxContext,
         l1_block: L1BlockWithBody,
-        sequencer_address: BitcoinAddress,
     ) -> Result<VerifiedMoveOSTransaction> {
-        self.actor
-            .send(ValidateL1BlockMessage {
-                ctx,
-                l1_block,
-                sequencer_address,
-            })
-            .await?
+        self.actor.send(ValidateL1BlockMessage { l1_block }).await?
     }
 
-    pub async fn validate_l1_tx(
-        &self,
-        ctx: TxContext,
-        l1_tx: L1Transaction,
-        sequencer_address: BitcoinAddress,
-    ) -> Result<VerifiedMoveOSTransaction> {
-        self.actor
-            .send(ValidateL1TxMessage {
-                ctx,
-                l1_tx,
-                sequencer_address,
-            })
-            .await?
+    pub async fn validate_l1_tx(&self, l1_tx: L1Transaction) -> Result<VerifiedMoveOSTransaction> {
+        self.actor.send(ValidateL1TxMessage { l1_tx }).await?
     }
 
     //TODO ensure the execute result

--- a/crates/rooch-pipeline-processor/src/actor/messages.rs
+++ b/crates/rooch-pipeline-processor/src/actor/messages.rs
@@ -3,10 +3,8 @@
 
 use anyhow::Result;
 use coerce::actor::message::Message;
-use moveos_types::moveos_std::tx_context::TxContext;
-use rooch_types::{
-    address::BitcoinAddress,
-    transaction::{ExecuteTransactionResponse, L1BlockWithBody, L1Transaction, RoochTransaction},
+use rooch_types::transaction::{
+    ExecuteTransactionResponse, L1BlockWithBody, L1Transaction, RoochTransaction,
 };
 
 #[derive(Clone)]
@@ -20,9 +18,7 @@ impl Message for ExecuteL2TxMessage {
 
 #[derive(Clone)]
 pub struct ExecuteL1BlockMessage {
-    pub ctx: TxContext,
     pub tx: L1BlockWithBody,
-    pub sequencer_address: BitcoinAddress,
 }
 
 impl Message for ExecuteL1BlockMessage {
@@ -31,9 +27,7 @@ impl Message for ExecuteL1BlockMessage {
 
 #[derive(Clone)]
 pub struct ExecuteL1TxMessage {
-    pub ctx: TxContext,
     pub tx: L1Transaction,
-    pub sequencer_address: BitcoinAddress,
 }
 
 impl Message for ExecuteL1TxMessage {

--- a/crates/rooch-pipeline-processor/src/proxy/mod.rs
+++ b/crates/rooch-pipeline-processor/src/proxy/mod.rs
@@ -7,12 +7,8 @@ use crate::actor::{
 };
 use anyhow::Result;
 use coerce::actor::ActorRef;
-use moveos_types::moveos_std::tx_context::TxContext;
-use rooch_types::{
-    address::BitcoinAddress,
-    transaction::{
-        rooch::RoochTransaction, ExecuteTransactionResponse, L1BlockWithBody, L1Transaction,
-    },
+use rooch_types::transaction::{
+    rooch::RoochTransaction, ExecuteTransactionResponse, L1BlockWithBody, L1Transaction,
 };
 
 #[derive(Clone)]
@@ -31,32 +27,13 @@ impl PipelineProcessorProxy {
 
     pub async fn execute_l1_block(
         &self,
-        ctx: TxContext,
         tx: L1BlockWithBody,
-        sequencer_address: BitcoinAddress,
     ) -> Result<ExecuteTransactionResponse> {
-        self.actor
-            .send(ExecuteL1BlockMessage {
-                ctx,
-                tx,
-                sequencer_address,
-            })
-            .await?
+        self.actor.send(ExecuteL1BlockMessage { tx }).await?
     }
 
-    pub async fn execute_l1_tx(
-        &self,
-        ctx: TxContext,
-        tx: L1Transaction,
-        sequencer_address: BitcoinAddress,
-    ) -> Result<ExecuteTransactionResponse> {
-        self.actor
-            .send(ExecuteL1TxMessage {
-                ctx,
-                tx,
-                sequencer_address,
-            })
-            .await?
+    pub async fn execute_l1_tx(&self, tx: L1Transaction) -> Result<ExecuteTransactionResponse> {
+        self.actor.send(ExecuteL1TxMessage { tx }).await?
     }
 }
 

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -295,7 +295,6 @@ pub async fn run_start_server(opt: RoochOpt, server_opt: ServerOpt) -> Result<Se
         let relayer = RelayerActor::new(
             executor_proxy,
             processor_proxy.clone(),
-            sequencer_keypair.copy(),
             ethereum_relayer_config,
             bitcoin_relayer_config,
         )

--- a/crates/rooch-types/src/framework/auth_validator.rs
+++ b/crates/rooch-types/src/framework/auth_validator.rs
@@ -175,15 +175,6 @@ impl MoveStructState for TxValidateResult {
 }
 
 impl TxValidateResult {
-    pub fn new_l1_block_or_tx(sequencer_address: BitcoinAddress) -> Self {
-        Self {
-            auth_validator_id: BuiltinAuthValidator::Bitcoin.flag().into(),
-            auth_validator: MoveOption::none(),
-            session_key: MoveOption::none(),
-            bitcoin_address: sequencer_address,
-        }
-    }
-
     pub fn new_for_test() -> Self {
         // generate a random bitcoin address for testing
         let bitcoin_address = BitcoinAddress::random();

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -1,9 +1,5 @@
 Feature: Rooch CLI integration tests
-    @serial
-    Scenario: Init
-      Then cmd: "init --skip-password"
-      Then cmd: "env switch --alias local"
- 
+
     @serial
     Scenario: rooch rpc test
       Given a server for rooch_rpc_test

--- a/crates/testsuite/features/reorg_test.feature
+++ b/crates/testsuite/features/reorg_test.feature
@@ -1,14 +1,7 @@
 Feature: Rooch Bitcoin Reorg tests
-    @serial
-    Scenario: Init
-      Then cmd: "init --skip-password"
-      Then cmd: "env switch --alias local"
 
     @serial
     Scenario: rooch bitcoin reorg test
-      Then cmd: "init --skip-password"
-      Then cmd: "env switch --alias local"
-
       # prepare servers
       Given a bitcoind server for bitcoin_reorg_test
       Given a server for bitcoin_reorg_test

--- a/frameworks/bitcoin-move/sources/pending_block.move
+++ b/frameworks/bitcoin-move/sources/pending_block.move
@@ -222,7 +222,7 @@ module bitcoin_move::pending_block{
         let store = borrow_mut_store();
         let block_obj = take_pending_block(block_hash);
         let (best_block_height, _best_block_hash) = types::unpack_block_height_hash(*option::borrow(&store.best_block));
-        assert!(best_block_height > store.reorg_block_count && best_block_height - store.reorg_block_count >= object::borrow(&block_obj).block_height, ErrorNeedToWaitMoreBlocks);
+        assert!(best_block_height >= store.reorg_block_count && best_block_height - store.reorg_block_count >= object::borrow(&block_obj).block_height, ErrorNeedToWaitMoreBlocks);
         assert!(object::contains_field(&block_obj, txid), ErrorPendingTxNotFound);
         let tx = object::remove_field(&mut block_obj, txid);
         let inprocess_block = InprocessBlock{

--- a/frameworks/moveos-stdlib/doc/tx_context.md
+++ b/frameworks/moveos-stdlib/doc/tx_context.md
@@ -20,6 +20,7 @@
 -  [Function `tx_meta`](#0x2_tx_context_tx_meta)
 -  [Function `tx_gas_payment_account`](#0x2_tx_context_tx_gas_payment_account)
 -  [Function `tx_result`](#0x2_tx_context_tx_result)
+-  [Function `is_system_call`](#0x2_tx_context_is_system_call)
 -  [Function `set_module_upgrade_flag`](#0x2_tx_context_set_module_upgrade_flag)
 -  [Function `drop`](#0x2_tx_context_drop)
 
@@ -219,6 +220,19 @@ The result is only available in the <code>post_execute</code> function.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="tx_result.md#0x2_tx_result">tx_result</a>(): <a href="tx_result.md#0x2_tx_result_TxResult">tx_result::TxResult</a>
+</code></pre>
+
+
+
+<a name="0x2_tx_context_is_system_call"></a>
+
+## Function `is_system_call`
+
+Check if the current transaction is a system call
+The system call is a special transaction initiated by the system.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_is_system_call">is_system_call</a>(): bool
 </code></pre>
 
 

--- a/frameworks/moveos-stdlib/sources/tx_context.move
+++ b/frameworks/moveos-stdlib/sources/tx_context.move
@@ -162,6 +162,13 @@ module moveos_std::tx_context {
         option::extract(&mut result)
     }
 
+    /// Check if the current transaction is a system call
+    /// The system call is a special transaction initiated by the system.
+    public fun is_system_call(): bool {
+        let sender = sender();
+        moveos_std::core_addresses::is_vm_address(sender)
+    }
+
     public(friend) fun set_module_upgrade_flag(is_upgrade: bool) {
         let ctx = borrow_mut();
         if(!contains<ModuleUpgradeFlag>(ctx)){

--- a/frameworks/rooch-framework/sources/transaction_validator.move
+++ b/frameworks/rooch-framework/sources/transaction_validator.move
@@ -111,6 +111,7 @@ module rooch_framework::transaction_validator {
     /// Transaction pre_execute function.
     /// Execute before the transaction is executed, automatically called by the MoveOS VM.
     /// This function is for Rooch to auto create account and address maping.
+    /// The system call transaction do not execute the pre_execute and post_execute function.
     fun pre_execute(
     ) {
         let sender = tx_context::sender();

--- a/moveos/moveos-types/src/moveos_std/tx_context.rs
+++ b/moveos/moveos-types/src/moveos_std/tx_context.rs
@@ -71,6 +71,11 @@ impl TxContext {
         }
     }
 
+    /// Create a new TxContext for system call cases
+    pub fn new_system_call_ctx(tx_hash: H256, tx_size: u64) -> Self {
+        Self::new(AccountAddress::ZERO, 0, u64::MAX, tx_hash, tx_size)
+    }
+
     /// Create a new TxContext with a zero tx_hash for read-only function call cases
     pub fn new_readonly_ctx(sender: AccountAddress) -> Self {
         //TODO define read-only function gas limit
@@ -81,6 +86,11 @@ impl TxContext {
             H256::zero(),
             0,
         )
+    }
+
+    /// Check if the current TxContext is a system call
+    pub fn is_system_call(&self) -> bool {
+        self.sender == AccountAddress::ZERO
     }
 
     /// Spawn a new TxContext with a new `ids_created` counter and empty map

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -309,7 +309,7 @@ impl MoveOS {
             Ok(status) => {
                 if log::log_enabled!(log::Level::Debug) {
                     log::debug!(
-                        "execute_user_action ok tx(hash:{}) vm_status:{:?}",
+                        "execute_action ok tx(hash:{}) vm_status:{:?}",
                         tx_hash,
                         status
                     );
@@ -319,7 +319,7 @@ impl MoveOS {
             Err((vm_err, need_respawn)) => {
                 if log::log_enabled!(log::Level::Warn) {
                     log::warn!(
-                        "execute_user_action error tx(hash:{}) vm_err:{:?} need_respawn:{}",
+                        "execute_action error tx(hash:{}) vm_err:{:?} need_respawn:{}",
                         tx_hash,
                         vm_err,
                         need_respawn

--- a/moveos/moveos/src/vm/moveos_vm.rs
+++ b/moveos/moveos/src/vm/moveos_vm.rs
@@ -316,10 +316,8 @@ where
                 let resolved_args = self.resolve_argument(&loaded_function, call.args, location)?;
                 let serialized_args = self.load_arguments(resolved_args)?;
                 if bypass_visibility {
-                    // bypass visibility call is system call, we do not charge gas for it, like L1 block transaction
-                    self.gas_meter.stop_metering();
-                    let result = self
-                        .session
+                    // bypass visibility call is system call, such as execute L1 block transaction
+                    self.session
                         .execute_function_bypass_visibility(
                             &call.function_id.module_id,
                             &call.function_id.function_name,
@@ -332,9 +330,7 @@ where
                                 ret.return_values.is_empty(),
                                 "Function should not return values"
                             );
-                        });
-                    self.gas_meter.start_metering();
-                    result
+                        })
                 } else {
                     self.session
                         .execute_entry_function(


### PR DESCRIPTION
## Summary

1. Define the SystemCallTx: the tx sender is 0x0.
2. Execute l1_block and l1_tx with 0x0.
3. SystemCallTx does not execute the `pre_execute` and `post_execute` functions.
4. The SystemCallTx still meters the gas usage but does not charge a gas fee.
5. If the SystemCallTx failed, just panic(TODO record a system status, and make the system unviable.)

- Closes #1998 

TODO:
1. Should we deprecate `pre_execute_functions` and `post_execute_functions` in the MoveOSTransaction?