### PR TITLE
Improvement the move publish output

### DIFF
--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -277,7 +277,10 @@ impl Publish {
                         };
                         let object_state = ObjectState::new(metadata, bytes);
                         let module = object_state.value_as_df::<MoveString, MoveModule>()?;
-                        let module_id = format!("{}::{}", package_owner, module.name);
+                        let module_id = ModuleId::new(
+                            package_owner.into(),
+                            Identifier::new(format!("{}", module.name))?,
+                        );
                         if flag == 0 {
                             new_modules.push(module_id);
                         } else {
@@ -292,7 +295,7 @@ impl Publish {
                 output.push_str("\n    None");
             } else {
                 for module in new_modules {
-                    output.push_str(&format!("\n    {}", module));
+                    output.push_str(&format!("\n    {}", module.short_str_lossless()));
                 }
             };
             output.push_str("\n\nUpdated modules:");
@@ -300,7 +303,7 @@ impl Publish {
                 output.push_str("\n    None");
             } else {
                 for module in updated_modules {
-                    output.push_str(&format!("\n    {}", module));
+                    output.push_str(&format!("\n    {}", module.short_str_lossless()));
                 }
             };
         }

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -5,10 +5,16 @@ use crate::cli_types::{CommandAction, TransactionOptions, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
 use move_cli::Move;
+use move_core_types::effects::Op;
 use move_core_types::{identifier::Identifier, language_storage::ModuleId};
 use moveos_compiler::dependency_order::sort_by_dependency_order;
+use moveos_types::move_std::string::MoveString;
+use moveos_types::moveos_std::module_store::ModuleStore;
+use moveos_types::moveos_std::move_module::MoveModule;
+use moveos_types::moveos_std::object::ObjectMeta;
 use moveos_types::{
-    addresses::MOVEOS_STD_ADDRESS, move_types::FunctionId, transaction::MoveAction,
+    addresses::MOVEOS_STD_ADDRESS, move_types::FunctionId, state::ObjectState,
+    transaction::MoveAction,
 };
 use moveos_verifier::build::run_verifier;
 use moveos_verifier::verifier;
@@ -49,6 +55,10 @@ pub struct Publish {
     /// For now, the option is kept for test only.
     #[clap(long)]
     pub by_move_action: bool,
+
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
 }
 
 #[async_trait]
@@ -198,5 +208,103 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
         //Directly return the result, the publish transaction may be failed.
         //Caller need to check the `execution_info.status` field.
         Ok(tx_result)
+    }
+
+    /// Executes the command, and serializes it to the common JSON output type
+    async fn execute_serialized(self) -> RoochResult<String> {
+        let json = self.json;
+        let result = self.execute().await?;
+
+        if json {
+            let output = serde_json::to_string_pretty(&result).unwrap();
+            if output == "null" {
+                return Ok("".to_string());
+            }
+            Ok(output)
+        } else {
+            Self::pretty_transaction_response(&result)
+        }
+    }
+}
+
+impl Publish {
+    fn pretty_transaction_response(
+        txn_response: &ExecuteTransactionResponseView,
+    ) -> RoochResult<String> {
+        let mut output = String::new();
+
+        // print execution info
+        let exe_info = &txn_response.execution_info;
+        output.push_str(&format!(
+            r#"Execution info:
+    status: {:?}
+    gas used: {}
+    tx hash: {}
+    state root: {}
+    event root: {}"#,
+            exe_info.status,
+            exe_info.gas_used,
+            exe_info.tx_hash,
+            exe_info.state_root,
+            exe_info.event_root
+        ));
+
+        if let Some(txn_output) = &txn_response.output {
+            // print modules
+            let changes = &txn_output.changeset.changes;
+            let module_store_id = ModuleStore::object_id();
+            let mut new_modules = vec![];
+            let mut updated_modules = vec![];
+            for change in changes {
+                if change.metadata.id != module_store_id {
+                    continue;
+                };
+
+                for package_change in &change.fields {
+                    let package_owner = package_change.metadata.owner.0;
+                    for module_change in &package_change.fields {
+                        let metadata = ObjectMeta::from(module_change.metadata.clone());
+
+                        let value = module_change.value.clone().map(Op::<Vec<u8>>::from).ok_or(
+                            RoochError::TransactionError(
+                                "Module change value is missing".to_owned(),
+                            ),
+                        )?;
+                        let (flag, bytes) = match value {
+                            Op::New(bytes) => (0, bytes),
+                            Op::Modify(bytes) => (1, bytes),
+                            Op::Delete => unreachable!("Module will never be deleted"),
+                        };
+                        let object_state = ObjectState::new(metadata, bytes);
+                        let module = object_state.value_as_df::<MoveString, MoveModule>()?;
+                        let module_id = format!("{}::{}", package_owner, module.name);
+                        if flag == 0 {
+                            new_modules.push(module_id);
+                        } else {
+                            updated_modules.push(module_id);
+                        }
+                    }
+                }
+            }
+
+            output.push_str("\n\nNew modules:");
+            if new_modules.is_empty() {
+                output.push_str("\n    None");
+            } else {
+                for module in new_modules {
+                    output.push_str(&format!("\n    {}", module));
+                }
+            };
+            output.push_str("\n\nUpdated modules:");
+            if updated_modules.is_empty() {
+                output.push_str("\n    None");
+            } else {
+                for module in updated_modules {
+                    output.push_str(&format!("\n    {}", module));
+                }
+            };
+        }
+
+        Ok(output)
     }
 }

