### PR TITLE
[gh-2295] support bitcoin multisig address 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7167,6 +7167,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
+name = "musig2"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed08befaac75bfb31ca5e87678c4e8490bcd21d0c98ccb4f12f4065a7567e83"
+dependencies = [
+ "base16ct 0.2.0",
+ "hmac",
+ "once_cell",
+ "secp",
+ "secp256k1 0.28.2",
+ "sha2 0.10.8",
+ "subtle",
+]
+
+[[package]]
 name = "named-lock"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9595,6 +9610,7 @@ dependencies = [
  "moveos-stdlib",
  "moveos-types",
  "moveos-verifier",
+ "musig2",
  "once_cell",
  "rooch-types",
  "serde 1.0.204",
@@ -10807,6 +10823,18 @@ dependencies = [
  "pkcs8 0.10.2",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4754628ff9006f80c6abd1cd1e88c5ca6f5a60eab151ad2e16268aab3514d0"
+dependencies = [
+ "base16ct 0.2.0",
+ "once_cell",
+ "secp256k1 0.28.2",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,6 +320,7 @@ rustc-hash = { version = "2.0.0" }
 xorf = { version = "0.11.0" }
 vergen-git2 = { version = "1.0.0", features = ["build", "cargo", "rustc"] }
 vergen-pretty = "0.3.4"
+musig2 = { version = "0.0.11" }
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES

--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -639,7 +639,7 @@ impl BitcoinAddress {
     pub fn new_witness_program(witness_program: &bitcoin::WitnessProgram) -> Self {
         // First byte is BitcoinAddress Payload type
         let mut bytes = vec![BitcoinAddressPayloadType::WitnessProgram.to_num()];
-        // Third byte represents Version 0 or PUSHNUM_1-PUSHNUM_16
+        // Second byte represents Version 0 or PUSHNUM_1-PUSHNUM_16
         bytes.push(witness_program.version().to_num());
         // Remain are Program data
         bytes.extend_from_slice(witness_program.program().as_bytes());

--- a/frameworks/rooch-framework/Cargo.toml
+++ b/frameworks/rooch-framework/Cargo.toml
@@ -28,6 +28,7 @@ smallvec = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 bitcoin = { workspace = true }
+musig2 = { workspace = true }
 
 move-binary-format = { workspace = true }
 move-bytecode-utils = { workspace = true }

--- a/frameworks/rooch-framework/doc/bitcoin_address.md
+++ b/frameworks/rooch-framework/doc/bitcoin_address.md
@@ -21,7 +21,8 @@
 -  [Function `verify_with_public_key`](#0x3_bitcoin_address_verify_with_public_key)
 -  [Function `to_rooch_address`](#0x3_bitcoin_address_to_rooch_address)
 -  [Function `verify_bitcoin_address_with_public_key`](#0x3_bitcoin_address_verify_bitcoin_address_with_public_key)
--  [Function `derive_multi_sign_address`](#0x3_bitcoin_address_derive_multi_sign_address)
+-  [Function `derive_multisig_xonly_pubkey_from_public_keys`](#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_public_keys)
+-  [Function `derive_bitcoin_taproot_address_from_multisig_xonly_pubkey`](#0x3_bitcoin_address_derive_bitcoin_taproot_address_from_multisig_xonly_pubkey)
 
 
 <pre><code><b>use</b> <a href="">0x1::string</a>;
@@ -287,11 +288,22 @@ Empty address is a special address that is used to if we parse address failed fr
 
 
 
-<a name="0x3_bitcoin_address_derive_multi_sign_address"></a>
+<a name="0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_public_keys"></a>
 
-## Function `derive_multi_sign_address`
+## Function `derive_multisig_xonly_pubkey_from_public_keys`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_derive_multi_sign_address">derive_multi_sign_address</a>(public_keys: &<a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, threshold: u64): <a href="bitcoin_address.md#0x3_bitcoin_address_BitcoinAddress">bitcoin_address::BitcoinAddress</a>
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_public_keys">derive_multisig_xonly_pubkey_from_public_keys</a>(public_keys: &<a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, threshold: u64): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<a name="0x3_bitcoin_address_derive_bitcoin_taproot_address_from_multisig_xonly_pubkey"></a>
+
+## Function `derive_bitcoin_taproot_address_from_multisig_xonly_pubkey`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_derive_bitcoin_taproot_address_from_multisig_xonly_pubkey">derive_bitcoin_taproot_address_from_multisig_xonly_pubkey</a>(xonly_pubkey: &<a href="">vector</a>&lt;u8&gt;): <a href="bitcoin_address.md#0x3_bitcoin_address_BitcoinAddress">bitcoin_address::BitcoinAddress</a>
 </code></pre>

--- a/frameworks/rooch-framework/doc/bitcoin_address.md
+++ b/frameworks/rooch-framework/doc/bitcoin_address.md
@@ -21,7 +21,7 @@
 -  [Function `verify_with_public_key`](#0x3_bitcoin_address_verify_with_public_key)
 -  [Function `to_rooch_address`](#0x3_bitcoin_address_to_rooch_address)
 -  [Function `verify_bitcoin_address_with_public_key`](#0x3_bitcoin_address_verify_bitcoin_address_with_public_key)
--  [Function `derive_multisig_xonly_pubkey_from_public_keys`](#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_public_keys)
+-  [Function `derive_multisig_xonly_pubkey_from_xonly_pubkeys`](#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_xonly_pubkeys)
 -  [Function `derive_bitcoin_taproot_address_from_multisig_xonly_pubkey`](#0x3_bitcoin_address_derive_bitcoin_taproot_address_from_multisig_xonly_pubkey)
 
 
@@ -52,11 +52,56 @@ We just keep the raw bytes of the address and do care about the network.
 ## Constants
 
 
-<a name="0x3_bitcoin_address_ErrorAddressBytesLen"></a>
+<a name="0x3_bitcoin_address_E_ARG_NOT_VECTOR_U8"></a>
 
 
 
-<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_ErrorAddressBytesLen">ErrorAddressBytesLen</a>: u64 = 1;
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_ARG_NOT_VECTOR_U8">E_ARG_NOT_VECTOR_U8</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x3_bitcoin_address_E_INVALID_ADDRESS"></a>
+
+
+
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_ADDRESS">E_INVALID_ADDRESS</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x3_bitcoin_address_E_INVALID_KEY_EGG_CONTEXT"></a>
+
+
+
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_KEY_EGG_CONTEXT">E_INVALID_KEY_EGG_CONTEXT</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x3_bitcoin_address_E_INVALID_PUBLIC_KEY"></a>
+
+
+
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_PUBLIC_KEY">E_INVALID_PUBLIC_KEY</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x3_bitcoin_address_E_INVALID_THRESHOLD"></a>
+
+
+
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_THRESHOLD">E_INVALID_THRESHOLD</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x3_bitcoin_address_E_INVALID_XONLY_PUBKEY"></a>
+
+
+
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_XONLY_PUBKEY">E_INVALID_XONLY_PUBKEY</a>: u64 = 6;
 </code></pre>
 
 
@@ -288,13 +333,13 @@ Empty address is a special address that is used to if we parse address failed fr
 
 
 
-<a name="0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_public_keys"></a>
+<a name="0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_xonly_pubkeys"></a>
 
-## Function `derive_multisig_xonly_pubkey_from_public_keys`
+## Function `derive_multisig_xonly_pubkey_from_xonly_pubkeys`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_public_keys">derive_multisig_xonly_pubkey_from_public_keys</a>(public_keys: &<a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, threshold: u64): <a href="">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_xonly_pubkeys">derive_multisig_xonly_pubkey_from_xonly_pubkeys</a>(public_keys: &<a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, threshold: u64): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 

--- a/frameworks/rooch-framework/doc/bitcoin_address.md
+++ b/frameworks/rooch-framework/doc/bitcoin_address.md
@@ -20,7 +20,7 @@
 -  [Function `from_string`](#0x3_bitcoin_address_from_string)
 -  [Function `verify_with_public_key`](#0x3_bitcoin_address_verify_with_public_key)
 -  [Function `to_rooch_address`](#0x3_bitcoin_address_to_rooch_address)
--  [Function `verify_with_pk`](#0x3_bitcoin_address_verify_with_pk)
+-  [Function `verify_bitcoin_address_with_public_key`](#0x3_bitcoin_address_verify_bitcoin_address_with_public_key)
 -  [Function `derive_multisig_xonly_pubkey_from_xonly_pubkeys`](#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_xonly_pubkeys)
 -  [Function `derive_bitcoin_taproot_address_from_multisig_xonly_pubkey`](#0x3_bitcoin_address_derive_bitcoin_taproot_address_from_multisig_xonly_pubkey)
 
@@ -52,56 +52,56 @@ We just keep the raw bytes of the address and do care about the network.
 ## Constants
 
 
-<a name="0x3_bitcoin_address_E_ARG_NOT_VECTOR_U8"></a>
+<a name="0x3_bitcoin_address_ErrorArgNotVectorU8"></a>
 
 
 
-<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_ARG_NOT_VECTOR_U8">E_ARG_NOT_VECTOR_U8</a>: u64 = 2;
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_ErrorArgNotVectorU8">ErrorArgNotVectorU8</a>: u64 = 2;
 </code></pre>
 
 
 
-<a name="0x3_bitcoin_address_E_INVALID_ADDRESS"></a>
+<a name="0x3_bitcoin_address_ErrorInvalidAddress"></a>
 
 
 
-<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_ADDRESS">E_INVALID_ADDRESS</a>: u64 = 1;
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidAddress">ErrorInvalidAddress</a>: u64 = 1;
 </code></pre>
 
 
 
-<a name="0x3_bitcoin_address_E_INVALID_KEY_EGG_CONTEXT"></a>
+<a name="0x3_bitcoin_address_ErrorInvalidKeyEggContext"></a>
 
 
 
-<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_KEY_EGG_CONTEXT">E_INVALID_KEY_EGG_CONTEXT</a>: u64 = 5;
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidKeyEggContext">ErrorInvalidKeyEggContext</a>: u64 = 5;
 </code></pre>
 
 
 
-<a name="0x3_bitcoin_address_E_INVALID_PUBLIC_KEY"></a>
+<a name="0x3_bitcoin_address_ErrorInvalidPublicKey"></a>
 
 
 
-<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_PUBLIC_KEY">E_INVALID_PUBLIC_KEY</a>: u64 = 3;
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidPublicKey">ErrorInvalidPublicKey</a>: u64 = 3;
 </code></pre>
 
 
 
-<a name="0x3_bitcoin_address_E_INVALID_THRESHOLD"></a>
+<a name="0x3_bitcoin_address_ErrorInvalidThreshold"></a>
 
 
 
-<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_THRESHOLD">E_INVALID_THRESHOLD</a>: u64 = 4;
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidThreshold">ErrorInvalidThreshold</a>: u64 = 4;
 </code></pre>
 
 
 
-<a name="0x3_bitcoin_address_E_INVALID_XONLY_PUBKEY"></a>
+<a name="0x3_bitcoin_address_ErrorInvalidXOnlyPublicKey"></a>
 
 
 
-<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_E_INVALID_XONLY_PUBKEY">E_INVALID_XONLY_PUBKEY</a>: u64 = 6;
+<pre><code><b>const</b> <a href="bitcoin_address.md#0x3_bitcoin_address_ErrorInvalidXOnlyPublicKey">ErrorInvalidXOnlyPublicKey</a>: u64 = 6;
 </code></pre>
 
 
@@ -322,13 +322,13 @@ Empty address is a special address that is used to if we parse address failed fr
 
 
 
-<a name="0x3_bitcoin_address_verify_with_pk"></a>
+<a name="0x3_bitcoin_address_verify_bitcoin_address_with_public_key"></a>
 
-## Function `verify_with_pk`
+## Function `verify_bitcoin_address_with_public_key`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_verify_with_pk">verify_with_pk</a>(bitcoin_addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BitcoinAddress">bitcoin_address::BitcoinAddress</a>, pk: &<a href="">vector</a>&lt;u8&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_verify_bitcoin_address_with_public_key">verify_bitcoin_address_with_public_key</a>(bitcoin_addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BitcoinAddress">bitcoin_address::BitcoinAddress</a>, pk: &<a href="">vector</a>&lt;u8&gt;): bool
 </code></pre>
 
 

--- a/frameworks/rooch-framework/doc/bitcoin_address.md
+++ b/frameworks/rooch-framework/doc/bitcoin_address.md
@@ -20,7 +20,7 @@
 -  [Function `from_string`](#0x3_bitcoin_address_from_string)
 -  [Function `verify_with_public_key`](#0x3_bitcoin_address_verify_with_public_key)
 -  [Function `to_rooch_address`](#0x3_bitcoin_address_to_rooch_address)
--  [Function `verify_bitcoin_address_with_public_key`](#0x3_bitcoin_address_verify_bitcoin_address_with_public_key)
+-  [Function `verify_with_pk`](#0x3_bitcoin_address_verify_with_pk)
 -  [Function `derive_multisig_xonly_pubkey_from_xonly_pubkeys`](#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_xonly_pubkeys)
 -  [Function `derive_bitcoin_taproot_address_from_multisig_xonly_pubkey`](#0x3_bitcoin_address_derive_bitcoin_taproot_address_from_multisig_xonly_pubkey)
 
@@ -322,13 +322,13 @@ Empty address is a special address that is used to if we parse address failed fr
 
 
 
-<a name="0x3_bitcoin_address_verify_bitcoin_address_with_public_key"></a>
+<a name="0x3_bitcoin_address_verify_with_pk"></a>
 
-## Function `verify_bitcoin_address_with_public_key`
+## Function `verify_with_pk`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_verify_bitcoin_address_with_public_key">verify_bitcoin_address_with_public_key</a>(bitcoin_addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BitcoinAddress">bitcoin_address::BitcoinAddress</a>, pk: &<a href="">vector</a>&lt;u8&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_verify_with_pk">verify_with_pk</a>(bitcoin_addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BitcoinAddress">bitcoin_address::BitcoinAddress</a>, pk: &<a href="">vector</a>&lt;u8&gt;): bool
 </code></pre>
 
 

--- a/frameworks/rooch-framework/doc/bitcoin_address.md
+++ b/frameworks/rooch-framework/doc/bitcoin_address.md
@@ -20,6 +20,8 @@
 -  [Function `from_string`](#0x3_bitcoin_address_from_string)
 -  [Function `verify_with_public_key`](#0x3_bitcoin_address_verify_with_public_key)
 -  [Function `to_rooch_address`](#0x3_bitcoin_address_to_rooch_address)
+-  [Function `verify_bitcoin_address_with_public_key`](#0x3_bitcoin_address_verify_bitcoin_address_with_public_key)
+-  [Function `derive_multi_sign_address`](#0x3_bitcoin_address_derive_multi_sign_address)
 
 
 <pre><code><b>use</b> <a href="">0x1::string</a>;
@@ -270,4 +272,26 @@ Empty address is a special address that is used to if we parse address failed fr
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_to_rooch_address">to_rooch_address</a>(addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BitcoinAddress">bitcoin_address::BitcoinAddress</a>): <b>address</b>
+</code></pre>
+
+
+
+<a name="0x3_bitcoin_address_verify_bitcoin_address_with_public_key"></a>
+
+## Function `verify_bitcoin_address_with_public_key`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_verify_bitcoin_address_with_public_key">verify_bitcoin_address_with_public_key</a>(bitcoin_addr: &<a href="bitcoin_address.md#0x3_bitcoin_address_BitcoinAddress">bitcoin_address::BitcoinAddress</a>, pk: &<a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<a name="0x3_bitcoin_address_derive_multi_sign_address"></a>
+
+## Function `derive_multi_sign_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_derive_multi_sign_address">derive_multi_sign_address</a>(public_keys: &<a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, threshold: u64): <a href="bitcoin_address.md#0x3_bitcoin_address_BitcoinAddress">bitcoin_address::BitcoinAddress</a>
 </code></pre>

--- a/frameworks/rooch-framework/doc/bitcoin_address.md
+++ b/frameworks/rooch-framework/doc/bitcoin_address.md
@@ -339,7 +339,7 @@ Empty address is a special address that is used to if we parse address failed fr
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_xonly_pubkeys">derive_multisig_xonly_pubkey_from_xonly_pubkeys</a>(public_keys: &<a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, threshold: u64): <a href="">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_address.md#0x3_bitcoin_address_derive_multisig_xonly_pubkey_from_xonly_pubkeys">derive_multisig_xonly_pubkey_from_xonly_pubkeys</a>(public_keys: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, threshold: u64): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 

--- a/frameworks/rooch-framework/sources/address_type/bitcoin_address.move
+++ b/frameworks/rooch-framework/sources/address_type/bitcoin_address.move
@@ -102,7 +102,7 @@ module rooch_framework::bitcoin_address {
 
     public fun verify_with_public_key(addr: &String, pk: &vector<u8>): bool {
         let bitcoin_addr = from_string(addr);
-        verify_bitcoin_address_with_public_key(&bitcoin_addr, pk)
+        verify_with_pk(&bitcoin_addr, pk)
     }
 
     public fun to_rooch_address(addr: &BitcoinAddress): address{
@@ -111,7 +111,7 @@ module rooch_framework::bitcoin_address {
     }
 
     // verify bitcoin address according to the pk bytes
-    public native fun verify_bitcoin_address_with_public_key(bitcoin_addr: &BitcoinAddress, pk: &vector<u8>): bool;
+    public native fun verify_with_pk(bitcoin_addr: &BitcoinAddress, pk: &vector<u8>): bool;
 
     // derive multisig xonly public key from public keys
     public native fun derive_multisig_xonly_pubkey_from_xonly_pubkeys(public_keys: &vector<vector<u8>>, threshold: u64): vector<u8>;

--- a/frameworks/rooch-framework/sources/address_type/bitcoin_address.move
+++ b/frameworks/rooch-framework/sources/address_type/bitcoin_address.move
@@ -164,15 +164,14 @@ module rooch_framework::bitcoin_address {
         let expected_xonly_pubkey = x"ffa540e2d3df158dfb202fc1a2cbb20c4920ba35e8f75bb11101bfa47d71449a";
         let pk_list = vector::empty<vector<u8>>();
 
-        let pk_1 = x"03935f972da013f80ae011890fa89b67a27b7be6ccb24d3274d18b2d4067f261a9";
-        let pk_2 = x"02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
-        let pk_3 = x"02dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659";
+        let pk_1 = x"f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
+        let pk_2 = x"ffa540e2d3df158dfb202fc1a2cbb20c4920ba35e8f75bb11101bfa47d71449a";
 
         vector::push_back(&mut pk_list, pk_1);
         vector::push_back(&mut pk_list, pk_2);
-        vector::push_back(&mut pk_list, pk_3);
 
-        let xonly_pubkey = derive_multisig_xonly_pubkey_from_xonly_pubkeys(&pk_list, 3);
+        // TODO: fix MISSING_DEPENDENCY (code 1021) error
+        let xonly_pubkey = derive_multisig_xonly_pubkey_from_xonly_pubkeys(&pk_list, 2);
 
         std::debug::print(&xonly_pubkey);
         std::debug::print(&expected_xonly_pubkey);

--- a/frameworks/rooch-framework/sources/address_type/bitcoin_address.move
+++ b/frameworks/rooch-framework/sources/address_type/bitcoin_address.move
@@ -114,7 +114,7 @@ module rooch_framework::bitcoin_address {
     public native fun verify_with_pk(bitcoin_addr: &BitcoinAddress, pk: &vector<u8>): bool;
 
     // derive multisig xonly public key from public keys
-    public native fun derive_multisig_xonly_pubkey_from_xonly_pubkeys(public_keys: &vector<vector<u8>>, threshold: u64): vector<u8>;
+    public native fun derive_multisig_xonly_pubkey_from_xonly_pubkeys(public_keys: vector<vector<u8>>, threshold: u64): vector<u8>;
  
     // derive bitcoin taproot address from the multisig xonly public key
     public native fun derive_bitcoin_taproot_address_from_multisig_xonly_pubkey(xonly_pubkey: &vector<u8>): BitcoinAddress;
@@ -161,7 +161,7 @@ module rooch_framework::bitcoin_address {
 
     #[test]
     fun test_derive_multisig_xonly_pubkey_from_xonly_pubkeys_success() {
-        let expected_xonly_pubkey = x"ffa540e2d3df158dfb202fc1a2cbb20c4920ba35e8f75bb11101bfa47d71449a";
+        let expected_xonly_pubkey = x"7b6474bd9206ad07c0bc6b0ac90d43f6f232235c9e9cbf0c47775bf47ca9c402";
         let pk_list = vector::empty<vector<u8>>();
 
         let pk_1 = x"f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
@@ -170,24 +170,19 @@ module rooch_framework::bitcoin_address {
         vector::push_back(&mut pk_list, pk_1);
         vector::push_back(&mut pk_list, pk_2);
 
-        // TODO: fix MISSING_DEPENDENCY (code 1021) error
-        let xonly_pubkey = derive_multisig_xonly_pubkey_from_xonly_pubkeys(&pk_list, 2);
-
-        std::debug::print(&xonly_pubkey);
-        std::debug::print(&expected_xonly_pubkey);
+        let xonly_pubkey = derive_multisig_xonly_pubkey_from_xonly_pubkeys(pk_list, 2);
 
         assert!(expected_xonly_pubkey == xonly_pubkey, E_INVALID_KEY_EGG_CONTEXT);
     }
 
-    // test covered from https://slowli.github.io/bech32-buffer/ using script version 1
     #[test]
     fun test_derive_bitcoin_taproot_address_from_multisig_xonly_pubkey_success() {
-        let xonly_pubkey = x"ffa540e2d3df158dfb202fc1a2cbb20c4920ba35e8f75bb11101bfa47d71449a";
+        let xonly_pubkey = x"7b6474bd9206ad07c0bc6b0ac90d43f6f232235c9e9cbf0c47775bf47ca9c402";
 
         let bitcoin_addr = derive_bitcoin_taproot_address_from_multisig_xonly_pubkey(&xonly_pubkey);
 
         let expected_bitcoin_addr = BitcoinAddress {
-            bytes: x"02010ca8363b3e074be0697eb46b5ac5a291d06ecbeb95cf16f685735147753f8b45",
+            bytes: x"020102f97a0a664c8493bfa28cfcf3450628bdc0ba7b3b0af2b57d4d057f15cb41f9",
         };
 
         assert!(expected_bitcoin_addr.bytes == bitcoin_addr.bytes, E_INVALID_XONLY_PUBKEY);

--- a/frameworks/rooch-framework/sources/address_type/bitcoin_address.move
+++ b/frameworks/rooch-framework/sources/address_type/bitcoin_address.move
@@ -96,8 +96,8 @@ module rooch_framework::bitcoin_address {
     }
 
     public fun verify_with_public_key(addr: &String, pk: &vector<u8>): bool {
-        let raw_bytes = string::bytes(addr);
-        verify_with_pk(raw_bytes, pk)
+        let bitcoin_addr = from_string(addr);
+        verify_bitcoin_address_with_public_key(&bitcoin_addr, pk)
     }
 
     public fun to_rooch_address(addr: &BitcoinAddress): address{
@@ -105,9 +105,14 @@ module rooch_framework::bitcoin_address {
         moveos_std::bcs::to_address(hash)
     }
 
+    // verify bitcoin address according to the pk bytes
+    public native fun verify_bitcoin_address_with_public_key(bitcoin_addr: &BitcoinAddress, pk: &vector<u8>): bool;
+
+    // derive multi signature address from public keys
+    public native fun derive_multi_sign_address(public_keys: &vector<vector<u8>>, threshold: u64): BitcoinAddress;
+
     /// Parse the Bitcoin address string bytes to Move BitcoinAddress
     native fun parse(raw_addr: &vector<u8>): BitcoinAddress;
-    native fun verify_with_pk (addr: &vector<u8>, pk: &vector<u8>): bool;
 
     #[test_only]
     public fun random_address_for_testing(): BitcoinAddress {
@@ -116,7 +121,7 @@ module rooch_framework::bitcoin_address {
     }
 
     #[test]
-    fun test_verify_with_pk_success() {
+    fun test_verify_with_public_key_success() {
         // p2tr
         let addr = string::utf8(b"bc1p8xpjpkc9uzj2dexcxjg9sw8lxje85xa4070zpcys589e3rf6k20qm6gjrt");
         let pk = x"038e3d29b653e40f5b620f9443ee05222d1e40be58f544b6fed3d464edd54db883";
@@ -141,8 +146,8 @@ module rooch_framework::bitcoin_address {
 
     #[test]
     fun test_validate_signature_fail() {
-        let addr = string::utf8(b"ac1p8xpjpkc9uzj2dexcxjg9sw8lxje85xa4070zpcys589e3rf6k20qm6gjrt");
-        let pk = x"038e3d29b653e40f5b620f9443ee05222d1e40be58f544b6fed3d464edd54db883";
+        let addr = string::utf8(b"bc1p8xpjpkc9uzj2dexcxjg9sw8lxje85xa4070zpcys589e3rf6k20qm6gjrt");
+        let pk = x"038e3d29b653e40f5b620f9443ee05222d1e40be58f544b6fed3d464edd54db884";
         assert!(!verify_with_public_key(&addr, &pk), 1004);
     }
 }

--- a/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
@@ -7,10 +7,10 @@ use crate::natives::rooch_framework::bitcoin_address::GasParameters;
 crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "bitcoin_address", [
     [.new.base, "parse.base", 1000 * MUL],
     [.new.per_byte, "parse.per_byte", 30 * MUL],
-    [.verify_bitcoin_address_with_public_key.base, "verify_bitcoin_address_with_public_key.base", 1000 * MUL],
-    [.verify_bitcoin_address_with_public_key.per_byte, "verify_bitcoin_address_with_public_key.per_byte", 30 * MUL],
-    [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.base, "derive_multisig_xonly_pubkey_from_xonly_pubkeys.base", 1000 * MUL],
-    [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte, "derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte", 30 * MUL],
-    [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base, "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base", 1000 * MUL],
-    [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.per_byte, "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.per_byte", 30 * MUL],
+    [.verify_with_pk.base, "verify_bitcoin_address_with_public_key.base", 1000 * MUL],
+    [.verify_with_pk.per_byte, "verify_bitcoin_address_with_public_key.per_byte", 30 * MUL],
+    [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.base, optional "derive_multisig_xonly_pubkey_from_xonly_pubkeys.base", 1000 * MUL],
+    [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte, optional "derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte", 30 * MUL],
+    [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base, optional "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base", 1000 * MUL],
+    [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.per_byte, optional "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.per_byte", 30 * MUL],
 ]);

--- a/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
@@ -5,10 +5,12 @@ use crate::natives::gas_parameter::native::MUL;
 use crate::natives::rooch_framework::bitcoin_address::GasParameters;
 
 crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "bitcoin_address", [
-    [.new.base, "parse.base", 1000 * MUL],
-    [.new.per_byte, "parse.per_byte", 30 * MUL],
     [.verify_with_pk.base, "verify_with_pk.base", 1000 * MUL],
     [.verify_with_pk.per_byte, "verify_with_pk.per_byte", 30 * MUL],
+    [.new.base, "parse.base", 1000 * MUL],
+    [.new.per_byte, "parse.per_byte", 30 * MUL],
+    [.verify_bitcoin_address_with_public_key.base, optional "verify_bitcoin_address_with_public_key.base", 1000 * MUL],
+    [.verify_bitcoin_address_with_public_key.per_byte, optional "verify_bitcoin_address_with_public_key.per_byte", 30 * MUL],
     [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.base, optional "derive_multisig_xonly_pubkey_from_xonly_pubkeys.base", 1000 * MUL],
     [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte, optional "derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte", 30 * MUL],
     [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base, optional "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base", 1000 * MUL],

--- a/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
@@ -5,8 +5,10 @@ use crate::natives::gas_parameter::native::MUL;
 use crate::natives::rooch_framework::bitcoin_address::GasParameters;
 
 crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "bitcoin_address", [
+    [.parse.base, "parse.base", 1000 * MUL],
+    [.parse.per_byte, "parse.per_byte", 30 * MUL],
     [.verify_bitcoin_address_with_public_key.base, "verify_bitcoin_address_with_public_key.base", 1000 * MUL],
     [.verify_bitcoin_address_with_public_key.per_byte, "verify_bitcoin_address_with_public_key.per_byte", 30 * MUL],
-    [.new.base, "parse.base", 1000 * MUL],
-    [.new.per_byte, "parse.per_byte", 30 * MUL],
+    [.derive_multi_sign_address.base, "parse.base", 1000 * MUL],
+    [.derive_multi_sign_address.per_byte, "parse.per_byte", 30 * MUL],
 ]);

--- a/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
@@ -9,6 +9,8 @@ crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasPar
     [.parse.per_byte, "parse.per_byte", 30 * MUL],
     [.verify_bitcoin_address_with_public_key.base, "verify_bitcoin_address_with_public_key.base", 1000 * MUL],
     [.verify_bitcoin_address_with_public_key.per_byte, "verify_bitcoin_address_with_public_key.per_byte", 30 * MUL],
-    [.derive_multi_sign_address.base, "parse.base", 1000 * MUL],
-    [.derive_multi_sign_address.per_byte, "parse.per_byte", 30 * MUL],
+    [.derive_multisig_xonly_pubkey_from_public_keys.base, "derive_multisig_xonly_pubkey_from_public_keys.base", 1000 * MUL],
+    [.derive_multisig_xonly_pubkey_from_public_keys.per_byte, "derive_multisig_xonly_pubkey_from_public_keys.per_byte", 30 * MUL],
+    [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base, "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base", 1000 * MUL],
+    [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.per_byte, "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.per_byte", 30 * MUL],
 ]);

--- a/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
@@ -5,8 +5,8 @@ use crate::natives::gas_parameter::native::MUL;
 use crate::natives::rooch_framework::bitcoin_address::GasParameters;
 
 crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "bitcoin_address", [
-    [.parse.base, "parse.base", 1000 * MUL],
-    [.parse.per_byte, "parse.per_byte", 30 * MUL],
+    [.new.base, "parse.base", 1000 * MUL],
+    [.new.per_byte, "parse.per_byte", 30 * MUL],
     [.verify_bitcoin_address_with_public_key.base, "verify_bitcoin_address_with_public_key.base", 1000 * MUL],
     [.verify_bitcoin_address_with_public_key.per_byte, "verify_bitcoin_address_with_public_key.per_byte", 30 * MUL],
     [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.base, "derive_multisig_xonly_pubkey_from_xonly_pubkeys.base", 1000 * MUL],

--- a/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
@@ -5,8 +5,8 @@ use crate::natives::gas_parameter::native::MUL;
 use crate::natives::rooch_framework::bitcoin_address::GasParameters;
 
 crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "bitcoin_address", [
-    [.verify_with_pk.base, "verify_with_pk.base", 1000 * MUL],
-    [.verify_with_pk.per_byte, "verify_with_pk.per_byte", 30 * MUL],
+    [.verify_bitcoin_address_with_public_key.base, "verify_bitcoin_address_with_public_key.base", 1000 * MUL],
+    [.verify_bitcoin_address_with_public_key.per_byte, "verify_bitcoin_address_with_public_key.per_byte", 30 * MUL],
     [.new.base, "parse.base", 1000 * MUL],
     [.new.per_byte, "parse.per_byte", 30 * MUL],
 ]);

--- a/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
@@ -7,8 +7,8 @@ use crate::natives::rooch_framework::bitcoin_address::GasParameters;
 crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "bitcoin_address", [
     [.new.base, "parse.base", 1000 * MUL],
     [.new.per_byte, "parse.per_byte", 30 * MUL],
-    [.verify_with_pk.base, "verify_bitcoin_address_with_public_key.base", 1000 * MUL],
-    [.verify_with_pk.per_byte, "verify_bitcoin_address_with_public_key.per_byte", 30 * MUL],
+    [.verify_with_pk.base, "verify_with_pk.base", 1000 * MUL],
+    [.verify_with_pk.per_byte, "verify_with_pk.per_byte", 30 * MUL],
     [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.base, optional "derive_multisig_xonly_pubkey_from_xonly_pubkeys.base", 1000 * MUL],
     [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte, optional "derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte", 30 * MUL],
     [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base, optional "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base", 1000 * MUL],

--- a/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/bitcoin_address.rs
@@ -9,8 +9,8 @@ crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasPar
     [.parse.per_byte, "parse.per_byte", 30 * MUL],
     [.verify_bitcoin_address_with_public_key.base, "verify_bitcoin_address_with_public_key.base", 1000 * MUL],
     [.verify_bitcoin_address_with_public_key.per_byte, "verify_bitcoin_address_with_public_key.per_byte", 30 * MUL],
-    [.derive_multisig_xonly_pubkey_from_public_keys.base, "derive_multisig_xonly_pubkey_from_public_keys.base", 1000 * MUL],
-    [.derive_multisig_xonly_pubkey_from_public_keys.per_byte, "derive_multisig_xonly_pubkey_from_public_keys.per_byte", 30 * MUL],
+    [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.base, "derive_multisig_xonly_pubkey_from_xonly_pubkeys.base", 1000 * MUL],
+    [.derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte, "derive_multisig_xonly_pubkey_from_xonly_pubkeys.per_byte", 30 * MUL],
     [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base, "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.base", 1000 * MUL],
     [.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.per_byte, "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.per_byte", 30 * MUL],
 ]);

--- a/frameworks/rooch-framework/src/natives/rooch_framework/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/rooch_framework/bitcoin_address.rs
@@ -101,6 +101,16 @@ pub fn verify_bitcoin_address_with_public_key(
     Ok(NativeResult::ok(cost, smallvec![Value::bool(is_ok)]))
 }
 
+// TODO: derive_multi_sign_address
+pub fn derive_multi_sign_address(
+    _gas_params: &FromBytesGasParameters,
+    _context: &mut NativeContext,
+    _ty_args: Vec<Type>,
+    mut _args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    todo!();
+}
+
 #[derive(Debug, Clone)]
 pub struct FromBytesGasParameters {
     pub base: InternalGas,
@@ -122,27 +132,36 @@ impl FromBytesGasParameters {
 
 #[derive(Debug, Clone)]
 pub struct GasParameters {
-    pub new: FromBytesGasParameters,
+    pub parse: FromBytesGasParameters,
     pub verify_bitcoin_address_with_public_key: FromBytesGasParameters,
+    pub derive_multi_sign_address: FromBytesGasParameters,
 }
 
 impl GasParameters {
     pub fn zeros() -> Self {
         Self {
-            new: FromBytesGasParameters::zeros(),
+            parse: FromBytesGasParameters::zeros(),
             verify_bitcoin_address_with_public_key: FromBytesGasParameters::zeros(),
+            derive_multi_sign_address: FromBytesGasParameters::zeros(),
         }
     }
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
     let natives = [
-        ("parse", make_native(gas_params.new, parse)),
+        ("parse", make_native(gas_params.parse, parse)),
         (
             "verify_bitcoin_address_with_public_key",
             make_native(
                 gas_params.verify_bitcoin_address_with_public_key,
                 verify_bitcoin_address_with_public_key,
+            ),
+        ),
+        (
+            "derive_multi_sign_address",
+            make_native(
+                gas_params.derive_multi_sign_address,
+                derive_multi_sign_address,
             ),
         ),
     ];

--- a/frameworks/rooch-framework/src/natives/rooch_framework/bitcoin_address.rs
+++ b/frameworks/rooch-framework/src/natives/rooch_framework/bitcoin_address.rs
@@ -133,7 +133,8 @@ pub fn derive_multisig_xonly_pubkey_from_xonly_pubkeys(
     let threshold_bytes = pop_arg!(args, u64);
     let pk_list = pop_arg!(args, Vec<Value>);
 
-    let mut cost = gas_params.base.unwrap() + gas_params.per_byte.unwrap() * NumBytes::new(threshold_bytes);
+    let mut cost =
+        gas_params.base.unwrap() + gas_params.per_byte.unwrap() * NumBytes::new(threshold_bytes);
 
     if pk_list.len() < threshold_bytes as usize {
         return Ok(NativeResult::err(cost, E_INVALID_THRESHOLD));
@@ -188,7 +189,8 @@ pub fn derive_bitcoin_taproot_address_from_multisig_xonly_pubkey(
 
     let xonly_pubkey_ref = xonly_pubkey_bytes.as_bytes_ref();
 
-    let cost = gas_params.base.unwrap() + gas_params.per_byte.unwrap() * NumBytes::new(xonly_pubkey_ref.len() as u64);
+    let cost = gas_params.base.unwrap()
+        + gas_params.per_byte.unwrap() * NumBytes::new(xonly_pubkey_ref.len() as u64);
 
     let internal_key = match XOnlyPublicKey::from_slice(&xonly_pubkey_ref) {
         Ok(xonly_pubkey) => xonly_pubkey,
@@ -250,7 +252,8 @@ impl GasParameters {
         Self {
             new: FromBytesGasParameters::zeros(),
             verify_with_pk: FromBytesGasParameters::zeros(),
-            derive_multisig_xonly_pubkey_from_xonly_pubkeys: FromBytesGasParametersOptional::zeros(),
+            derive_multisig_xonly_pubkey_from_xonly_pubkeys: FromBytesGasParametersOptional::zeros(
+            ),
             derive_bitcoin_taproot_address_from_multisig_xonly_pubkey:
                 FromBytesGasParametersOptional::zeros(),
         }
@@ -262,14 +265,15 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
         ("parse", make_native(gas_params.new, parse)),
         (
             "verify_with_pk",
-            make_native(
-                gas_params.verify_with_pk,
-                verify_with_pk,
-            ),
+            make_native(gas_params.verify_with_pk, verify_with_pk),
         ),
-    ].to_vec();
+    ]
+    .to_vec();
 
-    if !gas_params.derive_multisig_xonly_pubkey_from_xonly_pubkeys.is_empty() {
+    if !gas_params
+        .derive_multisig_xonly_pubkey_from_xonly_pubkeys
+        .is_empty()
+    {
         natives.push((
             "derive_multisig_xonly_pubkey_from_xonly_pubkeys",
             make_native(
@@ -279,7 +283,10 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
         ));
     }
 
-    if !gas_params.derive_bitcoin_taproot_address_from_multisig_xonly_pubkey.is_empty() {
+    if !gas_params
+        .derive_bitcoin_taproot_address_from_multisig_xonly_pubkey
+        .is_empty()
+    {
         natives.push((
             "derive_bitcoin_taproot_address_from_multisig_xonly_pubkey",
             make_native(


### PR DESCRIPTION
## Summary

Support multisig address and refactor current address verification with public key.

- Use MuSig2: https://conduition.io/code/musig2-crate/;
- Crate: https://docs.rs/musig2/latest/musig2/;
- Compatible with BIP-327 and BIP-340: https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki, https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki.

- Closes #2295 