### PR TITLE
refactor(statedb-genesis): objectID replaced by InscriptionId for saving  outpoint:inscriptions map memory usage

### DIFF
--- a/crates/rooch/src/commands/statedb/commands/genesis.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
-use std::sync::{Arc, mpsc, RwLock};
 use std::sync::mpsc::{Receiver, SyncSender};
+use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::time::SystemTime;
 
@@ -25,7 +25,6 @@ use rooch_types::rooch_network::RoochChainID;
 use smt::UpdateSet;
 
 use crate::cli_types::WalletContextOptions;
-use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 use crate::commands::statedb::commands::genesis_utxo::{
     apply_address_updates, apply_utxo_updates, produce_utxo_updates,
 };
@@ -33,6 +32,7 @@ use crate::commands::statedb::commands::import::{apply_fields, apply_nodes, fini
 use crate::commands::statedb::commands::inscription::{
     create_genesis_inscription_store_object, gen_inscription_ids_update, InscriptionSource,
 };
+use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 
 /// Import BTC ordinals & UTXO for genesis
 #[derive(Debug, Parser)]

--- a/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
-use std::sync::{Arc, mpsc, RwLock};
 use std::sync::mpsc::{Receiver, SyncSender};
+use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::time::SystemTime;
 
@@ -26,12 +26,12 @@ use rooch_types::rooch_network::RoochChainID;
 use smt::UpdateSet;
 
 use crate::cli_types::WalletContextOptions;
-use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 use crate::commands::statedb::commands::import::{apply_fields, apply_nodes, finish_import_job};
 use crate::commands::statedb::commands::utxo::{
     create_genesis_rooch_to_bitcoin_address_mapping_object, create_genesis_utxo_store_object,
     UTXORawData,
 };
+use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 
 /// Import UTXO for development and testing.
 #[derive(Debug, Parser)]

--- a/crates/rooch/src/commands/statedb/commands/inscription.rs
+++ b/crates/rooch/src/commands/statedb/commands/inscription.rs
@@ -106,7 +106,7 @@ impl InscriptionSource {
 }
 
 // sequence_number:inscription_id
-pub fn gen_inscription_ids_update(
+pub(crate) fn gen_inscription_ids_update(
     sequence_number: u32,
     inscription_id: InscriptionID,
 ) -> (FieldKey, ObjectState) {
@@ -117,7 +117,7 @@ pub fn gen_inscription_ids_update(
     (key, state)
 }
 
-fn derive_inscription_ids(ids: Option<Vec<InscriptionId>>) -> Vec<ObjectID> {
+pub(crate) fn derive_inscription_ids(ids: Option<Vec<InscriptionId>>) -> Vec<ObjectID> {
     if let Some(ids) = ids {
         let mut obj_ids = Vec::with_capacity(ids.len());
         for id in ids {
@@ -135,7 +135,7 @@ fn convert_to_rooch_inscription_id(id: InscriptionId) -> InscriptionID {
     InscriptionID::new(txid, id.index)
 }
 
-pub fn create_genesis_inscription_store_object(
+pub(crate) fn create_genesis_inscription_store_object(
     cursed_inscription_count: u32,
     blessed_inscription_count: u32,
     next_sequence_number: u32, // ord count

--- a/crates/rooch/src/commands/statedb/commands/mod.rs
+++ b/crates/rooch/src/commands/statedb/commands/mod.rs
@@ -10,10 +10,10 @@ use std::time::Instant;
 
 use bitcoin::hashes::Hash;
 use bitcoin::OutPoint;
-use move_core_types::account_address::AccountAddress;
 use xorf::{BinaryFuse8, Filter};
 use xxhash_rust::xxh3::xxh3_64;
 
+use bitcoin_move::natives::ord::inscription_id::InscriptionId;
 use moveos_store::MoveOSStore;
 use moveos_types::move_std::option::MoveOption;
 use moveos_types::move_std::string::MoveString;
@@ -22,11 +22,9 @@ use moveos_types::moveos_std::simple_multimap::{Element, SimpleMultiMap};
 use rooch_common::fs::file_cache::FileCacheManager;
 use rooch_config::RoochOpt;
 use rooch_db::RoochDB;
-use rooch_types::bitcoin::ord::{derive_inscription_id, InscriptionID};
-use rooch_types::into_address::IntoAddress;
 use rooch_types::rooch_network::RoochChainID;
 
-use crate::commands::statedb::commands::inscription::InscriptionSource;
+use crate::commands::statedb::commands::inscription::{derive_inscription_ids, InscriptionSource};
 
 pub mod export;
 pub mod genesis;
@@ -69,7 +67,7 @@ fn convert_option_string_to_move_type(opt: Option<String>) -> MoveOption<MoveStr
 #[derive(Clone, Default, PartialEq, Debug)]
 pub(crate) struct OutpointInscriptions {
     outpoint: OutPoint,
-    inscriptions: Vec<ObjectID>,
+    inscriptions: Vec<InscriptionId>,
 }
 
 impl OutpointInscriptions {
@@ -108,8 +106,8 @@ impl FromStr for OutpointInscriptions {
         let outpoint = OutPoint::from_str(parts[0])?;
         let inscriptions = parts[1]
             .split(',')
-            .map(ObjectID::from_str)
-            .collect::<Result<Vec<ObjectID>, _>>()?;
+            .map(InscriptionId::from_str)
+            .collect::<Result<Vec<InscriptionId>, _>>()?;
         Ok(OutpointInscriptions {
             outpoint,
             inscriptions,
@@ -117,16 +115,18 @@ impl FromStr for OutpointInscriptions {
     }
 }
 
-fn derive_utxo_seal(inscriptions: Option<Vec<ObjectID>>) -> SimpleMultiMap<MoveString, ObjectID> {
-    if let Some(obj_ids) = inscriptions {
-        SimpleMultiMap {
-            data: vec![Element {
-                key: MoveString::from_str(UTXO_SEAL_INSCRIPTION_PROTOCOL).unwrap(),
-                value: obj_ids,
-            }],
-        }
-    } else {
-        SimpleMultiMap::create()
+fn derive_utxo_inscription_seal(
+    inscriptions: Option<Vec<InscriptionId>>,
+) -> SimpleMultiMap<MoveString, ObjectID> {
+    let obj_ids = derive_inscription_ids(inscriptions);
+    if obj_ids.is_empty() {
+        return SimpleMultiMap::create();
+    }
+    SimpleMultiMap {
+        data: vec![Element {
+            key: MoveString::from_str(UTXO_SEAL_INSCRIPTION_PROTOCOL).unwrap(),
+            value: obj_ids,
+        }],
     }
 }
 
@@ -161,9 +161,6 @@ impl OutpointInscriptionsMap {
                 }
             }
             let src: InscriptionSource = InscriptionSource::from_str(&line);
-            let txid: AccountAddress = src.id.txid.into_address();
-            let inscription_id = InscriptionID::new(txid, src.id.index);
-            let obj_id = derive_inscription_id(&inscription_id);
             let satpoint_output = OutPoint::from_str(src.satpoint_outpoint.as_str()).unwrap();
             if satpoint_output == unbound_outpoint() {
                 unbound_count += 1;
@@ -171,7 +168,7 @@ impl OutpointInscriptionsMap {
             }
             items.push(OutpointInscriptions {
                 outpoint: satpoint_output,
-                inscriptions: vec![obj_id.clone()],
+                inscriptions: vec![src.id],
             });
             has_outpoint_count += 1;
         }
@@ -231,7 +228,7 @@ impl OutpointInscriptionsMap {
         let mut write_index = 0;
         for read_index in 1..items.len() {
             if items[write_index].outpoint == items[read_index].outpoint {
-                let drained_inscriptions: Vec<ObjectID> =
+                let drained_inscriptions: Vec<InscriptionId> =
                     items[read_index].inscriptions.drain(..).collect();
                 items[write_index].inscriptions.extend(drained_inscriptions);
             } else {
@@ -262,7 +259,7 @@ impl OutpointInscriptionsMap {
         }
     }
 
-    fn search(&self, outpoint: &OutPoint) -> Option<Vec<ObjectID>> {
+    fn search(&self, outpoint: &OutPoint) -> Option<Vec<InscriptionId>> {
         if !self.contains(outpoint) {
             return None;
         }
@@ -344,6 +341,14 @@ mod tests {
         OutPoint { txid, vout }
     }
 
+    fn random_inscription_id() -> InscriptionId {
+        let mut rng = rand::thread_rng();
+        let txid: Txid = Txid::from_slice(&rng.gen::<[u8; 32]>()).unwrap();
+        let index: u32 = rng.gen();
+
+        InscriptionId { txid, index }
+    }
+
     // all outpoints are unique
     fn random_outpoints(n: usize) -> Vec<OutPoint> {
         let mut outpoints = HashSet::new();
@@ -354,10 +359,10 @@ mod tests {
     }
 
     // all inscriptions are unique
-    fn random_inscriptions(n: usize) -> Vec<ObjectID> {
+    fn random_inscriptions(n: usize) -> Vec<InscriptionId> {
         let mut inscriptions = HashSet::new();
         while inscriptions.len() < n {
-            inscriptions.insert(ObjectID::random());
+            inscriptions.insert(random_inscription_id());
         }
         inscriptions.into_iter().collect()
     }
@@ -490,12 +495,12 @@ mod tests {
         for item in items.iter() {
             let outpoint_inscriptions = OutpointInscriptions {
                 outpoint: item.outpoint,
-                inscriptions: vec![item.inscriptions[0].clone()],
+                inscriptions: vec![item.inscriptions[0]],
             };
             unmerged_items.push(outpoint_inscriptions);
             let outpoint_inscriptions = OutpointInscriptions {
                 outpoint: item.outpoint,
-                inscriptions: vec![item.inscriptions[1].clone()],
+                inscriptions: vec![item.inscriptions[1]],
             };
             unmerged_items.push(outpoint_inscriptions);
         }

--- a/crates/rooch/src/commands/statedb/commands/utxo.rs
+++ b/crates/rooch/src/commands/statedb/commands/utxo.rs
@@ -15,12 +15,12 @@ use moveos_types::moveos_std::object::{
 use moveos_types::moveos_std::simple_multimap::SimpleMultiMap;
 use moveos_types::state::{FieldKey, ObjectState};
 use rooch_types::address::BitcoinAddress;
-use rooch_types::bitcoin::utxo::{BitcoinUTXOStore, UTXO};
 use rooch_types::bitcoin::{types, utxo};
+use rooch_types::bitcoin::utxo::{BitcoinUTXOStore, UTXO};
 use rooch_types::framework::address_mapping::RoochToBitcoinAddressMapping;
 use rooch_types::into_address::IntoAddress;
 
-use crate::commands::statedb::commands::{derive_utxo_seal, OutpointInscriptionsMap};
+use crate::commands::statedb::commands::{derive_utxo_inscription_seal, OutpointInscriptionsMap};
 
 const SCRIPT_TYPE_P2MS: &str = "p2ms";
 const SCRIPT_TYPE_P2PK: &str = "p2pk";
@@ -101,7 +101,7 @@ impl UTXORawData {
             Some(outpoint_inscriptions_map) => {
                 let inscriptions =
                     outpoint_inscriptions_map.search(&OutPoint::new(self.txid, self.vout));
-                derive_utxo_seal(inscriptions)
+                derive_utxo_inscription_seal(inscriptions)
             }
             None => SimpleMultiMap::create(),
         };

--- a/crates/rooch/src/commands/statedb/commands/utxo.rs
+++ b/crates/rooch/src/commands/statedb/commands/utxo.rs
@@ -15,8 +15,8 @@ use moveos_types::moveos_std::object::{
 use moveos_types::moveos_std::simple_multimap::SimpleMultiMap;
 use moveos_types::state::{FieldKey, ObjectState};
 use rooch_types::address::BitcoinAddress;
-use rooch_types::bitcoin::{types, utxo};
 use rooch_types::bitcoin::utxo::{BitcoinUTXOStore, UTXO};
+use rooch_types::bitcoin::{types, utxo};
 use rooch_types::framework::address_mapping::RoochToBitcoinAddressMapping;
 use rooch_types::into_address::IntoAddress;
 


### PR DESCRIPTION
## Summary

InscriptionId is much shorter than objectID(because Inscription's objectID has parent),
saving ~30% memory usage for outpoint:inscriptions map

