### PR TITLE
docs(statedb): update the README for statedb genesis cmd

### DIFF
--- a/crates/rooch/src/commands/statedb/README.md
+++ b/crates/rooch/src/commands/statedb/README.md
@@ -4,48 +4,119 @@ A tool to export and import rooch statedb.
 
 ### Usage
 
-1. rooch statedb genesis-utxo
+#### Prerequisite for genesis-* command
+
+1. bitcoind synced with `-txindex=1` and `-server=1` option:
 
 ```shell
-rooch statedb genesis-utxo --input ~/utxo.txt -d ~/.rooch -n main
+bitcoind -datadir=<datadir> -txindex=1 -server=1
 ```
 
-Step 1, cleanup database files
+2. set block height to genesis block height:
+
+expect height: `<h>`
+
+get `<h+1>` block hash:
 
 ```shell
-rooch server clean -n main -d  {your rooch data dir} 
+bitcoin-cli -datadir=<datadir> -conf=<datadir/bitcoin.conf> -rpccookiefile=<datadir/.cookie> getblockhash <h+1>
+<h+1 block hash>
 ```
 
-Step 2, start server to initialization genesis
+invalid `<h+1>` block:
 
 ```shell
-rooch server start -n main -d  {your rooch data dir} 
+bitcoin-cli -datadir=<datadir> -conf=<datadir/bitcoin.conf> -rpccookiefile=<datadir/.cookie> invalidateblock <h+1 block hash>
 ```
 
-Step 3, stop server
+check block height:
 
 ```shell
-kill {server pid} or Ctrl-C
+bitcoin-cli -datadir=<datadir> -conf=<datadir/bitcoin.conf> -rpccookiefile=<datadir/.cookie> getblockcount
+<h>
 ```
 
-Step 4 run statedb genesis-utxo command
+3. prepare utxo source file:
+
+> - stop bitcoind first
+> - clone chainstate:
 
 ```shell
-rooch statedb genesis-utxo --input {your utxo file} -d {your rooch data dir} -n main
+rsync --delete -av <datadir/chainstate/> <chainstate_clone_path>
 ```
 
-2. rooch statedb export
+> - dump utxo source file(each line is a utxo record, format
+    is `count,txid,vout,height,coinbase,amount,script,type,address`) by
+    [bitcoin-utxo-dump](https://github.com/in3rsha/bitcoin-utxo-dump):
+
+```shell
+bitcoin-utxo-dump -f count,txid,vout,height,coinbase,amount,script,type,address -db <chainstate_clone_path> -o <output>
+```
+
+> - check max height of dump file is <h> by python script:
+
+```python
+import pandas as pd
+import sys
+
+if len(sys.argv) != 2:
+    print("Usage: python max_height.py filename")
+    sys.exit(1)
+
+filename = sys.argv[1]
+
+df = pd.read_csv(filename)
+
+max_height = df['height'].max()
+
+print(f"The maximum height is: {max_height}")
+```
+
+4. prepare ord source file(if needed):
+
+> - start bitcoind again
+> - dump ord source file by
+    [ord](https://github.com/popcnt1/ord):
+
+```shell
+ord --index=<ord_dump_dir/index.redb> --cookie-file=<bitcoincore_dir/.cookie> index export --output <output>
+```
+
+5. prepare genesis env:
+
+```shell
+rooch genesis init -n main -d <rooch_datadir>
+```
+
+#### Commands
+
+**genesis-utxo**:
+
+```shell
+rooch statedb genesis-utxo --input <utxo_src_path> -d <rooch_datadir> -n main --batch-size <utxo_batch_size>
+```
+
+**genesis-ord**:
+
+```shell
+rooch statedb genesis-ord --utxo-source <utxo_src_path> --ord-source <ord_src_path> -d <rooch_datadir> -n main --tmp-dir <tmp_dir> --utxo-batch-size <utxo_batch_size> --ord-batch-size <ord_batch_size>
+```
+
+***tips***:
+
+> - `--tmp-dir` is optional, default is under `tmpfs`. Specify it if space is limited(in production env, we always need
+    to set it to a disk path).
+> - `--batch-size`/`--utxo-batch-size` is optional, default is 2M. Set it smaller if memory is limited.
+> - `--ord-batch-size` is optional, default is 1M. Set it smaller if memory is limited.
+
+**rooch statedb export**:
 
 ```shell
 rooch statedb export --output {your file} -d {your rooch data dir} -n main -m {export mode}
 ```
 
-3. rooch statedb import
+**rooch statedb import**:
 
 ```shell
 rooch statedb import --input {your file} -d {your rooch data dir} -n main
 ```
-
-### Config
-
-For better import throughput, please increase block cache size for RocksdbConfig of moveos. 16GiB is a good start.


### PR DESCRIPTION
## Summary

update the README for statedb genesis cmd to include sage details, prerequisites and reformat commands

Detailed explanation:
The README of statedb in the rooch command has been significantly updated. This includes the prerequisite for genesis-* commands, including detailed steps to set block height and prepare utxo source file. The instructions are now more detailed and provide examples. The display of commands have been reformatted for clarity. Additionally, extraneous information such as the config section has been removed.