--- a/crates/testsuite/features/bitseed.feature
+++ b/crates/testsuite/features/bitseed.feature
@@ -25,7 +25,7 @@ Feature: Rooch CLI bitseed tests
       Then assert: "{{$.wallet[-1].total}} == 5000000000"
 
       # publish bitseed runner
-      Then cmd: "move publish -p ../../examples/bitseed_runner  --named-addresses rooch_examples=default"
+      Then cmd: "move publish -p ../../examples/bitseed_runner  --named-addresses rooch_examples=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
       # generator

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -96,7 +96,7 @@ Feature: Rooch CLI integration tests
     Scenario: event
     Given a server for event
     # event example and event prc
-    Then cmd: "move publish -p ../../examples/event  --named-addresses rooch_examples=default"
+    Then cmd: "move publish -p ../../examples/event  --named-addresses rooch_examples=default --json"
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
     Then cmd: "move run --function default::event_test::emit_event  --args 10u64"
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
@@ -121,7 +121,7 @@ Feature: Rooch CLI integration tests
   @serial
   Scenario: indexer
     Given a server for indexer
-    Then cmd: "move publish -p ../../examples/event  --named-addresses rooch_examples=default"
+    Then cmd: "move publish -p ../../examples/event  --named-addresses rooch_examples=default --json"
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
     Then cmd: "move run --function default::event_test::emit_event  --args 10u64"
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
@@ -164,7 +164,7 @@ Feature: Rooch CLI integration tests
   @serial
     Scenario: kv_store example
       Given a server for kv_store
-      Then cmd: "move publish -p ../../examples/kv_store  --named-addresses rooch_examples=default"
+      Then cmd: "move publish -p ../../examples/kv_store  --named-addresses rooch_examples=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function default::kv_store::add_value --args string:key1 --args string:value1"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
@@ -183,7 +183,7 @@ Feature: Rooch CLI integration tests
     Scenario: entry_function example
       Given a server for entry_function
 
-      Then cmd: "move publish -p ../../examples/entry_function_arguments/  --named-addresses rooch_examples=default"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments/  --named-addresses rooch_examples=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function default::entry_function::emit_bool --args bool:true "
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
@@ -217,7 +217,7 @@ Feature: Rooch CLI integration tests
       Given a server for publish_through_move_action
 
       # The counter example
-      Then cmd: "move publish -p ../../examples/counter  --named-addresses rooch_examples=default --by-move-action"
+      Then cmd: "move publish -p ../../examples/counter  --named-addresses rooch_examples=default --by-move-action --json"
       Then assert: "'{{$.move[-1]}}' contains INVALID_MODULE_PUBLISHER"
 
       Then stop the server
@@ -227,7 +227,7 @@ Feature: Rooch CLI integration tests
       Given a server for publish_through_entry_function
 
       # The counter example
-      Then cmd: "move publish -p ../../examples/counter  --named-addresses rooch_examples=default"
+      Then cmd: "move publish -p ../../examples/counter  --named-addresses rooch_examples=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move view --function default::counter::value"
       Then assert: "{{$.move[-1].return_values[0].decoded_value}} == 0"
@@ -238,17 +238,17 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.resource[-1].decoded_value.value.value.value.value}} == 1"
 
       # The entry_function_arguments example
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/  --named-addresses rooch_examples=default"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/  --named-addresses rooch_examples=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function default::entry_function::emit_mix --args 3u8 --args "vector<object_id>:0x2342,0x3132" "
       Then assert: "'{{$.move[-1]}}' contains FUNCTION_RESOLUTION_FAILURE"
