### PR TITLE
[rpc] Unify object rpc struct

### DIFF
--- a/crates/data_verify/src/ord_verify.rs
+++ b/crates/data_verify/src/ord_verify.rs
@@ -119,9 +119,13 @@ pub fn match_inscription_data(
 ) -> bool {
     let ord_inscription_info_body = format!("0x{}", ord_inscription_info.body);
 
-    (rooch_inscription_info.owner_bitcoin_address.is_some()
+    (rooch_inscription_info
+        .metadata
+        .owner_bitcoin_address
+        .is_some()
         && ord_inscription_info.address
             == rooch_inscription_info
+                .metadata
                 .owner_bitcoin_address
                 .unwrap()
                 .to_string())

--- a/crates/rooch-indexer/migrations/2023-11-21-122437_object_states/up.sql
+++ b/crates/rooch-indexer/migrations/2023-11-21-122437_object_states/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE object_states
 (
-    object_id          VARCHAR        NOT NULL       PRIMARY KEY,
+    id          VARCHAR        NOT NULL       PRIMARY KEY,
     owner              VARCHAR        NOT NULL,
     flag               SMALLINT       NOT NULL,
     state_root         VARCHAR        NOT NULL,

--- a/crates/rooch-indexer/src/actor/messages.rs
+++ b/crates/rooch-indexer/src/actor/messages.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use coerce::actor::message::Message;
 use moveos_types::moveos_std::event::Event;
+use moveos_types::moveos_std::object::ObjectID;
 use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::state::{ObjectState, StateChangeSet};
 use moveos_types::transaction::{MoveAction, TransactionExecutionInfo, VerifiedMoveOSTransaction};
@@ -94,7 +95,7 @@ impl Message for QueryIndexerEventsMessage {
     type Result = Result<Vec<IndexerEvent>>;
 }
 
-/// Query Indexer Global States Message
+/// Query Indexer Object States Message
 #[derive(Debug, Serialize, Deserialize)]
 pub struct QueryIndexerObjectStatesMessage {
     pub filter: ObjectStateFilter,
@@ -106,4 +107,17 @@ pub struct QueryIndexerObjectStatesMessage {
 
 impl Message for QueryIndexerObjectStatesMessage {
     type Result = Result<Vec<IndexerObjectState>>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QueryIndexerObjectIdsMessage {
+    pub filter: ObjectStateFilter,
+    // exclusive cursor if `Some`, otherwise start from the beginning
+    pub cursor: Option<IndexerStateID>,
+    pub limit: usize,
+    pub descending_order: bool,
+}
+
+impl Message for QueryIndexerObjectIdsMessage {
+    type Result = Result<Vec<(ObjectID, IndexerStateID)>>;
 }

--- a/crates/rooch-indexer/src/actor/reader_indexer.rs
+++ b/crates/rooch-indexer/src/actor/reader_indexer.rs
@@ -8,9 +8,12 @@ use crate::indexer_reader::IndexerReader;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use coerce::actor::{context::ActorContext, message::Handler, Actor};
+use moveos_types::moveos_std::object::ObjectID;
 use rooch_types::indexer::event::IndexerEvent;
-use rooch_types::indexer::state::IndexerObjectState;
+use rooch_types::indexer::state::{IndexerObjectState, IndexerStateID};
 use rooch_types::indexer::transaction::IndexerTransaction;
+
+use super::messages::QueryIndexerObjectIdsMessage;
 
 pub struct IndexerReaderActor {
     indexer_reader: IndexerReader,
@@ -77,6 +80,25 @@ impl Handler<QueryIndexerObjectStatesMessage> for IndexerReaderActor {
         } = msg;
         self.indexer_reader
             .query_object_states_with_filter(filter, cursor, limit, descending_order)
+            .map_err(|e| anyhow!(format!("Failed to query indexer object states: {:?}", e)))
+    }
+}
+
+#[async_trait]
+impl Handler<QueryIndexerObjectIdsMessage> for IndexerReaderActor {
+    async fn handle(
+        &mut self,
+        msg: QueryIndexerObjectIdsMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<Vec<(ObjectID, IndexerStateID)>> {
+        let QueryIndexerObjectIdsMessage {
+            filter,
+            cursor,
+            limit,
+            descending_order,
+        } = msg;
+        self.indexer_reader
+            .query_object_ids_with_filter(filter, cursor, limit, descending_order)
             .map_err(|e| anyhow!(format!("Failed to query indexer object states: {:?}", e)))
     }
 }

--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -17,6 +17,7 @@ use diesel::{
     r2d2::ConnectionManager, Connection, ExpressionMethods, QueryDsl, RunQueryDsl, SqliteConnection,
 };
 use move_core_types::language_storage::StructTag;
+use moveos_types::moveos_std::object::ObjectID;
 use rooch_types::indexer::event::{EventFilter, IndexerEvent, IndexerEventID};
 use rooch_types::indexer::state::{IndexerObjectState, IndexerStateID, ObjectStateFilter};
 use rooch_types::indexer::transaction::{IndexerTransaction, TransactionFilter};
@@ -28,7 +29,7 @@ pub const TX_ORDER_STR: &str = "tx_order";
 pub const TX_HASH_STR: &str = "tx_hash";
 pub const TX_SENDER_STR: &str = "sender";
 pub const CREATED_AT_STR: &str = "created_at";
-pub const OBJECT_ID_STR: &str = "object_id";
+pub const OBJECT_ID_STR: &str = "id";
 
 pub const TRANSACTION_ORIGINAL_ADDRESS_STR: &str = "multichain_original_address";
 
@@ -37,7 +38,7 @@ pub const EVENT_INDEX_STR: &str = "event_index";
 pub const EVENT_SEQ_STR: &str = "event_seq";
 pub const EVENT_TYPE_STR: &str = "event_type";
 
-pub const STATE_OBJECT_ID_STR: &str = "object_id";
+pub const STATE_OBJECT_ID_STR: &str = "id";
 pub const STATE_INDEX_STR: &str = "state_index";
 pub const STATE_OBJECT_TYPE_STR: &str = "object_type";
 pub const STATE_OWNER_STR: &str = "owner";
@@ -329,13 +330,13 @@ impl IndexerReader {
         Ok(result)
     }
 
-    pub fn query_object_states_with_filter(
+    fn query_stored_states_with_filter(
         &self,
         filter: ObjectStateFilter,
         cursor: Option<IndexerStateID>,
         limit: usize,
         descending_order: bool,
-    ) -> IndexerResult<Vec<IndexerObjectState>> {
+    ) -> IndexerResult<Vec<StoredObjectState>> {
         let (tx_order, state_index) = if let Some(cursor) = cursor {
             let IndexerStateID {
                 tx_order,
@@ -413,13 +414,44 @@ impl IndexerReader {
         let stored_states = self
             .get_inner_indexer_reader(INDEXER_OBJECT_STATES_TABLE_NAME)?
             .run_query(|conn| diesel::sql_query(query).load::<StoredObjectState>(conn))?;
+        Ok(stored_states)
+    }
 
+    pub fn query_object_states_with_filter(
+        &self,
+        filter: ObjectStateFilter,
+        cursor: Option<IndexerStateID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<IndexerObjectState>> {
+        let stored_states =
+            self.query_stored_states_with_filter(filter, cursor, limit, descending_order)?;
         let result = stored_states
             .into_iter()
-            .map(|v| v.try_into_indexer_global_state())
+            .map(|v| v.try_parse_indexer_object_state())
             .collect::<Result<Vec<_>>>()
             .map_err(|e| {
                 IndexerError::SQLiteReadError(format!("Cast indexer object states failed: {:?}", e))
+            })?;
+
+        Ok(result)
+    }
+
+    pub fn query_object_ids_with_filter(
+        &self,
+        filter: ObjectStateFilter,
+        cursor: Option<IndexerStateID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<(ObjectID, IndexerStateID)>> {
+        let stored_states =
+            self.query_stored_states_with_filter(filter, cursor, limit, descending_order)?;
+        let result = stored_states
+            .into_iter()
+            .map(|v| v.try_parse_id())
+            .collect::<Result<Vec<_>>>()
+            .map_err(|e| {
+                IndexerError::SQLiteReadError(format!("Cast indexer object ids failed: {:?}", e))
             })?;
 
         Ok(result)

--- a/crates/rooch-indexer/src/models/states.rs
+++ b/crates/rooch-indexer/src/models/states.rs
@@ -3,11 +3,11 @@
 
 use crate::schema::object_states;
 use diesel::prelude::*;
-use move_core_types::language_storage::StructTag;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::language_storage::TypeTag;
 use moveos_types::h256::H256;
-use moveos_types::moveos_std::object::ObjectID;
-use rooch_types::address::RoochAddress;
-use rooch_types::indexer::state::IndexerObjectState;
+use moveos_types::moveos_std::object::{ObjectID, ObjectMeta};
+use rooch_types::indexer::state::{IndexerObjectState, IndexerStateID};
 use std::str::FromStr;
 
 #[derive(Queryable, QueryableByName, Insertable, Debug, Clone)]
@@ -15,79 +15,94 @@ use std::str::FromStr;
 pub struct StoredObjectState {
     /// The global state key
     #[diesel(sql_type = diesel::sql_types::Text)]
-    pub object_id: String,
+    pub id: String,
     /// The owner of the object
     #[diesel(sql_type = diesel::sql_types::Text)]
     pub owner: String,
     /// A flag to indicate whether the object is shared or frozen
     #[diesel(sql_type = diesel::sql_types::SmallInt)]
     pub flag: i16,
-    /// The T struct tag of the object value
-    #[diesel(sql_type = diesel::sql_types::Text)]
-    pub object_type: String,
     /// The table state root of the object
     #[diesel(sql_type = diesel::sql_types::Text)]
     pub state_root: String,
     /// The table length
     #[diesel(sql_type = diesel::sql_types::BigInt)]
     pub size: i64,
-    /// The tx order of this transaction
-    #[diesel(sql_type = diesel::sql_types::BigInt)]
-    pub tx_order: i64,
-    /// The state index in the tx
-    #[diesel(sql_type = diesel::sql_types::BigInt)]
-    pub state_index: i64,
     /// The object created timestamp on chain
     #[diesel(sql_type = diesel::sql_types::BigInt)]
     pub created_at: i64,
     /// The object updated timestamp on chain
     #[diesel(sql_type = diesel::sql_types::BigInt)]
     pub updated_at: i64,
+    /// The T struct tag of the object value
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub object_type: String,
+    /// The tx order of this transaction
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub tx_order: i64,
+    /// The state index in the tx
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub state_index: i64,
 }
 
 impl From<IndexerObjectState> for StoredObjectState {
     fn from(state: IndexerObjectState) -> Self {
+        let metadata = state.metadata;
+        let tx_order = state.tx_order;
+        let state_index = state.state_index;
         Self {
-            object_id: state.object_id.to_string(),
-            owner: state.owner.to_hex_literal(),
-            flag: state.flag as i16,
-            object_type: state.object_type.to_string(),
-            state_root: state
+            id: metadata.id.to_string(),
+            owner: metadata.owner.to_hex_literal(),
+            flag: metadata.flag as i16,
+            state_root: metadata
                 .state_root
                 .map(|h| format!("{:?}", h))
                 .unwrap_or_default(),
-            size: state.size as i64,
-            tx_order: state.tx_order as i64,
-            state_index: state.state_index as i64,
-            created_at: state.created_at as i64,
-            updated_at: state.updated_at as i64,
+            size: metadata.size as i64,
+            created_at: metadata.created_at as i64,
+            updated_at: metadata.updated_at as i64,
+            object_type: metadata.object_type.to_string(),
+            tx_order: tx_order as i64,
+            state_index: state_index as i64,
         }
     }
 }
 
 impl StoredObjectState {
-    pub fn try_into_indexer_global_state(&self) -> Result<IndexerObjectState, anyhow::Error> {
-        let object_id = ObjectID::from_str(self.object_id.as_str())?;
-        let owner = RoochAddress::from_str(self.owner.as_str())?;
-        let object_type = StructTag::from_str(self.object_type.as_str())?;
+    pub fn try_parse_indexer_object_state(&self) -> Result<IndexerObjectState, anyhow::Error> {
+        let id = ObjectID::from_str(self.id.as_str())?;
+        let owner = AccountAddress::from_str(self.owner.as_str())?;
+        let object_type = TypeTag::from_str(self.object_type.as_str())?;
         let state_root = if self.state_root.is_empty() {
             None
         } else {
             Some(H256::from_str(self.state_root.as_str())?)
         };
-
-        let state = IndexerObjectState {
-            object_id,
+        let metadata = ObjectMeta {
+            id,
             owner,
             flag: self.flag as u8,
-            object_type,
             state_root,
             size: self.size as u64,
-            tx_order: self.tx_order as u64,
-            state_index: self.state_index as u64,
             created_at: self.created_at as u64,
             updated_at: self.updated_at as u64,
+            object_type,
+        };
+        let state = IndexerObjectState {
+            metadata,
+            tx_order: self.tx_order as u64,
+            state_index: self.state_index as u64,
         };
         Ok(state)
+    }
+
+    pub fn try_parse_id(&self) -> Result<(ObjectID, IndexerStateID), anyhow::Error> {
+        let tx_order = self.tx_order as u64;
+        let state_index = self.state_index as u64;
+        let indexer_state_id = IndexerStateID {
+            tx_order,
+            state_index,
+        };
+        Ok((ObjectID::from_str(self.id.as_str())?, indexer_state_id))
     }
 }

--- a/crates/rooch-indexer/src/proxy/mod.rs
+++ b/crates/rooch-indexer/src/proxy/mod.rs
@@ -4,13 +4,14 @@
 use crate::actor::indexer::IndexerActor;
 use crate::actor::messages::{
     IndexerEventsMessage, IndexerStatesMessage, IndexerTransactionMessage,
-    QueryIndexerEventsMessage, QueryIndexerObjectStatesMessage, QueryIndexerTransactionsMessage,
-    UpdateIndexerMessage,
+    QueryIndexerEventsMessage, QueryIndexerObjectIdsMessage, QueryIndexerObjectStatesMessage,
+    QueryIndexerTransactionsMessage, UpdateIndexerMessage,
 };
 use crate::actor::reader_indexer::IndexerReaderActor;
 use anyhow::Result;
 use coerce::actor::ActorRef;
 use moveos_types::moveos_std::event::Event;
+use moveos_types::moveos_std::object::ObjectID;
 use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::state::{ObjectState, StateChangeSet};
 use moveos_types::transaction::{MoveAction, TransactionExecutionInfo, VerifiedMoveOSTransaction};
@@ -149,6 +150,24 @@ impl IndexerProxy {
     ) -> Result<Vec<IndexerObjectState>> {
         self.reader_actor
             .send(QueryIndexerObjectStatesMessage {
+                filter,
+                cursor,
+                limit,
+                descending_order,
+            })
+            .await?
+    }
+
+    pub async fn query_object_ids(
+        &self,
+        filter: ObjectStateFilter,
+        // exclusive cursor if `Some`, otherwise start from the beginning
+        cursor: Option<IndexerStateID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> Result<Vec<(ObjectID, IndexerStateID)>> {
+        self.reader_actor
+            .send(QueryIndexerObjectIdsMessage {
                 filter,
                 cursor,
                 limit,

--- a/crates/rooch-indexer/src/schema.rs
+++ b/crates/rooch-indexer/src/schema.rs
@@ -18,8 +18,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    object_states (object_id) {
-        object_id -> Text,
+    object_states (id) {
+        id -> Text,
         owner -> Text,
         flag -> SmallInt,
         state_root -> Text,

--- a/crates/rooch-indexer/src/tests/test_indexer.rs
+++ b/crates/rooch-indexer/src/tests/test_indexer.rs
@@ -27,17 +27,16 @@ use rooch_types::test_utils::{
 fn random_update_object_states(states: Vec<IndexerObjectState>) -> Vec<IndexerObjectState> {
     states
         .into_iter()
-        .map(|item| IndexerObjectState {
-            object_id: item.object_id,
-            owner: item.owner,
-            flag: item.flag,
-            object_type: item.object_type,
-            state_root: item.state_root,
-            size: item.size + 1,
-            tx_order: item.tx_order,
-            state_index: item.state_index,
-            created_at: item.created_at,
-            updated_at: item.updated_at + 1,
+        .map(|item| {
+            let mut metadata = item.metadata;
+            metadata.size = metadata.size + 1;
+            metadata.updated_at = metadata.updated_at + 1;
+
+            IndexerObjectState {
+                metadata,
+                tx_order: item.tx_order,
+                state_index: item.state_index,
+            }
         })
         .collect()
 }
@@ -161,7 +160,7 @@ fn test_state_store() -> Result<()> {
     let mut new_object_states = random_new_object_states()?;
     let new_object_ids = new_object_states
         .iter()
-        .map(|state| state.object_id.clone())
+        .map(|state| state.metadata.id.clone())
         .collect::<Vec<ObjectID>>();
     let mut update_object_states = random_update_object_states(new_object_states.clone());
     let remove_object_states = random_remove_object_states();

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -35,7 +35,7 @@
         {
           "name": "limit",
           "schema": {
-            "$ref": "#/components/schemas/usize"
+            "$ref": "#/components/schemas/u64"
           }
         },
         {
@@ -73,7 +73,7 @@
         {
           "name": "limit",
           "schema": {
-            "$ref": "#/components/schemas/usize"
+            "$ref": "#/components/schemas/u64"
           }
         },
         {
@@ -184,7 +184,7 @@
         {
           "name": "limit",
           "schema": {
-            "$ref": "#/components/schemas/usize"
+            "$ref": "#/components/schemas/u64"
           }
         }
       ],
@@ -477,7 +477,7 @@
         {
           "name": "limit",
           "schema": {
-            "$ref": "#/components/schemas/usize"
+            "$ref": "#/components/schemas/u64"
           }
         },
         {
@@ -515,7 +515,7 @@
         {
           "name": "limit",
           "schema": {
-            "$ref": "#/components/schemas/usize"
+            "$ref": "#/components/schemas/u64"
           }
         },
         {
@@ -553,7 +553,7 @@
         {
           "name": "limit",
           "schema": {
-            "$ref": "#/components/schemas/usize"
+            "$ref": "#/components/schemas/u64"
           }
         },
         {
@@ -591,7 +591,7 @@
         {
           "name": "limit",
           "schema": {
-            "$ref": "#/components/schemas/usize"
+            "$ref": "#/components/schemas/u64"
           }
         },
         {
@@ -629,7 +629,7 @@
         {
           "name": "limit",
           "schema": {
-            "$ref": "#/components/schemas/usize"
+            "$ref": "#/components/schemas/u64"
           }
         },
         {
@@ -3063,9 +3063,6 @@
         "type": "string"
       },
       "u64": {
-        "type": "string"
-      },
-      "usize": {
         "type": "string"
       }
     }

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -887,15 +887,19 @@
                 "properties": {
                   "end_time": {
                     "description": "right endpoint of time interval, milliseconds since block, exclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/u64"
+                      }
+                    ]
                   },
                   "start_time": {
                     "description": "left endpoint of time interval, milliseconds since block, inclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/u64"
+                      }
+                    ]
                   }
                 }
               }
@@ -918,15 +922,19 @@
                 "properties": {
                   "from_order": {
                     "description": "left endpoint of transaction order, inclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/u64"
+                      }
+                    ]
                   },
                   "to_order": {
                     "description": "right endpoint of transaction order, exclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/u64"
+                      }
+                    ]
                   }
                 }
               }
@@ -1247,7 +1255,7 @@
             ],
             "properties": {
               "owner": {
-                "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
+                "$ref": "#/components/schemas/rooch_rpc_api::jsonrpc_types::address::RoochOrBitcoinAddress"
               }
             },
             "additionalProperties": false
@@ -1434,20 +1442,20 @@
             ]
           },
           "offset": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "parents": {
             "$ref": "#/components/schemas/alloc::vec::Vec<moveos_types::moveos_std::object::ObjectID>"
           },
           "pointer": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint64",
-            "minimum": 0.0
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/u64"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "sequence_number": {
             "type": "integer",
@@ -1587,14 +1595,10 @@
                 "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
               },
               "block_height": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
+                "$ref": "#/components/schemas/u64"
               },
               "chain_id": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
+                "$ref": "#/components/schemas/u64"
               },
               "type": {
                 "type": "string",
@@ -1617,9 +1621,7 @@
                 "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
               },
               "chain_id": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
+                "$ref": "#/components/schemas/u64"
               },
               "txid": {
                 "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
@@ -1662,9 +1664,7 @@
                 ]
               },
               "sequence_number": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
+                "$ref": "#/components/schemas/u64"
               },
               "type": {
                 "type": "string",
@@ -2538,9 +2538,7 @@
             "$ref": "#/components/schemas/primitive_types::H256"
           },
           "gas_used": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "state_root": {
             "$ref": "#/components/schemas/primitive_types::H256"
@@ -2613,15 +2611,19 @@
                 "properties": {
                   "end_time": {
                     "description": "right endpoint of time interval, milliseconds since block, exclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/u64"
+                      }
+                    ]
                   },
                   "start_time": {
                     "description": "left endpoint of time interval, milliseconds since block, inclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/u64"
+                      }
+                    ]
                   }
                 }
               }
@@ -2644,15 +2646,19 @@
                 "properties": {
                   "from_order": {
                     "description": "left endpoint of transaction order, inclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/u64"
+                      }
+                    ]
                   },
                   "to_order": {
                     "description": "right endpoint of transaction order, exclusive",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/u64"
+                      }
+                    ]
                   }
                 }
               }
@@ -2681,9 +2687,7 @@
             }
           },
           "gas_used": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "is_upgrade": {
             "type": "boolean"
@@ -2751,7 +2755,7 @@
             ],
             "properties": {
               "owner": {
-                "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
+                "$ref": "#/components/schemas/rooch_rpc_api::jsonrpc_types::address::RoochOrBitcoinAddress"
               }
             },
             "additionalProperties": false
