### PR TITLE
docs: jemalloc needs cmake to compile

### DIFF
--- a/docs/website/pages/build/getting-started/installation.en-US.mdx
+++ b/docs/website/pages/build/getting-started/installation.en-US.mdx
@@ -7,7 +7,7 @@
 #### Install dependencies
 
 ```shell
-sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++ protobuf-compiler
+sudo apt install git curl cmake gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++ protobuf-compiler
 ```
 
 #### Install Rust

--- a/docs/website/pages/build/getting-started/installation.zh-CN.mdx
+++ b/docs/website/pages/build/getting-started/installation.zh-CN.mdx
@@ -7,7 +7,7 @@
 #### 安装依赖
 
 ```shell
-sudo apt install git curl gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++ protobuf-compiler
+sudo apt install git curl cmake gcc lld pkg-config libssl-dev libclang-dev libsqlite3-dev g++ protobuf-compiler
 ```
 
 #### 安装 Rust


### PR DESCRIPTION
## Summary

jemalloc needs cmake to compile

The following errors will occur if you do not have cmake installed.

```bash
running: cd "/code/rooch/target/debug/build/tikv-jemalloc-sys-69f431b389e09613/out/build" && "make" "-j" "16"

--- stderr
thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tikv-jemalloc-sys-0.5.4+5.3.0-patched/build.rs:347:19:
failed to execute command: No such file or directory (os error 2)
```