### PR TITLE
feat(rocksdb): enable blobDB of

### DIFF
--- a/moveos/moveos-config/src/store_config.rs
+++ b/moveos/moveos-config/src/store_config.rs
@@ -75,8 +75,8 @@ impl Default for RocksdbConfig {
             wal_bytes_per_sync: 1u64 << 20,
             row_cache_size: 1u64 << 27,
             max_write_buffer_numer: 4,
-            block_cache_size: 1u64 << 31,
-            block_size: 1u64 << 10,
+            block_cache_size: 1u64 << 32,
+            block_size: 4 * 1024,
         }
     }
 }

--- a/moveos/raw-store/src/rocks/mod.rs
+++ b/moveos/raw-store/src/rocks/mod.rs
@@ -252,6 +252,9 @@ impl RocksDB {
         db_opts.set_wal_recovery_mode(rocksdb::DBRecoveryMode::PointInTime); // for memtable crash recovery
         db_opts.enable_statistics();
         db_opts.set_statistics_level(rocksdb::statistics::StatsLevel::ExceptTimeForMutex);
+        db_opts.set_enable_blob_files(true);
+        db_opts.set_min_blob_size(1024);
+        db_opts.set_enable_blob_gc(false);
         db_opts
 
         // db_opts.enable_statistics();


### PR DESCRIPTION
## Summary

1. The configurations for block_cache_size and block_size have been updated in 'store_config.rs' for better memory management.
2. certain features related to 'blob' files are now enabled in 'rocks/mod.rs'.

- Closes #2039 