@@ -2902,9 +2906,11 @@
           },
           "value": {
             "description": "The value of the UTXO",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/u64"
+              }
+            ]
           },
           "vout": {
             "description": "The vout of the UTXO",

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -29,7 +29,7 @@
         {
           "name": "cursor",
           "schema": {
-            "$ref": "#/components/schemas/IndexerStateID"
+            "$ref": "#/components/schemas/IndexerStateIDView"
           }
         },
         {
@@ -49,7 +49,7 @@
         "name": "InscriptionPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_InscriptionStateView_and_IndexerStateID"
+          "$ref": "#/components/schemas/PageView_for_InscriptionStateView_and_IndexerStateIDView"
         }
       }
     },
@@ -67,7 +67,7 @@
         {
           "name": "cursor",
           "schema": {
-            "$ref": "#/components/schemas/IndexerStateID"
+            "$ref": "#/components/schemas/IndexerStateIDView"
           }
         },
         {
@@ -87,7 +87,7 @@
         "name": "UTXOPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_UTXOStateView_and_IndexerStateID"
+          "$ref": "#/components/schemas/PageView_for_UTXOStateView_and_IndexerStateIDView"
         }
       }
     },
@@ -178,7 +178,7 @@
         {
           "name": "cursor",
           "schema": {
-            "$ref": "#/components/schemas/IndexerStateID"
+            "$ref": "#/components/schemas/IndexerStateIDView"
           }
         },
         {
@@ -192,7 +192,7 @@
         "name": "BalanceInfoPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_BalanceInfoView_and_IndexerStateID"
+          "$ref": "#/components/schemas/PageView_for_BalanceInfoView_and_IndexerStateIDView"
         }
       }
     },
@@ -247,7 +247,7 @@
         "name": "EventPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_EventView_and_uint64"
+          "$ref": "#/components/schemas/PageView_for_EventView_and_u64"
         }
       }
     },
@@ -453,7 +453,7 @@
         "name": "TransactionWithInfoPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_TransactionWithInfoView_and_uint64"
+          "$ref": "#/components/schemas/PageView_for_TransactionWithInfoView_and_u64"
         }
       }
     },
@@ -547,7 +547,7 @@
         {
           "name": "cursor",
           "schema": {
-            "$ref": "#/components/schemas/IndexerEventID"
+            "$ref": "#/components/schemas/IndexerEventIDView"
           }
         },
         {
@@ -567,7 +567,7 @@
         "name": "IndexerEventPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_IndexerEventView_and_IndexerEventID"
+          "$ref": "#/components/schemas/PageView_for_IndexerEventView_and_IndexerEventIDView"
         }
       }
     },
@@ -585,7 +585,7 @@
         {
           "name": "cursor",
           "schema": {
-            "$ref": "#/components/schemas/IndexerStateID"
+            "$ref": "#/components/schemas/IndexerStateIDView"
           }
         },
         {
@@ -605,7 +605,7 @@
         "name": "IndexerObjectStatePageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_IndexerObjectStateView_and_IndexerStateID"
+          "$ref": "#/components/schemas/PageView_for_IndexerObjectStateView_and_IndexerStateIDView"
         }
       }
     },
@@ -643,7 +643,7 @@
         "name": "TransactionWithInfoPageView",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/PageView_for_TransactionWithInfoView_and_uint64"
+          "$ref": "#/components/schemas/PageView_for_TransactionWithInfoView_and_u64"
         }
       }
     },
@@ -935,8 +935,7 @@
           }
         ]
       },
-      "EventID": {
-        "description": "A struct that represents a globally unique id for an Event stream that a user can listen to. the Unique ID is a combination of event handle id and event seq number. the ID is local to this particular fullnode and will be different from other fullnode.",
+      "EventIDView": {
         "type": "object",
         "required": [
           "event_handle_id",
@@ -953,9 +952,11 @@
           },
           "event_seq": {
             "description": "For expansion: The number of messages that have been emitted to the path previously",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/u64"
+              }
+            ]
           }
         }
       },
@@ -992,12 +993,10 @@
             "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
           },
           "event_id": {
-            "$ref": "#/components/schemas/EventID"
+            "$ref": "#/components/schemas/EventIDView"
           },
           "event_index": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "event_type": {
             "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
@@ -1073,7 +1072,7 @@
         "description": "Hex string encoding.",
         "type": "string"
       },
-      "IndexerEventID": {
+      "IndexerEventIDView": {
         "type": "object",
         "required": [
           "event_index",
@@ -1081,14 +1080,10 @@
         ],
         "properties": {
           "event_index": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "tx_order": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           }
         }
       },
@@ -1105,9 +1100,7 @@
         ],
         "properties": {
           "created_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "decoded_event_data": {
             "anyOf": [
@@ -1123,13 +1116,13 @@
             "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
           },
           "event_id": {
-            "$ref": "#/components/schemas/EventID"
+            "$ref": "#/components/schemas/EventIDView"
           },
           "event_type": {
             "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
           },
           "indexer_event_id": {
-            "$ref": "#/components/schemas/IndexerEventID"
+            "$ref": "#/components/schemas/IndexerEventIDView"
           },
           "sender": {
             "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
@@ -1144,7 +1137,7 @@
         "required": [
           "created_at",
           "flag",
-          "object_id",
+          "id",
           "object_type",
           "owner",
           "size",
@@ -1155,9 +1148,7 @@
         ],
         "properties": {
           "created_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "decoded_value": {
             "anyOf": [
@@ -1184,11 +1175,11 @@
             "format": "uint8",
             "minimum": 0.0
           },
-          "object_id": {
+          "id": {
             "$ref": "#/components/schemas/ObjectID"
           },
           "object_type": {
-            "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+            "$ref": "#/components/schemas/move_core_types::language_storage::TypeTag"
           },
           "owner": {
             "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
@@ -1200,14 +1191,10 @@
             ]
           },
           "size": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "state_index": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "state_root": {
             "anyOf": [
@@ -1220,14 +1207,10 @@
             ]
           },
           "tx_order": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "updated_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "value": {
             "description": "bcs bytes of the Object.",
@@ -1239,7 +1222,7 @@
           }
         }
       },
-      "IndexerStateID": {
+      "IndexerStateIDView": {
         "type": "object",
         "required": [
           "state_index",
@@ -1247,28 +1230,24 @@
         ],
         "properties": {
           "state_index": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "tx_order": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           }
         }
       },
       "InscriptionFilterView": {
         "oneOf": [
           {
-            "description": "Query by owner, represent by bitcoin address",
+            "description": "Query by owner, support rooch address and bitcoin address",
             "type": "object",
             "required": [
               "owner"
             ],
             "properties": {
               "owner": {
-                "$ref": "#/components/schemas/rooch_types::address::BitcoinAddress"
+                "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
               }
             },
             "additionalProperties": false
@@ -1327,9 +1306,10 @@
         "required": [
           "created_at",
           "flag",
-          "object_id",
+          "id",
           "object_type",
           "owner",
+          "size",
           "state_index",
           "tx_order",
           "updated_at",
@@ -1337,20 +1317,18 @@
         ],
         "properties": {
           "created_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "flag": {
             "type": "integer",
             "format": "uint8",
             "minimum": 0.0
           },
-          "object_id": {
+          "id": {
             "$ref": "#/components/schemas/ObjectID"
           },
           "object_type": {
-            "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+            "$ref": "#/components/schemas/move_core_types::language_storage::TypeTag"
           },
           "owner": {
             "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
@@ -1361,20 +1339,27 @@
               "null"
             ]
           },
+          "size": {
+            "$ref": "#/components/schemas/u64"
+          },
           "state_index": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
+          },
+          "state_root": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/primitive_types::H256"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "tx_order": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "updated_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "value": {
             "$ref": "#/components/schemas/InscriptionView"
@@ -1977,16 +1962,14 @@
           "created_at",
           "flag",
           "id",
+          "object_type",
           "owner",
           "size",
-          "updated_at",
-          "value_type"
+          "updated_at"
         ],
         "properties": {
           "created_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "flag": {
             "type": "integer",
@@ -1996,13 +1979,20 @@
           "id": {
             "$ref": "#/components/schemas/ObjectID"
           },
+          "object_type": {
+            "$ref": "#/components/schemas/move_core_types::language_storage::TypeTag"
+          },
           "owner": {
             "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
           },
+          "owner_bitcoin_address": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "size": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "state_root": {
             "anyOf": [
@@ -2015,12 +2005,7 @@
             ]
           },
           "updated_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "value_type": {
-            "$ref": "#/components/schemas/move_core_types::language_storage::TypeTag"
+            "$ref": "#/components/schemas/u64"
           }
         }
       },
