### PR TITLE
[Sqlite] Optimize Sqlite concurrent read and write mode and tune key database configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
 dependencies = [
- "proc-macro2 1.0.85",
+ "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 1.0.109",
  "synstructure",
@@ -533,7 +533,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.85",
+ "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -699,7 +699,7 @@ dependencies = [
  "gloo-net",
  "http 1.1.0",
  "js-sys",
- "lazy_static 1.4.0",
+ "lazy_static 1.5.0",
  "log",
  "rustls 0.22.4",
  "rustls-pki-types",
@@ -1388,7 +1388,7 @@ dependencies = [
  "darling 0.20.9",
  "mime",
  "new_mime_guess",
- "proc-macro2 1.0.85",
+ "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.65",
 ]
@@ -2983,7 +2983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
 dependencies = [
  "darling 0.20.9",
- "proc-macro2 1.0.85",
+ "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.65",
 ]
@@ -3201,7 +3201,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "proc-macro2 1.0.85",
+ "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.65",
 ]
@@ -7752,7 +7752,7 @@ dependencies = [
  "humantime",
  "hyper 0.14.28",
  "indicatif",
- "lazy_static 1.4.0",
+ "lazy_static 1.5.0",
  "log",
  "mime",
  "mime_guess",
@@ -10726,7 +10726,7 @@ version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
 dependencies = [
- "proc-macro2 1.0.85",
+ "proc-macro2 1.0.86",
  "quote 1.0.36",
  "rust-embed-utils",
  "syn 2.0.65",
@@ -11530,7 +11530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling 0.20.9",
- "proc-macro2 1.0.85",
+ "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.65",
 ]
@@ -12055,7 +12055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.85",
+ "proc-macro2 1.0.86",
  "quote 1.0.36",
  "rustversion",
  "syn 1.0.109",
@@ -12196,7 +12196,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.85",
+ "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
@@ -14187,7 +14187,7 @@ dependencies = [
  "base64 0.13.1",
  "data-encoding",
  "der-parser",
- "lazy_static 1.4.0",
+ "lazy_static 1.5.0",
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",

--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -43,8 +43,8 @@ pub const STATE_OBJECT_TYPE_STR: &str = "object_type";
 pub const STATE_OWNER_STR: &str = "owner";
 
 #[derive(Clone)]
-pub(crate) struct InnerIndexerReader {
-    pool: crate::SqliteConnectionPool,
+pub struct InnerIndexerReader {
+    pub(crate) pool: crate::SqliteConnectionPool,
 }
 
 impl InnerIndexerReader {
@@ -120,7 +120,7 @@ impl IndexerReader {
         })
     }
 
-    fn get_inner_indexer_reader(&self, table_name: &str) -> Result<InnerIndexerReader> {
+    pub fn get_inner_indexer_reader(&self, table_name: &str) -> Result<InnerIndexerReader> {
         Ok(self
             .inner_indexer_reader_mapping
             .get(table_name)

--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -9,8 +9,8 @@ use crate::schema::object_states;
 use crate::schema::{events, transactions};
 use crate::{
     IndexerResult, IndexerStoreMeta, SqliteConnectionConfig, SqliteConnectionPoolConfig,
-    SqlitePoolConnection, INDEXER_EVENTS_TABLE_NAME, INDEXER_OBJECT_STATES_TABLE_NAME,
-    INDEXER_TRANSACTIONS_TABLE_NAME,
+    SqlitePoolConnection, DEFAULT_BUSY_TIMEOUT, INDEXER_EVENTS_TABLE_NAME,
+    INDEXER_OBJECT_STATES_TABLE_NAME, INDEXER_TRANSACTIONS_TABLE_NAME,
 };
 use anyhow::{anyhow, Result};
 use diesel::{
@@ -54,7 +54,11 @@ impl InnerIndexerReader {
     ) -> Result<Self> {
         let manager = ConnectionManager::<SqliteConnection>::new(db_url);
 
-        let connection_config = SqliteConnectionConfig { read_only: true };
+        let connection_config = SqliteConnectionConfig {
+            read_only: true,
+            enable_wal: true,
+            busy_timeout: DEFAULT_BUSY_TIMEOUT,
+        };
 
         let pool = diesel::r2d2::Pool::builder()
             .max_size(config.pool_size)

--- a/crates/rooch-indexer/src/lib.rs
+++ b/crates/rooch-indexer/src/lib.rs
@@ -34,7 +34,6 @@ pub type IndexerResult<T> = Result<T, IndexerError>;
 pub type IndexerTableName = &'static str;
 pub const INDEXER_EVENTS_TABLE_NAME: IndexerTableName = "events";
 pub const INDEXER_OBJECT_STATES_TABLE_NAME: IndexerTableName = "object_states";
-// pub const INDEXER_TABLE_CHANGE_SETS_TABLE_NAME: IndexerTableName = "object_changes";
 pub const INDEXER_TRANSACTIONS_TABLE_NAME: IndexerTableName = "transactions";
 
 /// Please note that adding new indexer table needs to be added in vec simultaneously.
@@ -42,7 +41,6 @@ static INDEXER_VEC_TABLE_NAME: Lazy<Vec<IndexerTableName>> = Lazy::new(|| {
     vec![
         INDEXER_EVENTS_TABLE_NAME,
         INDEXER_OBJECT_STATES_TABLE_NAME,
-        // INDEXER_TABLE_CHANGE_SETS_TABLE_NAME,
         INDEXER_TRANSACTIONS_TABLE_NAME,
     ]
 });
@@ -193,8 +191,8 @@ pub struct SqliteConnectionPoolConfig {
 }
 
 impl SqliteConnectionPoolConfig {
-    const DEFAULT_POOL_SIZE: u32 = 30;
-    const DEFAULT_CONNECTION_TIMEOUT: u64 = 30;
+    const DEFAULT_POOL_SIZE: u32 = 64;
+    const DEFAULT_CONNECTION_TIMEOUT: u64 = 120;
 
     fn connection_config(&self) -> SqliteConnectionConfig {
         SqliteConnectionConfig { read_only: false }

--- a/crates/rooch-indexer/src/models/transactions.rs
+++ b/crates/rooch-indexer/src/models/transactions.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::schema::transactions;
+use crate::utils::escape_sql_string;
 use diesel::prelude::*;
 use moveos_types::h256::H256;
 use rooch_types::address::RoochAddress;
@@ -97,4 +98,10 @@ impl TryFrom<StoredTransaction> for IndexerTransaction {
         };
         Ok(indexer_transaction)
     }
+}
+
+pub fn escape_transaction(mut transaction: StoredTransaction) -> StoredTransaction {
+    transaction.sender = escape_sql_string(transaction.sender.clone());
+    transaction.status = escape_sql_string(transaction.status.clone());
+    transaction
 }

--- a/crates/rooch-indexer/src/store/sqlite_store.rs
+++ b/crates/rooch-indexer/src/store/sqlite_store.rs
@@ -12,7 +12,7 @@ use tracing::log;
 
 use crate::models::events::StoredEvent;
 use crate::models::states::StoredObjectState;
-use crate::models::transactions::StoredTransaction;
+use crate::models::transactions::{escape_transaction, StoredTransaction};
 use crate::schema::{events, object_states, transactions};
 use crate::utils::escape_sql_string;
 use crate::{get_sqlite_pool_connection, SqliteConnectionPool};
@@ -133,7 +133,7 @@ impl SqliteIndexerStore {
         let mut connection = get_sqlite_pool_connection(&self.connection_pool)?;
         let transactions = transactions
             .into_iter()
-            .map(StoredTransaction::from)
+            .map(|v| escape_transaction(StoredTransaction::from(v)))
             .collect::<Vec<_>>();
 
         diesel::insert_into(transactions::table)

--- a/crates/rooch-indexer/src/tests/mod.rs
+++ b/crates/rooch-indexer/src/tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+mod test_concurrence;
 mod test_indexer;

--- a/crates/rooch-indexer/src/tests/test_concurrence.rs
+++ b/crates/rooch-indexer/src/tests/test_concurrence.rs
@@ -1,0 +1,116 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use crate::errors::{Context, IndexerError};
+    use crate::indexer_reader::IndexerReader;
+    use crate::models::events::StoredEvent;
+    use crate::schema::events;
+    use crate::{get_sqlite_pool_connection, IndexerStore, INDEXER_EVENTS_TABLE_NAME};
+    use anyhow::Result;
+    use diesel::RunQueryDsl;
+    use move_core_types::account_address::AccountAddress;
+    use moveos_types::moveos_std::tx_context::TxContext;
+    use moveos_types::test_utils::random_event;
+    use rooch_config::store_config::DEFAULT_DB_INDEXER_SUBDIR;
+    use rooch_types::indexer::event::IndexerEvent;
+    use rooch_types::test_utils::random_ledger_transaction;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn test_sqlite_writer_sqlite_reader_concurrence() {
+        let count = sqlite_writer_sqlite_reader_concurrence().unwrap();
+        assert_eq!(count, get_row_count());
+    }
+
+    fn get_row_count() -> i64 {
+        1000
+        // 10000
+    }
+    fn get_sleep_duration() -> Duration {
+        Duration::from_millis(1)
+    }
+
+    /// Make tx_order using assigned tx_order and event_index to 0
+    fn random_indexer_event(tx_order: u64) -> IndexerEvent {
+        let mut random_event = random_event();
+        random_event.event_index = 0;
+        let mut random_transaction = random_ledger_transaction();
+        random_transaction.sequence_info.tx_order = tx_order;
+        let tx_context = TxContext::new_readonly_ctx(AccountAddress::random());
+
+        IndexerEvent::new(random_event, random_transaction, tx_context)
+    }
+
+    fn sqlite_writer_sqlite_reader_concurrence() -> Result<i64> {
+        let sleep_duration = get_sleep_duration();
+
+        let tmpdir = moveos_config::temp_dir();
+        let indexer_db = tmpdir.path().join(DEFAULT_DB_INDEXER_SUBDIR);
+        let indexer_store = IndexerStore::new(indexer_db.clone())?;
+        let indexer_reader = IndexerReader::new(indexer_db)?;
+
+        let write_connection_pool = indexer_store
+            .get_sqlite_store(INDEXER_EVENTS_TABLE_NAME)?
+            .connection_pool;
+        let inner_indexer_reader =
+            indexer_reader.get_inner_indexer_reader(INDEXER_EVENTS_TABLE_NAME)?;
+
+        // Spawn a thread to write to the DB
+        let writer = thread::spawn(move || {
+            let mut connection = get_sqlite_pool_connection(&write_connection_pool).unwrap();
+
+            // Loop inserting rows
+            for i in 0..get_row_count() {
+                let events_data = vec![random_indexer_event(i as u64)];
+                let events = events_data
+                    .into_iter()
+                    .map(StoredEvent::from)
+                    .collect::<Vec<_>>();
+
+                diesel::insert_into(events::table)
+                    .values(events.as_slice())
+                    .execute(&mut connection)
+                    .map_err(|e| IndexerError::SQLiteWriteError(e.to_string()))
+                    .context("Failed to write test case events to SQLiteDB")
+                    .unwrap();
+
+                thread::sleep(sleep_duration);
+            }
+        });
+
+        // Give the writer time to get started
+        thread::sleep(Duration::from_secs(2));
+
+        // Spawn a thread to read from the DB
+        let reader = thread::spawn(move || {
+            let query = "SELECT * FROM events order by tx_order desc, event_index desc limit 1";
+            tracing::debug!("query object test case events: {}", query);
+
+            // Loop querying the number of rows
+            loop {
+                let result = inner_indexer_reader
+                    .run_query(|conn| diesel::sql_query(query).load::<StoredEvent>(conn))
+                    .unwrap();
+                let count = if result.is_empty() {
+                    0
+                } else {
+                    result[0].tx_order
+                };
+
+                if count % 100 == 0 {
+                    println!("SQLite tx_order : {}", count);
+                };
+                if count >= get_row_count() {
+                    return count;
+                };
+                thread::sleep(sleep_duration);
+            }
+        });
+
+        writer.join().unwrap();
+        Ok(reader.join().unwrap())
+    }
+}

--- a/crates/rooch-indexer/src/tests/test_concurrence.rs
+++ b/crates/rooch-indexer/src/tests/test_concurrence.rs
@@ -27,7 +27,6 @@ mod tests {
 
     fn get_row_count() -> i64 {
         1000
-        // 10000
     }
     fn get_sleep_duration() -> Duration {
         Duration::from_millis(1)
@@ -100,11 +99,8 @@ mod tests {
                     result[0].tx_order
                 };
 
-                if count % 100 == 0 {
-                    println!("SQLite tx_order : {}", count);
-                };
-                if count >= get_row_count() {
-                    return count;
+                if count + 1 >= get_row_count() {
+                    return count + 1;
                 };
                 thread::sleep(sleep_duration);
             }

--- a/crates/rooch-indexer/src/tests/test_indexer.rs
+++ b/crates/rooch-indexer/src/tests/test_indexer.rs
@@ -270,20 +270,3 @@ fn test_escape_transaction() -> Result<()> {
     assert_eq!(query_transactions.len(), 1);
     Ok(())
 }
-
-// #[test]
-// fn test_default_busy() -> Result<()> {
-//     // let temp_dir = tempfile::tempdir().unwrap();
-//     // let temp_dir = moveos_config::temp_dir();
-//     let path = moveos_config::temp_dir.path().join("test.sqlite");
-//
-//     let mut db1 = Connection::open(&path)?;
-//     let tx1 = db1.transaction_with_behavior(TransactionBehavior::Exclusive)?;
-//     let db2 = Connection::open(&path)?;
-//     let r: Result<()> = db2.query_row("PRAGMA schema_version", [], |_| unreachable!());
-//     assert_eq!(
-//         r.unwrap_err().sqlite_error_code(),
-//         Some(ErrorCode::DatabaseBusy)
-//     );
-//     tx1.rollback()
-// }

--- a/crates/rooch-indexer/src/tests/test_indexer.rs
+++ b/crates/rooch-indexer/src/tests/test_indexer.rs
@@ -223,3 +223,67 @@ fn test_object_type_query() -> Result<()> {
     assert_eq!(query_object_states.len(), 1);
     Ok(())
 }
+
+#[test]
+fn test_escape_transaction() -> Result<()> {
+    let tmpdir = moveos_config::temp_dir();
+    let indexer_db = tmpdir.path().join(DEFAULT_DB_INDEXER_SUBDIR);
+    let indexer_store = IndexerStore::new(indexer_db.clone())?;
+    let indexer_reader = IndexerReader::new(indexer_db)?;
+
+    let random_transaction = random_ledger_transaction();
+
+    let random_execution_info = TransactionExecutionInfo::new(
+        H256::random(),
+        H256::random(),
+        random(),
+        H256::random(),
+        rand::random(),
+        KeptVMStatus::Executed,
+    );
+
+    let tx_context = TxContext::new_readonly_ctx(AccountAddress::random());
+    let move_action = random_verified_move_action();
+    let random_moveos_tx = VerifiedMoveOSTransaction {
+        root: ObjectEntity::genesis_root_object(),
+        ctx: tx_context,
+        action: move_action,
+        pre_execute_functions: random_function_calls(),
+        post_execute_functions: random_function_calls(),
+    };
+
+    let mut indexer_transaction = IndexerTransaction::new(
+        random_transaction,
+        random_execution_info,
+        random_moveos_tx.action.into(),
+        random_moveos_tx.ctx.clone(),
+    )?;
+    // construct escape field
+    let quotes = "Executed: ''There is no escape'";
+    indexer_transaction.status = quotes.to_string();
+    let transactions = vec![indexer_transaction];
+    let _ = indexer_store.persist_transactions(transactions)?;
+
+    let filter = TransactionFilter::Sender(random_moveos_tx.ctx.sender.into());
+    let query_transactions =
+        indexer_reader.query_transactions_with_filter(filter, None, 1, true)?;
+    assert_eq!(query_transactions.len(), 1);
+    Ok(())
+}
+
+// #[test]
+// fn test_default_busy() -> Result<()> {
+//     // let temp_dir = tempfile::tempdir().unwrap();
+//     // let temp_dir = moveos_config::temp_dir();
+//     let path = moveos_config::temp_dir.path().join("test.sqlite");
+//
+//     let mut db1 = Connection::open(&path)?;
+//     let tx1 = db1.transaction_with_behavior(TransactionBehavior::Exclusive)?;
+//     let db2 = Connection::open(&path)?;
+//     let r: Result<()> = db2.query_row("PRAGMA schema_version", [], |_| unreachable!());
+//     assert_eq!(
+//         r.unwrap_err().sqlite_error_code(),
+//         Some(ErrorCode::DatabaseBusy)
+//     );
+//     tx1.rollback()
+// }


### PR DESCRIPTION
## Summary

Summary about this PR

1. Using `WAL` mode instead of a default `rollback journal` for Sqlite, to provide more concurrency as readers do not block writers and a writer does not block readers.
2. Enable `busy_timeout` config to avoid "database is locked"
3. Add concurrent read and write test cases

- Closes #1966