### PR TITLE
fix(docker): Update OpenSSL to version 1.1.1f-1ubuntu2.23

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,8 +36,8 @@ RUN set -eux; \
     chmod +x rustup-init
 
 RUN set -eux; \
-    wget "http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb"; \
-    DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb;
+    wget "http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb"; \
+    DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb;
 
 ENV RUST_VERSION=1.78.0
 
@@ -64,8 +64,8 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
-    wget "http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb"; \
-    DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb;
+    wget "http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb"; \
+    DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb;
 
 ENV RELEASE_PATH="/rooch/target/release"
 COPY --from=builder $RELEASE_PATH/rooch \

--- a/docker/DockerfileDebug
+++ b/docker/DockerfileDebug
@@ -36,8 +36,8 @@ RUN set -eux; \
     chmod +x rustup-init
 
 RUN set -eux; \
-    wget "http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb"; \
-    DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb;
+    wget "http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb"; \
+    DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb;
 
 ENV RUST_VERSION=1.78.0
 
@@ -64,8 +64,8 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
-    wget "http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb"; \
-    DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb;
+    wget "http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb"; \
+    DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb;
 
 ENV RELEASE_PATH="/rooch/target/debug"
 COPY --from=builder $RELEASE_PATH/rooch \


### PR DESCRIPTION

## Summary

1.1.1f-1ubuntu2.22 is not found.

Upgraded libssl1.1 from 1.1.1f-1ubuntu2.22 to 1.1.1f-1ubuntu2.23 in Dockerfile and DockerfileDebug. This ensures the latest security patches and fixes are included in the build environment.

