### PR TITLE
Implementation of transaction dry run

### DIFF
--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::messages::{
+    ConvertL2TransactionData, DryRunTransactionMessage, DryRunTransactionResult,
     ExecuteTransactionMessage, ExecuteTransactionResult, GetRootMessage, ValidateL1BlockMessage,
     ValidateL1TxMessage, ValidateL2TxMessage,
 };
@@ -20,8 +21,8 @@ use moveos_types::moveos_std::object::ObjectMeta;
 use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::state::ObjectState;
 use moveos_types::state_resolver::RootObjectResolver;
-use moveos_types::transaction::VerifiedMoveOSTransaction;
 use moveos_types::transaction::{FunctionCall, MoveOSTransaction, VerifiedMoveAction};
+use moveos_types::transaction::{MoveAction, VerifiedMoveOSTransaction};
 use prometheus::Registry;
 use rooch_genesis::FrameworksGasParameters;
 use rooch_store::RoochStore;
@@ -33,6 +34,7 @@ use rooch_types::framework::{system_post_execute_functions, system_pre_execute_f
 use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::transaction::{
     AuthenticatorInfo, L1Block, L1BlockWithBody, L1Transaction, RoochTransaction,
+    RoochTransactionData,
 };
 use std::sync::Arc;
 use tracing::{debug, warn};
@@ -87,6 +89,21 @@ impl ExecutorActor {
     }
 
     #[named]
+    pub fn dry_run(&mut self, tx: VerifiedMoveOSTransaction) -> Result<DryRunTransactionResult> {
+        let fn_name = function_name!();
+        let _timer = self
+            .metrics
+            .executor_execute_tx_latency_seconds
+            .with_label_values(&[fn_name])
+            .start_timer();
+        let (raw_output, vm_error_info) = self.moveos.execute_only(tx)?;
+        Ok(DryRunTransactionResult {
+            raw_output,
+            vm_error_info,
+        })
+    }
+
+    #[named]
     pub fn execute(&mut self, tx: VerifiedMoveOSTransaction) -> Result<ExecuteTransactionResult> {
         let fn_name = function_name!();
         let _timer = self
@@ -96,7 +113,9 @@ impl ExecutorActor {
             .start_timer();
         let tx_hash = tx.ctx.tx_hash();
         let size = tx.ctx.tx_size;
-        let output = self.moveos.execute_and_apply(tx)?;
+        let (raw_output, _) = self.moveos.execute_only(tx)?;
+        let output = MoveOS::apply_transaction_output(&self.moveos.db, raw_output)?;
+
         let execution_info = self
             .moveos_store
             .handle_tx_output(tx_hash, output.clone())?;
@@ -313,6 +332,41 @@ impl ExecutorActor {
 
         Ok(vm_result)
     }
+
+    pub fn convert_to_verified_tx(
+        &self,
+        tx_data: RoochTransactionData,
+    ) -> Result<VerifiedMoveOSTransaction> {
+        let root = self.root.clone();
+
+        let mut tx_ctx = TxContext::new(
+            tx_data.sender.into(),
+            tx_data.sequence_number,
+            tx_data.max_gas_amount,
+            tx_data.tx_hash(),
+            tx_data.tx_size(),
+        );
+
+        tx_ctx.add(TxValidateResult::new_for_test())?;
+
+        let verified_action = match tx_data.action {
+            MoveAction::Script(script_call) => VerifiedMoveAction::Script { call: script_call },
+            MoveAction::Function(function_call) => VerifiedMoveAction::Function {
+                call: function_call,
+                bypass_visibility: false,
+            },
+            MoveAction::ModuleBundle(module_bundle) => VerifiedMoveAction::ModuleBundle {
+                module_bundle,
+                init_function_modules: vec![],
+            },
+        };
+
+        Ok(VerifiedMoveOSTransaction::new(
+            root,
+            tx_ctx,
+            verified_action,
+        ))
+    }
 }
 
 impl Actor for ExecutorActor {}
@@ -325,6 +379,17 @@ impl Handler<ValidateL2TxMessage> for ExecutorActor {
         _ctx: &mut ActorContext,
     ) -> Result<VerifiedMoveOSTransaction> {
         self.validate_l2_tx(msg.tx)
+    }
+}
+
+#[async_trait]
+impl Handler<ConvertL2TransactionData> for ExecutorActor {
+    async fn handle(
+        &mut self,
+        msg: ConvertL2TransactionData,
+        _ctx: &mut ActorContext,
+    ) -> Result<VerifiedMoveOSTransaction> {
+        self.convert_to_verified_tx(msg.tx_data)
     }
 }
 
@@ -358,6 +423,17 @@ impl Handler<ExecuteTransactionMessage> for ExecutorActor {
         _ctx: &mut ActorContext,
     ) -> Result<ExecuteTransactionResult> {
         self.execute(msg.tx)
+    }
+}
+
+#[async_trait]
+impl Handler<DryRunTransactionMessage> for ExecutorActor {
+    async fn handle(
+        &mut self,
+        msg: DryRunTransactionMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<DryRunTransactionResult> {
+        self.dry_run(msg.tx)
     }
 }
 

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -12,12 +12,14 @@ use moveos_types::moveos_std::event::{AnnotatedEvent, Event, EventID};
 use moveos_types::moveos_std::object::ObjectMeta;
 use moveos_types::state::{AnnotatedState, FieldKey, ObjectState};
 use moveos_types::state_resolver::{AnnotatedStateKV, StateKV};
-use moveos_types::transaction::FunctionCall;
 use moveos_types::transaction::TransactionExecutionInfo;
 use moveos_types::transaction::TransactionOutput;
 use moveos_types::transaction::VerifiedMoveOSTransaction;
+use moveos_types::transaction::{FunctionCall, RawTransactionOutput, VMErrorInfo};
 use rooch_types::address::MultiChainAddress;
-use rooch_types::transaction::{L1BlockWithBody, L1Transaction, RoochTransaction};
+use rooch_types::transaction::{
+    L1BlockWithBody, L1Transaction, RoochTransaction, RoochTransactionData,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
@@ -26,6 +28,15 @@ pub struct ValidateL2TxMessage {
 }
 
 impl Message for ValidateL2TxMessage {
+    type Result = Result<VerifiedMoveOSTransaction>;
+}
+
+#[derive(Debug)]
+pub struct ConvertL2TransactionData {
+    pub tx_data: RoochTransactionData,
+}
+
+impl Message for ConvertL2TransactionData {
     type Result = Result<VerifiedMoveOSTransaction>;
 }
 
@@ -60,6 +71,21 @@ pub struct ExecuteTransactionResult {
 
 impl Message for ExecuteTransactionMessage {
     type Result = Result<ExecuteTransactionResult>;
+}
+
+#[derive(Debug)]
+pub struct DryRunTransactionMessage {
+    pub tx: VerifiedMoveOSTransaction,
+}
+
+impl Message for DryRunTransactionMessage {
+    type Result = Result<DryRunTransactionResult>;
+}
+
+#[derive(Debug)]
+pub struct DryRunTransactionResult {
+    pub raw_output: RawTransactionOutput,
+    pub vm_error_info: Option<VMErrorInfo>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::actor::messages::{
-    GetEventsByEventHandleMessage, GetEventsByEventIDsMessage, GetTxExecutionInfosByHashMessage,
-    ListAnnotatedStatesMessage, ListStatesMessage, RefreshStateMessage, ValidateL1BlockMessage,
-    ValidateL1TxMessage,
+    ConvertL2TransactionData, DryRunTransactionResult, GetEventsByEventHandleMessage,
+    GetEventsByEventIDsMessage, GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage,
+    ListStatesMessage, RefreshStateMessage, ValidateL1BlockMessage, ValidateL1TxMessage,
 };
 use crate::actor::reader_executor::ReaderExecutorActor;
 use crate::actor::{
@@ -37,7 +37,9 @@ use moveos_types::{
 };
 use rooch_types::bitcoin::network::BitcoinNetwork;
 use rooch_types::framework::chain_id::ChainID;
-use rooch_types::transaction::{L1BlockWithBody, L1Transaction, RoochTransaction};
+use rooch_types::transaction::{
+    L1BlockWithBody, L1Transaction, RoochTransaction, RoochTransactionData,
+};
 use tokio::runtime::Handle;
 
 #[derive(Clone)]
@@ -61,6 +63,15 @@ impl ExecutorProxy {
         self.actor.send(ValidateL2TxMessage { tx }).await?
     }
 
+    pub async fn convert_to_verified_tx(
+        &self,
+        tx_data: RoochTransactionData,
+    ) -> Result<VerifiedMoveOSTransaction> {
+        self.actor
+            .send(ConvertL2TransactionData { tx_data })
+            .await?
+    }
+
     pub async fn validate_l1_block(
         &self,
         l1_block: L1BlockWithBody,
@@ -82,6 +93,17 @@ impl ExecutorProxy {
             .send(crate::actor::messages::ExecuteTransactionMessage { tx })
             .await??;
         Ok((result.output, result.transaction_info))
+    }
+
+    pub async fn dry_run_transaction(
+        &self,
+        tx: VerifiedMoveOSTransaction,
+    ) -> Result<DryRunTransactionResult> {
+        let result = self
+            .actor
+            .send(crate::actor::messages::DryRunTransactionMessage { tx })
+            .await??;
+        Ok(result)
     }
 
     pub async fn execute_view_function(

--- a/crates/rooch-integration-test-runner/src/lib.rs
+++ b/crates/rooch-integration-test-runner/src/lib.rs
@@ -181,7 +181,8 @@ impl<'a> MoveOSTestAdapter<'a> for MoveOSTestRunner<'a> {
 
         let tx = MoveOSTransaction::new_for_test(self.root.clone(), sender, action);
         let verified_tx = self.validate_tx(tx)?;
-        let output = self.moveos.execute_and_apply(verified_tx)?;
+        let (raw_output, _) = self.moveos.execute_only(verified_tx)?;
+        let output = MoveOS::apply_transaction_output(&self.moveos.db, raw_output)?;
         self.root = output.changeset.root_metadata();
         Ok((Some(tx_output_to_str(output)), module))
     }
@@ -219,7 +220,8 @@ impl<'a> MoveOSTestAdapter<'a> for MoveOSTestRunner<'a> {
             MoveAction::new_script_call(script_bytes, type_args, args),
         );
         let verified_tx = self.validate_tx(tx)?;
-        let output = self.moveos.execute_and_apply(verified_tx)?;
+        let (raw_output, _) = self.moveos.execute_only(verified_tx)?;
+        let output = MoveOS::apply_transaction_output(&self.moveos.db, raw_output)?;
         self.root = output.changeset.root_metadata();
         //TODO return values
         let value = SerializedReturnValues {
@@ -260,7 +262,8 @@ impl<'a> MoveOSTestAdapter<'a> for MoveOSTestRunner<'a> {
             MoveAction::new_function_call(function_id, type_args, args),
         );
         let verified_tx = self.validate_tx(tx)?;
-        let output = self.moveos.execute_and_apply(verified_tx)?;
+        let (raw_output, _) = self.moveos.execute_only(verified_tx)?;
+        let output = MoveOS::apply_transaction_output(&self.moveos.db, raw_output)?;
         self.root = output.changeset.root_metadata();
         debug_assert!(
             output.status == move_core_types::vm_status::KeptVMStatus::Executed,

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -134,12 +134,6 @@
           "schema": {
             "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
           }
-        },
-        {
-          "name": "tx_option",
-          "schema": {
-            "$ref": "#/components/schemas/TxOptions"
-          }
         }
       ],
       "result": {
@@ -1092,6 +1086,16 @@
           "sequence_info"
         ],
         "properties": {
+          "error_info": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DryRunTransactionResponseView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "execution_info": {
             "$ref": "#/components/schemas/TransactionExecutionInfoView"
           },

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -126,6 +126,31 @@
       }
     },
     {
+      "name": "rooch_dryRunRawTransaction",
+      "params": [
+        {
+          "name": "tx_bcs_hex",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
+          }
+        },
+        {
+          "name": "tx_option",
+          "schema": {
+            "$ref": "#/components/schemas/TxOptions"
+          }
+        }
+      ],
+      "result": {
+        "name": "DryRunTransactionResponseView",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/DryRunTransactionResponseView"
+        }
+      }
+    },
+    {
       "name": "rooch_executeRawTransaction",
       "description": "Send the signed transaction in bcs hex format This method blocks waiting for the transaction to be executed.",
       "params": [
@@ -861,6 +886,21 @@
             "additionalProperties": {
               "type": "string"
             }
+          }
+        }
+      },
+      "DryRunTransactionResponseView": {
+        "type": "object",
+        "required": [
+          "raw_output",
+          "vm_error_info"
+        ],
+        "properties": {
+          "raw_output": {
+            "$ref": "#/components/schemas/RawTransactionOutputView"
+          },
+          "vm_error_info": {
+            "$ref": "#/components/schemas/VMErrorInfo"
           }
         }
       },
