### PR TITLE
fix server panic when bitcoin address is empty

### DIFF
--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -661,6 +661,9 @@ impl BitcoinAddress {
 
     ///  Format the base58 as a hexadecimal string
     pub fn format(&self, network: u8) -> Result<String, anyhow::Error> {
+        if self.bytes.is_empty() {
+            anyhow::bail!("bitcoin address is empty");
+        }
         let payload_type = BitcoinAddressPayloadType::try_from(self.bytes[0])?;
         match payload_type {
             BitcoinAddressPayloadType::PubkeyHash => {


### PR DESCRIPTION
## Summary

Fix server panic when bitcoin address is empty, #2247

Still need to figure out why there's an empty bitcoin address.