### PR TITLE
Missing version update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/rooch-network/rooch"
 rust-version = "1.78.0"
-version = "0.6.1"
+version = "0.6.2"
 
 [workspace.dependencies]
 # Internal crate dependencies.


### PR DESCRIPTION
## Summary
The 0.6.2 is released; however, the version is in cargo.toml not up-to-date(0.6.1).
<img width="259" alt="image" src="https://github.com/user-attachments/assets/fe2aa4e1-1967-4260-bd20-0ac36ec43a5d">


