### PR TITLE
[cli]Line break output after password output

### DIFF
--- a/crates/rooch/src/cli_types.rs
+++ b/crates/rooch/src/cli_types.rs
@@ -99,7 +99,7 @@ pub struct TransactionOptions {
     pub(crate) session_key: Option<AuthenticationKey>,
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug)]
 pub struct WalletContextOptions {
     /// The key store password
     #[clap(long)]
@@ -119,10 +119,11 @@ impl WalletContextOptions {
         if ctx.keystore.get_if_password_is_empty() {
             Ok(ctx)
         } else {
-            let password = self
-                .password
-                .clone()
-                .or_else(|| prompt_password("Enter the keystore password:").ok());
+            let password = self.password.clone().or_else(|| {
+                let password = prompt_password("Enter the keystore password:").ok();
+                println!();
+                password
+            });
             let is_verified = verify_password(password.clone(), ctx.keystore.get_password_hash())?;
             if !is_verified {
                 return Err(RoochError::InvalidPasswordError(

--- a/crates/rooch/src/cli_types.rs
+++ b/crates/rooch/src/cli_types.rs
@@ -99,7 +99,7 @@ pub struct TransactionOptions {
     pub(crate) session_key: Option<AuthenticationKey>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Parser)]
 pub struct WalletContextOptions {
     /// The key store password
     #[clap(long)]

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -69,9 +69,11 @@ impl CommandAction<Option<AccountsView>> for ListCommand {
         let password = if context.keystore.get_if_password_is_empty() {
             None
         } else {
-            Some(
+            let password = Some(
                 prompt_password("Enter the password to create a new key pair:").unwrap_or_default(),
-            )
+            );
+            println!();
+            password
         };
 
         let accounts: Vec<LocalAccount> = context.keystore.get_accounts(password)?;


### PR DESCRIPTION
## Summary

- Add line break after entering password

before:


![697e89bafea5616ce0313b873e4f1f1](https://github.com/user-attachments/assets/3c355d46-eac0-464b-b220-3d4a7fa60028)
after:
![043ac3760c4fc8bca59254816e6469e](https://github.com/user-attachments/assets/b6c12979-83d8-4293-a682-e6bee7496043)
