### PR TITLE
feat(common): add new 'rooch-common' crate with utility functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9767,6 +9767,7 @@ dependencies = [
  "proptest-derive",
  "raw-store",
  "regex",
+ "rooch-common",
  "rooch-config",
  "rooch-db",
  "rooch-framework",
@@ -9866,6 +9867,10 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "rooch-common"
+version = "0.5.7"
 
 [[package]]
 name = "rooch-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "moveos/moveos-wasm",
     "moveos/moveos-object-runtime",
     "moveos/moveos-compiler",
+    "crates/rooch-common",
     "crates/rooch-key",
     "crates/rooch-types",
     "crates/rooch-framework-tests",
@@ -92,6 +93,7 @@ accumulator = { path = "moveos/moveos-commons/accumulator" }
 
 # crates for Rooch
 rooch = { path = "crates/rooch" }
+rooch-common = { path = "crates/rooch-common" }
 rooch-key = { path = "crates/rooch-key" }
 rooch-types = { path = "crates/rooch-types" }
 rooch-framework-tests = { path = "crates/rooch-framework-tests" }

--- a/crates/rooch-common/Cargo.toml
+++ b/crates/rooch-common/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rooch-common"
+
+# Workspace inherited keys
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }

--- a/crates/rooch-common/README.md
+++ b/crates/rooch-common/README.md
@@ -1,0 +1,1 @@
+# Rooch Common

--- a/crates/rooch-common/src/lib.rs
+++ b/crates/rooch-common/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod utils;

--- a/crates/rooch-common/src/utils/humanize.rs
+++ b/crates/rooch-common/src/utils/humanize.rs
@@ -1,0 +1,40 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+pub fn human_readable_size(bytes: u64) -> String {
+    let units = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+    let mut size = bytes as f64;
+    let mut unit = units[0];
+
+    for &u in &units[1..] {
+        if size < 1024.0 {
+            break;
+        }
+        size /= 1024.0;
+        unit = u;
+    }
+
+    format!("{:.2} {}", size, unit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_human_readable_size() {
+        assert_eq!(human_readable_size(0), "0.00 B");
+        assert_eq!(human_readable_size(1024), "1.00 KB");
+        assert_eq!(human_readable_size(1024 * 1024), "1.00 MB");
+        assert_eq!(human_readable_size(1024 * 1024 * 1024), "1.00 GB");
+        assert_eq!(human_readable_size(1024 * 1024 * 1024 * 1024), "1.00 TB");
+        assert_eq!(
+            human_readable_size(1024 * 1024 * 1024 * 1024 * 1024),
+            "1.00 PB"
+        );
+        assert_eq!(
+            human_readable_size(1024 * 1024 * 1024 * 1024 * 1024 * 1024),
+            "1.00 EB"
+        );
+    }
+}

--- a/crates/rooch-common/src/utils/mod.rs
+++ b/crates/rooch-common/src/utils/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod humanize;

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -73,7 +73,7 @@ moveos = { workspace = true }
 moveos-verifier = { workspace = true }
 moveos-object-runtime = { workspace = true }
 moveos-compiler = { workspace = true }
-moveos-config ={ workspace = true }
+moveos-config = { workspace = true }
 
 framework-builder = { workspace = true }
 framework-types = { workspace = true }
@@ -93,5 +93,6 @@ rooch-rpc-client = { workspace = true }
 rooch-integration-test-runner = { workspace = true }
 rooch-indexer = { workspace = true }
 rooch-db = { workspace = true }
+rooch-common = { workspace = true }
 
 framework-release = { workspace = true }


### PR DESCRIPTION
## Summary

This commit introduces a new 'rooch-common' crate to the workspace and that contains utility functions for the project. It includes a function for converting byte sizes to human-readable formats, which has been incorporated into the ORD update code. This will allow for clearer log messages describing the size of the batches processed.

