### PR TITLE
docs: update prerequirements for compiling rooch in docs

### DIFF
--- a/docs/website/pages/build/getting-started/installation.en-US.mdx
+++ b/docs/website/pages/build/getting-started/installation.en-US.mdx
@@ -7,7 +7,7 @@
 #### Install dependencies
 
 ```shell
-sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++
+sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++ protobuf-compiler
 ```
 
 #### Install Rust

--- a/docs/website/pages/build/getting-started/installation.zh-CN.mdx
+++ b/docs/website/pages/build/getting-started/installation.zh-CN.mdx
@@ -7,7 +7,7 @@
 #### 安装依赖
 
 ```shell
-sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++
+sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++ protobuf-compiler
 ```
 
 #### 安装 Rust


### PR DESCRIPTION
## Summary

solve issue #2148 , need to install `protobuf-compiler` before compiling rooch on ubuntu.

- Closes #2148