### PR TITLE
[Indexer] Support query event by event type and sender

### DIFF
--- a/crates/rooch-common/src/fs/file_cache.rs
+++ b/crates/rooch-common/src/fs/file_cache.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io::Result;
-#[cfg(target_os = "linux")]
 use std::path::Path;
-#[cfg(not(target_os = "linux"))]
-use std::path::PathBuf;
 
 pub struct FileCacheManager {
     #[cfg(target_os = "linux")]
@@ -41,7 +38,7 @@ impl FileCacheManager {
     }
 
     #[cfg(not(target_os = "linux"))]
-    pub fn new(_: PathBuf) -> Result<Self> {
+    pub fn new<P: AsRef<Path>>(_path: P) -> Result<Self> {
         Ok(FileCacheManager {})
     }
 

--- a/crates/rooch-common/src/fs/file_cache.rs
+++ b/crates/rooch-common/src/fs/file_cache.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io::Result;
+#[cfg(target_os = "linux")]
 use std::path::Path;
+#[cfg(not(target_os = "linux"))]
+use std::path::PathBuf;
 
 pub struct FileCacheManager {
     #[cfg(target_os = "linux")]

--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -20,6 +20,7 @@ use diesel::{
 };
 use function_name::named;
 use move_core_types::language_storage::StructTag;
+use moveos_types::moveos_std::event::EventHandle;
 use moveos_types::moveos_std::object::ObjectID;
 use prometheus::Registry;
 use rooch_types::indexer::event::{EventFilter, IndexerEvent, IndexerEventID};
@@ -283,9 +284,17 @@ impl IndexerReader {
         };
 
         let main_where_clause = match filter {
-            EventFilter::EventType(struct_tag) => {
-                let event_type_str = format!("0x{}", struct_tag.to_canonical_string());
-                format!("{EVENT_TYPE_STR} = \"{}\"", event_type_str)
+            EventFilter::EventTypeWithSender { event_type, sender } => {
+                let event_handle_id = EventHandle::derive_event_handle_id(&event_type);
+                format!(
+                    "{TX_SENDER_STR} = \"{}\" AND {EVENT_HANDLE_ID_STR} = \"{}\"",
+                    sender.to_hex_literal(),
+                    event_handle_id
+                )
+            }
+            EventFilter::EventType(event_type) => {
+                let event_handle_id = EventHandle::derive_event_handle_id(&event_type);
+                format!("{EVENT_HANDLE_ID_STR} = \"{}\"", event_handle_id)
             }
             EventFilter::Sender(sender) => {
                 format!("{TX_SENDER_STR} = \"{}\"", sender.to_hex_literal())

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -928,6 +928,31 @@
       "EventFilterView": {
         "oneOf": [
           {
+            "description": "Query by event type with sender",
+            "type": "object",
+            "required": [
+              "event_type_with_sender"
+            ],
+            "properties": {
+              "event_type_with_sender": {
+                "type": "object",
+                "required": [
+                  "event_type",
+                  "sender"
+                ],
+                "properties": {
+                  "event_type": {
+                    "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+                  },
+                  "sender": {
+                    "$ref": "#/components/schemas/rooch_rpc_api::jsonrpc_types::address::UnitedAddress"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Query by event type.",
             "type": "object",
             "required": [
@@ -2138,14 +2163,10 @@
               "object_type_with_owner": {
                 "type": "object",
                 "required": [
-                  "filter_out",
                   "object_type",
                   "owner"
                 ],
                 "properties": {
-                  "filter_out": {
-                    "type": "boolean"
-                  },
                   "object_type": {
                     "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
                   },
@@ -2549,6 +2570,11 @@
           "descending": {
             "description": "If true, return query items in descending order.",
             "default": true,
+            "type": "boolean"
+          },
+          "filterOut": {
+            "description": "If true, filter out all match items.",
+            "default": false,
             "type": "boolean"
           },
           "showDisplay": {

--- a/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
@@ -173,6 +173,11 @@ impl From<IndexerEvent> for IndexerEventView {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum EventFilterView {
+    /// Query by event type with sender
+    EventTypeWithSender {
+        event_type: StructTagView,
+        sender: UnitedAddressView,
+    },
     /// Query by event type.
     EventType(StructTagView),
     /// Query by sender address.
@@ -199,6 +204,12 @@ pub enum EventFilterView {
 impl From<EventFilterView> for EventFilter {
     fn from(event_filter: EventFilterView) -> Self {
         match event_filter {
+            EventFilterView::EventTypeWithSender { event_type, sender } => {
+                Self::EventTypeWithSender {
+                    event_type: event_type.into(),
+                    sender: sender.into(),
+                }
+            }
             EventFilterView::EventType(event_type) => Self::EventType(event_type.into()),
             EventFilterView::Sender(address) => Self::Sender(address.into()),
             EventFilterView::TxHash(tx_hash) => Self::TxHash(tx_hash.into()),

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rpc_options.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rpc_options.rs
@@ -77,6 +77,8 @@ pub struct QueryOptions {
     pub decode: bool,
     /// If true, result with display rendered is returned
     pub show_display: bool,
+    /// If true, filter out all match items.
+    pub filter_out: bool,
 }
 
 impl QueryOptions {
@@ -89,6 +91,11 @@ impl QueryOptions {
         self.show_display = show_display;
         self
     }
+
+    pub fn filter_out(mut self, filter_out: bool) -> Self {
+        self.filter_out = filter_out;
+        self
+    }
 }
 
 impl Default for QueryOptions {
@@ -97,6 +104,7 @@ impl Default for QueryOptions {
             descending: true,
             decode: false,
             show_display: false,
+            filter_out: false,
         }
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -3,7 +3,7 @@
 
 use super::{
     AnnotatedMoveStructView, BytesView, H256View, HumanReadableDisplay, ObjectIDVecView,
-    RoochAddressView, StrView, StructTagView, TypeTagView, UnitedAddressView,
+    QueryOptions, RoochAddressView, StrView, StructTagView, TypeTagView, UnitedAddressView,
 };
 use anyhow::Result;
 use move_core_types::effects::Op;
@@ -371,7 +371,6 @@ pub enum ObjectStateFilterView {
     /// Query by object value type and owner.
     ObjectTypeWithOwner {
         object_type: StructTagView,
-        filter_out: bool,
         owner: UnitedAddressView,
     },
     /// Query by object value type.
@@ -385,17 +384,16 @@ pub enum ObjectStateFilterView {
 impl ObjectStateFilterView {
     pub fn try_into_object_state_filter(
         state_filter: ObjectStateFilterView,
+        query_option: QueryOptions,
     ) -> Result<ObjectStateFilter> {
         Ok(match state_filter {
-            ObjectStateFilterView::ObjectTypeWithOwner {
-                object_type,
-                filter_out,
-                owner,
-            } => ObjectStateFilter::ObjectTypeWithOwner {
-                object_type: object_type.into(),
-                filter_out,
-                owner: owner.into(),
-            },
+            ObjectStateFilterView::ObjectTypeWithOwner { object_type, owner } => {
+                ObjectStateFilter::ObjectTypeWithOwner {
+                    object_type: object_type.into(),
+                    owner: owner.into(),
+                    filter_out: query_option.filter_out,
+                }
+            }
             ObjectStateFilterView::ObjectType(object_type) => {
                 ObjectStateFilter::ObjectType(object_type.into())
             }

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -733,7 +733,8 @@ impl RoochAPIServer for RoochServer {
         let query_option = query_option.unwrap_or_default();
         let descending_order = query_option.descending;
 
-        let global_state_filter = ObjectStateFilterView::try_into_object_state_filter(filter)?;
+        let global_state_filter =
+            ObjectStateFilterView::try_into_object_state_filter(filter, query_option.clone())?;
         let mut object_states = self
             .rpc_service
             .query_object_states(

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -239,8 +239,6 @@ impl RpcService {
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<IndexerEvent>> {
-        // ) -> Result<Vec<AnnotatedEvent>> {
-
         let resp = self
             .indexer
             .query_events(filter, cursor, limit, descending_order)

--- a/crates/rooch-types/src/indexer/event.rs
+++ b/crates/rooch-types/src/indexer/event.rs
@@ -82,6 +82,11 @@ impl IndexerEventID {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum EventFilter {
+    /// Query by event type with sender
+    EventTypeWithSender {
+        event_type: StructTag,
+        sender: RoochAddress,
+    },
     /// Query by event type.
     EventType(StructTag),
     /// Query by sender address.
@@ -107,6 +112,9 @@ pub enum EventFilter {
 impl EventFilter {
     fn try_matches(&self, item: &IndexerEvent) -> Result<bool> {
         Ok(match self {
+            EventFilter::EventTypeWithSender {
+                event_type, sender, ..
+            } => struct_tag_match(&item.event_type, event_type) && sender == &item.sender,
             EventFilter::EventType(event_type) => struct_tag_match(&item.event_type, event_type),
             EventFilter::Sender(sender) => sender == &item.sender,
             EventFilter::TxHash(tx_hash) => tx_hash == &item.tx_hash,

--- a/crates/rooch-types/src/indexer/state.rs
+++ b/crates/rooch-types/src/indexer/state.rs
@@ -134,8 +134,8 @@ pub enum ObjectStateFilter {
     /// Query by object type and owner.
     ObjectTypeWithOwner {
         object_type: StructTag,
-        filter_out: bool,
         owner: AccountAddress,
+        filter_out: bool,
     },
     /// Query by object type.
     ObjectType(StructTag),

--- a/crates/rooch/src/commands/object.rs
+++ b/crates/rooch/src/commands/object.rs
@@ -70,7 +70,6 @@ impl CommandAction<IndexerObjectStatePageView> for ObjectCommand {
             let owner_addr: RoochAddressView = owner.into_rooch_address(&address_mapping)?.into();
             filter = Some(ObjectStateFilterView::ObjectTypeWithOwner {
                 object_type: obj_type.into(),
-                filter_out: self.filter_out,
                 owner: owner_addr.into(),
             });
         } else if self.owner.is_some() {
@@ -89,6 +88,7 @@ impl CommandAction<IndexerObjectStatePageView> for ObjectCommand {
             descending: self.descending_order,
             decode: true,
             show_display: self.show_display,
+            filter_out: self.filter_out,
         };
 
         if filter.is_none() {

--- a/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
@@ -164,7 +164,7 @@ pub(crate) fn produce_utxo_updates(
 ) {
     let input = input.as_ref();
     // produce utxo updates is slower than produce address map updates, so we put cache manager to drop cache here
-    let file_cache_mgr = FileCacheManager::new(input).unwrap();
+    let file_cache_mgr = FileCacheManager::new(input.to_path_buf()).unwrap();
     let mut cache_drop_offset: u64 = 0;
     let mut reader = BufReader::with_capacity(8 * 1024 * 1024, File::open(input).unwrap());
     let mut is_title_line = true;

--- a/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
@@ -164,7 +164,7 @@ pub(crate) fn produce_utxo_updates(
 ) {
     let input = input.as_ref();
     // produce utxo updates is slower than produce address map updates, so we put cache manager to drop cache here
-    let file_cache_mgr = FileCacheManager::new(input.to_path_buf()).unwrap();
+    let file_cache_mgr = FileCacheManager::new(input).unwrap();
     let mut cache_drop_offset: u64 = 0;
     let mut reader = BufReader::with_capacity(8 * 1024 * 1024, File::open(input).unwrap());
     let mut is_title_line = true;


### PR DESCRIPTION
## Summary

1. Support query event by event type and sender, and the query can use sqlite index
2. Migrate `filter_out` from ObjectStateFilterView::ObjectTypeWithOwner to QueryOptions, eliminate the restriction of forcing filter_out to be passed in ObjectStateFilterView::ObjectTypeWithOwner

TODO:
QueryOptions uses camelCase for serialization, and some parameters use snake_case for parameter passing. Should we unify them?

- Closes #2404