### PR TITLE
fix(common): add Linux-specific file caching logic

### DIFF
--- a/crates/rooch-common/src/fs/file_cache.rs
+++ b/crates/rooch-common/src/fs/file_cache.rs
@@ -1,25 +1,25 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::File;
-use std::io::{Error, Result};
-use std::os::unix::io::AsRawFd;
+use std::io::Result;
 use std::path::PathBuf;
 
 pub struct FileCacheManager {
     #[cfg(target_os = "linux")]
-    file: File,
+    file: std::fs::File,
 }
 
 impl FileCacheManager {
     #[cfg(target_os = "linux")]
     pub fn new(file_path: PathBuf) -> Result<Self> {
-        let file = File::open(file_path)?;
+        let file = std::fs::File::open(file_path)?;
         Ok(FileCacheManager { file })
     }
 
     #[cfg(target_os = "linux")]
     pub fn drop_cache_range(&self, offset: u64, len: u64) -> Result<()> {
+        use std::os::unix::io::AsRawFd;
+
         let fd = self.file.as_raw_fd();
         let ret = unsafe {
             libc::posix_fadvise(
@@ -31,7 +31,7 @@ impl FileCacheManager {
         };
 
         if ret != 0 {
-            return Err(Error::from_raw_os_error(ret));
+            return Err(std::io::Error::from_raw_os_error(ret));
         }
 
         Ok(())

--- a/crates/rooch-common/src/fs/file_cache.rs
+++ b/crates/rooch-common/src/fs/file_cache.rs
@@ -8,15 +8,18 @@ use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 
 pub struct FileCacheManager {
+    #[cfg(target_os = "linux")]
     file: File,
 }
 
 impl FileCacheManager {
+    #[cfg(target_os = "linux")]
     pub fn new(file_path: PathBuf) -> Result<Self> {
         let file = File::open(file_path)?;
         Ok(FileCacheManager { file })
     }
 
+    #[cfg(target_os = "linux")]
     pub fn drop_cache_range(&self, offset: u64, len: u64) -> Result<()> {
         let fd = self.file.as_raw_fd();
         let ret = unsafe {
@@ -32,6 +35,16 @@ impl FileCacheManager {
             return Err(Error::from_raw_os_error(ret));
         }
 
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn new(_: PathBuf) -> Result<Self> {
+        Ok(FileCacheManager {})
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn drop_cache_range(&self, _: u64, _: u64) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/rooch-common/src/fs/file_cache.rs
+++ b/crates/rooch-common/src/fs/file_cache.rs
@@ -1,7 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use libc::{posix_fadvise, POSIX_FADV_DONTNEED};
 use std::fs::File;
 use std::io::{Error, Result};
 use std::os::unix::io::AsRawFd;
@@ -23,11 +22,11 @@ impl FileCacheManager {
     pub fn drop_cache_range(&self, offset: u64, len: u64) -> Result<()> {
         let fd = self.file.as_raw_fd();
         let ret = unsafe {
-            posix_fadvise(
+            libc::posix_fadvise(
                 fd,
                 offset as libc::off_t,
                 len as libc::off_t,
-                POSIX_FADV_DONTNEED,
+                libc::POSIX_FADV_DONTNEED,
             )
         };
 


### PR DESCRIPTION
## Summary

Implemented conditional logic in the FileCacheManager module where certain methods are only applicable when the target OS is Linux. Methods like `new()` and `drop_cache_range()` are now specifically designated for Linux, while others are designated otherwise. This ensures correct functioning across diverse OS.

- Closes #2075 