### PR TITLE
[cli] rooch session-key list

### DIFF
--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{Ok, Result};
 use jsonrpsee::http_client::HttpClient;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::account::Account;
@@ -12,7 +12,7 @@ use rooch_rpc_api::jsonrpc_types::{
 };
 use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, EventOptions, EventPageView,
-    RoochAddressView, StateOptions, StatePageView, StructTagView,
+    ObjectIDView, RoochAddressView, StateOptions, StatePageView, StructTagView,
 };
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, ObjectStateView};
 use rooch_rpc_api::jsonrpc_types::{
@@ -167,6 +167,19 @@ impl RoochRpcClient {
         Ok(self
             .http
             .list_states(access_path, cursor, limit.map(Into::into), None)
+            .await?)
+    }
+
+    pub async fn list_field_states(
+        &self,
+        object_id: ObjectIDView,
+        cursor: Option<String>,
+        limit: Option<u64>,
+        state_option: Option<StateOptions>,
+    ) -> Result<StatePageView> {
+        Ok(self
+            .http
+            .list_field_states(object_id, cursor, limit.map(Into::into), state_option)
             .await?)
     }
 

--- a/crates/rooch/src/commands/session_key/commands/list.rs
+++ b/crates/rooch/src/commands/session_key/commands/list.rs
@@ -1,0 +1,92 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::{CommandAction, WalletContextOptions};
+use async_trait::async_trait;
+use clap::Parser;
+use move_core_types::identifier::Identifier;
+use moveos_types::move_types::FunctionId;
+use moveos_types::moveos_std::object::ObjectID;
+use moveos_types::transaction::FunctionCall;
+use rooch_rpc_api::jsonrpc_types::{
+    AnnotatedFunctionResultView, AnnotatedMoveValueView, StateOptions, StatePageView,
+};
+use rooch_types::address::ParsedAddress;
+use rooch_types::error::{RoochError, RoochResult};
+use std::collections::BTreeMap;
+
+/// List all session keys by address
+#[derive(Debug, Parser)]
+pub struct ListCommand {
+    #[clap(short = 'a', long = "address", value_parser=ParsedAddress::parse, default_value = "default")]
+    /// The account's address to list session keys, if absent, show the default active account.
+    address: ParsedAddress,
+
+    #[clap(flatten)]
+    pub context_options: WalletContextOptions,
+}
+
+#[async_trait]
+impl CommandAction<Vec<BTreeMap<Identifier, AnnotatedMoveValueView>>> for ListCommand {
+    async fn execute(self) -> RoochResult<Vec<BTreeMap<Identifier, AnnotatedMoveValueView>>> {
+        let context = self.context_options.build()?;
+        let mapping = context.address_mapping();
+        let address_addr = self.address.into_account_address(&mapping)?;
+
+        let function_id = "0x3::session_key::handle".parse::<FunctionId>()?;
+        let function_call = FunctionCall::new(function_id, vec![], vec![address_addr.to_vec()]);
+        let client = context.get_client().await?;
+        let view_result = client
+            .rooch
+            .execute_view_function(function_call)
+            .await
+            .map_err(|e| RoochError::ViewFunctionError(e.to_string()))?;
+        let obj_id = extract_obj_id(view_result)
+            .ok_or(RoochError::from(anyhow::anyhow!("Session key not found")))?;
+
+        let options = StateOptions::new().decode(true);
+        let field_result = client
+            .rooch
+            .list_field_states(obj_id.into(), None, None, Some(options))
+            .await
+            .map_err(RoochError::from)?;
+
+        Ok(extract_session_keys(field_result))
+    }
+}
+
+fn extract_obj_id(view_result: AnnotatedFunctionResultView) -> Option<ObjectID> {
+    if let Some(return_value) = view_result.return_values {
+        if let AnnotatedMoveValueView::Struct(struct_value) =
+            return_value.first()?.decoded_value.clone()
+        {
+            if let Some(AnnotatedMoveValueView::Vector(vec)) =
+                struct_value.value.first_key_value().map(|(_, value)| value)
+            {
+                if let AnnotatedMoveValueView::Address(addr) = vec.first()? {
+                    addr.to_string().parse::<ObjectID>().ok()
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+fn extract_session_keys(
+    field_result: StatePageView,
+) -> Vec<BTreeMap<Identifier, AnnotatedMoveValueView>> {
+    let mut value = vec![];
+    for data in field_result.data {
+        if let Some(decoded_value) = data.state.decoded_value {
+            value.push(decoded_value.value)
+        }
+    }
+    value
+}

--- a/crates/rooch/src/commands/session_key/commands/mod.rs
+++ b/crates/rooch/src/commands/session_key/commands/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod create;
+pub mod list;

--- a/crates/rooch/src/commands/session_key/mod.rs
+++ b/crates/rooch/src/commands/session_key/mod.rs
@@ -5,6 +5,7 @@ use crate::cli_types::CommandAction;
 use async_trait::async_trait;
 use clap::Parser;
 use commands::create::CreateCommand;
+use commands::list::ListCommand;
 use rooch_types::error::RoochResult;
 
 pub mod commands;
@@ -23,6 +24,7 @@ impl CommandAction<String> for SessionKey {
             SessionKeyCommand::Create(create) => create.execute().await.map(|resp| {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
             }),
+            SessionKeyCommand::List(list) => list.execute_serialized().await,
         }
     }
 }
@@ -30,5 +32,6 @@ impl CommandAction<String> for SessionKey {
 #[derive(clap::Subcommand)]
 #[clap(name = "session_key")]
 pub enum SessionKeyCommand {
-    Create(CreateCommand),
+    Create(Box<CreateCommand>),
+    List(ListCommand),
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -55,6 +55,7 @@ Feature: Rooch CLI integration tests
       # session key
       Then cmd: "session-key create  --app-name test --app-url https:://test.rooch.network --scope 0x3::empty::empty"
       Then cmd: "session-key list"
+      Then assert: "'{{$.session-key[-1]}}' not_contains Error"
       Then cmd: "move run --function 0x3::empty::empty  --session-key {{$.session-key[-1][0].name}}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -54,7 +54,8 @@ Feature: Rooch CLI integration tests
 
       # session key
       Then cmd: "session-key create  --app-name test --app-url https:://test.rooch.network --scope 0x3::empty::empty"
-      Then cmd: "move run --function 0x3::empty::empty  --session-key {{$.session-key[-1].authentication_key}}"
+      Then cmd: "session-key list"
+      Then cmd: "move run --function 0x3::empty::empty  --session-key {{$.session-key[-1][0].name}}"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
       # transaction

--- a/frameworks/rooch-framework/doc/session_key.md
+++ b/frameworks/rooch-framework/doc/session_key.md
@@ -22,6 +22,7 @@
 -  [Function `active_session_key`](#0x3_session_key_active_session_key)
 -  [Function `remove_session_key`](#0x3_session_key_remove_session_key)
 -  [Function `remove_session_key_entry`](#0x3_session_key_remove_session_key_entry)
+-  [Function `handle`](#0x3_session_key_handle)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -30,6 +31,7 @@
 <b>use</b> <a href="">0x1::vector</a>;
 <b>use</b> <a href="">0x2::account</a>;
 <b>use</b> <a href="">0x2::features</a>;
+<b>use</b> <a href="">0x2::object</a>;
 <b>use</b> <a href="">0x2::table</a>;
 <b>use</b> <a href="">0x2::timestamp</a>;
 <b>use</b> <a href="">0x2::tx_context</a>;
@@ -259,4 +261,15 @@ Check the current tx is in the session scope or not
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="session_key.md#0x3_session_key_remove_session_key_entry">remove_session_key_entry</a>(sender: &<a href="">signer</a>, authentication_key: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<a name="0x3_session_key_handle"></a>
+
+## Function `handle`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="session_key.md#0x3_session_key_handle">handle</a>(account_address: <b>address</b>): <a href="_Option">option::Option</a>&lt;<a href="_ObjectID">object::ObjectID</a>&gt;
 </code></pre>

--- a/frameworks/rooch-framework/sources/session_key.move
+++ b/frameworks/rooch-framework/sources/session_key.move
@@ -5,6 +5,7 @@ module rooch_framework::session_key {
     use std::vector;
     use std::option::{Self, Option};
     use std::signer;
+    use moveos_std::object::ObjectID;
     use moveos_std::account;
     use moveos_std::tx_context; 
     use moveos_std::table::{Self, Table};
@@ -258,6 +259,14 @@ module rooch_framework::session_key {
 
     public entry fun remove_session_key_entry(sender: &signer, authentication_key: vector<u8>) {
         remove_session_key(sender, authentication_key);
+    }
+
+    public fun handle(account_address: address) : Option<ObjectID> {
+        if (!account::exists_resource<SessionKeys>(account_address)){
+            return option::none()
+        };
+        let session_keys = account::borrow_resource<SessionKeys>(account_address);
+        option::some(table::handle(&session_keys.keys))
     }
 
     #[test]


### PR DESCRIPTION
```
rooch session-key list -h
List all session keys by address

Usage: rooch session-key list [OPTIONS]

Options:
  -a, --address <ADDRESS>        The account's address to list session keys, if absent, show the default active account [default: default]
      --password <PASSWORD>      The key store password
      --config-dir <CONFIG_DIR>  rooch config path
  -h, --help                     Print help
```