-      Then cmd: "move publish -p ../../examples/entry_function_arguments/  --named-addresses rooch_examples=default"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments/  --named-addresses rooch_examples=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function default::entry_function::emit_mix --args 3u8 --args "vector<object_id>:0x2342,0x3132" "
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
       # check compatibility
-      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/  --named-addresses rooch_examples=default"
+      Then cmd: "move publish -p ../../examples/entry_function_arguments_old/  --named-addresses rooch_examples=default --json"
       Then assert: "'{{$.move[-1].execution_info.status.type}}' == 'moveabort'"
 
       Then stop the server
@@ -257,7 +257,7 @@ Feature: Rooch CLI integration tests
   Scenario: coins example
       Given a server for coins
       Then cmd: "account create --json"
-      Then cmd: "move publish -p ../../examples/coins  --named-addresses coins=default"
+      Then cmd: "move publish -p ../../examples/coins  --named-addresses coins=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function default::fixed_supply_coin::faucet --args object:default::fixed_supply_coin::Treasury"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
@@ -280,7 +280,7 @@ Feature: Rooch CLI integration tests
   @serial
   Scenario: Issue a coin through module_template
     Given a server for issue_coin
-    Then cmd: "move publish -p ../../examples/module_template/  --named-addresses rooch_examples=default"
+    Then cmd: "move publish -p ../../examples/module_template/  --named-addresses rooch_examples=default --json"
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
     
     #TODO: uncomment this once move_module::binding_module_address is ready
@@ -301,7 +301,7 @@ Feature: Rooch CLI integration tests
       Given a server for basic_object
       Then cmd: "account create"
       Then cmd: "account list --json"
-      Then cmd: "move publish -p ../../examples/basic_object  --named-addresses basic_object=default"
+      Then cmd: "move publish -p ../../examples/basic_object  --named-addresses basic_object=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       
       #object pub transfer
@@ -351,7 +351,7 @@ Feature: Rooch CLI integration tests
   Scenario: object display example
       Given a server for object_display
       Then cmd: "account create"
-      Then cmd: "move publish -p ../../examples/display  --named-addresses display=default"
+      Then cmd: "move publish -p ../../examples/display  --named-addresses display=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
       Then cmd: "move run --function default::display::create_object --sender default --args 'string:test_object' --args 'address:default' --args 'string:test object description'"
@@ -382,7 +382,7 @@ Feature: Rooch CLI integration tests
       Given a server for wasm_test
 
       # publish wasm execution
-      Then cmd: "move publish -p ../../examples/wasm_execution  --named-addresses rooch_examples=default"
+      Then cmd: "move publish -p ../../examples/wasm_execution  --named-addresses rooch_examples=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
       # test wasm trap
@@ -432,7 +432,7 @@ Feature: Rooch CLI integration tests
     Scenario: view_function_loop example
       Given a server for view_function_loop
       Then cmd: "account create"
-      Then cmd: "move publish -p ../../examples/view_function_loop  --named-addresses rooch_examples=default"
+      Then cmd: "move publish -p ../../examples/view_function_loop  --named-addresses rooch_examples=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move view --function default::out_of_gas_loop::out_of_gas"
       Then assert: "{{$.move[-1].vm_status.ExecutionFailure.status_code}} == 4002"


### PR DESCRIPTION
## Summary

move publish output will be like:

```shell
Publish modules to address: rooch1r9jts4m7nwprtmm0jw29849npajq6w2eu0tukvlft6shld9awzqqu5xrs6(0x1964b8577e9b8235ef6f939453d4b30f640d3959e3d7cb33e95ea17fb4bd7080)
Execution info:
    status: Executed
    gas used: 1990641
    tx hash: 0x5172464817ffbdc5cd53efff42f1406ac18c71470e27481041c9653ea83f4fc4
    state root: 0xdc64059cad1a91dd8d0966d3bf5cba03f0ac70a13bf2e47e2f934a8d98f7690d
    event root: 0x8c7f0afee95e0ccf202d0094e9d9b94ca855f6e72f41a10c550dcee71dc85152

New modules:
    None

Updated modules:
    0x1964b8577e9b8235ef6f939453d4b30f640d3959e3d7cb33e95ea17fb4bd7080::display
```

- Closes #2238 