### PR TITLE
chore: refine statedb/genesis cmd

### DIFF
--- a/crates/rooch/src/commands/statedb/README.md
+++ b/crates/rooch/src/commands/statedb/README.md
@@ -126,10 +126,10 @@ rooch genesis init -n main -d <rooch_datadir>
 rooch statedb genesis-utxo --input <utxo_src_path> -d <rooch_datadir> -n main --batch-size <utxo_batch_size>
 ```
 
-**genesis-ord**:
+**genesis**:
 
 ```shell
-rooch statedb genesis-ord --utxo-source <utxo_src_path> --ord-source <ord_src_path> -d <rooch_datadir> -n main --utxo-ord-map <db_dir> --utxo-batch-size <utxo_batch_size> --ord-batch-size <ord_batch_size>
+rooch statedb genesis --utxo-source <utxo_src_path> --ord-source <ord_src_path> -d <rooch_datadir> -n main --utxo-ord-map <db_dir> --utxo-batch-size <utxo_batch_size> --ord-batch-size <ord_batch_size>
 ```
 
 ***tips***:

--- a/crates/rooch/src/commands/statedb/commands/export.rs
+++ b/crates/rooch/src/commands/statedb/commands/export.rs
@@ -27,7 +27,6 @@ use crate::commands::statedb::commands::{
 };
 
 /// Export statedb
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[repr(u8)]
 #[serde(rename_all = "lowercase")]

--- a/crates/rooch/src/commands/statedb/commands/genesis.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis.rs
@@ -297,7 +297,7 @@ fn import_utxo(
     root_state_root: H256,
     startup_time: Instant,
 ) {
-    let (tx, rx) = mpsc::sync_channel(2);
+    let (tx, rx) = mpsc::sync_channel(1);
     let produce_updates_thread = thread::spawn(move || {
         produce_utxo_updates(tx, input_path, batch_size, Some(utxo_ord_map_db))
     });

--- a/crates/rooch/src/commands/statedb/commands/import.rs
+++ b/crates/rooch/src/commands/statedb/commands/import.rs
@@ -1,12 +1,21 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli_types::WalletContextOptions;
-use crate::commands::statedb::commands::export::ExportID;
-use crate::commands::statedb::commands::{GLOBAL_STATE_TYPE_PREFIX, GLOBAL_STATE_TYPE_ROOT};
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::mpsc::{Receiver, SyncSender};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::SystemTime;
+
 use anyhow::{Error, Result};
 use chrono::{DateTime, Local};
 use clap::Parser;
+use serde::{Deserialize, Serialize};
+
 use moveos_store::MoveOSStore;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::object::{ObjectID, ObjectMeta, GENESIS_STATE_ROOT};
@@ -18,19 +27,13 @@ use rooch_db::RoochDB;
 use rooch_genesis::RoochGenesis;
 use rooch_types::error::{RoochError, RoochResult};
 use rooch_types::rooch_network::RoochChainID;
-use serde::{Deserialize, Serialize};
 use smt::{TreeChangeSet, UpdateSet};
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::{BufRead, BufReader, Read};
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::sync::mpsc::{Receiver, SyncSender};
-use std::sync::{mpsc, Arc};
-use std::thread;
-use std::time::SystemTime;
 
-/// Import statedb
+use crate::cli_types::WalletContextOptions;
+use crate::commands::statedb::commands::export::ExportID;
+use crate::commands::statedb::commands::{GLOBAL_STATE_TYPE_PREFIX, GLOBAL_STATE_TYPE_ROOT};
+
+/// Import state data exported by export command.
 #[derive(Debug, Parser)]
 pub struct ImportCommand {
     #[clap(long, short = 'i')]

--- a/crates/rooch/src/commands/statedb/mod.rs
+++ b/crates/rooch/src/commands/statedb/mod.rs
@@ -1,14 +1,16 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli_types::CommandAction;
-use crate::commands::statedb::commands::genesis_ord::GenesisOrdCommand;
-use crate::commands::statedb::commands::genesis_utxo::GenesisUTXOCommand;
-use crate::commands::statedb::commands::import::ImportCommand;
 use async_trait::async_trait;
 use clap::Parser;
+
 use commands::export::ExportCommand;
 use rooch_types::error::RoochResult;
+
+use crate::cli_types::CommandAction;
+use crate::commands::statedb::commands::genesis::GenesisCommand;
+use crate::commands::statedb::commands::genesis_utxo::GenesisUTXOCommand;
+use crate::commands::statedb::commands::import::ImportCommand;
 
 pub mod commands;
 
@@ -32,7 +34,7 @@ impl CommandAction<String> for Statedb {
             StatedbCommand::GenesisUTXO(genesis_utxo) => genesis_utxo.execute().await.map(|resp| {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
             }),
-            StatedbCommand::GenesisORD(genesis_ord) => genesis_ord.execute().await.map(|resp| {
+            StatedbCommand::Genesis(genesis) => genesis.execute().await.map(|resp| {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
             }),
         }
@@ -45,5 +47,5 @@ pub enum StatedbCommand {
     Export(ExportCommand),
     Import(ImportCommand),
     GenesisUTXO(GenesisUTXOCommand),
-    GenesisORD(GenesisOrdCommand),
+    Genesis(GenesisCommand),
 }


### PR DESCRIPTION
## Summary

1. Refactor finish_task into finish_job for clarity and reusability in multiple contexts. Renamed GenesisOrdCommand to GenesisCommand and moved it to the genesis module to better reflect its purpose and usage.
2. Update the buffer size of mpsc sync_channel from 2 to 1 to improve synchronization efficiency. This change ensures faster message passing and reduced memory usage, contributing to better overall performance.
3. update releated readme

