### PR TITLE
fix(statedb-export): fix export indexer cmd

### DIFF
--- a/crates/rooch/src/commands/indexer/commands/rebuild.rs
+++ b/crates/rooch/src/commands/indexer/commands/rebuild.rs
@@ -1,7 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli_types::WalletContextOptions;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
@@ -9,10 +8,9 @@ use std::str::FromStr;
 use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, SyncSender};
 use std::thread;
-use std::time::SystemTime;
+use std::time::Instant;
 
 use anyhow::{Error, Result};
-use chrono::{DateTime, Local};
 use clap::Parser;
 
 use moveos_types::state::ObjectState;
@@ -25,7 +23,7 @@ use rooch_types::indexer::state::IndexerObjectState;
 use rooch_types::rooch_network::RoochChainID;
 
 use crate::commands::indexer::commands::init_indexer;
-use crate::commands::statedb::commands::import::parse_state_data_from_csv_line;
+use crate::commands::statedb::commands::import::parse_csv_fields;
 use crate::commands::statedb::commands::{
     GLOBAL_STATE_TYPE_OBJECT, GLOBAL_STATE_TYPE_PREFIX, GLOBAL_STATE_TYPE_ROOT,
 };
@@ -34,7 +32,7 @@ use crate::commands::statedb::commands::{
 #[derive(Debug, Parser)]
 pub struct RebuildCommand {
     #[clap(long, short = 'i')]
-    /// import input file. like ~/.rooch/local/indexer.csv or indexer.csv
+    /// import an input file. like ~/.rooch/local/indexer.csv or indexer.csv
     pub input: PathBuf,
 
     #[clap(long = "data-dir", short = 'd')]
@@ -42,15 +40,12 @@ pub struct RebuildCommand {
     pub base_data_dir: Option<PathBuf>,
 
     /// If local chainid, start the service with a temporary data store.
-    /// All data will be deleted when the service is stopped.
+    /// All data would be deleted when the service is stopped.
     #[clap(long, short = 'n', help = R_OPT_NET_HELP)]
     pub chain_id: Option<RoochChainID>,
 
     #[clap(long, short = 'b', default_value = "20971")]
     pub batch_size: Option<usize>,
-
-    #[clap(flatten)]
-    pub context_options: WalletContextOptions,
 }
 
 impl RebuildCommand {
@@ -74,18 +69,11 @@ impl RebuildCommand {
         Ok(())
     }
 
-    fn init(self) -> (IndexerStore, IndexerReader, SystemTime) {
-        let start_time = SystemTime::now();
-        let datetime: DateTime<Local> = start_time.into();
-
+    fn init(self) -> (IndexerStore, IndexerReader, Instant) {
+        let start_time = Instant::now();
         let (indexer_store, indexer_reader) =
             init_indexer(self.base_data_dir.clone(), self.chain_id.clone()).unwrap();
-
-        println!(
-            "indexer task progress started at {}, batch_size: {}",
-            datetime,
-            self.batch_size.unwrap()
-        );
+        log::info!("indexer rebuild started");
         (indexer_store, indexer_reader, start_time)
     }
 }
@@ -107,27 +95,26 @@ fn produce_updates(
     let tx_order: u64 = 0;
     let mut state_index_generator = indexer_reader.query_last_state_index_by_tx_order(tx_order)?;
     println!(
-        "Indexer rebuild produce_updates state_index_generator start from: {}",
+        "Indexer rebuild. last_state_index starts from: {}",
         state_index_generator
     );
 
     loop {
         let mut updates = BatchUpdates {
-            object_states: vec![],
+            object_states: Vec::with_capacity(batch_size),
         };
 
         for line in csv_reader.by_ref().lines().take(batch_size) {
             let line = line?;
 
             if line.starts_with(GLOBAL_STATE_TYPE_PREFIX) {
-                let (c1, _c2) = parse_state_data_from_csv_line(&line)?;
-                let state_type = c1;
+                let (state_type, _) = parse_csv_fields(&line)?;
                 last_state_type = Some(state_type);
                 continue;
             }
 
-            let (_c1, c2) = parse_state_data_from_csv_line(&line)?;
-            let state = ObjectState::from_str(&c2)?;
+            let (_c1, state_str) = parse_csv_fields(&line)?;
+            let state = ObjectState::from_str(&state_str)?;
 
             let state_type = last_state_type
                 .clone()
@@ -153,14 +140,26 @@ fn produce_updates(
 fn apply_updates(
     rx: Receiver<BatchUpdates>,
     indexer_store: IndexerStore,
-    _task_start_time: SystemTime,
+    task_start_time: Instant,
 ) -> Result<()> {
+    let mut ok_count: usize = 0;
     while let Ok(batch) = rx.recv() {
-        let loop_start_time = SystemTime::now();
+        let loop_start_time = Instant::now();
+        let count = batch.object_states.len();
         indexer_store.persist_or_update_object_states(batch.object_states)?;
-
-        println!("This bacth cost: {:?}", loop_start_time.elapsed().unwrap());
+        println!(
+            "{} updates applied in: {:?}",
+            count,
+            loop_start_time.elapsed()
+        );
+        ok_count += count;
     }
+
+    println!(
+        "Indexer rebuild task finished({} updates applied) in: {:?}",
+        ok_count,
+        task_start_time.elapsed()
+    );
 
     Ok(())
 }

--- a/crates/rooch/src/commands/statedb/commands/export.rs
+++ b/crates/rooch/src/commands/statedb/commands/export.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt::Display;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -21,40 +22,45 @@ use rooch_types::error::{RoochError, RoochResult};
 use rooch_types::framework::address_mapping::RoochToBitcoinAddressMapping;
 use rooch_types::rooch_network::RoochChainID;
 
-use crate::cli_types::WalletContextOptions;
 use crate::commands::statedb::commands::{
     init_job, GLOBAL_STATE_TYPE_FIELD, GLOBAL_STATE_TYPE_OBJECT, GLOBAL_STATE_TYPE_ROOT,
 };
 
 /// Export statedb
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
-#[repr(u8)]
 #[serde(rename_all = "lowercase")]
 pub enum ExportMode {
-    // dump UTXO, Inscription and relative Objects, including RoochToBitcoinAddressMapping object
     #[default]
-    Genesis = 0,
+    Genesis = 0, // dump InscriptionStore, BitcoinUTXOStore, RoochToBitcoinAddressMapping for genesis start-up
     Full = 1,
     Snapshot = 2,
-    // rebuild indexer, including UTXO and Inscription
-    Indexer = 3,
+    Indexer = 3, // dump InscriptionStore, BitcoinUTXOStore for rebuild indexer
     Object = 4,
 }
 
-impl TryFrom<u8> for ExportMode {
-    type Error = anyhow::Error;
+impl Display for ExportMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExportMode::Genesis => write!(f, "genesis"),
+            ExportMode::Full => write!(f, "full"),
+            ExportMode::Snapshot => write!(f, "snapshot"),
+            ExportMode::Indexer => write!(f, "indexer"),
+            ExportMode::Object => write!(f, "object"),
+        }
+    }
+}
 
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(ExportMode::Genesis),
-            1 => Ok(ExportMode::Full),
-            2 => Ok(ExportMode::Snapshot),
-            3 => Ok(ExportMode::Indexer),
-            4 => Ok(ExportMode::Object),
-            _ => Err(anyhow::anyhow!(
-                "Statedb cli export mode {} is invalid",
-                value
-            )),
+impl FromStr for ExportMode {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "genesis" => Ok(ExportMode::Genesis),
+            "full" => Ok(ExportMode::Full),
+            "snapshot" => Ok(ExportMode::Snapshot),
+            "indexer" => Ok(ExportMode::Indexer),
+            "object" => Ok(ExportMode::Object),
+            _ => Err("export-mode no match"),
         }
     }
 }
@@ -69,7 +75,7 @@ impl ExportMode {
 pub struct ExportID {
     pub object_id: ObjectID,
     pub state_root: H256,
-    pub parent_state_root: H256,
+    pub parent_state_root: H256, // If object has no parent, it'll be itself state root.
     pub timestamp: u64,
 }
 
@@ -89,7 +95,7 @@ impl ExportID {
     }
 }
 
-impl std::fmt::Display for ExportID {
+impl Display for ExportID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let state_root_str = format!("{:?}", self.state_root);
         let parent_state_root_str = format!("{:?}", self.parent_state_root);
@@ -124,6 +130,37 @@ impl FromStr for ExportID {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ExportObjectName {
+    UtxoStore,
+    InscriptionStore,
+    AddressMap,
+}
+
+impl Display for ExportObjectName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExportObjectName::UtxoStore => write!(f, "utxo-store"),
+            ExportObjectName::InscriptionStore => write!(f, "inscription-store"),
+            ExportObjectName::AddressMap => write!(f, "address-map"),
+        }
+    }
+}
+
+impl FromStr for ExportObjectName {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "utxo-store" => Ok(ExportObjectName::UtxoStore),
+            "inscription-store" => Ok(ExportObjectName::InscriptionStore),
+            "address-map" => Ok(ExportObjectName::AddressMap),
+            _ => Err("object-name no match"),
+        }
+    }
+}
+
 #[derive(Debug, Parser)]
 pub struct ExportCommand {
     /// export state root, default latest state root
@@ -141,7 +178,7 @@ pub struct ExportCommand {
     // #[serde(skip_serializing_if = "Option::is_none")]
     #[clap(long, short = 'm')]
     /// statedb export mode, default is genesis mode
-    pub mode: Option<u8>,
+    pub mode: Option<ExportMode>,
 
     /// export object id, for object mode
     #[clap(long, short = 'i')]
@@ -151,9 +188,6 @@ pub struct ExportCommand {
     /// All data will be deleted when the service is stopped.
     #[clap(long, short = 'n', help = R_OPT_NET_HELP)]
     pub chain_id: Option<RoochChainID>,
-
-    #[clap(flatten)]
-    pub context_options: WalletContextOptions,
 }
 
 impl ExportCommand {
@@ -169,7 +203,7 @@ impl ExportCommand {
         })?;
         let root_state_root = self.state_root.unwrap_or(root.state_root());
 
-        let mode = ExportMode::try_from(self.mode.unwrap_or(ExportMode::Genesis.to_num()))?;
+        let mode = self.mode.unwrap_or_default();
         match mode {
             ExportMode::Genesis => {
                 Self::export_genesis(&moveos_store, root_state_root, &mut writer)?;
@@ -223,19 +257,73 @@ impl ExportCommand {
         root_state_root: H256,
         writer: &mut Writer<W>,
     ) -> Result<()> {
-        let utxo_store_id = BitcoinUTXOStore::object_id();
-        let inscription_store_id = InscriptionStore::object_id();
-        let genesis_object_ids_field_keys = vec![
-            utxo_store_id.clone().field_key(),
-            inscription_store_id.clone().field_key(),
+        // export root's ExportID
+        export_root_export_id(root_state_root, writer)?;
+        // export utxo, inscription store object
+        let field_keys = vec![
+            BitcoinUTXOStore::object_id().field_key(),
+            InscriptionStore::object_id().field_key(),
         ];
-
-        Self::export_genesis_fields(
+        export_fields(moveos_store, root_state_root, writer, field_keys)?;
+        // export utxo store fields
+        let utxo_store_state_root = get_state_root(
             moveos_store,
             root_state_root,
+            BitcoinUTXOStore::object_id().field_key(),
+        );
+        Self::export_top_level_fields(
+            moveos_store,
+            utxo_store_state_root,
+            BitcoinUTXOStore::object_id(),
+            Some(ExportObjectName::UtxoStore.to_string()),
             writer,
-            genesis_object_ids_field_keys,
-        )
+        )?;
+        // export inscription store fields
+        let inscription_store_state_root = get_state_root(
+            moveos_store,
+            root_state_root,
+            InscriptionStore::object_id().field_key(),
+        );
+        Self::export_top_level_fields(
+            moveos_store,
+            inscription_store_state_root,
+            BitcoinUTXOStore::object_id(),
+            Some(ExportObjectName::InscriptionStore.to_string()),
+            writer,
+        )?;
+        writer.flush()?;
+        Ok(())
+    }
+
+    // export top level fields of an object, no recursive export child field
+    fn export_top_level_fields<W: std::io::Write>(
+        moveos_store: &MoveOSStore,
+        obj_state_root: H256,
+        object_id: ObjectID,
+        object_name: Option<String>, // human-readable object name for debug
+        writer: &mut Writer<W>,
+    ) -> Result<()> {
+        let starting_key = None;
+        let mut count: u64 = 0;
+
+        let iter = moveos_store
+            .get_state_store()
+            .iter(obj_state_root, starting_key)?;
+
+        for item in iter {
+            let (k, v) = item?;
+            writer.write_record([k.to_string().as_str(), v.to_string().as_str()])?;
+            count += 1;
+        }
+
+        println!(
+            "export_top_level_fields object_id {:?}({}), state_root: {:?} export field counts {}",
+            object_id,
+            object_name.unwrap_or("unknown".to_string()),
+            obj_state_root,
+            count
+        );
+        Ok(())
     }
 
     fn export_genesis_fields<W: std::io::Write>(
@@ -378,6 +466,29 @@ impl ExportCommand {
     }
 }
 
+// export root's export id for further checking in import job.
+fn export_root_export_id<W: std::io::Write>(
+    root_state_root: H256,
+    writer: &mut Writer<W>,
+) -> Result<()> {
+    let root_export_id = ExportID::new(ObjectID::root(), root_state_root, root_state_root, 0);
+    writer.write_record([GLOBAL_STATE_TYPE_ROOT, root_export_id.to_string().as_str()])?;
+    Ok(())
+}
+
+fn export_fields<W: std::io::Write>(
+    moveos_store: &MoveOSStore,
+    state_root: H256,
+    writer: &mut Writer<W>,
+    field_keys: Vec<FieldKey>,
+) -> Result<()> {
+    let state_kvs = get_object_states(moveos_store, state_root, field_keys);
+    for (k, v) in state_kvs.into_iter() {
+        writer.write_record([k.to_string().as_str(), v.to_string().as_str()])?;
+    }
+    Ok(())
+}
+
 fn get_object_states(
     moveos_store: &MoveOSStore,
     state_root: H256,
@@ -388,8 +499,20 @@ fn get_object_states(
         let state = moveos_store
             .get_field_at(state_root, &object_field_key)
             .unwrap()
-            .expect("state should exist.");
+            .expect("state must be existed.");
         kvs.push((object_field_key, state));
     }
     kvs
+}
+
+fn get_state_root(
+    moveos_store: &MoveOSStore,
+    state_root: H256,
+    object_field_key: FieldKey,
+) -> H256 {
+    let state = moveos_store
+        .get_field_at(state_root, &object_field_key)
+        .unwrap()
+        .expect("state must be existed.");
+    state.state_root()
 }

--- a/crates/rooch/src/commands/statedb/commands/genesis.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
+use std::sync::{Arc, mpsc, RwLock};
 use std::sync::mpsc::{Receiver, SyncSender};
-use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::time::SystemTime;
 
@@ -24,6 +24,7 @@ use rooch_types::error::RoochResult;
 use rooch_types::rooch_network::RoochChainID;
 use smt::UpdateSet;
 
+use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 use crate::commands::statedb::commands::genesis_utxo::{
     apply_address_updates, apply_utxo_updates, produce_utxo_updates,
 };
@@ -31,11 +32,11 @@ use crate::commands::statedb::commands::import::{apply_fields, apply_nodes, fini
 use crate::commands::statedb::commands::inscription::{
     create_genesis_inscription_store_object, gen_inscription_ids_update, InscriptionSource,
 };
-use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 
 /// Import BTC ordinals & UTXO for genesis
 #[derive(Debug, Parser)]
 pub struct GenesisCommand {
+    #[clap(long, short = 'i')]
     /// utxo source data file. like ~/.rooch/local/utxo.csv or utxo.csv
     /// The file format is csv, and the first line is the header, the header is as follows:
     /// count, txid, vout, height, coinbase, amount, script, type,address

--- a/crates/rooch/src/commands/statedb/commands/genesis.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis.rs
@@ -24,7 +24,6 @@ use rooch_types::error::RoochResult;
 use rooch_types::rooch_network::RoochChainID;
 use smt::UpdateSet;
 
-use crate::cli_types::WalletContextOptions;
 use crate::commands::statedb::commands::genesis_utxo::{
     apply_address_updates, apply_utxo_updates, produce_utxo_updates,
 };
@@ -77,9 +76,6 @@ pub struct GenesisCommand {
     /// All data will be deleted when the service is stopped.
     #[clap(long, short = 'n', help = R_OPT_NET_HELP)]
     pub chain_id: Option<RoochChainID>,
-
-    #[clap(flatten)]
-    pub context_options: WalletContextOptions,
 }
 
 impl GenesisCommand {

--- a/crates/rooch/src/commands/statedb/commands/genesis.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
-use std::sync::{Arc, mpsc, RwLock};
 use std::sync::mpsc::{Receiver, SyncSender};
+use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::time::SystemTime;
 
@@ -24,7 +24,6 @@ use rooch_types::error::RoochResult;
 use rooch_types::rooch_network::RoochChainID;
 use smt::UpdateSet;
 
-use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 use crate::commands::statedb::commands::genesis_utxo::{
     apply_address_updates, apply_utxo_updates, produce_utxo_updates,
 };
@@ -32,6 +31,7 @@ use crate::commands::statedb::commands::import::{apply_fields, apply_nodes, fini
 use crate::commands::statedb::commands::inscription::{
     create_genesis_inscription_store_object, gen_inscription_ids_update, InscriptionSource,
 };
+use crate::commands::statedb::commands::{init_job, OutpointInscriptionsMap};
 
 /// Import BTC ordinals & UTXO for genesis
 #[derive(Debug, Parser)]

--- a/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
@@ -25,7 +25,6 @@ use rooch_types::error::RoochResult;
 use rooch_types::rooch_network::RoochChainID;
 use smt::UpdateSet;
 
-use crate::cli_types::WalletContextOptions;
 use crate::commands::statedb::commands::import::{apply_fields, apply_nodes, finish_import_job};
 use crate::commands::statedb::commands::utxo::{
     create_genesis_rooch_to_bitcoin_address_mapping_object, create_genesis_utxo_store_object,
@@ -54,9 +53,6 @@ pub struct GenesisUTXOCommand {
 
     #[clap(long, short = 'b', default_value = "524288")]
     pub batch_size: Option<usize>,
-
-    #[clap(flatten)]
-    pub context_options: WalletContextOptions,
 }
 
 impl GenesisUTXOCommand {

--- a/crates/rooch/src/commands/statedb/commands/import.rs
+++ b/crates/rooch/src/commands/statedb/commands/import.rs
@@ -14,9 +14,9 @@ use std::time::{Instant, SystemTime};
 use anyhow::{Error, Result};
 use chrono::{DateTime, Local};
 use clap::Parser;
-use metrics::RegistryService;
 use serde::{Deserialize, Serialize};
 
+use metrics::RegistryService;
 use moveos_store::MoveOSStore;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::object::{ObjectID, ObjectMeta, GENESIS_STATE_ROOT};
@@ -149,7 +149,7 @@ fn produce_updates(
                 if line.starts_with(GLOBAL_STATE_TYPE_ROOT) {
                     break;
                 }
-                let (_c1, c2) = parse_state_data_from_csv_line(&line)?;
+                let (_c1, c2) = parse_csv_fields(&line)?;
                 let export_id = ExportID::from_str(&c2)?;
                 // let eventual_state_root = export_id.parent_state_root;
                 // // TODO add cache to avoid duplicate read smt
@@ -162,7 +162,7 @@ fn produce_updates(
                 continue;
             }
 
-            let (c1, c2) = parse_state_data_from_csv_line(&line)?;
+            let (c1, c2) = parse_csv_fields(&line)?;
             let key_state = FieldKey::from_str(&c1)?;
             let state = ObjectState::from_str(&c2)?;
             let state_id = last_state_id.clone().expect("State ID should have value");
@@ -180,7 +180,7 @@ fn produce_updates(
 }
 
 // csv format: c1,c2
-pub fn parse_state_data_from_csv_line(line: &str) -> Result<(String, String)> {
+pub fn parse_csv_fields(line: &str) -> Result<(String, String)> {
     let str_list: Vec<&str> = line.trim().split(',').collect();
     if str_list.len() != 2 {
         return Err(Error::from(RoochError::from(Error::msg(format!(


### PR DESCRIPTION
## Summary

1. Export ExportID for root
2. Export UXTO & Inscription Store object
3. Export top-level fields of UTXO & Inscription Store(both of them only have top-level fields)

For fast recovery data, refactor later
