### PR TITLE
docs: update examples/blog docs

### DIFF
--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -16,7 +16,7 @@ So before you start experiencing, you need to:
 
 * Install [Docker](https://docs.docker.com/engine/install/).
 
-* Install `curl` and `jp` commands (jp - commandline JSON processor). We can use `jp` to process JSON RPC returned JSON results when testing contracts.
+* Install `curl` and `jq` commands (jq - commandline JSON processor). We can use `jq` to process JSON RPC returned JSON results when testing contracts.
 
 * (Optional) Install MySQL database. Can be used to deploy and test off-chain services.
 
@@ -269,9 +269,9 @@ You can add a pipe operation (` | jq '.result.data[0].parsed_event_data.value.id
 
 > **Tip**
 >
-> Before using the `jp` command (jq - commandline JSON processor), you may need to install it on your machine first.
+> Before using the `jq` command (jq - commandline JSON processor), you may need to install it on your machine first.
 
-The command with `jp` processing looks like this:
+The command with `jq` processing looks like this:
 
 ```shell
 curl --location --request POST 'http://localhost:6767' \
@@ -450,7 +450,7 @@ The returned transaction execution status should be failed:
 
 ## Using the Off-chain Service
 
-By querying the RESTful API of the off-chain service, you can easily get the detailed information of articles and comments, without using the `curl` and `jp` commands introduced above.
+By querying the RESTful API of the off-chain service, you can easily get the detailed information of articles and comments, without using the `curl` and `jq` commands introduced above.
 
 > **Tip**
 >

--- a/examples/blog/README_CN.md
+++ b/examples/blog/README_CN.md
@@ -16,7 +16,7 @@
 
 * 安装 [Docker](https://docs.docker.com/engine/install/)。
 
-* 安装 curl 以及 jp 命令（jp - commandline JSON processor）。我们在测试合约的时候可以使用 jp 来处理 JSON RPC 返回的 JSON 结果。
+* 安装 curl 以及 jq 命令（jq - commandline JSON processor）。我们在测试合约的时候可以使用 jq 来处理 JSON RPC 返回的 JSON 结果。
 
 * （可选）安装 MySQL 数据库。可用于部署和测试链下服务。
 
@@ -269,9 +269,9 @@ curl --location --request POST 'http://localhost:6767' \
 
 > **提示**
 >
-> 在使用 `jp` 命令（jq - commandline JSON processor）之前，你可能需要在本机上先安装它。
+> 在使用 `jq` 命令（jq - commandline JSON processor）之前，你可能需要在本机上先安装它。
 
-添加 `jp` 处理后的命令像下面这样：
+添加 `jq` 处理后的命令像下面这样：
 
 ```shell
 curl --location --request POST 'http://localhost:6767' \
@@ -450,7 +450,7 @@ rooch move run --function {ACCOUNT_ADDRESS}::article_aggregate::delete --sender-
 
 ## 使用链下服务
 
-通过查询链下服务的 RESTful API，你可以更容易地查询到文章和评论的具体信息，而不需要使用上面介绍的 curl 和 jp 命令。
+通过查询链下服务的 RESTful API，你可以更容易地查询到文章和评论的具体信息，而不需要使用上面介绍的 curl 和 jq 命令。
 
 > **提示**
 >


### PR DESCRIPTION
## Summary

I think it should be `jq` for command line json processor in the docs, not `jp`