@@ -2487,6 +2527,25 @@
           }
         }
       },
+      "RawTransactionOutputView": {
+        "type": "object",
+        "required": [
+          "gas_used",
+          "is_upgrade",
+          "status"
+        ],
+        "properties": {
+          "gas_used": {
+            "$ref": "#/components/schemas/u64"
+          },
+          "is_upgrade": {
+            "type": "boolean"
+          },
+          "status": {
+            "$ref": "#/components/schemas/KeptVMStatusView"
+          }
+        }
+      },
       "ScriptCallView": {
         "type": "object",
         "required": [
@@ -2988,6 +3047,24 @@
             "type": "integer",
             "format": "uint32",
             "minimum": 0.0
+          }
+        }
+      },
+      "VMErrorInfo": {
+        "type": "object",
+        "required": [
+          "error_message",
+          "execution_state"
+        ],
+        "properties": {
+          "error_message": {
+            "type": "string"
+          },
+          "execution_state": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/crates/rooch-pipeline-processor/src/actor/processor.rs
+++ b/crates/rooch-pipeline-processor/src/actor/processor.rs
@@ -9,6 +9,7 @@ use coerce::actor::{context::ActorContext, message::Handler, Actor};
 use function_name::named;
 use moveos_types::transaction::VerifiedMoveOSTransaction;
 use prometheus::Registry;
+use rooch_executor::actor::messages::DryRunTransactionResult;
 use rooch_executor::proxy::ExecutorProxy;
 use rooch_indexer::proxy::IndexerProxy;
 use rooch_proposer::proxy::ProposerProxy;
@@ -271,6 +272,37 @@ impl PipelineProcessorActor {
             execution_info,
             output,
         })
+    }
+
+    #[named]
+    pub async fn dry_run_tx(
+        &mut self,
+        tx: LedgerTransaction,
+        mut moveos_tx: VerifiedMoveOSTransaction,
+    ) -> Result<DryRunTransactionResult> {
+        let fn_name = function_name!();
+        let _timer = self
+            .metrics
+            .pipeline_processor_execution_tx_latency_seconds
+            .with_label_values(&[fn_name])
+            .start_timer();
+        // Add sequence info to tx context, let the Move contract can get the sequence info
+        moveos_tx.ctx.add(tx.sequence_info.clone())?;
+        // We must add TransactionSequenceInfo and TransactionSequenceInfoV1 both to the tx_context because the rust code is upgraded first, then the framework is upgraded.
+        // The old framework will read the TransactionSequenceInfoV1.
+        let tx_sequence_info_v1 = TransactionSequenceInfoV1::from(tx.sequence_info.clone());
+        moveos_tx.ctx.add(tx_sequence_info_v1)?;
+
+        // Then execute
+        let size = moveos_tx.ctx.tx_size;
+        let dry_run_tx_result = self.executor.dry_run_transaction(moveos_tx.clone()).await?;
+
+        self.metrics
+            .pipeline_processor_execution_tx_bytes
+            .with_label_values(&[fn_name])
+            .observe(size as f64);
+
+        Ok(dry_run_tx_result)
     }
 }
 

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -6,12 +6,12 @@ use crate::jsonrpc_types::address::UnitedAddressView;
 use crate::jsonrpc_types::event_view::{EventFilterView, IndexerEventIDView};
 use crate::jsonrpc_types::transaction_view::{TransactionFilterView, TransactionWithInfoView};
 use crate::jsonrpc_types::{
-    AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, BytesView, EventOptions,
-    EventPageView, ExecuteTransactionResponseView, FieldKeyView, FunctionCallView, H256View,
-    IndexerEventPageView, IndexerObjectStatePageView, IndexerStateIDView, ModuleABIView,
-    ObjectIDVecView, ObjectIDView, ObjectStateFilterView, ObjectStateView, QueryOptions,
-    RoochAddressView, StateOptions, StatePageView, StrView, StructTagView,
-    TransactionWithInfoPageView, TxOptions,
+    AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, BytesView,
+    DryRunTransactionResponseView, EventOptions, EventPageView, ExecuteTransactionResponseView,
+    FieldKeyView, FunctionCallView, H256View, IndexerEventPageView, IndexerObjectStatePageView,
+    IndexerStateIDView, ModuleABIView, ObjectIDVecView, ObjectIDView, ObjectStateFilterView,
+    ObjectStateView, QueryOptions, RoochAddressView, StateOptions, StatePageView, StrView,
+    StructTagView, TransactionWithInfoPageView, TxOptions,
 };
 use crate::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -38,6 +38,9 @@ pub trait RoochAPI {
         tx_bcs_hex: BytesView,
         tx_option: Option<TxOptions>,
     ) -> RpcResult<ExecuteTransactionResponseView>;
