### PR TITLE
🔨 typescript-sdk zh-CN link error

### DIFF
--- a/docs/website/pages/build/reference/sdk/typescript-sdk.en-US.mdx
+++ b/docs/website/pages/build/reference/sdk/typescript-sdk.en-US.mdx
@@ -20,7 +20,6 @@ The project comes with a counter example. The Increase method in the counter con
 
 The Rooch context and wallet context are also included, making it easy to connect to wallets, send transactions, manage accounts, and handle chains.
 
-
 ## Learn More
 
-Explore the Rooch SDK documentation (here)[https://www.npmjs.com/package/@roochnetwork/rooch-sdk].
+Explore the Rooch SDK documentation (here)[https://www.npmjs.com/package/@roochnetwork/rooch-sdk]

--- a/docs/website/pages/build/reference/sdk/typescript-sdk.zh-CN.mdx
+++ b/docs/website/pages/build/reference/sdk/typescript-sdk.zh-CN.mdx
@@ -22,4 +22,4 @@ npm dev
 
 ## 了解更多
 
-查阅 (Rooch SDK 文档) [https://www.npmjs.com/package/@roochnetwork/rooch-sdk]。
+查阅 (Rooch SDK 文档) [https://www.npmjs.com/package/@roochnetwork/rooch-sdk]


### PR DESCRIPTION
## Summary

简体中文下SDK跳转链接出错。

<img width="1117" alt="rooch_link" src="https://github.com/user-attachments/assets/a8976945-362a-484f-94c7-1671f0e3255f">

改为英文. 可以正常显示，为了样式统一并且便于用户理解，建议一起删掉


