### PR TITLE
🔨 Remove Pagination's default property herf

### DIFF
--- a/infra/rooch-portal/src/components/custom-pagination.tsx
+++ b/infra/rooch-portal/src/components/custom-pagination.tsx
@@ -26,7 +26,6 @@ const PaginationComponent: React.FC<PaginationComponentProps> = ({
       <PaginationContent>
         <PaginationItem>
           <PaginationPrevious
-            href="#"
             onClick={() => currentPage > 0 && onPageChange(currentPage - 1)}
             className={`cursor-pointer border-none hover:bg-inherit ${
               currentPage <= 0 ? 'text-gray-500 cursor-not-allowed hover:text-gray-500' : ''
@@ -36,7 +35,6 @@ const PaginationComponent: React.FC<PaginationComponentProps> = ({
         </PaginationItem>
         <PaginationItem>
           <PaginationLink
-            href="#"
             onClick={() => onPageChange(currentPage)}
             isActive={true}
             className="cursor-pointer"
@@ -46,7 +44,6 @@ const PaginationComponent: React.FC<PaginationComponentProps> = ({
         </PaginationItem>
         <PaginationItem>
           <PaginationNext
-            href="#"
             onClick={() => hasNextPage && onPageChange(currentPage + 1)}
             className={`cursor-pointer border-none hover:bg-inherit ${
               !hasNextPage ? 'text-gray-500 cursor-not-allowed hover:text-gray-500' : ''


### PR DESCRIPTION
## Summary

CustomPagination Adding a default herf will cause the page to make meaningless jumps as well as add # hash to the url, greatly affecting the user experience.

https://github.com/user-attachments/assets/ec519bcc-0a69-446c-9603-2fd873faf56f


https://github.com/user-attachments/assets/b85b51f5-05f3-4c2e-9324-1c817d7c420c

Affects components:
- BitcoinAssetsOrdi
- AssetsCoin
- AssetsNft
- UtxoView

The default herf=# in the test impact component is meaningless and affects the experience, if you need to jump links you can customize the herf separately in the prop.