+
+    #[method(name = "dryRunRawTransaction")]
+    async fn dry_run(&self, tx_bcs_hex: BytesView) -> RpcResult<DryRunTransactionResponseView>;
 
     /// Execute a read-only function call
     /// The function do not change the state of Application

--- a/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/execute_tx_response.rs
@@ -6,8 +6,8 @@ use super::{HumanReadableDisplay, ModuleIdView, StateChangeSetView, StrView};
 use crate::jsonrpc_types::event_view::EventView;
 use crate::jsonrpc_types::H256View;
 use move_core_types::vm_status::{AbortLocation, KeptVMStatus};
-use moveos_types::transaction::TransactionExecutionInfo;
 use moveos_types::transaction::TransactionOutput;
+use moveos_types::transaction::{TransactionExecutionInfo, VMErrorInfo};
 use rooch_types::transaction::ExecuteTransactionResponse;
 use rooch_types::transaction::{authenticator::Authenticator, TransactionSequenceInfo};
 use schemars::JsonSchema;
@@ -180,10 +180,24 @@ impl From<TransactionOutput> for TransactionOutputView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RawTransactionOutputView {
+    pub status: KeptVMStatusView,
+    pub gas_used: StrView<u64>,
+    pub is_upgrade: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunTransactionResponseView {
+    pub raw_output: RawTransactionOutputView,
+    pub vm_error_info: VMErrorInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ExecuteTransactionResponseView {
     pub sequence_info: TransactionSequenceInfoView,
     pub execution_info: TransactionExecutionInfoView,
     pub output: Option<TransactionOutputView>,
+    pub error_info: Option<DryRunTransactionResponseView>,
 }
 
 impl ExecuteTransactionResponseView {
@@ -192,6 +206,7 @@ impl ExecuteTransactionResponseView {
             sequence_info: response.sequence_info.into(),
             execution_info: response.execution_info.into(),
             output: None,
+            error_info: None,
         }
     }
 }
@@ -202,6 +217,7 @@ impl From<ExecuteTransactionResponse> for ExecuteTransactionResponseView {
             sequence_info: response.sequence_info.into(),
             execution_info: response.execution_info.into(),
             output: Some(response.output.into()),
+            error_info: None,
         }
     }
 }

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -9,6 +9,7 @@ use moveos_types::{access_path::AccessPath, state::ObjectState, transaction::Fun
 use rooch_rpc_api::api::rooch_api::RoochAPIClient;
 use rooch_rpc_api::jsonrpc_types::{
     account_view::BalanceInfoView, transaction_view::TransactionWithInfoView,
+    DryRunTransactionResponseView,
 };
 use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, EventOptions, EventPageView,
@@ -20,6 +21,7 @@ use rooch_rpc_api::jsonrpc_types::{
 };
 use rooch_rpc_api::jsonrpc_types::{TransactionWithInfoPageView, TxOptions};
 use rooch_types::indexer::state::IndexerStateID;
+use rooch_types::transaction::RoochTransactionData;
 use rooch_types::{address::RoochAddress, transaction::rooch::RoochTransaction};
 use std::sync::Arc;
 
@@ -48,6 +50,17 @@ impl RoochRpcClient {
         let tx_payload = bcs::to_bytes(&tx)?;
         self.http
             .execute_raw_transaction(tx_payload.into(), tx_option)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    pub async fn dry_run_tx(
+        &self,
+        tx: RoochTransactionData,
+    ) -> Result<DryRunTransactionResponseView> {
+        let tx_payload = bcs::to_bytes(&tx)?;
+        self.http
+            .dry_run(tx_payload.into())
             .await
             .map_err(|e| anyhow::anyhow!(e))
     }

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -12,7 +12,9 @@ use rooch_config::{rooch_config_dir, ROOCH_CLIENT_CONFIG};
 use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_key::keystore::file_keystore::FileBasedKeystore;
 use rooch_key::keystore::Keystore;
-use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, KeptVMStatusView, TxOptions};
+use rooch_rpc_api::jsonrpc_types::{
+    DryRunTransactionResponseView, ExecuteTransactionResponseView, KeptVMStatusView, TxOptions,
+};
 use rooch_types::address::ParsedAddress;
 use rooch_types::address::RoochAddress;
 use rooch_types::addresses;
@@ -90,7 +92,7 @@ impl WalletContext {
         }
     }
 
