### PR TITLE
fix(statedb): fix export genesis error caused by object struct changes

### DIFF
--- a/crates/rooch/src/commands/statedb/commands/export.rs
+++ b/crates/rooch/src/commands/statedb/commands/export.rs
@@ -22,7 +22,7 @@ use rooch_types::rooch_network::RoochChainID;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::time::SystemTime;
+use std::time::{Instant, SystemTime};
 
 /// Export statedb
 
@@ -167,7 +167,7 @@ impl ExportCommand {
         })?;
         println!("root object: {:?}", root);
 
-        let mut _start_time = SystemTime::now();
+        let start_time = Instant::now();
         let file_name = self.output.display().to_string();
         let mut writer_builder = csv::WriterBuilder::new();
         let writer_builder = writer_builder.delimiter(b',').double_quote(false);
@@ -198,7 +198,7 @@ impl ExportCommand {
             }
         }
 
-        println!("Finish export task.");
+        println!("Finish export task in {}." start_time.elapsed());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

### Original Error

```
Error: CSV error: found record with 1 fields, but the previous record has 2 fields
```

### Fix

The issue was fixed by exporting `(FieldKey, ObjectState)`.

### Refine Codes

1. general init_job() used, simplifies both of the initialization of genesis jobs and export tasks
2. utilize instant time instead of system time for recording time cost

