### PR TITLE
Provide API to query move module ABI

### DIFF
--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -298,6 +298,32 @@
       }
     },
     {
+      "name": "rooch_getModuleABI",
+      "description": "get module ABI by module id",
+      "params": [
+        {
+          "name": "module_addr",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
+          }
+        },
+        {
+          "name": "module_name",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "ModuleABIView",
+        "schema": {
+          "$ref": "#/components/schemas/ModuleABIView"
+        }
+      }
+    },
+    {
       "name": "rooch_getObjectStates",
       "description": "Get object states by object id",
       "params": [
@@ -1665,6 +1691,46 @@
           }
         ]
       },
+      "ModuleABIView": {
+        "description": "A Move module ABI",
+        "type": "object",
+        "required": [
+          "address",
+          "friends",
+          "functions",
+          "name",
+          "structs"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/move_core_types::account_address::AccountAddress"
+          },
+          "friends": {
+            "description": "Friends of the module",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/move_core_types::language_storage::ModuleId"
+            }
+          },
+          "functions": {
+            "description": "Public or entry functions of the module",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MoveFunctionView"
+            }
+          },
+          "name": {
+            "$ref": "#/components/schemas/move_core_types::identifier::Identifier"
+          },
+          "structs": {
+            "description": "Structs of the module",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MoveStructView"
+            }
+          }
+        }
+      },
       "MoveActionTypeView": {
         "type": "string",
         "enum": [
@@ -1723,6 +1789,63 @@
           }
         }
       },
+      "MoveFunctionTypeParamView": {
+        "description": "Move function generic type param",
+        "type": "object",
+        "required": [
+          "constraints"
+        ],
+        "properties": {
+          "constraints": {
+            "description": "Move abilities tied to the generic type param and associated with the function that uses it",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/move_binary_format::file_format::Ability"
+            }
+          }
+        }
+      },
+      "MoveFunctionView": {
+        "description": "Move function",
+        "type": "object",
+        "required": [
+          "is_entry",
+          "name",
+          "params",
+          "return",
+          "type_params"
+        ],
+        "properties": {
+          "is_entry": {
+            "description": "Whether the function can be called as an entry function directly in a transaction",
+            "type": "boolean"
+          },
+          "name": {
+            "$ref": "#/components/schemas/move_core_types::identifier::Identifier"
+          },
+          "params": {
+            "description": "Parameters associated with the move function",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/rooch_rpc_api::jsonrpc_types::module_abi_view::MoveABIType"
+            }
+          },
+          "return": {
+            "description": "Return type of the function",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/rooch_rpc_api::jsonrpc_types::module_abi_view::MoveABIType"
+            }
+          },
+          "type_params": {
+            "description": "Generic type params associated with the Move function",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MoveFunctionTypeParamView"
+            }
+          }
+        }
+      },
       "MoveString": {
         "type": "object",
         "required": [
@@ -1735,6 +1858,84 @@
               "type": "integer",
               "format": "uint8",
               "minimum": 0.0
+            }
+          }
+        }
+      },
+      "MoveStructFieldView": {
+        "description": "Move struct field",
+        "type": "object",
+        "required": [
+          "name",
+          "type"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/move_core_types::identifier::Identifier"
+          },
+          "type": {
+            "$ref": "#/components/schemas/rooch_rpc_api::jsonrpc_types::module_abi_view::MoveABIType"
+          }
+        }
+      },
+      "MoveStructTypeParamView": {
+        "description": "Move generic type param",
+        "type": "object",
+        "required": [
+          "constraints",
+          "is_phantom"
+        ],
+        "properties": {
+          "constraints": {
+            "description": "Move abilities tied to the generic type param and associated with the type that uses it",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/move_binary_format::file_format::Ability"
+            }
+          },
+          "is_phantom": {
+            "description": "Whether the type is a phantom type",
+            "type": "boolean"
+          }
+        }
+      },
+      "MoveStructView": {
+        "description": "A move struct",
+        "type": "object",
+        "required": [
+          "abilities",
+          "fields",
+          "is_native",
+          "name",
+          "type_params"
+        ],
+        "properties": {
+          "abilities": {
+            "description": "Abilities associated with the struct",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/move_binary_format::file_format::Ability"
+            }
+          },
+          "fields": {
+            "description": "Fields associated with the struct",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MoveStructFieldView"
+            }
+          },
+          "is_native": {
+            "description": "Whether the struct is a native struct of Move",
+            "type": "boolean"
+          },
+          "name": {
+            "$ref": "#/components/schemas/move_core_types::identifier::Identifier"
+          },
+          "type_params": {
+            "description": "Generic types associated with the struct",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MoveStructTypeParamView"
             }
           }
         }