-    /// Parse and resolve addresses from a map of name to address string    
+    /// Parse and resolve addresses from a map of name to address string
     pub fn parse_and_resolve_addresses(
         &self,
         addresses: BTreeMap<String, String>,
@@ -189,6 +191,18 @@ impl WalletContext {
     ) -> RoochResult<ExecuteTransactionResponseView> {
         let tx = self.sign(sender, action, password, max_gas_amount).await?;
         self.execute(tx).await
+    }
+
+    pub async fn dry_run(
+        &self,
+        tx: RoochTransactionData,
+    ) -> RoochResult<DryRunTransactionResponseView> {
+        let client = self.get_client().await?;
+        client
+            .rooch
+            .dry_run_tx(tx)
+            .await
+            .map_err(|e| RoochError::DryRunTransactionError(e.to_string()))
     }
 
     pub fn assert_execute_success(

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -19,12 +19,12 @@ use rooch_rpc_api::jsonrpc_types::{
     account_view::BalanceInfoView,
     event_view::{EventFilterView, EventView, IndexerEventIDView, IndexerEventView},
     transaction_view::{TransactionFilterView, TransactionWithInfoView},
-    AccessPathView, BalanceInfoPageView, EventOptions, EventPageView,
-    ExecuteTransactionResponseView, FunctionCallView, H256View, IndexerEventPageView,
-    IndexerObjectStatePageView, IndexerStateIDView, ModuleABIView, ObjectIDVecView,
-    ObjectStateFilterView, ObjectStateView, QueryOptions, RoochAddressView, StateKVView,
-    StateOptions, StatePageView, StrView, StructTagView, TransactionWithInfoPageView, TxOptions,
-    UnitedAddressView,
+    AccessPathView, BalanceInfoPageView, DryRunTransactionResponseView, EventOptions,
+    EventPageView, ExecuteTransactionResponseView, FunctionCallView, H256View,
+    IndexerEventPageView, IndexerObjectStatePageView, IndexerStateIDView, ModuleABIView,
+    ObjectIDVecView, ObjectStateFilterView, ObjectStateView, QueryOptions,
+    RawTransactionOutputView, RoochAddressView, StateKVView, StateOptions, StatePageView, StrView,
+    StructTagView, TransactionWithInfoPageView, TxOptions, UnitedAddressView,
 };
 use rooch_rpc_api::{
     api::rooch_api::RoochAPIServer,
@@ -36,7 +36,7 @@ use rooch_rpc_api::{
     RpcError, RpcResult,
 };
 use rooch_types::indexer::state::IndexerStateID;
-use rooch_types::transaction::{RoochTransaction, TransactionWithInfo};
+use rooch_types::transaction::{RoochTransaction, RoochTransactionData, TransactionWithInfo};
 use std::cmp::min;
 use std::str::FromStr;
 use tracing::{debug, info};
@@ -156,6 +156,25 @@ impl RoochAPIServer for RoochServer {
             ExecuteTransactionResponseView::new_without_output(tx_response)
         };
         Ok(result)
+    }
+
+    async fn dry_run(&self, payload: BytesView) -> RpcResult<DryRunTransactionResponseView> {
+        let tx = bcs::from_bytes::<RoochTransactionData>(&payload.0)?;
+        let tx_result = self.rpc_service.dry_run_tx(tx).await?;
+        let raw_output = tx_result.raw_output;
+
+        let raw_output_view = RawTransactionOutputView {
+            status: raw_output.status.into(),
+            gas_used: raw_output.gas_used.into(),
+            is_upgrade: raw_output.is_upgrade,
+        };
+
+        let tx_response = DryRunTransactionResponseView {
+            raw_output: raw_output_view,
+            vm_error_info: tx_result.vm_error_info.unwrap_or_default(),
+        };
+
+        Ok(tx_response)
     }
 
     async fn execute_view_function(

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -14,6 +14,7 @@ use moveos_types::moveos_std::object::ObjectID;
 use moveos_types::state::{AnnotatedState, FieldKey, ObjectState};
 use moveos_types::state_resolver::{AnnotatedStateKV, StateKV};
 use moveos_types::transaction::{FunctionCall, TransactionExecutionInfo};
+use rooch_executor::actor::messages::DryRunTransactionResult;
 use rooch_executor::proxy::ExecutorProxy;
 use rooch_indexer::proxy::IndexerProxy;
 use rooch_pipeline_processor::proxy::PipelineProcessorProxy;
@@ -25,7 +26,9 @@ use rooch_types::framework::address_mapping::RoochToBitcoinAddressMapping;
 use rooch_types::indexer::event::{EventFilter, IndexerEvent, IndexerEventID};
 use rooch_types::indexer::state::{IndexerStateID, ObjectStateFilter};
 use rooch_types::indexer::transaction::{IndexerTransaction, TransactionFilter};
-use rooch_types::transaction::{ExecuteTransactionResponse, LedgerTransaction, RoochTransaction};
+use rooch_types::transaction::{
+    ExecuteTransactionResponse, LedgerTransaction, RoochTransaction, RoochTransactionData,
+};
 use std::collections::{BTreeMap, HashMap};
 
 /// RpcService is the implementation of the RPC service.
@@ -81,6 +84,11 @@ impl RpcService {
 
     pub async fn execute_tx(&self, tx: RoochTransaction) -> Result<ExecuteTransactionResponse> {
         self.pipeline_processor.execute_l2_tx(tx).await
+    }
+
+    pub async fn dry_run_tx(&self, tx: RoochTransactionData) -> Result<DryRunTransactionResult> {
+        let verified_tx = self.executor.convert_to_verified_tx(tx).await?;
+        self.executor.dry_run_transaction(verified_tx).await
     }
 
     pub async fn execute_view_function(

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -50,6 +50,8 @@ pub enum RoochError {
     SignMessageError(String),
     #[error("Transaction error: {0}")]
     TransactionError(String),
+    #[error("DryRun Transaction error: {0}")]
+    DryRunTransactionError(String),
     #[error("View function error: {0}")]
     ViewFunctionError(String),
     #[error("Import account error: {0}")]

--- a/crates/rooch-types/src/transaction/rooch.rs
+++ b/crates/rooch-types/src/transaction/rooch.rs
@@ -65,6 +65,10 @@ impl RoochTransactionData {
         moveos_types::h256::sha3_256_of(self.encode().as_slice())
     }
 
+    pub fn tx_size(&self) -> u64 {
+        bcs::serialized_size(self).expect("serialize transaction size should success") as u64
+    }
+
     pub fn sign(&self, kp: &RoochKeyPair) -> RoochTransaction {
         let auth = Authenticator::sign(kp, self);
         RoochTransaction::new(self.clone(), auth)

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -133,24 +133,6 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
 
         let max_gas_amount: Option<u64> = self.tx_options.max_gas_amount;
 
-        /*
-        let output_dry_run_message = |dry_run_resp: DryRunTransactionResponseView| {
-            println!(
-                "Transaction dry run failed: {:?}",
-                dry_run_resp.vm_error_info.error_message
-            );
-            println!("\nStack trace:");
-            for (idx, item) in dry_run_resp
-                .vm_error_info
-                .execution_state
-                .iter()
-                .enumerate()
-            {
-                println!("{} {}", idx, item);
-            }
-        };
-         */
-
         // Prepare and execute the transaction based on the action type
         let tx_result = if !self.by_move_action {
             let args = bcs::to_bytes(&bundles).unwrap();

--- a/crates/rooch/src/commands/move_cli/commands/publish.rs
+++ b/crates/rooch/src/commands/move_cli/commands/publish.rs
@@ -20,7 +20,9 @@ use moveos_verifier::build::run_verifier;
 use moveos_verifier::verifier;
 use rooch_key::key_derive::verify_password;
 use rooch_key::keystore::account_keystore::AccountKeystore;
-use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, HumanReadableDisplay};
+use rooch_rpc_api::jsonrpc_types::{
+    ExecuteTransactionResponseView, HumanReadableDisplay, KeptVMStatusView,
+};
 use rooch_types::address::RoochAddress;
 use rooch_types::error::{RoochError, RoochResult};
 use rooch_types::transaction::rooch::RoochTransaction;
@@ -131,6 +133,24 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
 
         let max_gas_amount: Option<u64> = self.tx_options.max_gas_amount;
 
+        /*
+        let output_dry_run_message = |dry_run_resp: DryRunTransactionResponseView| {
+            println!(
+                "Transaction dry run failed: {:?}",
+                dry_run_resp.vm_error_info.error_message
+            );
+            println!("\nStack trace:");
+            for (idx, item) in dry_run_resp
+                .vm_error_info
+                .execution_state
+                .iter()
+                .enumerate()
+            {
+                println!("{} {}", idx, item);
+            }
+        };
+         */
+
         // Prepare and execute the transaction based on the action type
         let tx_result = if !self.by_move_action {
             let args = bcs::to_bytes(&bundles).unwrap();
@@ -146,8 +166,16 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
                 vec![args],
             );
 
+            let dry_run_result = context
+                .dry_run(
+                    context
+                        .build_tx_data(sender, action.clone(), max_gas_amount)
+                        .await?,
+                )
+                .await;
+
             // Handle transaction with or without authenticator
-            match self.tx_options.authenticator {
+            let mut result = match self.tx_options.authenticator {
                 Some(authenticator) => {
                     let tx_data = context
                         .build_tx_data(sender, action, max_gas_amount)
@@ -179,7 +207,15 @@ impl CommandAction<ExecuteTransactionResponseView> for Publish {
                             .await?
                     }
                 }
+            };
+
+            if let Ok(dry_run_resp) = dry_run_result {
+                if dry_run_resp.raw_output.status != KeptVMStatusView::Executed {
+                    result.error_info = Some(dry_run_resp);
+                }
             }
+
+            result
         } else {
             // Handle MoveAction.ModuleBundle case
             let action = MoveAction::ModuleBundle(bundles);
@@ -238,6 +274,21 @@ impl Publish {
         output.push_str(&exe_info.to_human_readable_string(false, 0));
 
         if let Some(txn_output) = &txn_response.output {
+            // print error info
+            if let Some(error_info) = txn_response.clone().error_info {
+                output.push_str(
+                    format!(
+                        "\n\n\nTransaction dry run failed:\n {:?}",
+                        error_info.vm_error_info.error_message
+                    )
+                    .as_str(),
+                );
+                output.push_str("\nCallStack trace:\n".to_string().as_str());
+                for (idx, item) in error_info.vm_error_info.execution_state.iter().enumerate() {
+                    output.push_str(format!("{} {}\n", idx, item).as_str());
+                }
+            };
+
             // print modules
             let changes = &txn_output.changeset.changes;
             let module_store_id = ModuleStore::object_id();

--- a/moveos/moveos-types/src/transaction.rs
+++ b/moveos/moveos-types/src/transaction.rs
@@ -33,6 +33,7 @@ use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use rand::random;
+use schemars::JsonSchema;
 
 /// Call a Move script
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
@@ -366,6 +367,21 @@ pub struct VerifiedMoveOSTransaction {
 impl VerifiedMoveOSTransaction {
     pub fn new(root: ObjectMeta, ctx: TxContext, action: VerifiedMoveAction) -> Self {
         Self { root, ctx, action }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VMErrorInfo {
+    pub error_message: String,
+    pub execution_state: Vec<String>,
+}
+
+impl Default for VMErrorInfo {
+    fn default() -> Self {
+        Self {
+            error_message: "".to_string(),
+            execution_state: vec![],
+        }
     }
 }
 

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -4,18 +4,24 @@
 use crate::gas::table::{
     get_gas_schedule_entries, initial_cost_schedule, ClassifiedGasMeter, CostTable, MoveOSGasMeter,
 };
+use crate::vm::data_cache::MoveosDataCache;
 use crate::vm::moveos_vm::{MoveOSSession, MoveOSVM};
 use anyhow::{bail, Result};
 use backtrace::Backtrace;
+use move_binary_format::binary_views::BinaryIndexedView;
 use move_binary_format::errors::VMError;
 use move_binary_format::errors::{vm_status_of_result, Location, PartialVMError, VMResult};
+use move_binary_format::file_format::FunctionDefinitionIndex;
+use move_binary_format::CompiledModule;
 use move_core_types::identifier::IdentStr;
+use move_core_types::language_storage::ModuleId;
 use move_core_types::value::MoveTypeLayout;
 use move_core_types::vm_status::{KeptVMStatus, VMStatus};
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::Identifier, vm_status::StatusCode,
 };
 use move_vm_runtime::config::VMConfig;
+use move_vm_runtime::data_cache::TransactionCache;
 use move_vm_runtime::native_functions::NativeFunction;
 use moveos_store::config_store::ConfigDBStore;
 use moveos_store::event_store::EventDBStore;
@@ -32,7 +38,7 @@ use moveos_types::moveos_std::tx_result::TxResult;
 use moveos_types::startup_info::StartupInfo;
 use moveos_types::state::{MoveStructState, MoveStructType, ObjectState};
 use moveos_types::state_resolver::RootObjectResolver;
-use moveos_types::transaction::FunctionCall;
+use moveos_types::transaction::{FunctionCall, VMErrorInfo};
 use moveos_types::transaction::{
     MoveOSTransaction, RawTransactionOutput, TransactionOutput, VerifiedMoveAction,
     VerifiedMoveOSTransaction,
@@ -100,7 +106,7 @@ impl Clone for MoveOSConfig {
 
 pub struct MoveOS {
     vm: MoveOSVM,
-    db: MoveOSStore,
+    pub db: MoveOSStore,
     cost_table: Arc<RwLock<Option<CostTable>>>,
     system_pre_execute_functions: Vec<FunctionCall>,
     system_post_execute_functions: Vec<FunctionCall>,
@@ -165,7 +171,7 @@ impl MoveOS {
         if raw_output.status != KeptVMStatus::Executed {
             bail!("genesis tx should success, error: {:?}", raw_output.status);
         }
-        let output = self.apply_transaction_output(raw_output.clone())?;
+        let output = Self::apply_transaction_output(&self.db, raw_output.clone())?;
         log::info!(
             "execute genesis tx state_root:{:?}, state_size:{}",
             output.changeset.state_root,
@@ -244,7 +250,10 @@ impl MoveOS {
         })
     }
 
-    pub fn execute(&self, tx: VerifiedMoveOSTransaction) -> Result<RawTransactionOutput> {
+    pub fn execute(
+        &self,
+        tx: VerifiedMoveOSTransaction,
+    ) -> Result<(RawTransactionOutput, Option<VMErrorInfo>)> {
         let VerifiedMoveOSTransaction { root, ctx, action } = tx;
         let tx_hash = ctx.tx_hash();
         if log::log_enabled!(log::Level::Debug) {
@@ -287,7 +296,7 @@ impl MoveOS {
                         status
                     );
                 }
-                self.execution_cleanup(is_system_call, session, status)
+                self.execution_cleanup(is_system_call, session, status, None)
             }
             Err(vm_err) => {
                 if log::log_enabled!(log::Level::Warn) {
@@ -297,27 +306,49 @@ impl MoveOS {
                         vm_err
                     );
                 }
+
+                let vm_error_info = VMErrorInfo {
+                    error_message: vm_err.to_string(),
+                    execution_state: extract_execution_state(
+                        vm_err.clone(),
+                        &session.session.data_cache,
+                    )?,
+                };
                 // If it is a system call, we should not respawn the session.
                 if !is_system_call {
                     let mut s = session.respawn(system_env);
                     //Because the session is respawned, the pre_execute function should be called again.
                     s.execute_function_call(self.system_pre_execute_functions.clone(), false)
                         .expect("system_pre_execute should not fail.");
-                    self.execution_cleanup(is_system_call, s, vm_err.into_vm_status())
+                    self.execution_cleanup(
+                        is_system_call,
+                        s,
+                        vm_err.into_vm_status(),
+                        Some(vm_error_info),
+                    )
                 } else {
-                    self.execution_cleanup(is_system_call, session, vm_err.into_vm_status())
+                    self.execution_cleanup(
+                        is_system_call,
+                        session,
+                        vm_err.into_vm_status(),
+                        Some(vm_error_info),
+                    )
                 }
             }
         }
     }
 
-    pub fn execute_and_apply(&self, tx: VerifiedMoveOSTransaction) -> Result<TransactionOutput> {
-        let raw_output = self.execute(tx)?;
-        let output = self.apply_transaction_output(raw_output.clone())?;
-        Ok(output)
+    pub fn execute_only(
+        &self,
+        tx: VerifiedMoveOSTransaction,
+    ) -> Result<(RawTransactionOutput, Option<VMErrorInfo>)> {
+        self.execute(tx)
     }
 
-    fn apply_transaction_output(&self, output: RawTransactionOutput) -> Result<TransactionOutput> {
+    pub fn apply_transaction_output(
+        db: &MoveOSStore,
+        output: RawTransactionOutput,
+    ) -> Result<TransactionOutput> {
         let RawTransactionOutput {
             status,
             mut changeset,
@@ -326,16 +357,14 @@ impl MoveOS {
             is_upgrade,
         } = output;
 
-        self.db
-            .get_state_store()
+        db.get_state_store()
             .apply_change_set(&mut changeset)
             .map_err(|e| {
                 PartialVMError::new(StatusCode::STORAGE_ERROR)
                     .with_message(e.to_string())
                     .finish(Location::Undefined)
             })?;
-        let event_ids = self
-            .db
+        let event_ids = db
             .get_event_store()
             .save_events(tx_events.clone())
             .map_err(|e| {
@@ -353,8 +382,7 @@ impl MoveOS {
         let new_state_root = changeset.state_root;
         let size = changeset.global_size;
 
-        self.db
-            .get_config_store()
+        db.get_config_store()
             .save_startup_info(StartupInfo::new(new_state_root, size))
             .map_err(|e| {
                 PartialVMError::new(StatusCode::STORAGE_ERROR)
@@ -462,7 +490,8 @@ impl MoveOS {
         is_system_call: bool,
         mut session: MoveOSSession<'_, '_, RootObjectResolver<MoveOSStore>, MoveOSGasMeter>,
         status: VMStatus,
-    ) -> Result<RawTransactionOutput> {
+        vm_error_info: Option<VMErrorInfo>,
+    ) -> Result<(RawTransactionOutput, Option<VMErrorInfo>)> {
         let kept_status = match status.keep_or_discard() {
             Ok(kept_status) => {
                 if is_system_call && kept_status != KeptVMStatus::Executed {
@@ -511,7 +540,7 @@ impl MoveOS {
         }
 
         let (_ctx, output) = session.finish_with_extensions(kept_status)?;
-        Ok(output)
+        Ok((output, vm_error_info))
     }
 
     pub fn flush_module_cache(&self, is_upgrade: bool) -> Result<()> {
@@ -520,4 +549,45 @@ impl MoveOS {
         };
         Ok(())
     }
+}
+
+fn extract_execution_state(
+    vm_err: VMError,
+    data_cache: &MoveosDataCache<RootObjectResolver<MoveOSStore>>,
+) -> Result<Vec<String>> {
+    let mut execution_stack_trace = Vec::new();
+    if let Some(exec_state) = vm_err.exec_state() {
+        for execute_record in exec_state.stack_trace() {
+            match execute_record {
+                (Some(module_id), func_idx, code_offset) => {
+                    let func_name = func_name_from_db(module_id, func_idx, data_cache)?;
+                    execution_stack_trace.push(format!(
+                        "{}::{}.{}",
+                        module_id.short_str_lossless(),
+                        func_name,
+                        code_offset
+                    ));
+                }
+                (None, func_idx, code_offset) => {
+                    execution_stack_trace.push(format!("{}::{}", func_idx, code_offset));
+                }
+            }
+        }
+    };
+
+    Ok(execution_stack_trace)
+}
+
+fn func_name_from_db(
+    module_id: &ModuleId,
+    func_idx: &FunctionDefinitionIndex,
+    data_cache: &MoveosDataCache<RootObjectResolver<MoveOSStore>>,
+) -> Result<String> {
+    let module_bytes = data_cache.load_module(module_id)?;
+    let compiled_module = CompiledModule::deserialize(module_bytes.as_slice())?;
+    let module_bin_view = BinaryIndexedView::Module(&compiled_module);
+    let func_def = module_bin_view.function_def_at(*func_idx)?;
+    Ok(module_bin_view
+        .identifier_at(module_bin_view.function_handle_at(func_def.function).name)
+        .to_string())
 }


### PR DESCRIPTION
**When publishing the module, perform a dry run. If an error occurs, stop and report the following error:**

Transaction dry run failed: "VMError with status ABORTED with sub status 6789 at location Module ModuleId { address: 285529d7fd13ffcda9d89cd250b4025ba9226c0e2e57f5ca3d739cb236dc259d, name: Identifier(\"counter\") } and message 0x285529d7fd13ffcda9d89cd250b4025ba9226c0e2e57f5ca3d739cb236dc259d::counter::f5 at offset 1 at code offset 1 in function definition 4"

CallStack trace:
0 0x285529d7fd13ffcda9d89cd250b4025ba9226c0e2e57f5ca3d739cb236dc259d::counter::f4.0
1 0x285529d7fd13ffcda9d89cd250b4025ba9226c0e2e57f5ca3d739cb236dc259d::counter::f3.0
2 0x285529d7fd13ffcda9d89cd250b4025ba9226c0e2e57f5ca3d739cb236dc259d::counter::f2.0
3 0x285529d7fd13ffcda9d89cd250b4025ba9226c0e2e57f5ca3d739cb236dc259d::counter::f1.0
4 0x285529d7fd13ffcda9d89cd250b4025ba9226c0e2e57f5ca3d739cb236dc259d::counter::init.6

**Do we need to dry run trasaction when executing normal transaction?**