### PR TITLE
[Sqlite] Adjust busy timeout to avoid database locked

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -9,7 +9,7 @@ runs:
     - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld --no-install-recommends --assume-yes
       shell: bash
 
-    - uses: dtolnay/rust-toolchain@1.77.2
+    - uses: dtolnay/rust-toolchain@1.78.0
       with:
         override: true
         components: rustfmt, clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,9 +3017,9 @@ checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
 name = "diesel"
-version = "2.1.6"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff236accb9a5069572099f0b350a92e9560e8e63a9b8d546162f4a5e03026bb2"
+checksum = "62d6dcd069e7b5fe49a302411f759d4cf1cf2c27fe798ef46fb8baefc053dd2b"
 dependencies = [
  "chrono",
  "diesel_derives",
@@ -3043,11 +3043,12 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.4"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14701062d6bed917b5c7103bdffaee1e4609279e240488ad24e7bd979ca6866c"
+checksum = "59de76a222c2b8059f789cbe07afbfd8deb8c31dd0bc2a21f85e256c1def8259"
 dependencies = [
  "diesel_table_macro_syntax",
+ "dsl_auto_type",
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.65",
@@ -3055,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_migrations"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
+checksum = "8a73ce704bad4231f001bff3314d91dce4aba0770cee8b233991859abc15c1f6"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -3066,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
  "syn 2.0.65",
 ]
@@ -3220,6 +3221,20 @@ name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0892a17df262a24294c382f0d5997571006e7a4348b4327557c4ff1cd4a8bccc"
+dependencies = [
+ "darling 0.20.9",
+ "either",
+ "heck 0.5.0",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.65",
+]
 
 [[package]]
 name = "dunce"
@@ -6130,19 +6145,19 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
+checksum = "fd01039851e82f8799046eabbb354056283fb265c8ec0996af940f4e85a380ff"
 dependencies = [
  "serde 1.0.203",
- "toml 0.7.8",
+ "toml 0.8.14",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
+checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
 dependencies = [
  "migrations_internals",
  "proc-macro2 1.0.86",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ homepage = "https://rooch.network"
 license = "Apache-2.0"
 publish = false
 repository = "https://github.com/rooch-network/rooch"
-rust-version = "1.77.2"
+rust-version = "1.78.0"
 version = "0.5.6"
 
 
@@ -243,7 +243,7 @@ uint = "0.9.5"
 rlp = "0.5.2"
 const-hex = "1.12.0"
 cached = "0.43.0"
-diesel = { version = "2.1.0", features = [
+diesel = { version = "2.2.1", features = [
     "chrono",
     "sqlite",
     "r2d2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ moveos-config = { path = "moveos/moveos-config" }
 moveos-wasm = { path = "moveos/moveos-wasm" }
 moveos-object-runtime = { path = "moveos/moveos-object-runtime" }
 moveos-compiler = { path = "moveos/moveos-compiler" }
+accumulator = { path = "moveos/moveos-commons/accumulator" }
 
 # crates for Rooch
 rooch = { path = "crates/rooch" }
@@ -230,7 +231,6 @@ tower = { version = "0.4.12", features = ["full", "util", "timeout", "load-shed"
 tower-http = { version = "0.4.4", features = ["cors", "full", "trace", "set-header", "propagate-header"] }
 mirai-annotations = "1.12.0"
 lru = "0.11.0"
-accumulator = { path = "moveos/moveos-commons/accumulator" }
 bs58 = "0.5.1"
 dirs-next = "2.0.0"
 anstream = { version = "0.3" }
@@ -250,6 +250,8 @@ diesel = { version = "2.2.1", features = [
     "serde_json",
     "64-column-tables",
 ] }
+diesel-derive-enum = { version = "2.1.0", features = ["sqlite"] }
+diesel_migrations = { version = "2.2.0" }
 axum = { version = "0.6.6", default-features = false, features = [
     "headers",
     "tokio",
@@ -273,8 +275,6 @@ serenity = { version = "0.12.2", default-features = false, features = [
     "rustls_backend",
     "model",
 ] }
-diesel-derive-enum = { version = "2.0.1", features = ["sqlite"] }
-diesel_migrations = { version = "2.0.0" }
 tap = "1.0.1"
 dotenvy = "0.15"
 sized-chunks = { version = "0.6" }

--- a/crates/rooch-indexer/src/lib.rs
+++ b/crates/rooch-indexer/src/lib.rs
@@ -17,7 +17,6 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::path::PathBuf;
 use std::string::ToString;
-use std::thread;
 use std::time::Duration;
 
 pub mod actor;
@@ -261,10 +260,27 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
         conn.batch_execute(&pragma_builder)
             .map_err(diesel::r2d2::Error::QueryError)?;
 
-        thread::sleep(Duration::from_millis(10));
-
         Ok(())
     }
+
+    // fn on_acquire(&self, conn: &mut SqliteConnection) -> Result<(), diesel::r2d2::Error> {
+    //     (|| {
+    //         let mut pragma_builder = String::new();
+    //         if self.read_only {
+    //             pragma_builder.push_str("PRAGMA query_only = true;");
+    //         }
+    //         // WAL mode has better write-concurrency. When synchronous is NORMAL it will fsync only in critical moments
+    //         if self.enable_wal {
+    //             pragma_builder.push_str("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;");
+    //         }
+    //         pragma_builder.push_str(&format!("PRAGMA busy_timeout = {};", self.busy_timeout));
+    //
+    //         conn.batch_execute(&pragma_builder)?;
+    //
+    //         Ok(())
+    //     })()
+    //     .map_err(diesel::r2d2::Error::QueryError)
+    // }
 }
 
 pub fn get_sqlite_pool_connection(

--- a/crates/rooch-indexer/src/lib.rs
+++ b/crates/rooch-indexer/src/lib.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::path::PathBuf;
 use std::string::ToString;
+use std::thread;
 use std::time::Duration;
 
 pub mod actor;
@@ -33,7 +34,7 @@ pub mod utils;
 /// Type alias to improve readability.
 pub type IndexerResult<T> = Result<T, IndexerError>;
 
-pub const DEFAULT_BUSY_TIMEOUT: u64 = 5000; // millsecond
+pub const DEFAULT_BUSY_TIMEOUT: u64 = 2000; // millsecond
 pub type IndexerTableName = &'static str;
 pub const INDEXER_EVENTS_TABLE_NAME: IndexerTableName = "events";
 pub const INDEXER_OBJECT_STATES_TABLE_NAME: IndexerTableName = "object_states";
@@ -194,7 +195,7 @@ pub struct SqliteConnectionPoolConfig {
 }
 
 impl SqliteConnectionPoolConfig {
-    const DEFAULT_POOL_SIZE: u32 = 64;
+    const DEFAULT_POOL_SIZE: u32 = 16;
     const DEFAULT_CONNECTION_TIMEOUT: u64 = 120; // second
 
     fn connection_config(&self) -> SqliteConnectionConfig {
@@ -236,7 +237,6 @@ impl Default for SqliteConnectionPoolConfig {
 struct SqliteConnectionConfig {
     // SQLite does not support the statement_timeout parameter
     read_only: bool,
-
     enable_wal: bool,
     busy_timeout: u64,
 }
@@ -248,16 +248,20 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
         &self,
         conn: &mut SqliteConnection,
     ) -> std::result::Result<(), diesel::r2d2::Error> {
+        let mut pragma_builder = String::new();
         if self.read_only {
-            conn.batch_execute("PRAGMA read_uncommitted = 0;")
-                .map_err(diesel::r2d2::Error::QueryError)?;
+            pragma_builder.push_str("PRAGMA query_only = true;");
         }
+        // WAL mode has better write-concurrency. When synchronous is NORMAL it will fsync only in critical moments
         if self.enable_wal {
-            conn.batch_execute("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")
-                .map_err(diesel::r2d2::Error::QueryError)?;
+            pragma_builder.push_str("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;");
         }
-        conn.batch_execute(&format!("PRAGMA busy_timeout = {};", self.busy_timeout))
+        pragma_builder.push_str(&format!("PRAGMA busy_timeout = {};", self.busy_timeout));
+
+        conn.batch_execute(&pragma_builder)
             .map_err(diesel::r2d2::Error::QueryError)?;
+
+        thread::sleep(Duration::from_millis(10));
 
         Ok(())
     }

--- a/crates/rooch-indexer/src/utils.rs
+++ b/crates/rooch-indexer/src/utils.rs
@@ -14,8 +14,7 @@ pub fn create_all_tables_if_not_exists(
     conn: &mut SqlitePoolConnection,
     _table_name: String,
 ) -> Result<(), anyhow::Error> {
-    // debug!("Indexer creates all tables in the db ...");
-    println!("Indexer creates all tables in the db ...");
+    debug!("Indexer creates all tables in the db ...");
     let migration = MIGRATIONS;
 
     // Create the __diesel_schema_migrations table if not exist

--- a/crates/rooch-indexer/src/utils.rs
+++ b/crates/rooch-indexer/src/utils.rs
@@ -14,7 +14,8 @@ pub fn create_all_tables_if_not_exists(
     conn: &mut SqlitePoolConnection,
     _table_name: String,
 ) -> Result<(), anyhow::Error> {
-    debug!("Indexer creates all tables in the db ...");
+    // debug!("Indexer creates all tables in the db ...");
+    println!("Indexer creates all tables in the db ...");
     let migration = MIGRATIONS;
 
     // Create the __diesel_schema_migrations table if not exist

--- a/crates/rooch-key/src/keystore/base_keystore.rs
+++ b/crates/rooch-key/src/keystore/base_keystore.rs
@@ -62,7 +62,7 @@ impl AccountKeystore for BaseKeyStore {
             let keypair: RoochKeyPair = encryption.decrypt_with_type(password.clone())?;
             let public_key = keypair.public();
             let bitcoin_address = public_key.bitcoin_address()?;
-            let has_session_key = self.session_keys.get(address).is_some();
+            let has_session_key = self.session_keys.contains_key(address);
             let local_account = LocalAccount {
                 address: *address,
                 bitcoin_address,

--- a/crates/rooch-open-rpc-macros/src/lib.rs
+++ b/crates/rooch-open-rpc-macros/src/lib.rs
@@ -122,6 +122,7 @@ pub fn open_rpc(attr: TokenStream, item: TokenStream) -> TokenStream {
 trait OptionalQuote {
     fn to_quote(&self) -> TokenStream2;
 
+    #[allow(dead_code)]
     fn unwrap_quote<F>(&self, quote: F) -> TokenStream2
     where
         F: FnOnce(LitStr) -> TokenStream2;

--- a/crates/rooch-open-rpc/src/lib.rs
+++ b/crates/rooch-open-rpc/src/lib.rs
@@ -309,7 +309,7 @@ impl Default for RpcModuleDocBuilder {
     fn default() -> Self {
         let schema_generator = SchemaSettings::default()
             .with(|s| {
-                s.definitions_path = "#/components/schemas/".to_owned();
+                "#/components/schemas/".clone_into(&mut s.definitions_path);
             })
             .into_generator();
 

--- a/moveos/moveos-types/src/moveos_std/display.rs
+++ b/moveos/moveos-types/src/moveos_std/display.rs
@@ -108,7 +108,7 @@ fn get_value_from_move_struct(move_value: &AnnotatedMoveValue, var_name: &str) -
                 for (key, value) in move_struct.value.iter() {
                     fields.insert(key.to_string(), value);
                 }
-                if let Some(value) = fields.get(&part.to_owned()) {
+                if let Some(value) = fields.get(part) {
                     current_value = value;
                 } else {
                     anyhow::bail!("Field value {} cannot be found in struct", var_name);

--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -835,8 +835,9 @@ impl<'a> ExtendedChecker<'a> {
                                                             error_msg.as_str(),
                                                         );
                                                     }
-                                                    gas_free_function_info.gas_validate =
-                                                        full_function_name.clone();
+                                                    gas_free_function_info
+                                                        .gas_validate
+                                                        .clone_from(&full_function_name)
                                                 }
 
                                                 if attribute_key == GAS_FREE_CHARGE_POST {
@@ -899,12 +900,14 @@ impl<'a> ExtendedChecker<'a> {
                                                 .or_default();
 
                                             if attribute_key == GAS_FREE_VALIDATE {
-                                                gas_free_function_info.gas_validate =
-                                                    full_function_name.clone();
+                                                gas_free_function_info
+                                                    .gas_validate
+                                                    .clone_from(&full_function_name)
                                             }
                                             if attribute_key == GAS_FREE_CHARGE_POST {
-                                                gas_free_function_info.gas_charge_post =
-                                                    full_function_name.clone();
+                                                gas_free_function_info
+                                                    .gas_charge_post
+                                                    .clone_from(&full_function_name)
                                             }
                                         }
                                     }

--- a/moveos/moveos-verifier/src/verifier.rs
+++ b/moveos/moveos-verifier/src/verifier.rs
@@ -1448,7 +1448,7 @@ where
             None => {}
             Some(metadata) => {
                 let data_struct_maps = metadata.data_struct_map;
-                if data_struct_maps.get(struct_name).is_some() {
+                if data_struct_maps.contains_key(struct_name) {
                     return (true, ErrorCode::UNKNOWN_CODE);
                 }
             }
@@ -1461,7 +1461,7 @@ where
             None => {}
             Some(metadata) => {
                 let data_struct_maps = metadata.data_struct_map;
-                if data_struct_maps.get(struct_name).is_some() {
+                if data_struct_maps.contains_key(struct_name) {
                     return (true, ErrorCode::UNKNOWN_CODE);
                 }
             }

--- a/moveos/raw-store/src/rocks/mod.rs
+++ b/moveos/raw-store/src/rocks/mod.rs
@@ -65,6 +65,7 @@ impl RocksDB {
                 "Duplicate column family name found.",
             );
         }
+        #[allow(clippy::unnecessary_to_owned)]
         if Self::db_exists(path) {
             let cf_vec = Self::list_cf(path)?;
             let mut db_cfs_set: HashSet<_> = cf_vec.iter().collect();

--- a/moveos/smt/src/jellyfish_merkle/nibble_path/mod.rs
+++ b/moveos/smt/src/jellyfish_merkle/nibble_path/mod.rs
@@ -324,7 +324,7 @@ impl<'a> NibbleIterator<'a> {
 
 /// Advance both iterators if their next nibbles are the same until either reaches the end or
 /// the find a mismatch. Return the number of matched nibbles.
-pub fn skip_common_prefix<'a, 'b, I1: 'a, I2: 'b>(x: &'a mut I1, y: &mut I2) -> usize
+pub fn skip_common_prefix<I1, I2>(x: &mut I1, y: &mut I2) -> usize
 where
     I1: Iterator + Peekable,
     I2: Iterator + Peekable,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.78.0"


### PR DESCRIPTION
## Summary

SQLite does not support concurrent multiple writers. Whether it is the default journal_mode = DELETE or journal_mode = WAL, only one writer can write successfully simultaneously. The `busy timeout` support allows the writer to wait for other writers to release the lock when "database locked".

1. Adjust the `busy timeout` initialization timing, also adjust the busy timeout from 5s -> 10s and pool_size from 64 -> 16 to avoid `database is locked`
2. Upgrade the sqlite ORM lib `diesel` from 2.1.0 -> 2.2.1
3. Meanwhile, upgrade rust toolchain from 1.77.2 to 1.78.0

- Closes #issue