### PR TITLE
[server] Add service_status to server start command

### DIFF
--- a/crates/rooch-benchmarks/config/bench_tx.toml
+++ b/crates/rooch-benchmarks/config/bench_tx.toml
@@ -1,5 +1,4 @@
 tx_type = "empty"
 pprof_output = "flamegraph"
-# when tx_type is "btc-block", the following two options are required
-data_import_flag = true
+# when tx_type is "btc-block", the following options are required
 btc_block_dir = "target/btc_blocks"

--- a/crates/rooch-benchmarks/src/tx.rs
+++ b/crates/rooch-benchmarks/src/tx.rs
@@ -15,6 +15,7 @@ use rooch_store::RoochStore;
 use rooch_test_transaction_builder::TestTransactionBuilder;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::multichain_id::RoochMultiChainID;
+use rooch_types::service_status::ServiceStatus;
 use rooch_types::transaction::rooch::RoochTransaction;
 use rooch_types::transaction::L1BlockWithBody;
 use std::fs;
@@ -25,7 +26,7 @@ pub const EXAMPLE_SIMPLE_BLOG_PACKAGE_NAME: &str = "simple_blog";
 pub const EXAMPLE_SIMPLE_BLOG_NAMED_ADDRESS: &str = "simple_blog";
 
 pub fn gen_sequencer(keypair: RoochKeyPair, rooch_store: RoochStore) -> Result<SequencerActor> {
-    SequencerActor::new(keypair, rooch_store.clone(), false)
+    SequencerActor::new(keypair, rooch_store.clone(), ServiceStatus::Active)
 }
 
 pub fn create_publish_transaction(

--- a/crates/rooch-config/src/lib.rs
+++ b/crates/rooch-config/src/lib.rs
@@ -8,6 +8,7 @@ use once_cell::sync::Lazy;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::genesis_config::GenesisConfig;
 use rooch_types::rooch_network::{BuiltinChainID, RoochChainID, RoochNetwork};
+use rooch_types::service_status::ServiceStatus;
 use serde::{Deserialize, Serialize};
 use std::fs::create_dir_all;
 use std::str::FromStr;
@@ -131,13 +132,8 @@ pub struct RoochOpt {
     #[clap(long, default_value_t)]
     pub da: DAConfig,
 
-    #[clap(long)]
-    /// The data import flag. If true, may be ignore the indexer write
-    pub data_import_flag: bool,
-
-    #[clap(long)]
-    /// The read only flag. If true, the service will only provide read only rpc method.
-    pub read_only: bool,
+    #[clap(long, default_value_t, value_enum)]
+    pub service_status: ServiceStatus,
 
     #[serde(skip)]
     #[clap(skip)]
@@ -171,8 +167,7 @@ impl RoochOpt {
             sequencer_account: None,
             proposer_account: None,
             da: DAConfig::default(),
-            data_import_flag: false,
-            read_only: false,
+            service_status: ServiceStatus::default(),
             base: None,
         };
         opt.init()?;

--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -38,7 +38,6 @@ pub struct ExecutorActor {
     moveos: MoveOS,
     moveos_store: MoveOSStore,
     rooch_store: RoochStore,
-    read_only: bool,
 }
 
 type ValidateAuthenticatorResult =
@@ -49,7 +48,6 @@ impl ExecutorActor {
         root: ObjectMeta,
         moveos_store: MoveOSStore,
         rooch_store: RoochStore,
-        read_only: bool,
     ) -> Result<Self> {
         let resolver = RootObjectResolver::new(root.clone(), &moveos_store);
         let gas_parameters = FrameworksGasParameters::load_from_chain(&resolver)?;
@@ -67,7 +65,6 @@ impl ExecutorActor {
             moveos,
             moveos_store,
             rooch_store,
-            read_only,
         })
     }
 
@@ -84,9 +81,6 @@ impl ExecutorActor {
     }
 
     pub fn execute(&mut self, tx: VerifiedMoveOSTransaction) -> Result<ExecuteTransactionResult> {
-        if self.read_only {
-            return Err(anyhow::anyhow!("The service is read only"));
-        }
         let tx_hash = tx.ctx.tx_hash();
         let output = self.moveos.execute_and_apply(tx)?;
         let execution_info = self

--- a/crates/rooch-framework-tests/src/binding_test.rs
+++ b/crates/rooch-framework-tests/src/binding_test.rs
@@ -70,7 +70,6 @@ impl RustBindingTest {
             root.clone(),
             rooch_db.moveos_store.clone(),
             rooch_db.rooch_store.clone(),
-            false,
         )?;
 
         let reader_executor = ReaderExecutorActor::new(

--- a/crates/rooch-pipeline-processor/src/actor/processor.rs
+++ b/crates/rooch-pipeline-processor/src/actor/processor.rs
@@ -10,9 +10,12 @@ use rooch_executor::proxy::ExecutorProxy;
 use rooch_indexer::proxy::IndexerProxy;
 use rooch_proposer::proxy::ProposerProxy;
 use rooch_sequencer::proxy::SequencerProxy;
-use rooch_types::transaction::{
-    ExecuteTransactionResponse, L1BlockWithBody, L1Transaction, LedgerTransaction, LedgerTxData,
-    RoochTransaction,
+use rooch_types::{
+    service_status::ServiceStatus,
+    transaction::{
+        ExecuteTransactionResponse, L1BlockWithBody, L1Transaction, LedgerTransaction,
+        LedgerTxData, RoochTransaction,
+    },
 };
 use tracing::{debug, info};
 
@@ -22,8 +25,7 @@ pub struct PipelineProcessorActor {
     pub(crate) sequencer: SequencerProxy,
     pub(crate) proposer: ProposerProxy,
     pub(crate) indexer: IndexerProxy,
-    pub(crate) data_import_flag: bool,
-    pub(crate) read_only: bool,
+    pub(crate) service_status: ServiceStatus,
 }
 
 impl PipelineProcessorActor {
@@ -32,20 +34,18 @@ impl PipelineProcessorActor {
         sequencer: SequencerProxy,
         proposer: ProposerProxy,
         indexer: IndexerProxy,
-        data_import_flag: bool,
-        read_only: bool,
+        service_status: ServiceStatus,
     ) -> Self {
         Self {
             executor,
             sequencer,
             proposer,
             indexer,
-            data_import_flag,
-            read_only,
+            service_status,
         }
     }
 
-    async fn process_sequenced_tx_on_startup(&mut self) -> Result<()> {
+    pub async fn process_sequenced_tx_on_startup(&mut self) -> Result<()> {
         let last_order = self.sequencer.get_sequencer_order().await.unwrap_or(0);
         debug!("process_sequenced_tx_on_startup last_order: {}", last_order);
         if last_order == 0 {
@@ -168,7 +168,7 @@ impl PipelineProcessorActor {
         let output_clone = output.clone();
 
         // If bitcoin block data import, don't write all indexer
-        if !self.data_import_flag {
+        if !self.service_status.is_date_import_mode() {
             //The update_indexer is a notify call, do not block current task
             let result = indexer
                 .update_indexer(
@@ -194,16 +194,7 @@ impl PipelineProcessorActor {
 }
 
 #[async_trait]
-impl Actor for PipelineProcessorActor {
-    async fn started(&mut self, _ctx: &mut ActorContext) {
-        if self.read_only {
-            return;
-        }
-        if let Err(e) = self.process_sequenced_tx_on_startup().await {
-            log::error!("Process sequenced tx on startup error: {}", e);
-        }
-    }
-}
+impl Actor for PipelineProcessorActor {}
 
 #[async_trait]
 impl Handler<ExecuteL2TxMessage> for PipelineProcessorActor {

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -44,19 +44,13 @@ use tracing::{debug, info};
 pub struct RoochServer {
     rpc_service: RpcService,
     aggregate_service: AggregateService,
-    read_only: bool,
 }
 
 impl RoochServer {
-    pub fn new(
-        rpc_service: RpcService,
-        aggregate_service: AggregateService,
-        read_only: bool,
-    ) -> Self {
+    pub fn new(rpc_service: RpcService, aggregate_service: AggregateService) -> Self {
         Self {
             rpc_service,
             aggregate_service,
-            read_only,
         }
     }
 
@@ -102,9 +96,6 @@ impl RoochAPIServer for RoochServer {
     }
 
     async fn send_raw_transaction(&self, payload: BytesView) -> RpcResult<H256View> {
-        if self.read_only {
-            return Err(RpcError::ServiceUnavailable);
-        }
         debug!("send_raw_transaction payload: {:?}", payload);
         let mut tx = bcs::from_bytes::<RoochTransaction>(&payload.0)?;
         info!(

--- a/crates/rooch-types/src/lib.rs
+++ b/crates/rooch-types/src/lib.rs
@@ -19,5 +19,6 @@ pub mod multichain_id;
 pub mod rooch_key;
 pub mod rooch_network;
 pub mod sequencer;
+pub mod service_status;
 pub mod test_utils;
 pub mod transaction;

--- a/crates/rooch-types/src/service_status.rs
+++ b/crates/rooch-types/src/service_status.rs
@@ -1,0 +1,36 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, clap::ValueEnum, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ServiceStatus {
+    /// The service is active and running normally.
+    #[default]
+    Active,
+    /// The service is in maintenance mode.
+    Maintenance,
+    /// The service is in read-only mode.
+    ReadOnlyMode,
+    /// The service is in date import mode.
+    DateImportMode,
+}
+
+impl ServiceStatus {
+    pub fn is_active(&self) -> bool {
+        matches!(self, ServiceStatus::Active)
+    }
+
+    pub fn is_maintenance(&self) -> bool {
+        matches!(self, ServiceStatus::Maintenance)
+    }
+
+    pub fn is_read_only_mode(&self) -> bool {
+        matches!(self, ServiceStatus::ReadOnlyMode)
+    }
+
+    pub fn is_date_import_mode(&self) -> bool {
+        matches!(self, ServiceStatus::DateImportMode)
+    }
+}

--- a/crates/rooch-types/src/transaction/ledger_transaction.rs
+++ b/crates/rooch-types/src/transaction/ledger_transaction.rs
@@ -113,6 +113,18 @@ impl LedgerTxData {
             LedgerTxData::L1Tx(_) => None,
         }
     }
+
+    pub fn is_l1_block(&self) -> bool {
+        matches!(self, LedgerTxData::L1Block(_))
+    }
+
+    pub fn is_l1_tx(&self) -> bool {
+        matches!(self, LedgerTxData::L1Tx(_))
+    }
+
+    pub fn is_l2_tx(&self) -> bool {
+        matches!(self, LedgerTxData::L2Tx(_))
+    }
 }
 
 /// The transaction which is recorded in the L2 DA ledger.

--- a/crates/testsuite/tests/integration.rs
+++ b/crates/testsuite/tests/integration.rs
@@ -72,7 +72,6 @@ async fn start_server(w: &mut World, _scenario: String) {
             w.opt.btc_rpc_url = Some(bitcoin_rpc_url);
             w.opt.btc_rpc_username = Some(RPC_USER.to_string());
             w.opt.btc_rpc_password = Some(RPC_PASS.to_string());
-            w.opt.data_import_flag = false; // Enable data import without writing indexes
             w.opt.btc_sync_block_interval = Some(1u64); // Update sync interval as 1s
 
             info!("config btc rpc ok");

--- a/sdk/typescript/rooch-sdk/test-e2e/setup.ts
+++ b/sdk/typescript/rooch-sdk/test-e2e/setup.ts
@@ -104,7 +104,7 @@ export async function cmdPublishPackage(
   },
 ) {
   const result = await cmd(
-    `move publish -p ${packagePath} --named-addresses ${options.namedAddresses}`,
+    `move publish -p ${packagePath} --named-addresses ${options.namedAddresses} --json`,
   )
   const { execution_info } = JSON.parse(result)
 


### PR DESCRIPTION
## Summary

Unify data_import_flag and read_only to ServiceStatus, and provide `Maintenance` status for the sequencer to execute maintenance tx.