### PR TITLE
[Indexer] Optimize indexer query cache and pool core config

### DIFF
--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -108,7 +108,7 @@ pub struct IndexerReader {
 
 impl IndexerReader {
     pub fn new(db_path: PathBuf, registry: &Registry) -> Result<Self> {
-        let config = SqliteConnectionPoolConfig::default();
+        let config = SqliteConnectionPoolConfig::pool_config(true);
         Self::new_with_config(db_path, config, registry)
     }
 

--- a/crates/rooch-indexer/src/lib.rs
+++ b/crates/rooch-indexer/src/lib.rs
@@ -293,7 +293,7 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
             pragma_builder.push_str("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;");
         }
         // The mmap_size in SQLite is primarily associated with the database file, not the connection.
-        pragma_builder.push_str("PRAGMA mmap_size = 1073741824"); // 1GB
+        pragma_builder.push_str("PRAGMA mmap_size = 268435456"); // 256MB
         conn.batch_execute(&pragma_builder)
             .map_err(diesel::r2d2::Error::QueryError)?;
 


### PR DESCRIPTION
## Summary

part of #2366

1. Optimize cache_size from default 2MB to 64 MB per connection
2. Enable memory-mapped I/O for query, set mmap size to 256MB per database
3. Adjust indexer reader connections from 16 to 32 per database.

- Closes #issue