### PR TITLE
docs : fix pages' command mistakes

### DIFF
--- a/docs/website/pages/build/tutorial/move-examples.en-US.mdx
+++ b/docs/website/pages/build/tutorial/move-examples.en-US.mdx
@@ -11,7 +11,7 @@ We can use any legal character as the project name, including `-`, but when we u
 For example:
 
 ```shell
-move rooch new hello-world
+rooch move new hello-world
 ```
 
 However, `-` is not a legal character for naming addresses (variables), so after we create the project using `rooch move new`, be sure to check the project address alias in the `Move.toml` file for illegal characters.
@@ -23,7 +23,7 @@ Another way is to directly use `_` as the hyphen for the project name word when 
 For example:
 
 ```shell
-move rooch new hello_world
+rooch move new hello_world
 ```
 
 In Rooch's `examples`, the names of the projects we create use `_` connection. As for the actual development, which style to use, please decide according to your preferences.

--- a/docs/website/pages/build/tutorial/move-examples.zh-CN.mdx
+++ b/docs/website/pages/build/tutorial/move-examples.zh-CN.mdx
@@ -11,7 +11,7 @@ Rooch 提供自动创建并初始化项目的命令 `rooch move new`，当我们
 例如：
 
 ```shell
-move rooch new hello-world
+rooch move new hello-world
 ```
 
 然而，`-` 不是命名地址（变量）的合法字符，所以当我们使用 `rooch move new` 创建好项目后，务必检查 `Move.toml` 文件中的项目地址别名是否存在非法字符。
@@ -23,7 +23,7 @@ move rooch new hello-world
 例如：
 
 ```shell
-move rooch new hello_world
+rooch move new hello_world
 ```
 
 在 Rooch 的 `examples` 中，我们创建的项目的名字统一使用 `_` 连接，至于实际开发中，使用那种风格，请根据您的喜好决定。


### PR DESCRIPTION
## Summary

Summary about this PR
两行命令 `rooch move` 都写反啦
- Closes #issue2376