### PR TITLE
feat(common): add file cache manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9871,6 +9871,9 @@ dependencies = [
 [[package]]
 name = "rooch-common"
 version = "0.5.7"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "rooch-config"
@@ -14453,9 +14456,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
+checksum = "63658493314859b4dfdf3fb8c1defd61587839def09582db50b8a4e93afca6bb"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ criterion = { version = "0.5.1", features = [
     "async_tokio",
     "html_reports",
 ] }
-xxhash-rust = "0.8.8"
+xxhash-rust = { version = "0.8.11", features = ["std", "xxh3"] }
 base64 = "0.22.1"
 #criterion-cpu-time = "0.1.0"
 wasmer = "4.2.5"

--- a/crates/rooch-common/Cargo.toml
+++ b/crates/rooch-common/Cargo.toml
@@ -10,3 +10,6 @@ license = { workspace = true }
 publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
+
+[dependencies]
+libc = { workspace = true }

--- a/crates/rooch-common/src/fs/file_cache.rs
+++ b/crates/rooch-common/src/fs/file_cache.rs
@@ -1,0 +1,37 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+use std::io::{Error, Result};
+use std::os::unix::io::AsRawFd;
+
+use libc::{posix_fadvise, POSIX_FADV_DONTNEED};
+
+struct FileCacheManager {
+    file: File,
+}
+
+impl FileCacheManager {
+    pub fn new(file_path: &str) -> Result<Self> {
+        let file = File::open(file_path)?;
+        Ok(FileCacheManager { file })
+    }
+
+    pub fn drop_cache_range(&self, offset: u64, len: u64) -> Result<()> {
+        let fd = self.file.as_raw_fd();
+        let ret = unsafe {
+            posix_fadvise(
+                fd,
+                offset as libc::off_t,
+                len as libc::off_t,
+                POSIX_FADV_DONTNEED,
+            )
+        };
+
+        if ret != 0 {
+            return Err(Error::from_raw_os_error(ret));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/rooch-common/src/fs/file_cache.rs
+++ b/crates/rooch-common/src/fs/file_cache.rs
@@ -1,18 +1,18 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use libc::{posix_fadvise, POSIX_FADV_DONTNEED};
 use std::fs::File;
 use std::io::{Error, Result};
 use std::os::unix::io::AsRawFd;
+use std::path::PathBuf;
 
-use libc::{posix_fadvise, POSIX_FADV_DONTNEED};
-
-struct FileCacheManager {
+pub struct FileCacheManager {
     file: File,
 }
 
 impl FileCacheManager {
-    pub fn new(file_path: &str) -> Result<Self> {
+    pub fn new(file_path: PathBuf) -> Result<Self> {
         let file = File::open(file_path)?;
         Ok(FileCacheManager { file })
     }

--- a/crates/rooch-common/src/fs/mod.rs
+++ b/crates/rooch-common/src/fs/mod.rs
@@ -1,5 +1,4 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod fs;
-pub mod utils;
+pub mod file_cache;


### PR DESCRIPTION
## Summary

1.  introduces a new module, "fs", and within that module, a new "file_cache.rs" file that creates a FileCacheManager. This manager handles file caching using the std and libc libraries.
2. involves the reworking of file management in genesis_ord.rs through the integration of FileCacheManager. This new approach allows for improved file handling, including the tracking of bytes read to enable the optimization of cache dropping. 