@@ -2107,9 +2092,7 @@
         ],
         "properties": {
           "created_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "decoded_value": {
             "anyOf": [
@@ -2140,7 +2123,7 @@
             "$ref": "#/components/schemas/ObjectID"
           },
           "object_type": {
-            "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+            "$ref": "#/components/schemas/move_core_types::language_storage::TypeTag"
           },
           "owner": {
             "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
@@ -2152,9 +2135,7 @@
             ]
           },
           "size": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "state_root": {
             "anyOf": [
@@ -2167,9 +2148,7 @@
             ]
           },
           "updated_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "value": {
             "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
@@ -2210,7 +2189,7 @@
           }
         ]
       },
-      "PageView_for_BalanceInfoView_and_IndexerStateID": {
+      "PageView_for_BalanceInfoView_and_IndexerStateIDView": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -2230,7 +2209,7 @@
           "next_cursor": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/IndexerStateID"
+                "$ref": "#/components/schemas/IndexerStateIDView"
               },
               {
                 "type": "null"
@@ -2239,7 +2218,7 @@
           }
         }
       },
-      "PageView_for_EventView_and_uint64": {
+      "PageView_for_EventView_and_u64": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -2257,16 +2236,18 @@
             "type": "boolean"
           },
           "next_cursor": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint64",
-            "minimum": 0.0
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/u64"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
       },
-      "PageView_for_IndexerEventView_and_IndexerEventID": {
+      "PageView_for_IndexerEventView_and_IndexerEventIDView": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -2286,7 +2267,7 @@
           "next_cursor": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/IndexerEventID"
+                "$ref": "#/components/schemas/IndexerEventIDView"
               },
               {
                 "type": "null"
@@ -2295,7 +2276,7 @@
           }
         }
       },
-      "PageView_for_IndexerObjectStateView_and_IndexerStateID": {
+      "PageView_for_IndexerObjectStateView_and_IndexerStateIDView": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -2315,7 +2296,7 @@
           "next_cursor": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/IndexerStateID"
+                "$ref": "#/components/schemas/IndexerStateIDView"
               },
               {
                 "type": "null"
@@ -2324,7 +2305,7 @@
           }
         }
       },
-      "PageView_for_InscriptionStateView_and_IndexerStateID": {
+      "PageView_for_InscriptionStateView_and_IndexerStateIDView": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -2344,7 +2325,7 @@
           "next_cursor": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/IndexerStateID"
+                "$ref": "#/components/schemas/IndexerStateIDView"
               },
               {
                 "type": "null"
@@ -2378,7 +2359,7 @@
           }
         }
       },
-      "PageView_for_TransactionWithInfoView_and_uint64": {
+      "PageView_for_TransactionWithInfoView_and_u64": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -2396,16 +2377,18 @@
             "type": "boolean"
           },
           "next_cursor": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint64",
-            "minimum": 0.0
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/u64"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
       },
