### PR TITLE
fix(genesis_ord: implement sequence_number:inscription_id as InscriptionStore's dynamic field

### DIFF
--- a/crates/rooch-types/src/bitcoin/ord.rs
+++ b/crates/rooch-types/src/bitcoin/ord.rs
@@ -192,8 +192,6 @@ impl MoveStructState for InscriptionRecord {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InscriptionStore {
-    /// The inscriptions ids table_vec object id
-    pub inscriptions: ObjectID,
     /// cursed inscription number generator
     pub cursed_inscription_count: u32,
     /// blessed inscription number generator
@@ -217,7 +215,6 @@ impl MoveStructType for InscriptionStore {
 impl MoveStructState for InscriptionStore {
     fn struct_layout() -> move_core_types::value::MoveStructLayout {
         move_core_types::value::MoveStructLayout::new(vec![
-            ObjectID::type_layout(),
             u32::type_layout(),
             u32::type_layout(),
             u32::type_layout(),

--- a/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
@@ -214,7 +214,7 @@ fn index_utxo_ords(
     println!("indexing utxo:ords started at: {}", datetime);
 
     let mut ord_src_reader =
-        BufReader::with_capacity(8 * 1024 * 1024, File::open(ord_src_path).unwrap());
+        BufReader::with_capacity(8 * 1024 * 1024, File::open(ord_src_path.clone()).unwrap());
     let mut is_title_line = true;
 
     let mut ord_count: u64 = 0;
@@ -244,7 +244,7 @@ fn index_utxo_ords(
     }
 
     // too big file load in cache
-    let file_cache_manager = FileCacheManager::new(ord_src_path.clone()).unwrap();
+    let file_cache_manager = FileCacheManager::new(ord_src_path).unwrap();
     let _ = file_cache_manager.drop_cache_range(0, 1024 * 1024 * 1024 * 1024);
 
     let utxo_count = sort_merge_utxo_ords(&mut utxo_ords) as u64;

--- a/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
@@ -243,6 +243,10 @@ fn index_utxo_ords(
         ord_count += 1;
     }
 
+    // too big file load in cache
+    let file_cache_manager = FileCacheManager::new(ord_src_path.clone()).unwrap();
+    let _ = file_cache_manager.drop_cache_range(0, 1024 * 1024 * 1024 * 1024);
+
     let utxo_count = sort_merge_utxo_ords(&mut utxo_ords) as u64;
 
     if deep_check && utxo_ord_map_existed {


### PR DESCRIPTION
## Summary

1. remove table_vec in InscriptionStore
2. combine inscription_obj_id:Inscription and sequence_number:inscription_id into signle UpdateSet of InscriptonStore

https://github.com/rooch-network/rooch/issues/1798