### PR TITLE
[rpc] UTXOView seals output as a map

### DIFF
--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -2916,7 +2916,13 @@
           },
           "seals": {
             "description": "Protocol seals",
-            "type": "string"
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            }
           },
           "txid": {
             "description": "The txid of the UTXO",

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
@@ -86,7 +86,7 @@ impl UTXOView {
         let mut seals_view: HashMap<String, Vec<ObjectIDView>> = HashMap::new();
         utxo.seals.data.into_iter().for_each(|element| {
             seals_view.insert(
-                format!("{}", element.key),
+                format!("0x{}", element.key),
                 element
                     .value
                     .into_iter()

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/utxo.rs
@@ -3,7 +3,7 @@
 
 use crate::jsonrpc_types::btc::transaction::{hex_to_txid, TxidView};
 use crate::jsonrpc_types::{
-    H256View, IndexerObjectStateView, IndexerStateIDView, ObjectMetaView, StrView,
+    H256View, IndexerObjectStateView, IndexerStateIDView, ObjectIDView, ObjectMetaView, StrView,
     UnitedAddressView,
 };
 use anyhow::Result;
@@ -17,6 +17,7 @@ use rooch_types::indexer::state::ObjectStateFilter;
 use rooch_types::into_address::IntoAddress;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Eq, JsonSchema)]
 pub struct BitcoinOutPointView {
@@ -74,21 +75,32 @@ pub struct UTXOView {
     /// The value of the UTXO
     value: StrView<u64>,
     /// Protocol seals
-    seals: String,
+    seals: HashMap<String, Vec<ObjectIDView>>,
 }
 
 impl UTXOView {
     pub fn try_new_from_utxo(utxo: UTXO) -> Result<UTXOView, anyhow::Error> {
         // reversed bytes of txid
         let bitcoin_txid = Txid::from_byte_array(utxo.txid.into_bytes());
-        let seals_str = serde_json::to_string(&utxo.seals)?;
+
+        let mut seals_view: HashMap<String, Vec<ObjectIDView>> = HashMap::new();
+        utxo.seals.data.into_iter().for_each(|element| {
+            seals_view.insert(
+                format!("{}", element.key),
+                element
+                    .value
+                    .into_iter()
+                    .map(|id| id.into())
+                    .collect::<Vec<_>>(),
+            );
+        });
 
         Ok(UTXOView {
             txid: utxo.txid.into(),
             bitcoin_txid: bitcoin_txid.into(),
             vout: utxo.vout,
             value: utxo.value.into(),
-            seals: seals_str,
+            seals: seals_view,
         })
     }
 }


### PR DESCRIPTION
```
        "seals": {
          "0x36e363be4405cb74d36764b7534b13e94a633d839109f12e1116f96847c5b0b9::seal::MySeal": [
            "0x1135f85a7e50f391cd490dbd89a546a970baea3c298317e97d5005b99163f70e",
            "0x52589f4281a61f323744215f0b2f3a10286303b1256ee6e4c94b0bb0941356b9"
          ],
          "0x36e363be4405cb74d36764b7534b13e94a633d839109f12e1116f96847c5b0b9::seal::LockSeal": [
            "0xde600111085cf6e47b2ab113deac18ab506b6107ac65ba0ce506df3c6b6a1399"
          ]
        }

```

- Closes https://github.com/rooch-network/rooch/issues/1943