### PR TITLE
fix(statedb/genesis): use tempdir in testing

### DIFF
--- a/crates/rooch/src/commands/statedb/commands/genesis.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
-use std::sync::{Arc, mpsc, RwLock};
 use std::sync::mpsc::{Receiver, SyncSender};
+use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::time::SystemTime;
 
@@ -25,7 +25,6 @@ use rooch_types::rooch_network::RoochChainID;
 use smt::UpdateSet;
 
 use crate::cli_types::WalletContextOptions;
-use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 use crate::commands::statedb::commands::genesis_utxo::{
     apply_address_updates, apply_utxo_updates, produce_utxo_updates,
 };
@@ -33,6 +32,7 @@ use crate::commands::statedb::commands::import::{apply_fields, apply_nodes, fini
 use crate::commands::statedb::commands::inscription::{
     create_genesis_inscription_store_object, gen_inscription_ids_update, InscriptionSource,
 };
+use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 
 /// Import BTC ordinals & UTXO for genesis
 #[derive(Debug, Parser)]

--- a/crates/rooch/src/commands/statedb/commands/genesis.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
+use std::sync::{Arc, mpsc, RwLock};
 use std::sync::mpsc::{Receiver, SyncSender};
-use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::time::SystemTime;
 
@@ -25,6 +25,7 @@ use rooch_types::rooch_network::RoochChainID;
 use smt::UpdateSet;
 
 use crate::cli_types::WalletContextOptions;
+use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 use crate::commands::statedb::commands::genesis_utxo::{
     apply_address_updates, apply_utxo_updates, produce_utxo_updates,
 };
@@ -32,7 +33,6 @@ use crate::commands::statedb::commands::import::{apply_fields, apply_nodes, fini
 use crate::commands::statedb::commands::inscription::{
     create_genesis_inscription_store_object, gen_inscription_ids_update, InscriptionSource,
 };
-use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 
 /// Import BTC ordinals & UTXO for genesis
 #[derive(Debug, Parser)]
@@ -91,16 +91,17 @@ impl GenesisCommand {
         let pre_root_state_root = root.state_root();
 
         log::info!("indexing and dumping outpoint_inscriptions_map...");
-        let (outpoint_inscriptions_map, mapped_outpoint, mapped_inscription) =
+        let (outpoint_inscriptions_map, mapped_outpoint, mapped_inscription, unbound_count) =
             OutpointInscriptionsMap::index_and_dump(
                 self.ord_source.clone(),
                 self.outpoint_inscriptions_map_dump_path.clone(),
             );
         println!(
-            "{} outpoints : {} inscriptions mapped in: {:?}",
+            "{} outpoints : {} inscriptions mapped in: {:?} ({} unbound inscriptions ignored)",
             mapped_outpoint,
             mapped_inscription,
             start_time.elapsed(),
+            unbound_count
         );
 
         // import inscriptions and utxo parallel
@@ -251,21 +252,21 @@ fn apply_inscription_updates(
         let mut nodes: BTreeMap<H256, Vec<u8>> = BTreeMap::new();
 
         let cnt = batch.update_set.len();
-        let mut ord_tree_change_set =
+        let mut tree_change_set =
             apply_fields(moveos_store, inscription_store_state_root, batch.update_set).unwrap();
-        nodes.append(&mut ord_tree_change_set.nodes);
+        nodes.append(&mut tree_change_set.nodes);
 
-        inscription_store_state_root = ord_tree_change_set.state_root;
+        inscription_store_state_root = tree_change_set.state_root;
         cursed_inscription_count += batch.cursed_inscription_count;
         blessed_inscription_count += batch.blessed_inscription_count;
 
-        apply_nodes(moveos_store, nodes).expect("failed to apply ord nodes");
+        apply_nodes(moveos_store, nodes).expect("failed to apply inscription nodes");
 
         inscritpion_store_filed_count += cnt as u32;
 
         println!(
             "{} inscription applied ({} cursed, {} blessed). this batch: value size: {}, cost: {:?}",
-            inscritpion_store_filed_count / 2, // both ord and ord_id as field
+            inscritpion_store_filed_count / 2, // both inscription and inscription_id as field
             cursed_inscription_count,
             blessed_inscription_count,
             humanize::human_readable_bytes(batch.updates_value_bytes),

--- a/crates/rooch/src/commands/statedb/commands/mod.rs
+++ b/crates/rooch/src/commands/statedb/commands/mod.rs
@@ -319,6 +319,7 @@ mod tests {
 
     use bitcoin::Txid;
     use rand::Rng;
+    use tempfile::tempdir;
 
     use super::*;
 
@@ -512,7 +513,10 @@ mod tests {
         let map = OutpointInscriptionsMap::new_with_unsorted(items.clone());
         let (mapped_outpoint_count, mapped_inscription_count) = map.stats();
 
-        let dump_path = PathBuf::from("outpoint_inscriptions_map_index_and_dump_test");
+        let dump_path = tempdir()
+            .unwrap()
+            .path()
+            .join("outpoint_inscriptions_map_index_and_dump");
         map.dump(dump_path.clone());
         let map_from_load = OutpointInscriptionsMap::load(dump_path.clone());
         assert!(map_from_load.is_sorted_and_merged());

--- a/crates/rooch/src/commands/statedb/commands/mod.rs
+++ b/crates/rooch/src/commands/statedb/commands/mod.rs
@@ -143,13 +143,14 @@ fn unbound_outpoint() -> OutPoint {
 }
 
 impl OutpointInscriptionsMap {
-    fn index(src: PathBuf) -> (Self, usize, usize) {
+    fn index(src: PathBuf) -> (Self, usize, usize, usize) {
         let buf_size = 8 * 1024 * 1024; // inscription maybe large, using larger buffer than usual
         let mut reader = BufReader::with_capacity(buf_size, File::open(src.clone()).unwrap());
         let mut is_title_line = true;
 
         // collect all outpoint:inscription pairs except unbounded
         let mut has_outpoint_count: usize = 0;
+        let mut unbound_count: usize = 0;
         let mut items = Vec::with_capacity(80 * 1024 * 1024);
         for line in reader.by_ref().lines() {
             let line = line.unwrap();
@@ -165,6 +166,7 @@ impl OutpointInscriptionsMap {
             let obj_id = derive_inscription_id(&inscription_id);
             let satpoint_output = OutPoint::from_str(src.satpoint_outpoint.as_str()).unwrap();
             if satpoint_output == unbound_outpoint() {
+                unbound_count += 1;
                 continue; // skip unbounded outpoint
             }
             items.push(OutpointInscriptions {
@@ -180,15 +182,26 @@ impl OutpointInscriptionsMap {
             has_outpoint_count, mapped_inscription_count,
             "Inscription count mismatch after mapping"
         );
-        (map, mapped_outpoint_count, mapped_inscription_count)
+        (
+            map,
+            mapped_outpoint_count,
+            mapped_inscription_count,
+            unbound_count,
+        )
     }
 
-    fn index_and_dump(src: PathBuf, dump_path: Option<PathBuf>) -> (Self, usize, usize) {
-        let (map, mapped_outpoint_count, mapped_inscription_count) = Self::index(src.clone());
+    fn index_and_dump(src: PathBuf, dump_path: Option<PathBuf>) -> (Self, usize, usize, usize) {
+        let (map, mapped_outpoint_count, mapped_inscription_count, unbound_count) =
+            Self::index(src.clone());
         if let Some(dump_path) = dump_path {
             map.dump(dump_path);
         }
-        (map, mapped_outpoint_count, mapped_inscription_count)
+        (
+            map,
+            mapped_outpoint_count,
+            mapped_inscription_count,
+            unbound_count,
+        )
     }
 
     fn new_with_unsorted(items: Vec<OutpointInscriptions>) -> Self {


### PR DESCRIPTION
1. report unbount inscription when mapping outpoint:inscirptions
2. use tempdir when test