### PR TITLE
fix(docker): fix build issue caused by uninstalled tool in DockerfileDebug

### DIFF
--- a/docker/DockerfileDebug
+++ b/docker/DockerfileDebug
@@ -16,6 +16,7 @@ RUN set -eux; \
         libsnappy-dev \
         g++ \
         cmake \
+        make \
         libsqlite3-dev \
         libprotobuf-dev \
         protobuf-compiler; \
@@ -38,7 +39,7 @@ RUN set -eux; \
     wget "http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb"; \
     DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb;
 
-ENV RUST_VERSION=1.70.0
+ENV RUST_VERSION=1.78.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/scripts/deploy_rooch.sh
+++ b/scripts/deploy_rooch.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) RoochNetwork
+# SPDX-License-Identifier: Apache-2.0
 
 REF="\$1"
 BTC_TEST_RPC_URL="\$2"


### PR DESCRIPTION
## Summary

updated DockerfileDebug by adding make to the list of installed packages to fix building jemalloc issue, and bumped up the RUST_VERSION environment variable to use a more current version(as same as toolchain we're using).

