### PR TITLE
parse hex secret_key

### DIFF
--- a/crates/rooch-types/src/rooch_key.rs
+++ b/crates/rooch-types/src/rooch_key.rs
@@ -48,8 +48,9 @@ impl ParsedSecretKey {
             };
             Ok(Self(SecretKey::from_slice(&data[1..])?))
         } else {
+            let s = s.strip_prefix("0x").unwrap_or(s);
             match hex::decode(s) {
-                Ok(data) => match SecretKey::from_slice(&data.to_bytes()) {
+                Ok(data) => match SecretKey::from_slice(&data) {
                     Ok(a) => Ok(Self(a)),
                     Err(_) => Err(anyhow::Error::new(RoochError::CommandArgumentError(
                         "Parse from a raw material key failed".to_owned(),

--- a/crates/rooch-types/src/rooch_key.rs
+++ b/crates/rooch-types/src/rooch_key.rs
@@ -56,11 +56,9 @@ impl ParsedSecretKey {
                         "Parse from a raw material key failed".to_owned(),
                     ))),
                 },
-                Err(_) => {
-                    return Err(anyhow::Error::new(RoochError::CommandArgumentError(
-                        "Secret hex decode failed".to_owned(),
-                    )))
-                }
+                Err(_) => Err(anyhow::Error::new(RoochError::CommandArgumentError(
+                    "Secret hex decode failed".to_owned(),
+                ))),
             }
         }
     }

--- a/crates/rooch-types/src/rooch_key.rs
+++ b/crates/rooch-types/src/rooch_key.rs
@@ -48,11 +48,18 @@ impl ParsedSecretKey {
             };
             Ok(Self(SecretKey::from_slice(&data[1..])?))
         } else {
-            match SecretKey::from_slice(s.as_bytes()) {
-                Ok(a) => Ok(Self(a)),
-                Err(_) => Err(anyhow::Error::new(RoochError::CommandArgumentError(
-                    "Parse from a raw material key failed".to_owned(),
-                ))),
+            match hex::decode(s) {
+                Ok(data) => match SecretKey::from_slice(&data.to_bytes()) {
+                    Ok(a) => Ok(Self(a)),
+                    Err(_) => Err(anyhow::Error::new(RoochError::CommandArgumentError(
+                        "Parse from a raw material key failed".to_owned(),
+                    ))),
+                },
+                Err(_) => {
+                    return Err(anyhow::Error::new(RoochError::CommandArgumentError(
+                        "Secret hex decode failed".to_owned(),
+                    )))
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

When use  `rooch account import --secretkey` import account , use hex decode to secret_key.

- Closes #2327 