### PR TITLE
Minor Update Typo in  scripts/bitcoin/README.md

### DIFF
--- a/scripts/bitcoin/README.md
+++ b/scripts/bitcoin/README.md
@@ -21,7 +21,7 @@ This directory contains scripts for setting up a local development environment f
 
 ## Usage
 
-You can also configure the environment using the env script, use `./env -i`
+You can also configure the environment using the env script, use `./env.sh -i`
 
 1. Run `ord server` to start ord indexer server
 2. Run `ord wallet create` to create a new ord wallet


### PR DESCRIPTION
## Summary

The command for running env script seems missing "*.sh".