### PR TITLE
refactor(genesis ord): derive ord's object_id directly

### DIFF
--- a/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
@@ -493,17 +493,15 @@ fn convert_option_string_to_move_type(opt: Option<String>) -> MoveOption<MoveStr
     opt.map(MoveString::from).into()
 }
 
-// update id:object for parents
-// update outpoint:object for utxo
+// update outpoint:ord_objects for utxo
 fn update_ord_map(utxo_ord_map: Arc<sled::Db>, outpoint: OutPoint, obj_id: ObjectID) -> bool {
-    let obj_id_bytes = bcs::to_bytes(&obj_id).unwrap();
-
     let is_unbound = outpoint.txid == Hash::all_zeros() && outpoint.vout == 0;
     if is_unbound {
         return is_unbound; // unbound has no outpoint
     }
 
     // update outpoint:ord
+    let obj_id_bytes = bcs::to_bytes(&obj_id).unwrap();
     insert_ord_to_output(utxo_ord_map.clone(), outpoint, obj_id_bytes);
 
     is_unbound

--- a/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
@@ -151,7 +151,6 @@ impl GenesisOrdCommand {
 
         // 2. import od
         self.import_ord(
-            tmp_dir,
             utxo_ord_map.clone(),
             moveos_store.clone(),
             startup_update_set.clone(),
@@ -174,7 +173,6 @@ impl GenesisOrdCommand {
 
     fn import_ord(
         self,
-        tmp_dir: PathBuf,
         utxo_ord_map: Arc<sled::Db>,
         moveos_store: Arc<MoveOSStore>,
         startup_update_set: UpdateSet<KeyState, State>,
@@ -183,9 +181,8 @@ impl GenesisOrdCommand {
         let batch_size = self.ord_batch_size.unwrap();
 
         let (tx, rx) = mpsc::sync_channel(2);
-        let produce_updates_thread = thread::spawn(move || {
-            produce_ord_updates(tmp_dir, tx, input_path, batch_size, utxo_ord_map)
-        });
+        let produce_updates_thread =
+            thread::spawn(move || produce_ord_updates(tx, input_path, batch_size, utxo_ord_map));
         let apply_updates_thread = thread::spawn(move || {
             apply_ord_updates_to_state(rx, moveos_store, startup_update_set);
         });
@@ -355,17 +352,11 @@ struct BatchUpdatesOrd {
 }
 
 fn produce_ord_updates(
-    tmp_dir: PathBuf,
     tx: SyncSender<BatchUpdatesOrd>,
     input: PathBuf,
     batch_size: usize,
     utxo_ord_map: Arc<sled::Db>,
 ) {
-    let db_config = sled::Config::new()
-        .temporary(true)
-        .path(TempDir::new_in(tmp_dir).unwrap());
-    let id_ord_map = db_config.open().unwrap();
-
     let mut reader = BufReader::new(File::open(input).unwrap());
     let mut is_title_line = true;
     let mut index: u64 = 0;
@@ -394,7 +385,7 @@ fn produce_ord_updates(
                 updates.blessed_inscription_count += 1;
             }
             let (key, state, inscription_id) =
-                gen_ord_update(source, utxo_ord_map.clone(), &id_ord_map).unwrap();
+                gen_ord_update(source, utxo_ord_map.clone()).unwrap();
             updates.ord_updates.put(key, state);
             let (key2, state2) = gen_inscription_ids_update(index, inscription_id);
             updates.inscription_ids_updates.put(key2, state2);
@@ -407,7 +398,6 @@ fn produce_ord_updates(
     }
 
     drop(tx);
-    drop(id_ord_map);
 }
 
 fn gen_inscription_ids_update(index: u64, inscription_id: InscriptionID) -> (KeyState, State) {
@@ -445,17 +435,16 @@ impl InscriptionSource {
         Ok(address)
     }
 
-    pub fn to_inscription(self, id_ord_map: &sled::Db) -> (Inscription, InscriptionId) {
+    pub fn to_inscription(self) -> Inscription {
         let src = self;
 
-        let ord_id = src.id;
-        let txid: AccountAddress = ord_id.txid.into_address();
+        let txid: AccountAddress = src.id.txid.into_address();
 
-        let parents = get_ords_by_ids(id_ord_map, src.parent);
+        let parents = derive_obj_ids_by_inscription_ids(src.parent);
 
-        let inscription = Inscription {
+        Inscription {
             txid,
-            index: ord_id.index,
+            index: src.id.index,
             offset: src.satpoint_offset,
             sequence_number: src.sequence_number,
             inscription_number: src.inscription_number.unsigned_abs(),
@@ -468,17 +457,15 @@ impl InscriptionSource {
             pointer: src.pointer.into(),
             parents,
             rune: src.rune.into(),
-        };
-        (inscription, ord_id)
+        }
     }
 }
 
 fn gen_ord_update(
     src: InscriptionSource,
     utxo_ord_map: Arc<sled::Db>,
-    id_ord_map: &sled::Db,
 ) -> Result<(KeyState, State, InscriptionID)> {
-    let (inscription, src_inscription_id) = src.clone().to_inscription(id_ord_map);
+    let inscription = src.clone().to_inscription();
     let address = src.clone().get_rooch_address()?;
 
     let inscription_id = InscriptionID::new(inscription.txid, inscription.index);
@@ -497,13 +484,7 @@ fn gen_ord_update(
     let satpoint_output_str = src.satpoint_outpoint.clone();
     let satpoint_output = OutPoint::from_str(satpoint_output_str.as_str()).unwrap();
 
-    _ = update_ord_map(
-        utxo_ord_map,
-        id_ord_map,
-        src_inscription_id,
-        satpoint_output,
-        obj_id.clone(),
-    );
+    _ = update_ord_map(utxo_ord_map, satpoint_output, obj_id.clone());
 
     Ok((ord_obj.id.to_key(), ord_obj.into_state(), inscription_id))
 }
@@ -514,17 +495,8 @@ fn convert_option_string_to_move_type(opt: Option<String>) -> MoveOption<MoveStr
 
 // update id:object for parents
 // update outpoint:object for utxo
-fn update_ord_map(
-    utxo_ord_map: Arc<sled::Db>,
-    id_ord_map: &sled::Db,
-    id: InscriptionId,
-    outpoint: OutPoint,
-    obj_id: ObjectID,
-) -> bool {
+fn update_ord_map(utxo_ord_map: Arc<sled::Db>, outpoint: OutPoint, obj_id: ObjectID) -> bool {
     let obj_id_bytes = bcs::to_bytes(&obj_id).unwrap();
-    // update inscription_id:ord
-    let id_key = bcs::to_bytes(&id).unwrap();
-    id_ord_map.insert(id_key, obj_id_bytes.clone()).unwrap();
 
     let is_unbound = outpoint.txid == Hash::all_zeros() && outpoint.vout == 0;
     if is_unbound {
@@ -537,11 +509,11 @@ fn update_ord_map(
     is_unbound
 }
 
-fn get_ords_by_ids(id_ord_map: &sled::Db, ids: Option<Vec<InscriptionId>>) -> Vec<ObjectID> {
+fn derive_obj_ids_by_inscription_ids(ids: Option<Vec<InscriptionId>>) -> Vec<ObjectID> {
     if let Some(ids) = ids {
-        let mut obj_ids = Vec::new();
+        let mut obj_ids = Vec::with_capacity(ids.len());
         for id in ids {
-            let obj_id = get_ord_by_id(id_ord_map, id);
+            let obj_id = derive_inscription_id(&derive_rooch_inscription_id(id));
             obj_ids.push(obj_id)
         }
         obj_ids
@@ -550,13 +522,9 @@ fn get_ords_by_ids(id_ord_map: &sled::Db, ids: Option<Vec<InscriptionId>>) -> Ve
     }
 }
 
-fn get_ord_by_id(id_ord_map: &sled::Db, id: InscriptionId) -> ObjectID {
-    let id_key = bcs::to_bytes(&id).unwrap();
-    let value = id_ord_map
-        .get(id_key)
-        .unwrap()
-        .expect("get ord object id by inscriptionId must be succeed");
-    bcs::from_bytes(&value).unwrap()
+fn derive_rooch_inscription_id(id: InscriptionId) -> InscriptionID {
+    let txid: AccountAddress = id.txid.into_address();
+    InscriptionID::new(txid, id.index)
 }
 
 fn create_genesis_inscription_store_object(


### PR DESCRIPTION
## Summary

The changes refactor the genesis_ord module by eliminating the use of a temporary directory and related functions. Instead, the logic is refactored to derive information directly, reducing complexity and potential file system overhead. This change simplifies the code structure and improves performance.