### PR TITLE
[cli] Add version command to cli for more version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4343,6 +4343,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "gherkin"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,6 +4387,19 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -5791,6 +5816,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5875,6 +5912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -7439,6 +7477,15 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.65",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -9279,6 +9326,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "vergen-git2",
+ "vergen-pretty",
  "xorf",
  "xxhash-rust",
 ]
@@ -12028,7 +12077,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde 1.0.204",
  "time-core",
@@ -12923,6 +12974,62 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c32e7318e93a9ac53693b6caccfb05ff22e04a44c7cf8a279051f24c09da286f"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "derive_builder 0.20.0",
+ "getset",
+ "regex",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62c52cd2b2b8b7ec75fc20111b3022ac3ff83e4fc14b9497cfcfd39c54f9c67"
+dependencies = [
+ "anyhow",
+ "derive_builder 0.20.0",
+ "git2",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06bee42361e43b60f363bad49d63798d0f42fb1768091812270eca00c784720"
+dependencies = [
+ "anyhow",
+ "derive_builder 0.20.0",
+ "getset",
+ "rustversion",
+]
+
+[[package]]
+name = "vergen-pretty"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f70a99f8d8337b1255d93e559d884d62bd12ea1ea64be39d539e2ca88d5706a"
+dependencies = [
+ "anyhow",
+ "convert_case 0.6.0",
+ "derive_builder 0.20.0",
+ "rustversion",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,6 +318,8 @@ fastcrypto-zkp = { version = "0.1.3" }
 function_name = { version = "0.3.0" }
 rustc-hash = { version = "2.0.0" }
 xorf = { version = "0.11.0" }
+vergen-git2 = { version = "1.0.0", features = ["build", "cargo", "rustc"] }
+vergen-pretty = "0.3.4"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -51,6 +51,7 @@ rustc-hash = { workspace = true }
 rand = { workspace = true }
 xorf = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
+vergen-pretty = { workspace = true }
 
 move-bytecode-utils = { workspace = true }
 move-binary-format = { workspace = true }
@@ -101,3 +102,6 @@ rooch-common = { workspace = true }
 
 framework-release = { workspace = true }
 
+[build-dependencies]
+anyhow = { workspace = true }
+vergen-git2 = { workspace = true }

--- a/crates/rooch/build.rs
+++ b/crates/rooch/build.rs
@@ -1,27 +1,15 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use std::process::Command;
+use anyhow::Result;
+use vergen_git2::{BuildBuilder, CargoBuilder, Emitter, Git2Builder, RustcBuilder};
 
-fn main() {
-    // Get the current version from the Cargo.toml
-    let cargo_version = env!("CARGO_PKG_VERSION");
-
-    // Prepend 'v' to the version
-    let version_with_v = format!("v{}", cargo_version);
-
-    // Get the commit hash for the version specified in CARGO_PKG_VERSION
-    let git_commit_output = Command::new("git")
-        .args(["rev-list", "-n", "1", &version_with_v])
-        .output()
-        .expect("Failed to get git commit hash for version");
-    let git_commit_hash = String::from_utf8(git_commit_output.stdout)
-        .expect("Invalid UTF-8 sequence")
-        .trim()
-        .to_string();
-
-    // Set the environment variables
-    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_commit_hash);
-
-    println!("cargo:rerun-if-changed=build.rs");
+fn main() -> Result<()> {
+    Emitter::default()
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&Git2Builder::all_git()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .emit()?;
+    Ok(())
 }

--- a/crates/rooch/src/commands/mod.rs
+++ b/crates/rooch/src/commands/mod.rs
@@ -18,3 +18,4 @@ pub mod state;
 pub mod statedb;
 pub mod transaction;
 pub mod upgrade;
+pub mod version;

--- a/crates/rooch/src/commands/statedb/commands/mod.rs
+++ b/crates/rooch/src/commands/statedb/commands/mod.rs
@@ -512,9 +512,8 @@ mod tests {
         let items = random_items_default(10);
         let map = OutpointInscriptionsMap::new_with_unsorted(items.clone());
         let (mapped_outpoint_count, mapped_inscription_count) = map.stats();
-
-        let dump_path = tempdir()
-            .unwrap()
+        let tempdir = tempdir().unwrap();
+        let dump_path = tempdir
             .path()
             .join("outpoint_inscriptions_map_index_and_dump");
         map.dump(dump_path.clone());

--- a/crates/rooch/src/commands/version.rs
+++ b/crates/rooch/src/commands/version.rs
@@ -1,0 +1,42 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use crate::cli_types::CommandAction;
+use async_trait::async_trait;
+use clap::Parser;
+use rooch_types::error::{RoochError, RoochResult};
+use vergen_pretty::{vergen_pretty_env, PrettyBuilder};
+
+/// Retrieves events based on their event handle.
+#[derive(Debug, Parser)]
+pub struct Version {
+    /// Return command outputs in json format
+    #[clap(long, default_value = "false")]
+    json: bool,
+}
+
+#[async_trait]
+impl CommandAction<String> for Version {
+    async fn execute(self) -> RoochResult<String> {
+        let build_envs = vergen_pretty_env!();
+
+        if self.json {
+            let build_envs = build_envs
+                .into_iter()
+                .filter_map(|(k, v)| v.map(|v| (k, v)))
+                .collect::<BTreeMap<_, _>>();
+            Ok(serde_json::to_string_pretty(&build_envs)?)
+        } else {
+            let mut buff = vec![];
+            PrettyBuilder::default()
+                .env(build_envs)
+                .build()
+                .map_err(|e| RoochError::UnexpectedError(e.to_string()))?
+                .display(&mut buff)
+                .map_err(|e| RoochError::UnexpectedError(e.to_string()))?;
+            String::from_utf8(buff).map_err(|e| RoochError::UnexpectedError(e.to_string()))
+        }
+    }
+}

--- a/crates/rooch/src/lib.rs
+++ b/crates/rooch/src/lib.rs
@@ -10,6 +10,7 @@ use commands::{
     abi::ABI, account::Account, env::Env, genesis::Genesis, init::Init, move_cli::MoveCli,
     object::ObjectCommand, resource::ResourceCommand, rpc::Rpc, server::Server,
     session_key::SessionKey, state::StateCommand, transaction::Transaction, upgrade::Upgrade,
+    version::Version,
 };
 use once_cell::sync::Lazy;
 use rooch_types::error::RoochResult;
@@ -32,13 +33,14 @@ pub struct RoochCli {
 
 static LONG_VERSION: Lazy<String> = Lazy::new(|| {
     let cargo_version = env!("CARGO_PKG_VERSION");
-    let git_commit_hash = env!("GIT_COMMIT_HASH");
+    let git_commit_hash = env!("VERGEN_GIT_SHA");
     format!("{} (git commit {})", cargo_version, git_commit_hash)
 });
 
 #[allow(clippy::large_enum_variant)]
 #[derive(clap::Parser)]
 pub enum Command {
+    Version(Version),
     Account(Account),
     Init(Init),
     Move(MoveCli),
@@ -60,6 +62,7 @@ pub enum Command {
 
 pub async fn run_cli(opt: RoochCli) -> RoochResult<String> {
     match opt.cmd {
+        Command::Version(version) => version.execute().await,
         Command::Account(account) => account.execute().await,
         Command::Move(move_cli) => move_cli.execute().await,
         Command::Server(server) => server.execute().await,


### PR DESCRIPTION
## Summary

1. Fix #2242 , use the latest git commit hash.
2. use vergen-git2 to generate more version info.
3. Add `rooch version` command to output more version info.

```bash
rooch version
```
```text
  Date (build): 2024-07-29
           Timestamp (build): 2024-07-29T07:43:15.057110152Z
               Debug (cargo): true
        Dependencies (cargo): anyhow 1.0.86,async-trait 0.1.81,bcs 0.1.6,bcs-ext 1.13.6,bitcoin 0.31.2,bitcoin-move 0.6.4,chrono 0.4.38,clap 4.5.11,codespan-reporting 0.11.1,csv 1.3.0,datatest-stable 0.1.1,dirs 5.0.1,fastcrypto 0.1.8,framework-builder 0.6.4,framework-release 0.6.4,framework-types 0.6.4,hex 0.4.3,itertools 0.13.0,jemallocator 0.5.4,log 0.4.22,move-binary-format 0.0.3,move-bytecode-utils 0.1.0,move-bytecode-verifier 0.1.0,move-cli 0.1.0,move-command-line-common 0.1.0,move-compiler 0.0.1,move-core-types 0.0.4,move-coverage 0.1.0,move-disassembler 0.1.0,move-errmapgen 0.1.0,move-model 0.1.0,move-package 0.1.0,move-stdlib 0.1.1,move-unit-test 0.1.0,move-vm-runtime 0.1.0,move-vm-test-utils 0.1.0,moveos 0.6.4,moveos-common 0.6.4,moveos-compiler 0.6.4,moveos-config 0.6.4,moveos-object-runtime 0.6.4,moveos-stdlib 0.6.4,moveos-store 0.6.4,moveos-types 0.6.4,moveos-verifier 0.6.4,once_cell 1.19.0,parking_lot 0.12.3,rand 0.8.5,raw-store 0.6.4,regex 1.10.5,rooch-common 0.6.4,rooch-config 0.6.4,rooch-db 0.6.4,rooch-framework 0.6.4,rooch-genesis 0.6.4,rooch-indexer 0.6.4,rooch-integration-test-runner 0.6.4,rooch-key 0.6.4,rooch-rpc-api 0.6.4,rooch-rpc-client 0.6.4,rooch-rpc-server 0.6.4,rooch-types 0.6.4,rpassword 7.3.1,rustc-hash 2.0.0,serde 1.0.204,serde-reflection 0.3.6,serde_json 1.0.120,serde_with 2.3.3,serde_yaml 0.9.34+deprecated,smt 0.6.4,tempfile 3.10.1,termcolor 1.1.3,tokio 1.39.1,tracing 0.1.40,tracing-subscriber 0.3.18,vergen-git2 1.0.0,vergen-pretty 0.3.4,xorf 0.11.0,xxhash-rust 0.8.12
            Features (cargo): 
           Opt Level (cargo): 0
       Target Triple (cargo): x86_64-unknown-linux-gnu
              Branch (  git): cli_version
 Commit Author Email (  git): jolestar@gmail.com
  Commit Author Name (  git): jolestar
        Commit Count (  git): 1344
         Commit Date (  git): 2024-07-29
      Commit Message (  git): [cli] Add version command to cli for more version info
    Commit Timestamp (  git): 2024-07-29T07:40:27.000000000Z
            Describe (  git): 71c69f9
               Dirty (  git): false
                 SHA (  git): 71c69f9b5eed1cda2644b01f84bae06acd249bb2
             Channel (rustc): stable
         Commit Date (rustc): 2024-04-29
         Commit Hash (rustc): 9b00956e56009bab2aa15d7bff10916599e3d6d6
         Host Triple (rustc): x86_64-unknown-linux-gnu
        LLVM Version (rustc): 18.1
              Semver (rustc): 1.78.0
```

```bash
rooch version --json
```
```json
{
  "VERGEN_BUILD_DATE": "2024-07-29",
  "VERGEN_BUILD_TIMESTAMP": "2024-07-29T07:43:15.057110152Z",
  "VERGEN_CARGO_DEBUG": "true",
  "VERGEN_CARGO_DEPENDENCIES": "anyhow 1.0.86,async-trait 0.1.81,bcs 0.1.6,bcs-ext 1.13.6,bitcoin 0.31.2,bitcoin-move 0.6.4,chrono 0.4.38,clap 4.5.11,codespan-reporting 0.11.1,csv 1.3.0,datatest-stable 0.1.1,dirs 5.0.1,fastcrypto 0.1.8,framework-builder 0.6.4,framework-release 0.6.4,framework-types 0.6.4,hex 0.4.3,itertools 0.13.0,jemallocator 0.5.4,log 0.4.22,move-binary-format 0.0.3,move-bytecode-utils 0.1.0,move-bytecode-verifier 0.1.0,move-cli 0.1.0,move-command-line-common 0.1.0,move-compiler 0.0.1,move-core-types 0.0.4,move-coverage 0.1.0,move-disassembler 0.1.0,move-errmapgen 0.1.0,move-model 0.1.0,move-package 0.1.0,move-stdlib 0.1.1,move-unit-test 0.1.0,move-vm-runtime 0.1.0,move-vm-test-utils 0.1.0,moveos 0.6.4,moveos-common 0.6.4,moveos-compiler 0.6.4,moveos-config 0.6.4,moveos-object-runtime 0.6.4,moveos-stdlib 0.6.4,moveos-store 0.6.4,moveos-types 0.6.4,moveos-verifier 0.6.4,once_cell 1.19.0,parking_lot 0.12.3,rand 0.8.5,raw-store 0.6.4,regex 1.10.5,rooch-common 0.6.4,rooch-config 0.6.4,rooch-db 0.6.4,rooch-framework 0.6.4,rooch-genesis 0.6.4,rooch-indexer 0.6.4,rooch-integration-test-runner 0.6.4,rooch-key 0.6.4,rooch-rpc-api 0.6.4,rooch-rpc-client 0.6.4,rooch-rpc-server 0.6.4,rooch-types 0.6.4,rpassword 7.3.1,rustc-hash 2.0.0,serde 1.0.204,serde-reflection 0.3.6,serde_json 1.0.120,serde_with 2.3.3,serde_yaml 0.9.34+deprecated,smt 0.6.4,tempfile 3.10.1,termcolor 1.1.3,tokio 1.39.1,tracing 0.1.40,tracing-subscriber 0.3.18,vergen-git2 1.0.0,vergen-pretty 0.3.4,xorf 0.11.0,xxhash-rust 0.8.12",
  "VERGEN_CARGO_FEATURES": "",
  "VERGEN_CARGO_OPT_LEVEL": "0",
  "VERGEN_CARGO_TARGET_TRIPLE": "x86_64-unknown-linux-gnu",
  "VERGEN_GIT_BRANCH": "cli_version",
  "VERGEN_GIT_COMMIT_AUTHOR_EMAIL": "jolestar@gmail.com",
  "VERGEN_GIT_COMMIT_AUTHOR_NAME": "jolestar",
  "VERGEN_GIT_COMMIT_COUNT": "1344",
  "VERGEN_GIT_COMMIT_DATE": "2024-07-29",
  "VERGEN_GIT_COMMIT_MESSAGE": "[cli] Add version command to cli for more version info",
  "VERGEN_GIT_COMMIT_TIMESTAMP": "2024-07-29T07:40:27.000000000Z",
  "VERGEN_GIT_DESCRIBE": "71c69f9",
  "VERGEN_GIT_DIRTY": "false",
  "VERGEN_GIT_SHA": "71c69f9b5eed1cda2644b01f84bae06acd249bb2",
  "VERGEN_RUSTC_CHANNEL": "stable",
  "VERGEN_RUSTC_COMMIT_DATE": "2024-04-29",
  "VERGEN_RUSTC_COMMIT_HASH": "9b00956e56009bab2aa15d7bff10916599e3d6d6",
  "VERGEN_RUSTC_HOST_TRIPLE": "x86_64-unknown-linux-gnu",
  "VERGEN_RUSTC_LLVM_VERSION": "18.1",
  "VERGEN_RUSTC_SEMVER": "1.78.0"
}
```