@@ -2821,7 +3022,16 @@
       "bitcoin::hash_types::newtypes::Txid": {
         "type": "string"
       },
+      "move_binary_format::file_format::Ability": {
+        "type": "string"
+      },
       "move_core_types::account_address::AccountAddress": {
+        "type": "string"
+      },
+      "move_core_types::identifier::Identifier": {
+        "type": "string"
+      },
+      "move_core_types::language_storage::ModuleId": {
         "type": "string"
       },
       "move_core_types::language_storage::StructTag": {
@@ -2852,6 +3062,9 @@
         "type": "string"
       },
       "rooch_rpc_api::jsonrpc_types::address::RoochOrBitcoinAddress": {
+        "type": "string"
+      },
+      "rooch_rpc_api::jsonrpc_types::module_abi_view::MoveABIType": {
         "type": "string"
       },
       "rooch_types::address::BitcoinAddress": {

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -9,8 +9,8 @@ use crate::jsonrpc_types::{
     AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, BytesView, EventOptions,
     EventPageView, ExecuteTransactionResponseView, FieldKeyView, FunctionCallView, H256View,
     IndexerEventPageView, IndexerObjectStatePageView, ModuleABIView, ObjectIDVecView, ObjectIDView,
-    ObjectStateFilterView, ObjectStateView, QueryOptions, StateOptions, StatePageView, StrView,
-    StructTagView, TransactionWithInfoPageView, TxOptions,
+    ObjectStateFilterView, ObjectStateView, QueryOptions, RoochAddressView, StateOptions,
+    StatePageView, StrView, StructTagView, TransactionWithInfoPageView, TxOptions,
 };
 use crate::RpcResult;
 use jsonrpsee::proc_macros::rpc;

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -8,7 +8,7 @@ use crate::jsonrpc_types::transaction_view::{TransactionFilterView, TransactionW
 use crate::jsonrpc_types::{
     AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, BytesView, EventOptions,
     EventPageView, ExecuteTransactionResponseView, FieldKeyView, FunctionCallView, H256View,
-    IndexerEventPageView, IndexerObjectStatePageView, ObjectIDVecView, ObjectIDView,
+    IndexerEventPageView, IndexerObjectStatePageView, ModuleABIView, ObjectIDVecView, ObjectIDView,
     ObjectStateFilterView, ObjectStateView, QueryOptions, StateOptions, StatePageView, StrView,
     StructTagView, TransactionWithInfoPageView, TxOptions,
 };
@@ -146,6 +146,14 @@ pub trait RoochAPI {
         cursor: Option<IndexerStateID>,
         limit: Option<StrView<usize>>,
     ) -> RpcResult<BalanceInfoPageView>;
+
+    /// get module ABI by module id
+    #[method(name = "getModuleABI")]
+    async fn get_module_abi(
+        &self,
+        module_addr: RoochAddressView,
+        module_name: String,
+    ) -> RpcResult<Option<ModuleABIView>>;
 
     /// Query the transactions indexer by transaction filter
     #[method(name = "queryTransactions")]

--- a/crates/rooch-rpc-api/src/jsonrpc_types/mod.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/mod.rs
@@ -6,10 +6,12 @@
 mod str_view;
 mod execute_tx_response;
 mod function_return_value_view;
+mod module_abi_view;
 mod move_types;
 mod rooch_types;
 mod rpc_options;
 mod state_view;
+
 #[cfg(test)]
 mod tests;
 mod transaction_argument_view;
@@ -25,6 +27,7 @@ pub use self::rooch_types::*;
 pub use address::*;
 pub use execute_tx_response::*;
 pub use function_return_value_view::*;
+pub use module_abi_view::*;
 pub use move_types::*;
 pub use rpc_options::*;
 pub use state_view::*;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/module_abi_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/module_abi_view.rs
@@ -113,7 +113,13 @@ impl MoveABIStructTag {
 
 impl fmt::Display for MoveABIStructTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}::{}::{}", self.address, self.module, self.name)?;
+        write!(
+            f,
+            "0x{}::{}::{}",
+            self.address.short_str_lossless(),
+            self.module,
+            self.name
+        )?;
         if let Some(first_ty) = self.type_params.first() {
             write!(f, "<")?;
             write!(f, "{}", first_ty)?;
@@ -219,6 +225,7 @@ pub struct MoveFunctionView {
     /// Parameters associated with the move function
     pub params: Vec<MoveABITypeView>,
     /// Return type of the function
+    #[serde(rename = "return")]
     pub return_: Vec<MoveABITypeView>,
 }
 

--- a/crates/rooch-rpc-api/src/jsonrpc_types/module_abi_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/module_abi_view.rs
@@ -13,11 +13,7 @@ use move_binary_format::{
         Visibility,
     },
 };
-use move_core_types::{
-    account_address::AccountAddress,
-    identifier::Identifier,
-    language_storage::{StructTag, TypeTag},
-};
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug};
@@ -84,7 +80,7 @@ impl std::fmt::Display for MoveABITypeView {
 impl FromStr for MoveABITypeView {
     type Err = anyhow::Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
         // TODO
         unimplemented!("No scenario for deserializing MoveABITypeView")
     }
@@ -141,7 +137,7 @@ impl std::fmt::Display for MoveABIStructTagView {
 impl FromStr for MoveABIStructTagView {
     type Err = anyhow::Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
         // TODO
         unimplemented!("No scenario for deserializing MoveABIStructTagView")
     }
@@ -180,10 +176,10 @@ fn signature_token_to_abi_type(m: &CompiledModule, token: &SignatureToken) -> Mo
             MoveABIType::Vector(Box::new(signature_token_to_abi_type(m, t.borrow())))
         }
         SignatureToken::Struct(v) => {
-            MoveABIType::Struct(Box::new(signature_token_to_abi_struct_tag(&m, v, &[])))
+            MoveABIType::Struct(Box::new(signature_token_to_abi_struct_tag(m, v, &[])))
         }
         SignatureToken::StructInstantiation(shi, type_params) => MoveABIType::Struct(Box::new(
-            signature_token_to_abi_struct_tag(&m, shi, type_params),
+            signature_token_to_abi_struct_tag(m, shi, type_params),
         )),
         SignatureToken::TypeParameter(i) => MoveABIType::GenericTypeParam { index: *i },
         SignatureToken::Reference(t) => MoveABIType::Reference {
@@ -369,7 +365,7 @@ impl From<CompiledModule> for ModuleABIView {
             friends: m
                 .immediate_friends()
                 .into_iter()
-                .map(|m| ModuleIdView::from(m))
+                .map(ModuleIdView::from)
                 .collect(),
             functions: m
                 .function_defs

--- a/crates/rooch-rpc-api/src/jsonrpc_types/module_abi_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/module_abi_view.rs
@@ -1,0 +1,275 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::jsonrpc_types::{
+    AbilityView, AccountAddressView, IdentifierView, ModuleIdView, TypeTagView,
+};
+use anyhow::Result;
+use move_binary_format::{
+    access::ModuleAccess,
+    file_format::{
+        AbilitySet, CompiledModule, FieldDefinition, FunctionDefinition, SignatureToken,
+        StructDefinition, StructFieldInformation, StructHandleIndex, StructTypeParameter,
+        Visibility,
+    },
+};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{StructTag, TypeTag},
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
+use std::fmt::Debug;
+
+fn signature_token_to_struct_tag(
+    m: &CompiledModule,
+    index: &StructHandleIndex,
+    type_params: &[SignatureToken],
+) -> StructTag {
+    let s_handle = m.struct_handle_at(*index);
+    let m_handle = m.module_handle_at(s_handle.module);
+    StructTag {
+        address: (*m.address_identifier_at(m_handle.address)).into(),
+        module: m.identifier_at(m_handle.name).to_owned().into(),
+        name: m.identifier_at(s_handle.name).to_owned().into(),
+        type_params: type_params
+            .iter()
+            .map(|t| signature_token_to_type_tag(m, t))
+            .collect(),
+    }
+}
+
+fn signature_token_to_type_tag(m: &CompiledModule, token: &SignatureToken) -> TypeTag {
+    match token {
+        SignatureToken::Bool => TypeTag::Bool,
+        SignatureToken::U8 => TypeTag::U8,
+        SignatureToken::U16 => TypeTag::U16,
+        SignatureToken::U32 => TypeTag::U32,
+        SignatureToken::U64 => TypeTag::U64,
+        SignatureToken::U128 => TypeTag::U128,
+        SignatureToken::U256 => TypeTag::U256,
+        SignatureToken::Address => TypeTag::Address,
+        SignatureToken::Signer => TypeTag::Signer,
+        SignatureToken::Vector(t) => {
+            TypeTag::Vector(Box::new(signature_token_to_type_tag(m, t.borrow())))
+        }
+        SignatureToken::Struct(v) => TypeTag::from(signature_token_to_struct_tag(&m, v, &[])),
+        SignatureToken::StructInstantiation(shi, type_params) => {
+            TypeTag::from(signature_token_to_struct_tag(m, shi, type_params))
+        }
+        // SignatureToken::TypeParameter(i) => MoveType::GenericTypeParam { index: *i },
+        // SignatureToken::Reference(t) => MoveType::Reference {
+        //     mutable: false,
+        //     to: Box::new(self.new_move_type(t.borrow())),
+        // },
+        // SignatureToken::MutableReference(t) => MoveType::Reference {
+        //     mutable: true,
+        //     to: Box::new(self.new_move_type(t.borrow())),
+        // },
+        _ => todo!(),
+    }
+}
+
+/// Move function generic type param
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MoveFunctionTypeParamView {
+    /// Move abilities tied to the generic type param and associated with the function that uses it
+    pub constraints: Vec<AbilityView>,
+}
+
+impl From<&AbilitySet> for MoveFunctionTypeParamView {
+    fn from(constraints: &AbilitySet) -> Self {
+        Self {
+            constraints: constraints.into_iter().map(AbilityView::from).collect(),
+        }
+    }
+}
+
+/// Move function
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MoveFunctionView {
+    pub name: IdentifierView,
+    /// Whether the function can be called as an entry function directly in a transaction
+    pub is_entry: bool,
+    /// Generic type params associated with the Move function
+    pub type_params: Vec<MoveFunctionTypeParamView>,
+    /// Parameters associated with the move function
+    pub params: Vec<TypeTagView>,
+    /// Return type of the function
+    pub return_: Vec<TypeTagView>,
+}
+
+impl MoveFunctionView {
+    fn new(m: &CompiledModule, def: &FunctionDefinition) -> Self {
+        let fhandle = m.function_handle_at(def.function);
+        let name = m.identifier_at(fhandle.name).to_owned();
+        Self {
+            name: name.into(),
+            is_entry: def.is_entry,
+            type_params: fhandle
+                .type_parameters
+                .iter()
+                .map(MoveFunctionTypeParamView::from)
+                .collect(),
+            params: m
+                .signature_at(fhandle.parameters)
+                .0
+                .iter()
+                .map(|s| TypeTagView::from(signature_token_to_type_tag(m, s)))
+                .collect(),
+            return_: m
+                .signature_at(fhandle.return_)
+                .0
+                .iter()
+                .map(|s| TypeTagView::from(signature_token_to_type_tag(m, s)))
+                .collect(),
+        }
+    }
+}
+
+/// Move generic type param
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MoveStructTypeParamView {
+    /// Move abilities tied to the generic type param and associated with the type that uses it
+    pub constraints: Vec<AbilityView>,
+    /// Whether the type is a phantom type
+    pub is_phantom: bool,
+}
+
+impl From<&StructTypeParameter> for MoveStructTypeParamView {
+    fn from(param: &StructTypeParameter) -> Self {
+        Self {
+            constraints: param
+                .constraints
+                .into_iter()
+                .map(AbilityView::from)
+                .collect(),
+            is_phantom: param.is_phantom,
+        }
+    }
+}
+
+/// Move struct field
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MoveStructFieldView {
+    pub name: IdentifierView,
+    #[serde(rename = "type")]
+    pub ty: TypeTagView,
+}
+
+fn new_move_struct_field_view(m: &CompiledModule, def: &FieldDefinition) -> MoveStructFieldView {
+    MoveStructFieldView {
+        name: m.identifier_at(def.name).to_owned().into(),
+        ty: signature_token_to_type_tag(m, &def.signature.0).into(),
+    }
+}
+
+/// A move struct
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MoveStructView {
+    pub name: IdentifierView,
+    /// Whether the struct is a native struct of Move
+    pub is_native: bool,
+    /// Abilities associated with the struct
+    pub abilities: Vec<AbilityView>,
+    /// Generic types associated with the struct
+    pub type_params: Vec<MoveStructTypeParamView>,
+    /// Fields associated with the struct
+    pub fields: Vec<MoveStructFieldView>,
+}
+
+impl MoveStructView {
+    fn new(m: &CompiledModule, def: &StructDefinition) -> Self {
+        let handle = m.struct_handle_at(def.struct_handle);
+        let name = m.identifier_at(handle.name).to_owned();
+
+        let (is_native, fields) = match &def.field_information {
+            StructFieldInformation::Native => (true, vec![]),
+            StructFieldInformation::Declared(fields) => (
+                false,
+                fields
+                    .iter()
+                    .map(|f| new_move_struct_field_view(m, f))
+                    .collect(),
+            ),
+        };
+
+        let abilities = handle
+            .abilities
+            .into_iter()
+            .map(AbilityView::from)
+            .collect();
+        let type_params = handle
+            .type_parameters
+            .iter()
+            .map(MoveStructTypeParamView::from)
+            .collect();
+        Self {
+            name: name.into(),
+            is_native,
+            abilities,
+            type_params,
+            fields,
+        }
+    }
+}
+
+/// A Move module ABI
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ModuleABIView {
+    pub address: AccountAddressView,
+    pub name: IdentifierView,
+    /// Friends of the module
+    pub friends: Vec<ModuleIdView>,
+    /// Public or entry functions of the module
+    pub functions: Vec<MoveFunctionView>,
+    /// Structs of the module
+    pub structs: Vec<MoveStructView>,
+}
+
+impl ModuleABIView {
+    pub fn try_parse_from_module_bytes(module_bytes: &[u8]) -> Result<Self> {
+        Ok(CompiledModule::deserialize(module_bytes)?.into())
+    }
+}
+
+impl From<CompiledModule> for ModuleABIView {
+    fn from(m: CompiledModule) -> Self {
+        let (address, name) = <(AccountAddress, Identifier)>::from(m.self_id());
+        Self {
+            address: address.into(),
+            name: name.into(),
+            friends: m
+                .immediate_friends()
+                .into_iter()
+                .map(|m| ModuleIdView::from(m))
+                .collect(),
+            functions: m
+                .function_defs
+                .iter()
+                // Return all entry or public functions.
+                // Private entry functions are still callable by entry function transactions so
+                // they should be included.
+                // friend functions are treated as private functions.
+                // TODO: should friend functions be included?
+                .filter(|def| {
+                    def.is_entry
+                        || match def.visibility {
+                            Visibility::Public => true,
+                            Visibility::Private | Visibility::Friend => false,
+                        }
+                })
+                .map(|def| MoveFunctionView::new(&m, def))
+                .collect(),
+            structs: m
+                .struct_defs
+                .iter()
+                .map(|def| MoveStructView::new(&m, def))
+                .collect(),
+        }
+    }
+}
+
+// TODO: do we need to support export ABI of CompiledScript.

--- a/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
@@ -378,7 +378,7 @@ impl From<MoveAction> for MoveActionTypeView {
 
 impl std::fmt::Display for StrView<ModuleId> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.0)
+        write!(f, "{}", &self.0.short_str_lossless())
     }
 }
 

--- a/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
@@ -3,6 +3,7 @@
 
 use crate::jsonrpc_types::{BytesView, StrView};
 use anyhow::Result;
+use move_binary_format::file_format::Ability;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
@@ -90,6 +91,38 @@ impl FromStr for ObjectIDVecView {
 
 impl From<ObjectIDVecView> for Vec<ObjectID> {
     fn from(value: ObjectIDVecView) -> Self {
+        value.0
+    }
+}
+
+pub type AbilityView = StrView<Ability>;
+
+impl std::fmt::Display for AbilityView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Ability::Copy => write!(f, "copy"),
+            Ability::Drop => write!(f, "drop"),
+            Ability::Store => write!(f, "store"),
+            Ability::Key => write!(f, "key"),
+        }
+    }
+}
+
+impl FromStr for AbilityView {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "copy" => Ok(StrView(Ability::Copy)),
+            "drop" => Ok(StrView(Ability::Drop)),
+            "store" => Ok(StrView(Ability::Store)),
+            "key" => Ok(StrView(Ability::Key)),
+            _ => Err(anyhow::anyhow!("Invalid ability: {}", s)),
+        }
+    }
+}
+
+impl From<AbilityView> for Ability {
+    fn from(value: AbilityView) -> Self {
         value.0
     }
 }

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -11,6 +11,7 @@ use move_core_types::{
 use moveos_types::{
     access_path::AccessPath,
     h256::H256,
+    move_std::string::MoveString,
     moveos_std::{
         display::{get_object_display_id, get_resource_display_id, RawDisplay},
         move_module::MoveModule,
@@ -24,9 +25,10 @@ use rooch_rpc_api::jsonrpc_types::{
     transaction_view::{TransactionFilterView, TransactionWithInfoView},
     AccessPathView, AnnotatedMoveStructView, BalanceInfoPageView, DisplayFieldsView, EventOptions,
     EventPageView, ExecuteTransactionResponseView, FunctionCallView, H256View,
-    IndexerEventPageView, IndexerObjectStatePageView, IndexerObjectStateView, ObjectIDVecView,
-    ObjectStateFilterView, ObjectStateView, QueryOptions, RoochOrBitcoinAddressView, StateKVView,
-    StateOptions, StatePageView, StrView, StructTagView, TransactionWithInfoPageView, TxOptions,
+    IndexerEventPageView, IndexerObjectStatePageView, IndexerObjectStateView, ModuleABIView,
+    ObjectIDVecView, ObjectStateFilterView, ObjectStateView, QueryOptions, RoochAddressView,
+    RoochOrBitcoinAddressView, StateKVView, StateOptions, StatePageView, StrView, StructTagView,
+    TransactionWithInfoPageView, TxOptions,
 };
 use rooch_rpc_api::{
     api::rooch_api::RoochAPIServer,
@@ -639,7 +641,7 @@ impl RoochAPIServer for RoochServer {
 
         Ok(match module {
             Some(m) => {
-                let move_module = m.cast::<MoveModule>()?;
+                let move_module = m.value_as_df::<MoveString, MoveModule>()?.value;
                 Some(ModuleABIView::try_parse_from_module_bytes(
                     &move_module.byte_codes,
                 )?)

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -23,6 +23,8 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.rpc[-1][0].object_type}} == '0x2::module_store::Package'"
       Then cmd: "rpc request --method rooch_listFieldStates --params '["0x2214495c6abca5dd5a2bf0f2a28a74541ff10c89818a1244af24c4874325ebdb", null, "2", {"decode": false, "showDisplay": false}]' --json"
       Then assert: "{{$.rpc[-1].has_next_page}} == true"
+      Then cmd: "rpc request --method rooch_getModuleABI --params '["0x2", "display"]'"
+      Then assert: "{{$.rpc[-1].name}} == 'display'"
       Then stop the server 
     
     @serial


### PR DESCRIPTION
## Summary

1. add new RPC API `getModuleABI`
2. The ABIs of [moveos_std::display](https://github.com/rooch-network/rooch/blob/main/frameworks/moveos-stdlib/sources/display.move) as example, `rooch rpc request --method rooch_getModuleABI --params '["0x2", "display"]'`

```json
{
  "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
  "name": "display",
  "friends": [],
  "functions": [
    {
      "name": "borrow_mut_value",
      "is_entry": false,
      "type_params": [
        {
          "constraints": []
        }
      ],
      "params": [
        "&mut 0x2::object::Object<0x2::display::Display<T0>>",
        "&0x1::string::String"
      ],
      "return": [
        "&mut 0x1::string::String"
      ]
    },
    {
      "name": "borrow_value",
      "is_entry": false,
      "type_params": [
        {
          "constraints": []
        }
      ],
      "params": [
        "&0x2::object::Object<0x2::display::Display<T0>>",
        "&0x1::string::String"
      ],
      "return": [
        "&0x1::string::String"
      ]
    },
    {
      "name": "contains_key",
      "is_entry": false,
      "type_params": [
        {
          "constraints": []
        }
      ],
      "params": [
        "&0x2::object::Object<0x2::display::Display<T0>>",
        "&0x1::string::String"
      ],
      "return": [
        "bool"
      ]
    },
    {
      "name": "keys",
      "is_entry": false,
      "type_params": [
        {
          "constraints": []
        }
      ],
      "params": [
        "&0x2::object::Object<0x2::display::Display<T0>>"
      ],
      "return": [
        "vector<0x1::string::String>"
      ]
    },
    {
      "name": "object_display",
      "is_entry": false,
      "type_params": [
        {
          "constraints": [
            "key"
          ]
        }
      ],
      "params": [],
      "return": [
        "&mut 0x2::object::Object<0x2::display::Display<0x2::object::Object<T0>>>"
      ]
    },
    {
      "name": "remove_value",
      "is_entry": false,
      "type_params": [
        {
          "constraints": []
        }
      ],
      "params": [
        "&mut 0x2::object::Object<0x2::display::Display<T0>>",
        "&0x1::string::String"
      ],
      "return": []
    },
    {
      "name": "resource_display",
      "is_entry": false,
      "type_params": [
        {
          "constraints": [
            "key"
          ]
        }
      ],
      "params": [],
      "return": [
        "&mut 0x2::object::Object<0x2::display::Display<T0>>"
      ]
    },
    {
      "name": "set_value",
      "is_entry": false,
      "type_params": [
        {
          "constraints": []
        }
      ],
      "params": [
        "&mut 0x2::object::Object<0x2::display::Display<T0>>",
        "0x1::string::String",
        "0x1::string::String"
      ],
      "return": []
    },
    {
      "name": "values",
      "is_entry": false,
      "type_params": [
        {
          "constraints": []
        }
      ],
      "params": [
        "&0x2::object::Object<0x2::display::Display<T0>>"
      ],
      "return": [
        "vector<0x1::string::String>"
      ]
    }
  ],
  "structs": [
    {
      "name": "Display",
      "is_native": false,
      "abilities": [
        "key"
      ],
      "type_params": [
        {
          "constraints": [],
          "is_phantom": true
        }
      ],
      "fields": [
        {
          "name": "sample_map",
          "type": "0x2::simple_map::SimpleMap<0x1::string::String, 0x1::string::String>"
        }
      ]
    },
    {
      "name": "DisplayCreate",
      "is_native": false,
      "abilities": [
        "copy",
        "drop"
      ],
      "type_params": [
        {
          "constraints": [],
          "is_phantom": true
        }
      ],
      "fields": [
        {
          "name": "dummy_field",
          "type": "bool"
        }
      ]
    }
  ]
}

```

- Closes #2033