-      "PageView_for_UTXOStateView_and_IndexerStateID": {
+      "PageView_for_UTXOStateView_and_IndexerStateIDView": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -2425,7 +2408,7 @@
           "next_cursor": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/IndexerStateID"
+                "$ref": "#/components/schemas/IndexerStateIDView"
               },
               {
                 "type": "null"
@@ -2761,14 +2744,14 @@
       "UTXOFilterView": {
         "oneOf": [
           {
-            "description": "Query by owner, represent by bitcoin address",
+            "description": "Query by owner, support rooch address and bitcoin address",
             "type": "object",
             "required": [
               "owner"
             ],
             "properties": {
               "owner": {
-                "$ref": "#/components/schemas/rooch_types::address::BitcoinAddress"
+                "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
               }
             },
             "additionalProperties": false
@@ -2827,29 +2810,29 @@
         "required": [
           "created_at",
           "flag",
-          "object_id",
+          "id",
           "object_type",
           "owner",
+          "size",
           "state_index",
           "tx_order",
-          "updated_at"
+          "updated_at",
+          "value"
         ],
         "properties": {
           "created_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
           "flag": {
             "type": "integer",
             "format": "uint8",
             "minimum": 0.0
           },
-          "object_id": {
+          "id": {
             "$ref": "#/components/schemas/ObjectID"
           },
           "object_type": {
-            "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+            "$ref": "#/components/schemas/move_core_types::language_storage::TypeTag"
           },
           "owner": {
             "$ref": "#/components/schemas/rooch_types::address::RoochAddress"
@@ -2860,30 +2843,30 @@
               "null"
             ]
           },
+          "size": {
+            "$ref": "#/components/schemas/u64"
+          },
           "state_index": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/u64"
           },
-          "tx_order": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "updated_at": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "value": {
+          "state_root": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/UTXOView"
+                "$ref": "#/components/schemas/primitive_types::H256"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "tx_order": {
+            "$ref": "#/components/schemas/u64"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/u64"
+          },
+          "value": {
+            "$ref": "#/components/schemas/UTXOView"
           }
         }
       },
@@ -3065,9 +3048,6 @@
         "type": "string"
       },
       "rooch_rpc_api::jsonrpc_types::module_abi_view::MoveABIType": {
-        "type": "string"
-      },
-      "rooch_types::address::BitcoinAddress": {
         "type": "string"
       },
       "rooch_types::address::RoochAddress": {

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -2497,11 +2497,11 @@
       "StateKVView": {
         "type": "object",
         "required": [
-          "key_hex",
+          "field_key",
           "state"
         ],
         "properties": {
-          "key_hex": {
+          "field_key": {
             "$ref": "#/components/schemas/moveos_types::state::FieldKey"
           },
           "state": {

--- a/crates/rooch-rpc-api/src/api/btc_api.rs
+++ b/crates/rooch-rpc-api/src/api/btc_api.rs
@@ -3,11 +3,10 @@
 
 use crate::jsonrpc_types::btc::ord::InscriptionFilterView;
 use crate::jsonrpc_types::btc::utxo::UTXOFilterView;
-use crate::jsonrpc_types::{InscriptionPageView, StrView, UTXOPageView};
+use crate::jsonrpc_types::{IndexerStateIDView, InscriptionPageView, StrView, UTXOPageView};
 use crate::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use rooch_open_rpc_macros::open_rpc;
-use rooch_types::indexer::state::IndexerStateID;
 
 #[open_rpc(namespace = "btc")]
 #[rpc(server, client, namespace = "btc")]
@@ -19,7 +18,7 @@ pub trait BtcAPI {
         &self,
         filter: UTXOFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<IndexerStateID>,
+        cursor: Option<IndexerStateIDView>,
         limit: Option<StrView<usize>>,
         descending_order: Option<bool>,
     ) -> RpcResult<UTXOPageView>;
@@ -30,7 +29,7 @@ pub trait BtcAPI {
         &self,
         filter: InscriptionFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<IndexerStateID>,
+        cursor: Option<IndexerStateIDView>,
         limit: Option<StrView<usize>>,
         descending_order: Option<bool>,
     ) -> RpcResult<InscriptionPageView>;

--- a/crates/rooch-rpc-api/src/api/btc_api.rs
+++ b/crates/rooch-rpc-api/src/api/btc_api.rs
@@ -19,7 +19,7 @@ pub trait BtcAPI {
         filter: UTXOFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerStateIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         descending_order: Option<bool>,
     ) -> RpcResult<UTXOPageView>;
 
@@ -30,7 +30,7 @@ pub trait BtcAPI {
         filter: InscriptionFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerStateIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         descending_order: Option<bool>,
     ) -> RpcResult<InscriptionPageView>;
 }

--- a/crates/rooch-rpc-api/src/api/mod.rs
+++ b/crates/rooch-rpc-api/src/api/mod.rs
@@ -12,7 +12,7 @@ pub const DEFAULT_RESULT_LIMIT_USIZE: usize = DEFAULT_RESULT_LIMIT as usize;
 pub const MAX_RESULT_LIMIT: u64 = 200;
 pub const MAX_RESULT_LIMIT_USIZE: usize = MAX_RESULT_LIMIT as usize;
 
-// pub fn validate_limit(limit: Option<usize>, max: usize) -> Result<usize, anyhow::Error> {
+// pub fn validate_limit(limit: Option<u64>, max: usize) -> Result<usize, anyhow::Error> {
 //     match limit {
 //         Some(l) if l > max => Err(anyhow!("Page size limit {l} exceeds max limit {max}")),
 //         Some(0) => Err(anyhow!("Page size limit cannot be smaller than 1")),

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -63,7 +63,7 @@ pub trait RoochAPI {
         &self,
         access_path: AccessPathView,
         cursor: Option<String>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         state_option: Option<StateOptions>,
     ) -> RpcResult<StatePageView>;
 
@@ -95,7 +95,7 @@ pub trait RoochAPI {
         &self,
         object_id: ObjectIDView,
         cursor: Option<String>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         state_option: Option<StateOptions>,
     ) -> RpcResult<StatePageView> {
         let access_path_view =
@@ -143,7 +143,7 @@ pub trait RoochAPI {
         &self,
         account_addr: RoochOrBitcoinAddressView,
         cursor: Option<IndexerStateIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
     ) -> RpcResult<BalanceInfoPageView>;
 
     /// get module ABI by module id
@@ -161,7 +161,7 @@ pub trait RoochAPI {
         filter: TransactionFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<StrView<u64>>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<TransactionWithInfoPageView>;
 
@@ -172,7 +172,7 @@ pub trait RoochAPI {
         filter: EventFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerEventIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerEventPageView>;
 
@@ -183,7 +183,7 @@ pub trait RoochAPI {
         filter: ObjectStateFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerStateIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerObjectStatePageView>;
 }

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -3,21 +3,20 @@
 
 use crate::jsonrpc_types::account_view::BalanceInfoView;
 use crate::jsonrpc_types::address::RoochOrBitcoinAddressView;
-use crate::jsonrpc_types::event_view::EventFilterView;
+use crate::jsonrpc_types::event_view::{EventFilterView, IndexerEventIDView};
 use crate::jsonrpc_types::transaction_view::{TransactionFilterView, TransactionWithInfoView};
 use crate::jsonrpc_types::{
     AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, BytesView, EventOptions,
     EventPageView, ExecuteTransactionResponseView, FieldKeyView, FunctionCallView, H256View,
-    IndexerEventPageView, IndexerObjectStatePageView, ModuleABIView, ObjectIDVecView, ObjectIDView,
-    ObjectStateFilterView, ObjectStateView, QueryOptions, RoochAddressView, StateOptions,
-    StatePageView, StrView, StructTagView, TransactionWithInfoPageView, TxOptions,
+    IndexerEventPageView, IndexerObjectStatePageView, IndexerStateIDView, ModuleABIView,
+    ObjectIDVecView, ObjectIDView, ObjectStateFilterView, ObjectStateView, QueryOptions,
+    RoochAddressView, StateOptions, StatePageView, StrView, StructTagView,
+    TransactionWithInfoPageView, TxOptions,
 };
 use crate::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use moveos_types::{access_path::AccessPath, state::FieldKey};
 use rooch_open_rpc_macros::open_rpc;
-use rooch_types::indexer::event::IndexerEventID;
-use rooch_types::indexer::state::IndexerStateID;
 
 #[open_rpc(namespace = "rooch")]
 #[rpc(server, client, namespace = "rooch")]
@@ -143,7 +142,7 @@ pub trait RoochAPI {
     async fn get_balances(
         &self,
         account_addr: RoochOrBitcoinAddressView,
-        cursor: Option<IndexerStateID>,
+        cursor: Option<IndexerStateIDView>,
         limit: Option<StrView<usize>>,
     ) -> RpcResult<BalanceInfoPageView>;
 
@@ -172,7 +171,7 @@ pub trait RoochAPI {
         &self,
         filter: EventFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<IndexerEventID>,
+        cursor: Option<IndexerEventIDView>,
         limit: Option<StrView<usize>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerEventPageView>;
@@ -183,7 +182,7 @@ pub trait RoochAPI {
         &self,
         filter: ObjectStateFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<IndexerStateID>,
+        cursor: Option<IndexerStateIDView>,
         limit: Option<StrView<usize>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerObjectStatePageView>;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/address.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/address.rs
@@ -56,6 +56,12 @@ impl From<AccountAddress> for RoochAddressView {
     }
 }
 
+impl From<RoochAddressView> for AccountAddress {
+    fn from(value: RoochAddressView) -> Self {
+        value.0.into()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RoochOrBitcoinAddress {
     pub rooch_address: RoochAddress,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/ord.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/ord.rs
@@ -4,7 +4,7 @@
 use crate::jsonrpc_types::btc::transaction::{hex_to_txid, TxidView};
 use crate::jsonrpc_types::{
     BytesView, H256View, IndexerObjectStateView, IndexerStateIDView, MoveStringView,
-    ObjectIDVecView, ObjectMetaView, RoochAddressView, StrView,
+    ObjectIDVecView, ObjectMetaView, RoochOrBitcoinAddressView, StrView,
 };
 use anyhow::Result;
 use bitcoin::hashes::Hash;
@@ -38,7 +38,7 @@ impl From<BitcoinInscriptionIDView> for BitcoinInscriptionID {
 #[serde(rename_all = "snake_case")]
 pub enum InscriptionFilterView {
     /// Query by owner, support rooch address and bitcoin address
-    Owner(RoochAddressView),
+    Owner(RoochOrBitcoinAddressView),
     /// Query by inscription id, represent by bitcoin txid and index
     InscriptionId { txid: String, index: u32 },
     /// Query by object id.
@@ -52,7 +52,7 @@ impl InscriptionFilterView {
         Ok(match filter {
             InscriptionFilterView::Owner(owner) => ObjectStateFilter::ObjectTypeWithOwner {
                 object_type: Inscription::struct_tag(),
-                owner: owner.0,
+                owner: owner.0.rooch_address,
             },
             InscriptionFilterView::InscriptionId { txid, index } => {
                 let txid = hex_to_txid(txid.as_str())?;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
@@ -3,7 +3,8 @@
 
 use crate::jsonrpc_types::btc::transaction::{hex_to_txid, TxidView};
 use crate::jsonrpc_types::{
-    H256View, IndexerObjectStateView, IndexerStateIDView, ObjectMetaView, RoochAddressView, StrView,
+    H256View, IndexerObjectStateView, IndexerStateIDView, ObjectMetaView,
+    RoochOrBitcoinAddressView, StrView,
 };
 use anyhow::Result;
 use bitcoin::hashes::Hash;
@@ -33,7 +34,7 @@ impl From<BitcoinOutPointView> for bitcoin::OutPoint {
 #[serde(rename_all = "snake_case")]
 pub enum UTXOFilterView {
     /// Query by owner, support rooch address and bitcoin address
-    Owner(RoochAddressView),
+    Owner(RoochOrBitcoinAddressView),
     /// Query by bitcoin outpoint, represent by bitcoin txid and vout
     OutPoint { txid: String, vout: u32 },
     /// Query by object id.
@@ -47,7 +48,7 @@ impl UTXOFilterView {
         Ok(match filter_opt {
             UTXOFilterView::Owner(owner) => ObjectStateFilter::ObjectTypeWithOwner {
                 object_type: UTXO::struct_tag(),
-                owner: owner.0,
+                owner: owner.0.rooch_address,
             },
             UTXOFilterView::OutPoint { txid, vout } => {
                 let txid = hex_to_txid(txid.as_str())?;

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
@@ -1,17 +1,17 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::jsonrpc_types::address::BitcoinAddressView;
 use crate::jsonrpc_types::btc::transaction::{hex_to_txid, TxidView};
-use crate::jsonrpc_types::{H256View, RoochAddressView, StructTagView};
+use crate::jsonrpc_types::{
+    H256View, IndexerObjectStateView, IndexerStateIDView, ObjectMetaView, RoochAddressView, StrView,
+};
 use anyhow::Result;
 use bitcoin::hashes::Hash;
 use bitcoin::Txid;
 
 use moveos_types::moveos_std::object::ObjectID;
-use moveos_types::state::MoveStructType;
-use rooch_types::address::RoochAddress;
-use rooch_types::bitcoin::utxo::{self, UTXOState, UTXO};
+use moveos_types::state::{MoveState, MoveStructType};
+use rooch_types::bitcoin::utxo::{self, UTXO};
 use rooch_types::indexer::state::ObjectStateFilter;
 use rooch_types::into_address::IntoAddress;
 use schemars::JsonSchema;
@@ -32,8 +32,8 @@ impl From<BitcoinOutPointView> for bitcoin::OutPoint {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum UTXOFilterView {
-    /// Query by owner, represent by bitcoin address
-    Owner(BitcoinAddressView),
+    /// Query by owner, support rooch address and bitcoin address
+    Owner(RoochAddressView),
     /// Query by bitcoin outpoint, represent by bitcoin txid and vout
     OutPoint { txid: String, vout: u32 },
     /// Query by object id.
@@ -43,14 +43,11 @@ pub enum UTXOFilterView {
 }
 
 impl UTXOFilterView {
-    pub fn into_global_state_filter(
-        filter_opt: UTXOFilterView,
-        resolve_address: RoochAddress,
-    ) -> Result<ObjectStateFilter> {
+    pub fn into_global_state_filter(filter_opt: UTXOFilterView) -> Result<ObjectStateFilter> {
         Ok(match filter_opt {
-            UTXOFilterView::Owner(_owner) => ObjectStateFilter::ObjectTypeWithOwner {
+            UTXOFilterView::Owner(owner) => ObjectStateFilter::ObjectTypeWithOwner {
                 object_type: UTXO::struct_tag(),
-                owner: resolve_address,
+                owner: owner.0,
             },
             UTXOFilterView::OutPoint { txid, vout } => {
                 let txid = hex_to_txid(txid.as_str())?;
@@ -74,7 +71,7 @@ pub struct UTXOView {
     /// The vout of the UTXO
     vout: u32,
     /// The value of the UTXO
-    value: u64,
+    value: StrView<u64>,
     /// Protocol seals
     seals: String,
 }
@@ -89,7 +86,7 @@ impl UTXOView {
             txid: utxo.txid.into(),
             bitcoin_txid: bitcoin_txid.into(),
             vout: utxo.vout,
-            value: utxo.value,
+            value: utxo.value.into(),
             seals: seals_str,
         })
     }
@@ -97,42 +94,23 @@ impl UTXOView {
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UTXOStateView {
-    pub object_id: ObjectID,
-    pub owner: RoochAddressView,
-    pub owner_bitcoin_address: Option<String>,
-    pub flag: u8,
-    pub value: Option<UTXOView>,
-    pub object_type: StructTagView,
-    pub tx_order: u64,
-    pub state_index: u64,
-    pub created_at: u64,
-    pub updated_at: u64,
+    #[serde(flatten)]
+    pub metadata: ObjectMetaView,
+    pub value: UTXOView,
+    #[serde(flatten)]
+    pub indexer_id: IndexerStateIDView,
 }
 
-impl UTXOStateView {
-    pub fn try_new_from_utxo_state(
-        utxo: UTXOState,
-        network: u8,
-    ) -> Result<UTXOStateView, anyhow::Error> {
-        let owner_bitcoin_address = match utxo.owner_bitcoin_address {
-            Some(baddress) => Some(baddress.format(network)?),
-            None => None,
-        };
-        let utxo_view = match utxo.value {
-            Some(utxo) => Some(UTXOView::try_new_from_utxo(utxo)?),
-            None => None,
-        };
+impl TryFrom<IndexerObjectStateView> for UTXOStateView {
+    type Error = anyhow::Error;
+
+    fn try_from(state: IndexerObjectStateView) -> Result<Self, Self::Error> {
+        let utxo = UTXO::from_bytes(&state.value.0)?;
+        let utxo_view = UTXOView::try_new_from_utxo(utxo)?;
         Ok(UTXOStateView {
-            object_id: utxo.object_id,
-            owner: utxo.owner.into(),
-            owner_bitcoin_address,
-            flag: utxo.flag,
+            metadata: state.metadata,
             value: utxo_view,
-            object_type: utxo.object_type.into(),
-            tx_order: utxo.tx_order,
-            state_index: utxo.state_index,
-            created_at: utxo.created_at,
-            updated_at: utxo.updated_at,
+            indexer_id: state.indexer_id,
         })
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
@@ -170,17 +170,17 @@ pub enum EventFilterView {
     /// Return events emitted in [start_time, end_time) interval
     TimeRange {
         /// left endpoint of time interval, milliseconds since block, inclusive
-        start_time: u64,
+        start_time: StrView<u64>,
         /// right endpoint of time interval, milliseconds since block, exclusive
-        end_time: u64,
+        end_time: StrView<u64>,
     },
     /// Return events emitted in [from_order, to_order) interval
     // #[serde(rename_all = "camelCase")]
     TxOrderRange {
         /// left endpoint of transaction order, inclusive
-        from_order: u64,
+        from_order: StrView<u64>,
         /// right endpoint of transaction order, exclusive
-        to_order: u64,
+        to_order: StrView<u64>,
     },
 }
 
@@ -194,15 +194,15 @@ impl From<EventFilterView> for EventFilter {
                 start_time,
                 end_time,
             } => Self::TimeRange {
-                start_time,
-                end_time,
+                start_time: start_time.0,
+                end_time: end_time.0,
             },
             EventFilterView::TxOrderRange {
                 from_order,
                 to_order,
             } => Self::TxOrderRange {
-                from_order,
-                to_order,
+                from_order: from_order.0,
+                to_order: to_order.0,
             },
         }
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
@@ -119,7 +119,7 @@ pub struct TransactionExecutionInfoView {
     pub tx_hash: H256View,
     pub state_root: H256View,
     pub event_root: H256View,
-    pub gas_used: u64,
+    pub gas_used: StrView<u64>,
     pub status: KeptVMStatusView,
 }
 
@@ -129,7 +129,7 @@ impl From<TransactionExecutionInfo> for TransactionExecutionInfoView {
             tx_hash: transaction_execution_info.tx_hash.into(),
             state_root: transaction_execution_info.state_root.into(),
             event_root: transaction_execution_info.event_root.into(),
-            gas_used: transaction_execution_info.gas_used,
+            gas_used: transaction_execution_info.gas_used.into(),
             status: KeptVMStatusView::from(transaction_execution_info.status),
         }
     }
@@ -140,7 +140,7 @@ pub struct TransactionOutputView {
     pub status: KeptVMStatusView,
     pub changeset: StateChangeSetView,
     pub events: Vec<EventView>,
-    pub gas_used: u64,
+    pub gas_used: StrView<u64>,
     pub is_upgrade: bool,
 }
 
@@ -154,7 +154,7 @@ impl From<TransactionOutput> for TransactionOutputView {
                 .into_iter()
                 .map(|event| event.into())
                 .collect(),
-            gas_used: tx_output.gas_used,
+            gas_used: tx_output.gas_used.into(),
             is_upgrade: tx_output.is_upgrade,
         }
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -1,6 +1,8 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use super::event_view::IndexerEventIDView;
+use super::{HumanReadableDisplay, IndexerStateIDView};
 use crate::jsonrpc_types::account_view::BalanceInfoView;
 use crate::jsonrpc_types::btc::ord::InscriptionStateView;
 use crate::jsonrpc_types::btc::utxo::UTXOStateView;
@@ -12,25 +14,21 @@ use crate::jsonrpc_types::{
 };
 use move_core_types::u256::U256;
 use rooch_types::framework::coin::CoinInfo;
-use rooch_types::indexer::event::IndexerEventID;
-use rooch_types::indexer::state::IndexerStateID;
 use rooch_types::transaction::rooch::RoochTransaction;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::string::String;
 
-use super::HumanReadableDisplay;
-
-pub type EventPageView = PageView<EventView, u64>;
-pub type TransactionWithInfoPageView = PageView<TransactionWithInfoView, u64>;
+pub type EventPageView = PageView<EventView, StrView<u64>>;
+pub type TransactionWithInfoPageView = PageView<TransactionWithInfoView, StrView<u64>>;
 pub type StatePageView = PageView<StateKVView, String>;
-pub type BalanceInfoPageView = PageView<BalanceInfoView, IndexerStateID>;
-pub type IndexerEventPageView = PageView<IndexerEventView, IndexerEventID>;
+pub type BalanceInfoPageView = PageView<BalanceInfoView, IndexerStateIDView>;
+pub type IndexerEventPageView = PageView<IndexerEventView, IndexerEventIDView>;
 
-pub type IndexerObjectStatePageView = PageView<IndexerObjectStateView, IndexerStateID>;
+pub type IndexerObjectStatePageView = PageView<IndexerObjectStateView, IndexerStateIDView>;
 
-pub type UTXOPageView = PageView<UTXOStateView, IndexerStateID>;
-pub type InscriptionPageView = PageView<InscriptionStateView, IndexerStateID>;
+pub type UTXOPageView = PageView<UTXOStateView, IndexerStateIDView>;
+pub type InscriptionPageView = PageView<InscriptionStateView, IndexerStateIDView>;
 
 /// `next_cursor` points to the last item in the page;
 /// Reading with `next_cursor` will start from the next item after `next_cursor` if
@@ -68,7 +66,7 @@ Has next page: {:?}"#,
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct TransactionView {
-    pub sequence_number: u64,
+    pub sequence_number: StrView<u64>,
     pub sender: String,
     pub sender_bitcoin_address: Option<String>,
     pub action_type: MoveActionTypeView,
@@ -82,7 +80,7 @@ impl TransactionView {
         sender_bitcoin_address: Option<String>,
     ) -> Self {
         Self {
-            sequence_number: transaction.sequence_number(),
+            sequence_number: transaction.sequence_number().into(),
             sender: transaction.sender().to_string(),
             sender_bitcoin_address,
             action: transaction.action().clone().into(),

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -34,22 +34,22 @@ pub type FieldKeyView = StrView<FieldKey>;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct StateKVView {
-    pub key_hex: FieldKeyView,
+    pub field_key: FieldKeyView,
     pub state: ObjectStateView,
 }
 
 impl From<StateKV> for StateKVView {
     fn from(state: StateKV) -> Self {
         Self {
-            key_hex: state.0.into(),
+            field_key: state.0.into(),
             state: state.1.into(),
         }
     }
 }
 
 impl StateKVView {
-    pub fn new(key_hex: FieldKeyView, state: ObjectStateView) -> Self {
-        Self { key_hex, state }
+    pub fn new(field_key: FieldKeyView, state: ObjectStateView) -> Self {
+        Self { field_key, state }
     }
 }
 

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -14,7 +14,7 @@ use moveos_types::{
     moveos_std::object::{human_readable_flag, ObjectID},
     state::{AnnotatedState, ObjectState, StateChangeSet},
 };
-use rooch_types::indexer::state::{IndexerObjectState, ObjectStateFilter};
+use rooch_types::indexer::state::{IndexerStateID, ObjectStateFilter};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -57,12 +57,20 @@ impl StateKVView {
 pub struct ObjectMetaView {
     pub id: ObjectID,
     pub owner: RoochAddressView,
+    pub owner_bitcoin_address: Option<String>,
     pub flag: u8,
     pub state_root: Option<H256View>,
-    pub size: u64,
-    pub created_at: u64,
-    pub updated_at: u64,
-    pub value_type: TypeTagView,
+    pub size: StrView<u64>,
+    pub created_at: StrView<u64>,
+    pub updated_at: StrView<u64>,
+    pub object_type: TypeTagView,
+}
+
+impl ObjectMetaView {
+    pub fn with_owner_bitcoin_address(mut self, owner_bitcoin_address: Option<String>) -> Self {
+        self.owner_bitcoin_address = owner_bitcoin_address;
+        self
+    }
 }
 
 impl From<ObjectMeta> for ObjectMetaView {
@@ -70,12 +78,28 @@ impl From<ObjectMeta> for ObjectMetaView {
         Self {
             id: meta.id,
             owner: meta.owner.into(),
+            owner_bitcoin_address: None,
             flag: meta.flag,
             state_root: meta.state_root.map(Into::into),
-            size: meta.size,
-            created_at: meta.created_at,
-            updated_at: meta.updated_at,
-            value_type: meta.value_type.into(),
+            size: meta.size.into(),
+            created_at: meta.created_at.into(),
+            updated_at: meta.updated_at.into(),
+            object_type: meta.object_type.into(),
+        }
+    }
+}
+
+impl From<ObjectMetaView> for ObjectMeta {
+    fn from(meta: ObjectMetaView) -> Self {
+        Self {
+            id: meta.id,
+            owner: meta.owner.into(),
+            flag: meta.flag,
+            state_root: meta.state_root.map(Into::into),
+            size: meta.size.0,
+            created_at: meta.created_at.0,
+            updated_at: meta.updated_at.0,
+            object_type: meta.object_type.into(),
         }
     }
 }
@@ -148,49 +172,89 @@ impl From<ObjectChange> for ObjectChangeView {
     }
 }
 
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct IndexerStateIDView {
+    pub tx_order: StrView<u64>,
+    pub state_index: StrView<u64>,
+}
+
+impl From<IndexerStateID> for IndexerStateIDView {
+    fn from(id: IndexerStateID) -> Self {
+        Self {
+            tx_order: id.tx_order.into(),
+            state_index: id.state_index.into(),
+        }
+    }
+}
+
+impl From<IndexerStateIDView> for IndexerStateID {
+    fn from(id: IndexerStateIDView) -> Self {
+        Self {
+            tx_order: id.tx_order.0,
+            state_index: id.state_index.0,
+        }
+    }
+}
+
+impl std::fmt::Display for IndexerStateIDView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "IndexerStateID[tx order: {}, state index: {}]",
+            self.tx_order, self.state_index,
+        )
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct IndexerObjectStateView {
-    pub object_id: ObjectID,
-    pub owner: RoochAddressView,
-    pub owner_bitcoin_address: Option<String>,
-    pub flag: u8,
+    #[serde(flatten)]
+    pub metadata: ObjectMetaView,
     /// bcs bytes of the Object.
     pub value: BytesView,
     pub decoded_value: Option<AnnotatedMoveStructView>,
-    pub object_type: StructTagView,
-    pub state_root: Option<H256View>,
-    pub size: u64,
-    pub tx_order: u64,
-    pub state_index: u64,
-    pub created_at: u64,
-    pub updated_at: u64,
+    #[serde(flatten)]
+    pub indexer_id: IndexerStateIDView,
     pub display_fields: Option<DisplayFieldsView>,
 }
 
 impl IndexerObjectStateView {
     pub fn new_from_object_state(
-        state: IndexerObjectState,
-        value: Vec<u8>,
-        owner_bitcoin_address: Option<String>,
-        decoded_value: Option<AnnotatedMoveStructView>,
-        display_fields: Option<DisplayFieldsView>,
+        state: ObjectState,
+        indexer_id: IndexerStateID,
     ) -> IndexerObjectStateView {
+        let (metadata, value) = state.into_inner();
         IndexerObjectStateView {
-            object_id: state.object_id,
-            owner: state.owner.into(),
-            owner_bitcoin_address,
-            flag: state.flag,
+            metadata: metadata.into(),
             value: value.into(),
-            decoded_value,
-            object_type: state.object_type.into(),
-            state_root: state.state_root.map(Into::into),
-            size: state.size,
-            tx_order: state.tx_order,
-            state_index: state.state_index,
-            created_at: state.created_at,
-            updated_at: state.updated_at,
-            display_fields,
+            decoded_value: None,
+            indexer_id: indexer_id.into(),
+            display_fields: None,
         }
+    }
+
+    pub fn new_from_annotated_state(
+        state: AnnotatedState,
+        indexer_id: IndexerStateID,
+    ) -> IndexerObjectStateView {
+        let (metadata, value, decoded_value) = state.into_inner();
+        IndexerObjectStateView {
+            metadata: metadata.into(),
+            value: value.into(),
+            decoded_value: Some(AnnotatedMoveStructView::from(decoded_value)),
+            indexer_id: indexer_id.into(),
+            display_fields: None,
+        }
+    }
+
+    pub fn with_owner_bitcoin_address(mut self, owner_bitcoin_address: Option<String>) -> Self {
+        self.metadata.owner_bitcoin_address = owner_bitcoin_address;
+        self
+    }
+
+    pub fn with_display_fields(mut self, display_fields: Option<DisplayFieldsView>) -> Self {
+        self.display_fields = display_fields;
+        self
     }
 }
 
@@ -209,13 +273,13 @@ impl HumanReadableDisplay for IndexerObjectStateView {
   state_index    | {}
 {}"#,
             "-".repeat(100),
-            self.object_id,
-            self.object_type,
-            self.owner,
-            self.owner_bitcoin_address,
-            human_readable_flag(self.flag),
-            self.tx_order,
-            self.state_index,
+            self.metadata.id,
+            self.metadata.object_type,
+            self.metadata.owner,
+            self.metadata.owner_bitcoin_address,
+            human_readable_flag(self.metadata.flag),
+            self.indexer_id.tx_order,
+            self.indexer_id.state_index,
             "-".repeat(100),
         )
     }
@@ -262,15 +326,8 @@ impl ObjectStateFilterView {
 /// Object state view. Used as return type of `getObjectStates`.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ObjectStateView {
-    pub id: ObjectID,
-    pub owner: RoochAddressView,
-    pub owner_bitcoin_address: Option<String>,
-    pub flag: u8,
-    pub object_type: StructTagView,
-    pub state_root: Option<H256View>,
-    pub size: u64,
-    pub created_at: u64,
-    pub updated_at: u64,
+    #[serde(flatten)]
+    pub metadata: ObjectMetaView,
     pub value: BytesView,
     pub decoded_value: Option<AnnotatedMoveStructView>,
     pub display_fields: Option<DisplayFieldsView>,
@@ -279,17 +336,9 @@ pub struct ObjectStateView {
 impl ObjectStateView {
     pub fn new(object: AnnotatedState, decode: bool) -> Self {
         let (metadata, value, decoded_value) = object.into_inner();
-        let object_type = metadata.value_struct_tag().clone().into();
+
         ObjectStateView {
-            id: metadata.id,
-            owner: metadata.owner.into(),
-            owner_bitcoin_address: None,
-            flag: metadata.flag,
-            object_type,
-            state_root: metadata.state_root.map(Into::into),
-            size: metadata.size,
-            created_at: metadata.created_at,
-            updated_at: metadata.updated_at,
+            metadata: metadata.into(),
             value: value.into(),
             decoded_value: if decode {
                 Some(AnnotatedMoveStructView::from(decoded_value))
@@ -302,17 +351,8 @@ impl ObjectStateView {
 
     pub fn new_from_object_state(object: ObjectState) -> Self {
         let (metadata, value) = object.into_inner();
-        let value_struct_tag = metadata.value_struct_tag().clone();
         ObjectStateView {
-            id: metadata.id,
-            owner: metadata.owner.into(),
-            owner_bitcoin_address: None,
-            flag: metadata.flag,
-            object_type: value_struct_tag.into(),
-            state_root: metadata.state_root.map(Into::into),
-            size: metadata.size,
-            created_at: metadata.created_at,
-            updated_at: metadata.updated_at,
+            metadata: metadata.into(),
             value: value.into(),
             decoded_value: None,
             display_fields: None,
@@ -325,7 +365,7 @@ impl ObjectStateView {
     }
 
     pub fn with_owner_bitcoin_address(mut self, owner_bitcoin_address: Option<String>) -> Self {
-        self.owner_bitcoin_address = owner_bitcoin_address;
+        self.metadata.owner_bitcoin_address = owner_bitcoin_address;
         self
     }
 }
@@ -338,16 +378,7 @@ impl From<ObjectState> for ObjectStateView {
 
 impl From<ObjectStateView> for ObjectState {
     fn from(state: ObjectStateView) -> Self {
-        let metadata = ObjectMeta {
-            id: state.id,
-            owner: state.owner.0.into(),
-            flag: state.flag,
-            state_root: state.state_root.map(Into::into),
-            size: state.size,
-            created_at: state.created_at,
-            updated_at: state.updated_at,
-            value_type: state.object_type.0.into(),
-        };
+        let metadata = state.metadata.into();
         ObjectState::new(metadata, state.value.0)
     }
 }
@@ -371,11 +402,11 @@ impl HumanReadableDisplay for ObjectStateView {
   status         | {}
 {}"#,
             "-".repeat(100),
-            self.id,
-            self.object_type,
-            self.owner,
-            self.owner_bitcoin_address,
-            human_readable_flag(self.flag),
+            self.metadata.id,
+            self.metadata.object_type,
+            self.metadata.owner,
+            self.metadata.owner_bitcoin_address,
+            human_readable_flag(self.metadata.flag),
             "-".repeat(100),
         )
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
@@ -135,6 +135,12 @@ macro_rules! impl_str_view_for {
 // Because the max value of json number is less than u64::MAX, so we need to use string to represent usize, u64, i64, u128, i128, U256
 impl_str_view_for! {usize u64 i64 u128 i128 move_core_types::u256::U256 moveos_types::state::FieldKey}
 
+impl From<StrView<u64>> for usize {
+    fn from(view: StrView<u64>) -> usize {
+        view.0 as usize
+    }
+}
+
 pub type BytesView = StrView<Vec<u8>>;
 
 impl std::fmt::Display for BytesView {

--- a/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/str_view.rs
@@ -57,9 +57,48 @@ where
     where
         D: Deserializer<'de>,
     {
-        let s = <String>::deserialize(deserializer)?;
+        //We provide a custom deserializer for u64
+        //Support both string and number
 
-        StrView::<T>::from_str(&s).map_err(serde::de::Error::custom)
+        struct NumberOrStringVisitor;
+        enum NumberOrString {
+            U64(u64),
+            String(String),
+        }
+
+        impl NumberOrString {
+            pub fn into_string(self) -> String {
+                match self {
+                    NumberOrString::U64(v) => v.to_string(),
+                    NumberOrString::String(v) => v,
+                }
+            }
+        }
+
+        impl<'de> serde::de::Visitor<'de> for NumberOrStringVisitor {
+            type Value = NumberOrString;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string or an unsigned 64-bit integer")
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<NumberOrString, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(NumberOrString::U64(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<NumberOrString, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(NumberOrString::String(value.to_owned()))
+            }
+        }
+        let number_or_string = deserializer.deserialize_any(NumberOrStringVisitor)?;
+        let s = number_or_string.into_string();
+        Self::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/rooch-rpc-api/src/jsonrpc_types/tests/str_view_tests.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/tests/str_view_tests.rs
@@ -129,3 +129,14 @@ fn test_rooch_address_view() {
         "rooch16kg65sgpy497wc4j09ds6tha6e48cg45303fnxxxua6khevfa8sqwnxk0l",
     );
 }
+
+#[test]
+fn test_u64_deserialize_support_string_and_number() {
+    let u64_0: Result<StrView<u64>, serde_json::Error> = serde_json::from_str("0");
+    let u64_1: Result<StrView<u64>, serde_json::Error> = serde_json::from_str("\"1\"");
+    let u64_2: Result<StrView<u64>, serde_json::Error> = serde_json::from_str("1");
+
+    assert_eq!(u64_0.unwrap(), StrView(0));
+    assert_eq!(u64_1.unwrap(), StrView(1));
+    assert_eq!(u64_2.unwrap(), StrView(1));
+}

--- a/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use super::BytesView;
+use super::{BytesView, StrView};
 use crate::jsonrpc_types::{
     H256View, RoochOrBitcoinAddressView, TransactionExecutionInfoView, TransactionSequenceInfoView,
     TransactionView,
@@ -121,17 +121,17 @@ pub enum TransactionFilterView {
     /// Return transactions in [start_time, end_time) interval
     TimeRange {
         /// left endpoint of time interval, milliseconds since block, inclusive
-        start_time: u64,
+        start_time: StrView<u64>,
         /// right endpoint of time interval, milliseconds since block, exclusive
-        end_time: u64,
+        end_time: StrView<u64>,
     },
     /// Return events emitted in [from_order, to_order) interval
     // #[serde(rename_all = "camelCase")]
     TxOrderRange {
         /// left endpoint of transaction order, inclusive
-        from_order: u64,
+        from_order: StrView<u64>,
         /// right endpoint of transaction order, exclusive
-        to_order: u64,
+        to_order: StrView<u64>,
     },
 }
 
@@ -147,15 +147,15 @@ impl From<TransactionFilterView> for TransactionFilter {
                 start_time,
                 end_time,
             } => Self::TimeRange {
-                start_time,
-                end_time,
+                start_time: start_time.0,
+                end_time: end_time.0,
             },
             TransactionFilterView::TxOrderRange {
                 from_order,
                 to_order,
             } => Self::TxOrderRange {
-                from_order,
-                to_order,
+                from_order: from_order.0,
+                to_order: to_order.0,
             },
         }
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
@@ -15,16 +15,16 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct L1BlockView {
-    pub chain_id: u64,
-    pub block_height: u64,
+    pub chain_id: StrView<u64>,
+    pub block_height: StrView<u64>,
     pub block_hash: BytesView,
 }
 
 impl From<L1Block> for L1BlockView {
     fn from(block: L1Block) -> Self {
         Self {
-            chain_id: block.chain_id.id(),
-            block_height: block.block_height,
+            chain_id: block.chain_id.id().into(),
+            block_height: block.block_height.into(),
             block_hash: block.block_hash.into(),
         }
     }
@@ -32,7 +32,7 @@ impl From<L1Block> for L1BlockView {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct L1TransactionView {
-    pub chain_id: u64,
+    pub chain_id: StrView<u64>,
     pub block_hash: BytesView,
     pub txid: BytesView,
 }
@@ -40,7 +40,7 @@ pub struct L1TransactionView {
 impl From<L1Transaction> for L1TransactionView {
     fn from(tx: L1Transaction) -> Self {
         Self {
-            chain_id: tx.chain_id.id(),
+            chain_id: tx.chain_id.id().into(),
             block_hash: tx.block_hash.into(),
             txid: tx.txid.into(),
         }

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -206,7 +206,11 @@ impl RoochRpcClient {
     ) -> Result<BalanceInfoPageView> {
         Ok(self
             .http
-            .get_balances(account_addr.into(), cursor, limit.map(Into::into))
+            .get_balances(
+                account_addr.into(),
+                cursor.map(Into::into),
+                limit.map(Into::into),
+            )
             .await?)
     }
 
@@ -219,7 +223,12 @@ impl RoochRpcClient {
     ) -> Result<IndexerObjectStatePageView> {
         Ok(self
             .http
-            .query_object_states(filter, cursor, limit.map(Into::into), query_options)
+            .query_object_states(
+                filter,
+                cursor.map(Into::into),
+                limit.map(Into::into),
+                query_options,
+            )
             .await?)
     }
 }

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -162,7 +162,7 @@ impl RoochRpcClient {
         &self,
         access_path: AccessPathView,
         cursor: Option<String>,
-        limit: Option<usize>,
+        limit: Option<u64>,
     ) -> Result<StatePageView> {
         Ok(self
             .http
@@ -174,7 +174,7 @@ impl RoochRpcClient {
         &self,
         access_path: AccessPathView,
         cursor: Option<String>,
-        limit: Option<usize>,
+        limit: Option<u64>,
     ) -> Result<StatePageView> {
         Ok(self
             .http
@@ -202,7 +202,7 @@ impl RoochRpcClient {
         &self,
         account_addr: RoochAddressView,
         cursor: Option<IndexerStateID>,
-        limit: Option<usize>,
+        limit: Option<u64>,
     ) -> Result<BalanceInfoPageView> {
         Ok(self
             .http
@@ -218,7 +218,7 @@ impl RoochRpcClient {
         &self,
         filter: ObjectStateFilterView,
         cursor: Option<IndexerStateID>,
-        limit: Option<usize>,
+        limit: Option<u64>,
         query_options: Option<QueryOptions>,
     ) -> Result<IndexerObjectStatePageView> {
         Ok(self

--- a/crates/rooch-rpc-server/src/server/btc_server.rs
+++ b/crates/rooch-rpc-server/src/server/btc_server.rs
@@ -1,33 +1,26 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::service::{aggregate_service::AggregateService, rpc_service::RpcService};
+use crate::service::rpc_service::RpcService;
 use anyhow::Result;
 use jsonrpsee::{core::async_trait, RpcModule};
-use move_core_types::account_address::AccountAddress;
 use rooch_rpc_api::api::btc_api::BtcAPIServer;
 use rooch_rpc_api::api::{RoochRpcModule, DEFAULT_RESULT_LIMIT_USIZE, MAX_RESULT_LIMIT_USIZE};
 use rooch_rpc_api::jsonrpc_types::btc::ord::{InscriptionFilterView, InscriptionStateView};
 use rooch_rpc_api::jsonrpc_types::btc::utxo::{UTXOFilterView, UTXOStateView};
-use rooch_rpc_api::jsonrpc_types::{InscriptionPageView, StrView, UTXOPageView};
+use rooch_rpc_api::jsonrpc_types::{
+    IndexerStateIDView, InscriptionPageView, StrView, UTXOPageView,
+};
 use rooch_rpc_api::RpcResult;
-use rooch_types::indexer::state::IndexerStateID;
 use std::cmp::min;
 
 pub struct BtcServer {
     rpc_service: RpcService,
-    aggregate_service: AggregateService,
-    btc_network: u8,
 }
 
 impl BtcServer {
-    pub async fn new(rpc_service: RpcService, aggregate_service: AggregateService) -> Result<Self> {
-        let btc_network = rpc_service.get_bitcoin_network().await?;
-        Ok(Self {
-            rpc_service,
-            aggregate_service,
-            btc_network,
-        })
+    pub async fn new(rpc_service: RpcService) -> Result<Self> {
+        Ok(Self { rpc_service })
     }
 }
 
@@ -37,7 +30,7 @@ impl BtcAPIServer for BtcServer {
         &self,
         filter: UTXOFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<IndexerStateID>,
+        cursor: Option<IndexerStateIDView>,
         limit: Option<StrView<usize>>,
         descending_order: Option<bool>,
     ) -> RpcResult<UTXOPageView> {
@@ -47,31 +40,27 @@ impl BtcAPIServer for BtcServer {
         );
         let descending_order = descending_order.unwrap_or(true);
 
-        let resolve_address = match filter.clone() {
-            UTXOFilterView::Owner(address) => address.0.to_rooch_address(),
-            _ => AccountAddress::ZERO.into(),
-        };
-
-        let global_state_filter =
-            UTXOFilterView::into_global_state_filter(filter, resolve_address)?;
-        let states = self
+        let global_state_filter = UTXOFilterView::into_global_state_filter(filter)?;
+        let object_states = self
             .rpc_service
-            .query_object_states(global_state_filter, cursor, limit_of + 1, descending_order)
+            .query_object_states(
+                global_state_filter,
+                cursor.map(|c| c.into()),
+                limit_of + 1,
+                descending_order,
+                false,
+                false,
+            )
             .await?;
 
-        let mut data = self
-            .aggregate_service
-            .build_utxos(states)
-            .await?
+        let mut data = object_states
             .into_iter()
-            .map(|v| UTXOStateView::try_new_from_utxo_state(v, self.btc_network))
+            .map(UTXOStateView::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
         let has_next_page = data.len() > limit_of;
         data.truncate(limit_of);
-        let next_cursor = data.last().cloned().map_or(cursor, |t| {
-            Some(IndexerStateID::new(t.tx_order, t.state_index))
-        });
+        let next_cursor = data.last().cloned().map_or(cursor, |t| Some(t.indexer_id));
 
         Ok(UTXOPageView {
             data,
@@ -84,7 +73,7 @@ impl BtcAPIServer for BtcServer {
         &self,
         filter: InscriptionFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<IndexerStateID>,
+        cursor: Option<IndexerStateIDView>,
         limit: Option<StrView<usize>>,
         descending_order: Option<bool>,
     ) -> RpcResult<InscriptionPageView> {
@@ -94,31 +83,27 @@ impl BtcAPIServer for BtcServer {
         );
         let descending_order = descending_order.unwrap_or(true);
 
-        let resolve_address = match filter.clone() {
-            InscriptionFilterView::Owner(address) => address.0.to_rooch_address(),
-            _ => AccountAddress::ZERO.into(),
-        };
-
-        let global_state_filter =
-            InscriptionFilterView::into_global_state_filter(filter, resolve_address)?;
-        let states = self
+        let global_state_filter = InscriptionFilterView::into_global_state_filter(filter)?;
+        let object_states = self
             .rpc_service
-            .query_object_states(global_state_filter, cursor, limit_of + 1, descending_order)
+            .query_object_states(
+                global_state_filter,
+                cursor.map(Into::into),
+                limit_of + 1,
+                descending_order,
+                false,
+                false,
+            )
             .await?;
 
-        let mut data = self
-            .aggregate_service
-            .build_inscriptions(states)
-            .await?
+        let mut data = object_states
             .into_iter()
-            .map(|v| InscriptionStateView::try_new_from_inscription_state(v, self.btc_network))
+            .map(InscriptionStateView::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
         let has_next_page = data.len() > limit_of;
         data.truncate(limit_of);
-        let next_cursor = data.last().cloned().map_or(cursor, |t| {
-            Some(IndexerStateID::new(t.tx_order, t.state_index))
-        });
+        let next_cursor = data.last().cloned().map_or(cursor, |t| Some(t.indexer_id));
 
         Ok(InscriptionPageView {
             data,

--- a/crates/rooch-rpc-server/src/server/btc_server.rs
+++ b/crates/rooch-rpc-server/src/server/btc_server.rs
@@ -31,7 +31,7 @@ impl BtcAPIServer for BtcServer {
         filter: UTXOFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerStateIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         descending_order: Option<bool>,
     ) -> RpcResult<UTXOPageView> {
         let limit_of = min(
@@ -74,7 +74,7 @@ impl BtcAPIServer for BtcServer {
         filter: InscriptionFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerStateIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         descending_order: Option<bool>,
     ) -> RpcResult<InscriptionPageView> {
         let limit_of = min(

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -190,7 +190,7 @@ impl RoochAPIServer for RoochServer {
         &self,
         access_path: AccessPathView,
         cursor: Option<String>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         state_option: Option<StateOptions>,
     ) -> RpcResult<StatePageView> {
         let state_option = state_option.unwrap_or_default();
@@ -521,7 +521,7 @@ impl RoochAPIServer for RoochServer {
         &self,
         account_addr: RoochOrBitcoinAddressView,
         cursor: Option<IndexerStateIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
     ) -> RpcResult<BalanceInfoPageView> {
         let limit_of = min(
             limit.map(Into::into).unwrap_or(DEFAULT_RESULT_LIMIT_USIZE),
@@ -584,7 +584,7 @@ impl RoochAPIServer for RoochServer {
         filter: TransactionFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<StrView<u64>>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<TransactionWithInfoPageView> {
         let limit_of = min(
@@ -627,7 +627,7 @@ impl RoochAPIServer for RoochServer {
         filter: EventFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerEventIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerEventPageView> {
         let limit_of = min(
@@ -669,7 +669,7 @@ impl RoochAPIServer for RoochServer {
         filter: ObjectStateFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
         cursor: Option<IndexerStateIDView>,
-        limit: Option<StrView<usize>>,
+        limit: Option<StrView<u64>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerObjectStatePageView> {
         let limit_of = min(

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -12,21 +12,17 @@ use moveos_types::{
     access_path::AccessPath,
     h256::H256,
     move_std::string::MoveString,
-    moveos_std::{
-        display::{get_object_display_id, get_resource_display_id, RawDisplay},
-        move_module::MoveModule,
-        object::{ObjectEntity, ObjectID},
-    },
+    moveos_std::{move_module::MoveModule, object::ObjectID},
     state::{AnnotatedState, FieldKey},
 };
 use rooch_rpc_api::jsonrpc_types::{
     account_view::BalanceInfoView,
-    event_view::{EventFilterView, EventView, IndexerEventView},
+    event_view::{EventFilterView, EventView, IndexerEventIDView, IndexerEventView},
     transaction_view::{TransactionFilterView, TransactionWithInfoView},
-    AccessPathView, AnnotatedMoveStructView, BalanceInfoPageView, DisplayFieldsView, EventOptions,
-    EventPageView, ExecuteTransactionResponseView, FunctionCallView, H256View,
-    IndexerEventPageView, IndexerObjectStatePageView, IndexerObjectStateView, ModuleABIView,
-    ObjectIDVecView, ObjectStateFilterView, ObjectStateView, QueryOptions, RoochAddressView,
+    AccessPathView, BalanceInfoPageView, EventOptions, EventPageView,
+    ExecuteTransactionResponseView, FunctionCallView, H256View, IndexerEventPageView,
+    IndexerObjectStatePageView, IndexerStateIDView, ModuleABIView, ObjectIDVecView,
+    ObjectStateFilterView, ObjectStateView, QueryOptions, RoochAddressView,
     RoochOrBitcoinAddressView, StateKVView, StateOptions, StatePageView, StrView, StructTagView,
     TransactionWithInfoPageView, TxOptions,
 };
@@ -39,7 +35,6 @@ use rooch_rpc_api::{
     jsonrpc_types::BytesView,
     RpcError, RpcResult,
 };
-use rooch_types::indexer::event::IndexerEventID;
 use rooch_types::indexer::state::IndexerStateID;
 use rooch_types::transaction::{RoochTransaction, TransactionWithInfo};
 use std::cmp::min;
@@ -59,61 +54,6 @@ impl RoochServer {
         }
     }
 
-    async fn get_display_fields_and_render(
-        &self,
-        states: Vec<&AnnotatedState>,
-        is_object: bool,
-    ) -> Result<Vec<Option<DisplayFieldsView>>> {
-        let mut display_ids = vec![];
-        let mut displayable_states = vec![];
-        for s in &states {
-            displayable_states.push(if is_object {
-                let value_struct_tag = s.metadata.value_struct_tag();
-                display_ids.push(get_object_display_id(value_struct_tag.clone().into()));
-                true
-            } else if let Some(tag) = s.metadata.get_resource_struct_tag() {
-                display_ids.push(get_resource_display_id(tag.clone().into()));
-                true
-            } else {
-                false
-            });
-        }
-        // get display fields
-        let path = AccessPath::objects(display_ids);
-        let mut display_fields = self
-            .rpc_service
-            .get_states(path)
-            .await?
-            .into_iter()
-            .map(|option_s| {
-                option_s
-                    .map(|s| s.into_object_uncheck::<RawDisplay>())
-                    .transpose()
-            })
-            .collect::<Result<Vec<Option<ObjectEntity<RawDisplay>>>>>()?;
-        display_fields.reverse();
-
-        let mut display_field_views = vec![];
-        for (annotated_s, displayable) in states.into_iter().zip(displayable_states) {
-            display_field_views.push(if displayable {
-                debug_assert!(
-                    !display_fields.is_empty(),
-                    "Display fields should not be empty"
-                );
-                display_fields.pop().unwrap().map(|obj| {
-                    DisplayFieldsView::new(obj.value.render(
-                        &move_resource_viewer::AnnotatedMoveValue::Struct(
-                            annotated_s.decoded_value.clone(),
-                        ),
-                    ))
-                })
-            } else {
-                None
-            });
-        }
-        Ok(display_field_views)
-    }
-
     async fn transactions_to_view(
         &self,
         data: Vec<TransactionWithInfo>,
@@ -126,7 +66,7 @@ impl RoochServer {
             .rpc_service
             .get_bitcoin_addresses(rooch_addresses)
             .await?;
-        let bitcoin_network = self.rpc_service.get_bitcoin_network().await?;
+        let bitcoin_network = self.rpc_service.get_bitcoin_network();
         let data = data
             .into_iter()
             .map(|tx| {
@@ -151,7 +91,7 @@ impl RoochServer {
 #[async_trait]
 impl RoochAPIServer for RoochServer {
     async fn get_chain_id(&self) -> RpcResult<StrView<u64>> {
-        let chain_id = self.rpc_service.get_chain_id().await?;
+        let chain_id = self.rpc_service.get_chain_id();
         Ok(StrView(chain_id))
     }
 
@@ -212,7 +152,8 @@ impl RoochAPIServer for RoochServer {
             if show_display {
                 let valid_states = states.iter().filter_map(|s| s.as_ref()).collect::<Vec<_>>();
                 let mut valid_display_field_views = self
-                    .get_display_fields_and_render(valid_states, is_object)
+                    .rpc_service
+                    .get_display_fields_and_render(valid_states.as_slice(), is_object)
                     .await?;
                 valid_display_field_views.reverse();
                 states
@@ -275,7 +216,8 @@ impl RoochAPIServer for RoochServer {
             let state_refs: Vec<&AnnotatedState> = states.iter().collect();
             if show_display {
                 let display_field_views = self
-                    .get_display_fields_and_render(state_refs, is_object)
+                    .rpc_service
+                    .get_display_fields_and_render(state_refs.as_slice(), is_object)
                     .await?;
                 key_states
                     .into_iter()
@@ -328,13 +270,14 @@ impl RoochAPIServer for RoochServer {
         let decode = state_option.decode;
         let show_display = state_option.show_display;
 
-        let objects_view = if decode || show_display {
+        let mut objects_view = if decode || show_display {
             let states: Vec<Option<AnnotatedState>> =
                 self.rpc_service.get_annotated_states(access_path).await?;
 
             let mut valid_display_field_views = if show_display {
                 let valid_states = states.iter().filter_map(|s| s.as_ref()).collect::<Vec<_>>();
-                self.get_display_fields_and_render(valid_states, true)
+                self.rpc_service
+                    .get_display_fields_and_render(valid_states.as_slice(), true)
                     .await?
             } else {
                 vec![]
@@ -374,30 +317,15 @@ impl RoochAPIServer for RoochServer {
                 .collect()
         };
 
-        // Get owner_bitcoin_address
-        let addresses = objects_view
-            .iter()
-            .filter_map(|o| o.as_ref().map(|s| s.owner.into()))
-            .collect::<Vec<_>>();
-        let btc_network = self.rpc_service.get_bitcoin_network().await?;
-        let address_mapping = self.rpc_service.get_bitcoin_addresses(addresses).await?;
+        self.rpc_service
+            .fill_bitcoin_addresses(
+                objects_view
+                    .iter_mut()
+                    .filter_map(|state_opt| state_opt.as_mut().map(|state| &mut state.metadata))
+                    .collect(),
+            )
+            .await?;
 
-        let objects_view = objects_view
-            .into_iter()
-            .map(|o| {
-                o.map(|s| {
-                    let rooch_address = s.owner.into();
-                    let bitcoin_address = address_mapping
-                        .get(&rooch_address)
-                        .expect("should exist.")
-                        .clone()
-                        .map(|a| a.format(btc_network))
-                        .transpose()?;
-                    Ok(s.with_owner_bitcoin_address(bitcoin_address))
-                })
-                .transpose()
-            })
-            .collect::<Result<Vec<_>>>()?;
         Ok(objects_view)
     }
 
@@ -448,11 +376,11 @@ impl RoochAPIServer for RoochServer {
         //next_cursor is the last event's event_seq
         let next_cursor = data
             .last()
-            .map_or(cursor, |event| Some(event.event_id.event_seq));
+            .map_or(cursor, |event| Some(event.event_id.event_seq.0));
 
         Ok(EventPageView {
             data,
-            next_cursor,
+            next_cursor: next_cursor.map(StrView),
             has_next_page,
         })
     }
@@ -463,7 +391,7 @@ impl RoochAPIServer for RoochServer {
     ) -> RpcResult<Vec<Option<TransactionWithInfoView>>> {
         let tx_hashes: Vec<H256> = tx_hashes.iter().map(|m| (*m).into()).collect::<Vec<_>>();
 
-        let bitcoin_network = self.rpc_service.get_bitcoin_network().await?;
+        let bitcoin_network = self.rpc_service.get_bitcoin_network();
         let data = self
             .aggregate_service
             .get_transaction_with_info(tx_hashes)
@@ -571,7 +499,7 @@ impl RoochAPIServer for RoochServer {
 
         Ok(TransactionWithInfoPageView {
             data,
-            next_cursor,
+            next_cursor: next_cursor.map(StrView),
             has_next_page,
         })
     }
@@ -592,13 +520,14 @@ impl RoochAPIServer for RoochServer {
     async fn get_balances(
         &self,
         account_addr: RoochOrBitcoinAddressView,
-        cursor: Option<IndexerStateID>,
+        cursor: Option<IndexerStateIDView>,
         limit: Option<StrView<usize>>,
     ) -> RpcResult<BalanceInfoPageView> {
         let limit_of = min(
             limit.map(Into::into).unwrap_or(DEFAULT_RESULT_LIMIT_USIZE),
             MAX_RESULT_LIMIT_USIZE,
         );
+        let cursor: Option<IndexerStateID> = cursor.map(Into::into);
         let mut data = self
             .aggregate_service
             .get_balances(account_addr.into(), cursor, limit_of + 1)
@@ -617,7 +546,7 @@ impl RoochAPIServer for RoochServer {
                 .into_iter()
                 .map(|(_, balance_info)| balance_info)
                 .collect(),
-            next_cursor,
+            next_cursor: next_cursor.map(Into::into),
             has_next_page,
         })
     }
@@ -688,7 +617,7 @@ impl RoochAPIServer for RoochServer {
 
         Ok(TransactionWithInfoPageView {
             data,
-            next_cursor,
+            next_cursor: next_cursor.map(StrView),
             has_next_page,
         })
     }
@@ -697,7 +626,7 @@ impl RoochAPIServer for RoochServer {
         &self,
         filter: EventFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<IndexerEventID>,
+        cursor: Option<IndexerEventIDView>,
         limit: Option<StrView<usize>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerEventPageView> {
@@ -710,7 +639,12 @@ impl RoochAPIServer for RoochServer {
 
         let mut data = self
             .rpc_service
-            .query_events(filter.into(), cursor, limit_of + 1, descending_order)
+            .query_events(
+                filter.into(),
+                cursor.map(Into::into),
+                limit_of + 1,
+                descending_order,
+            )
             .await?
             .into_iter()
             .map(IndexerEventView::from)
@@ -734,7 +668,7 @@ impl RoochAPIServer for RoochServer {
         &self,
         filter: ObjectStateFilterView,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<IndexerStateID>,
+        cursor: Option<IndexerStateIDView>,
         limit: Option<StrView<usize>>,
         query_option: Option<QueryOptions>,
     ) -> RpcResult<IndexerObjectStatePageView> {
@@ -744,84 +678,30 @@ impl RoochAPIServer for RoochServer {
         );
         let query_option = query_option.unwrap_or_default();
         let descending_order = query_option.descending;
-        let decode = query_option.decode;
 
         let global_state_filter = ObjectStateFilterView::try_into_object_state_filter(filter)?;
-        let states = self
+        let mut object_states = self
             .rpc_service
-            .query_object_states(global_state_filter, cursor, limit_of + 1, descending_order)
+            .query_object_states(
+                global_state_filter,
+                cursor.map(Into::into),
+                limit_of + 1,
+                descending_order,
+                query_option.decode,
+                query_option.show_display,
+            )
             .await?;
 
-        let object_ids = states
-            .iter()
-            .map(|m| m.object_id.clone())
-            .collect::<Vec<_>>();
-        let access_path = AccessPath::objects(object_ids.clone());
-        let annotated_states = self
-            .rpc_service
-            .get_annotated_states(access_path)
-            .await?
-            .into_iter()
-            .map(|s| s.expect("object should exist!")) // TODO: is statedb always synced with indexer?
-            .collect::<Vec<_>>();
+        let has_next_page = object_states.len() > limit_of;
+        object_states.truncate(limit_of);
 
-        let annotated_states_with_display = if query_option.show_display {
-            let valid_states = annotated_states.iter().collect::<Vec<_>>();
-            let valid_display_field_views = self
-                .get_display_fields_and_render(valid_states, true)
-                .await?;
-            annotated_states
-                .into_iter()
-                .zip(valid_display_field_views)
-                .collect::<Vec<_>>()
-        } else {
-            annotated_states
-                .into_iter()
-                .map(|s| (s, None))
-                .collect::<Vec<_>>()
-        };
-
-        let network = self.rpc_service.get_bitcoin_network().await?;
-        let rooch_addresses = states.iter().map(|s| s.owner).collect::<Vec<_>>();
-        let bitcoin_addresses = self
-            .rpc_service
-            .get_bitcoin_addresses(rooch_addresses)
-            .await?
-            .into_values()
-            .map(|btc_addr| btc_addr.map(|addr| addr.format(network)).transpose())
-            .collect::<Result<Vec<Option<String>>>>()?;
-
-        let mut data = annotated_states_with_display
-            .into_iter()
-            .zip(states)
-            .zip(bitcoin_addresses)
-            .map(
-                |(((annotated_state, display_fields), state), bitcoin_address)| {
-                    let decoded_value = if decode {
-                        Some(AnnotatedMoveStructView::from(annotated_state.decoded_value))
-                    } else {
-                        None
-                    };
-                    IndexerObjectStateView::new_from_object_state(
-                        state,
-                        annotated_state.value,
-                        bitcoin_address,
-                        decoded_value,
-                        display_fields,
-                    )
-                },
-            )
-            .collect::<Vec<_>>();
-
-        let has_next_page = data.len() > limit_of;
-        data.truncate(limit_of);
-
-        let next_cursor = data.last().cloned().map_or(cursor, |t| {
-            Some(IndexerStateID::new(t.tx_order, t.state_index))
-        });
+        let next_cursor = object_states
+            .last()
+            .cloned()
+            .map_or(cursor, |t| Some(t.indexer_id));
 
         Ok(IndexerObjectStatePageView {
-            data,
+            data: object_states,
             next_cursor,
             has_next_page,
         })

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -249,7 +249,7 @@ impl RoochAPIServer for RoochServer {
         let has_next_page = data.len() > limit_of;
         data.truncate(limit_of);
         let next_cursor = data.last().map_or(cursor, |state_kv| {
-            Some(state_kv.key_hex.clone().to_string())
+            Some(state_kv.field_key.clone().to_string())
         });
 
         Ok(StatePageView {

--- a/crates/rooch-rpc-server/src/service/aggregate_service.rs
+++ b/crates/rooch-rpc-server/src/service/aggregate_service.rs
@@ -11,8 +11,6 @@ use moveos_types::state::PlaceholderStruct;
 use rooch_rpc_api::jsonrpc_types::account_view::BalanceInfoView;
 use rooch_rpc_api::jsonrpc_types::CoinInfoView;
 use rooch_types::address::RoochAddress;
-use rooch_types::bitcoin::ord::{Inscription, InscriptionState};
-use rooch_types::bitcoin::utxo::{UTXOState, UTXO};
 use rooch_types::framework::account_coin_store::AccountCoinStoreModule;
 use rooch_types::framework::coin::{CoinInfo, CoinModule};
 use rooch_types::framework::coin_store::{CoinStore, CoinStoreInfo};
@@ -137,7 +135,7 @@ impl AggregateService {
         let indexer_coin_stores = self.query_account_coin_stores(owner, cursor, limit).await?;
         let coin_store_ids = indexer_coin_stores
             .iter()
-            .map(|m| m.object_id.clone())
+            .map(|m| m.metadata.id.clone())
             .collect::<Vec<_>>();
 
         let coin_stores = self.get_coin_stores(coin_store_ids.clone()).await?;
@@ -155,7 +153,7 @@ impl AggregateService {
             let coin_store = coin_store.ok_or_else(|| {
                 anyhow::anyhow!(
                     "Can not find CoinStore with id: {}",
-                    indexer_coin_store.object_id
+                    indexer_coin_store.metadata.id
                 )
             })?;
             let coin_info = coin_info_map
@@ -199,103 +197,6 @@ impl AggregateService {
                 _ => Ok(None),
             })
             .collect::<Result<Vec<_>>>()
-    }
-
-    pub async fn build_utxos(&self, states: Vec<IndexerObjectState>) -> Result<Vec<UTXOState>> {
-        let object_ids = states
-            .iter()
-            .map(|m| m.object_id.clone())
-            .collect::<Vec<_>>();
-        let owners = states.iter().map(|m| m.owner).collect::<Vec<_>>();
-        let reverse_address_mapping = self.rpc_service.get_bitcoin_addresses(owners).await?;
-
-        // Global table 0x0 table's key type is always ObjectID.
-        let access_path = AccessPath::objects(object_ids.clone());
-        let objects = self
-            .rpc_service
-            .get_states(access_path)
-            .await?
-            .into_iter()
-            .zip(object_ids)
-            .map(|(state_opt, object_id)| {
-                Ok((
-                    object_id,
-                    state_opt
-                        .map(|state| {
-                            Ok::<UTXO, anyhow::Error>(state.into_object_uncheck::<UTXO>()?.value)
-                        })
-                        .transpose()?,
-                ))
-            })
-            .collect::<Result<HashMap<_, _>>>()?;
-
-        let data = states
-            .into_iter()
-            .map(|state| {
-                let utxo = objects.get(&state.object_id).cloned().flatten();
-                let reverse_address = reverse_address_mapping.get(&state.owner).cloned().flatten();
-
-                Ok(UTXOState::new_from_object_state(
-                    state,
-                    utxo,
-                    reverse_address,
-                ))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        Ok(data)
-    }
-
-    pub async fn build_inscriptions(
-        &self,
-        states: Vec<IndexerObjectState>,
-    ) -> Result<Vec<InscriptionState>> {
-        let object_ids = states
-            .iter()
-            .map(|m| m.object_id.clone())
-            .collect::<Vec<_>>();
-        let owners = states.iter().map(|m| m.owner).collect::<Vec<_>>();
-        let reverse_address_mapping = self.rpc_service.get_bitcoin_addresses(owners).await?;
-
-        // Global table 0x0 table's key type is always ObjectID.
-        let access_path = AccessPath::objects(object_ids.clone());
-        let objects = self
-            .rpc_service
-            .get_states(access_path)
-            .await?
-            .into_iter()
-            .zip(object_ids)
-            .map(|(state_opt, object_id)| {
-                Ok((
-                    object_id,
-                    state_opt
-                        .map(|state| {
-                            Ok::<Inscription, anyhow::Error>(
-                                state.into_object_uncheck::<Inscription>()?.value,
-                            )
-                        })
-                        .transpose()?,
-                ))
-            })
-            .collect::<Result<HashMap<_, _>>>()?;
-
-        let data = states
-            .into_iter()
-            .map(|state| {
-                let inscription = objects
-                    .get(&state.object_id)
-                    .cloned()
-                    .flatten()
-                    .ok_or(anyhow::anyhow!("Inscription should have value"))?;
-                let reverse_address = reverse_address_mapping.get(&state.owner).cloned().flatten();
-
-                Ok(InscriptionState::new_from_object_state(
-                    state,
-                    inscription,
-                    reverse_address,
-                ))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        Ok(data)
     }
 
     pub async fn build_transaction_with_infos(

--- a/crates/rooch-types/src/bitcoin/ord.rs
+++ b/crates/rooch-types/src/bitcoin/ord.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::types::{OutPoint, Transaction};
-use crate::address::{BitcoinAddress, RoochAddress};
 use crate::addresses::BITCOIN_MOVE_ADDRESS;
-use crate::indexer::state::IndexerObjectState;
 use crate::into_address::IntoAddress;
 use anyhow::Result;
 use move_core_types::language_storage::{StructTag, TypeTag};
@@ -277,41 +275,6 @@ impl<'a> ModuleBinding<'a> for OrdModule<'a> {
         Self: Sized,
     {
         Self { caller }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct InscriptionState {
-    pub object_id: ObjectID,
-    pub owner: RoochAddress,
-    pub owner_bitcoin_address: Option<BitcoinAddress>,
-    pub flag: u8,
-    pub value: Inscription,
-    pub object_type: StructTag,
-    pub tx_order: u64,
-    pub state_index: u64,
-    pub created_at: u64,
-    pub updated_at: u64,
-}
-
-impl InscriptionState {
-    pub fn new_from_object_state(
-        state: IndexerObjectState,
-        inscription: Inscription,
-        owner_bitcoin_address: Option<BitcoinAddress>,
-    ) -> Self {
-        Self {
-            object_id: state.object_id,
-            owner: state.owner,
-            owner_bitcoin_address,
-            flag: state.flag,
-            value: inscription,
-            object_type: state.object_type,
-            tx_order: state.tx_order,
-            state_index: state.state_index,
-            created_at: state.created_at,
-            updated_at: state.updated_at,
-        }
     }
 }
 

--- a/crates/rooch-types/src/bitcoin/utxo.rs
+++ b/crates/rooch-types/src/bitcoin/utxo.rs
@@ -2,13 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::types;
-use crate::address::{BitcoinAddress, RoochAddress};
 use crate::addresses::BITCOIN_MOVE_ADDRESS;
-use crate::indexer::state::IndexerObjectState;
 use anyhow::Result;
-use move_core_types::language_storage::StructTag;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
-use moveos_types::moveos_std::object;
+use moveos_types::moveos_std::object::{self};
 use moveos_types::state::MoveStructState;
 use moveos_types::{
     module_binding::{ModuleBinding, MoveFunctionCaller},
@@ -91,44 +88,6 @@ pub fn derive_utxo_id(outpoint: &types::OutPoint) -> ObjectID {
         BitcoinUTXOStore::object_id(),
         outpoint,
     )
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct UTXOState {
-    pub object_id: ObjectID,
-    pub owner: RoochAddress,
-    pub owner_bitcoin_address: Option<BitcoinAddress>,
-    pub flag: u8,
-    // There is a case when rooch bitcoin relayer synchronizes the bitcoin node data and processes the `process_block`
-    // in the contract, this process takes some time, and the object id in the Global state is deleted, but the ojbect
-    // id in the Indexer is not deleted yet. At this time, utxo is empty.
-    pub value: Option<UTXO>,
-    pub object_type: StructTag,
-    pub tx_order: u64,
-    pub state_index: u64,
-    pub created_at: u64,
-    pub updated_at: u64,
-}
-
-impl UTXOState {
-    pub fn new_from_object_state(
-        state: IndexerObjectState,
-        utxo: Option<UTXO>,
-        owner_bitcoin_address: Option<BitcoinAddress>,
-    ) -> Self {
-        Self {
-            object_id: state.object_id,
-            owner: state.owner,
-            owner_bitcoin_address,
-            flag: state.flag,
-            value: utxo,
-            object_type: state.object_type,
-            tx_order: state.tx_order,
-            state_index: state.state_index,
-            created_at: state.created_at,
-            updated_at: state.updated_at,
-        }
-    }
 }
 
 /// Rust bindings for BitcoinMove utxo module

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -8,7 +8,7 @@ use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
 use move_command_line_common::types::ParsedStructType;
-use rooch_rpc_api::api::MAX_RESULT_LIMIT_USIZE;
+use rooch_rpc_api::api::MAX_RESULT_LIMIT;
 use rooch_rpc_api::jsonrpc_types::account_view::BalanceInfoView;
 use rooch_types::address::ParsedAddress;
 use rooch_types::error::RoochResult;
@@ -60,7 +60,7 @@ impl CommandAction<Option<BalancesView>> for BalanceCommand {
             None => {
                 client
                     .rooch
-                    .get_balances(address_addr.into(), None, Some(MAX_RESULT_LIMIT_USIZE))
+                    .get_balances(address_addr.into(), None, Some(MAX_RESULT_LIMIT))
                     .await?
                     .data
             }

--- a/crates/rooch/src/commands/object.rs
+++ b/crates/rooch/src/commands/object.rs
@@ -31,7 +31,7 @@ pub struct ObjectCommand {
 
     /// Max number of items returned per page
     #[clap(long)]
-    limit: Option<usize>,
+    limit: Option<u64>,
 
     /// descending order
     #[clap(short = 'd', long, default_value = "false")]

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -320,7 +320,7 @@ Feature: Rooch CLI integration tests
       Then sleep: "2"
 
       Then cmd: "object -t {{$.address_mapping.default}}::child_object::Child --limit 10 -d"
-      Then assert: "{{$.object[-1].data[0].object_id}} == {{$.event[-1].data[0].decoded_event_data.value.id}}"
+      Then assert: "{{$.object[-1].data[0].id}} == {{$.event[-1].data[0].decoded_event_data.value.id}}"
 
       Then cmd: "move run --function default::third_party_module_for_child_object::update_child_age --args object:{{$.event[-1].data[0].decoded_event_data.value.id}} --args u64:10"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
@@ -354,7 +354,7 @@ Feature: Rooch CLI integration tests
       Then sleep: "2"
 
       Then cmd: "rpc request --method rooch_queryObjectStates --params '[{"object_type":"{{$.address_mapping.default}}::display::ObjectType"}, null, "10", {"descending": false,"showDisplay":true}]' --json"
-      Then assert: "{{$.rpc[-1].data[0].object_id}} == {{$.event[-1].data[0].decoded_event_data.value.id}}"
+      Then assert: "{{$.rpc[-1].data[0].id}} == {{$.event[-1].data[0].decoded_event_data.value.id}}"
       Then assert: "{{$.rpc[-1].data[0].display_fields.fields.name}} == test_object"
 
       Then cmd: "rpc request --method rooch_getObjectStates --params '["{{$.event[-1].data[0].decoded_event_data.value.id}}", {"decode": false, "showDisplay": true}]' --json"

--- a/moveos/moveos-object-runtime/src/runtime_object.rs
+++ b/moveos/moveos-object-runtime/src/runtime_object.rs
@@ -197,7 +197,7 @@ impl RuntimeObject {
                             "The loaded object id should be equal to the expected field object id"
                         );
                             let value_layout =
-                                layout_loader.get_type_layout(obj_state.value_type())?;
+                                layout_loader.get_type_layout(obj_state.object_type())?;
                             let state_bytes_len = obj_state.value.len() as u64;
                             (
                                 RuntimeObject::load(value_layout, obj_state)?,

--- a/moveos/moveos-object-runtime/src/runtime_object_meta.rs
+++ b/moveos/moveos-object-runtime/src/runtime_object_meta.rs
@@ -55,7 +55,7 @@ impl RuntimeObjectMeta {
             Self::Deleted(meta) => meta.metadata.id.clone(),
             Self::Fresh(v) | Self::Cached(v) => {
                 //If the object is removed, and init it again, the value type may be different
-                v.metadata.value_type = value_type;
+                v.metadata.object_type = value_type;
                 v.value_layout = value_layout;
                 return Ok(());
             }
@@ -121,7 +121,7 @@ impl RuntimeObjectMeta {
 
     pub fn value_type(&self) -> PartialVMResult<&TypeTag> {
         let meta = self.metadata()?;
-        Ok(&meta.value_type)
+        Ok(&meta.object_type)
     }
 
     pub fn value_layout(&self) -> PartialVMResult<&MoveTypeLayout> {

--- a/moveos/moveos-store/src/state_store/statedb.rs
+++ b/moveos/moveos-store/src/state_store/statedb.rs
@@ -156,7 +156,7 @@ impl StatelessResolver for StateDBStore {
         let result = self.smt.get(state_root, *key);
         if log::log_enabled!(log::Level::Trace) {
             let result_info = match &result {
-                Ok(Some(state)) => format!("Some({})", state.metadata.value_type),
+                Ok(Some(state)) => format!("Some({})", state.metadata.object_type),
                 Ok(None) => "None".to_string(),
                 Err(e) => format!("Error({:?})", e),
             };

--- a/moveos/moveos-types/src/addresses.rs
+++ b/moveos/moveos-types/src/addresses.rs
@@ -21,6 +21,11 @@ pub fn is_system_reserved_address(addr: AccountAddress) -> bool {
     bytes.iter().take(31).all(|u| u == &0u8) && bytes[31] > 0u8 && bytes[31] <= 10u8
 }
 
+pub fn is_vm_or_system_reserved_address(addr: AccountAddress) -> bool {
+    //zero is vm address
+    addr == AccountAddress::ZERO || is_system_reserved_address(addr)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/moveos/moveos-types/src/moveos_std/event.rs
+++ b/moveos/moveos-types/src/moveos_std/event.rs
@@ -125,11 +125,7 @@ impl FromStr for EventID {
 
 impl std::fmt::Display for EventID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "EventID[event handle id: {:?}, event seq: {}]",
-            self.event_handle_id, self.event_seq,
-        )
+        write!(f, "{}:{}", self.event_handle_id, self.event_seq)
     }
 }
 

--- a/moveos/moveos-types/src/state.rs
+++ b/moveos/moveos-types/src/state.rs
@@ -3,9 +3,8 @@
 
 use crate::h256;
 use crate::move_std::string::MoveString;
-use crate::moveos_std::object::{self, ObjectID};
 use crate::moveos_std::object::{
-    AnnotatedObject, DynamicField, ObjectEntity, ObjectMeta, RawData, RawObject,
+    AnnotatedObject, DynamicField, ObjectEntity, ObjectID, ObjectMeta, RawData, RawObject,
 };
 use anyhow::{bail, ensure, Result};
 use core::str;
@@ -652,12 +651,12 @@ impl ObjectState {
         &self.metadata.id
     }
 
-    pub fn value_type(&self) -> &TypeTag {
-        &self.metadata.value_type
+    pub fn object_type(&self) -> &TypeTag {
+        &self.metadata.object_type
     }
 
-    pub fn value_struct_tag(&self) -> &StructTag {
-        self.metadata.value_struct_tag()
+    pub fn object_struct_tag(&self) -> &StructTag {
+        self.metadata.object_struct_tag()
     }
 
     pub fn flag(&self) -> u8 {
@@ -681,24 +680,16 @@ impl ObjectState {
     }
 
     pub fn match_type(&self, type_tag: &TypeTag) -> bool {
-        self.value_type() == type_tag
+        self.metadata.match_type(type_tag)
     }
 
     pub fn match_struct_type(&self, type_tag: &StructTag) -> bool {
-        match self.value_type() {
-            TypeTag::Struct(struct_tag) => struct_tag.as_ref() == type_tag,
-            _ => false,
-        }
+        self.metadata.match_struct_type(type_tag)
     }
 
     pub fn match_dynamic_field_type(&self, name_type: TypeTag, value_type: TypeTag) -> bool {
-        if self.is_dynamic_field() {
-            self.match_struct_type(&object::construct_dynamic_field_struct_tag(
-                name_type, value_type,
-            ))
-        } else {
-            false
-        }
+        self.metadata
+            .match_dynamic_field_type(name_type, value_type)
     }
 
     pub fn is_dynamic_field(&self) -> bool {
@@ -729,7 +720,7 @@ impl ObjectState {
     where
         T: MoveStructState,
     {
-        let val_type = self.value_type();
+        let val_type = self.object_type();
         match val_type {
             TypeTag::Struct(struct_tag) => {
                 ensure!(
@@ -776,7 +767,7 @@ impl ObjectState {
     }
 
     pub fn into_raw_object(self) -> Result<RawObject> {
-        let object_struct_tag = self.value_struct_tag().clone();
+        let object_struct_tag = self.object_struct_tag().clone();
         Ok(RawObject::new_with_object_meta(
             self.metadata,
             RawData {
@@ -795,7 +786,7 @@ impl ObjectState {
         annotator: &MoveValueAnnotator<T>,
     ) -> Result<AnnotatedState> {
         let decoded_value = annotator
-            .view_resource(self.value_struct_tag(), &self.value)
+            .view_resource(self.object_struct_tag(), &self.value)
             .map_err(|e| anyhow::anyhow!("Annotate the MoveValue error: {:?}", e))?;
         Ok(AnnotatedState::new(self, decoded_value))
     }

--- a/moveos/moveos-types/src/state_resolver.rs
+++ b/moveos/moveos-types/src/state_resolver.rs
@@ -159,7 +159,7 @@ where
                     s.match_dynamic_field_type(MoveString::type_tag(), resource_tag.clone().into()),
                     "Resource type mismatch, expected field value type: {:?}, actual: {:?}",
                     resource_tag,
-                    s.value_type()
+                    s.object_type()
                 );
                 let field = RawField::parse_resource_field(&s.value, resource_tag.clone().into())?;
                 Ok(field.value)

--- a/moveos/moveos/src/vm/tx_argument_resolver.rs
+++ b/moveos/moveos/src/vm/tx_argument_resolver.rs
@@ -92,7 +92,7 @@ where
                         )
                         .with_message(format!(
                             "Invalid object type, object type in argument:{:?}, object type in store:{:?}",
-                            object_type, object.value_type()
+                            object_type, object.object_type()
                         )).finish(location.clone()));
                     }
                     if object.is_dynamic_field() {

--- a/sdk/typescript/rooch-sdk/src/client/types/generated.ts
+++ b/sdk/typescript/rooch-sdk/src/client/types/generated.ts
@@ -147,13 +147,13 @@ export interface IndexerObjectStateView {
   decoded_value?: AnnotatedMoveStructView | null
   display_fields?: DisplayFieldsView | null
   flag: number
-  object_id: string
+  id: string
   object_type: string
   owner: string
   owner_bitcoin_address?: string | null
   size: string
   state_index: string
-  state_root: string
+  state_root: string | null
   tx_order: string
   updated_at: string
   /** bcs bytes of the Object. */
@@ -297,7 +297,7 @@ export interface ObjectStateView {
   owner: string
   owner_bitcoin_address?: string | null
   size: string
-  state_root: string
+  state_root: string | null
   updated_at: string
   value: string
 }

--- a/sdk/typescript/rooch-sdk/src/client/types/generated.ts
+++ b/sdk/typescript/rooch-sdk/src/client/types/generated.ts
@@ -421,7 +421,7 @@ export interface StateChangeSetView {
   global_size: string
 }
 export interface StateKVView {
-  key_hex: string
+  field_key: string
   state: StateView
 }
 export interface StateOptions {


### PR DESCRIPTION
## Summary

part of #2102 

1. Unify `object_id` to `id`.
2. Reuse `ObjectMetaView` in `ObjectStateView` and `IndexerObjectStateView` and `UTXOStateView` and `InscriptionStateView`.
3. Unify `value_type` to `object_type`.
4. Unify `u64` to `StrView<u64>` in RPC types.
5. StrView<u64> support deserialize from String and u64 both.
6. Replace `StrView<usize>` to `StrView<u64>`.
7. Rename `key_hex` to `field_key`.


- Closes #issue