### PR TITLE
fix: Display vector byte if movestring can't format to utf8

### DIFF
--- a/moveos/moveos-types/src/move_std/string.rs
+++ b/moveos/moveos-types/src/move_std/string.rs
@@ -35,11 +35,14 @@ impl std::fmt::Debug for MoveString {
 
 impl std::fmt::Display for MoveString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            std::str::from_utf8(&self.bytes).map_err(|_| std::fmt::Error)?
-        )
+        match std::str::from_utf8(&self.bytes) {
+            Ok(s) => {
+                write!(f, "{}", s)
+            }
+            Err(_) => {
+                write!(f, "{:?}", &self.bytes)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Summary about this PR

- Closes #2388 