### PR TITLE
[framework] Refactor result, make the error as generics

### DIFF
--- a/frameworks/rooch-nursery/doc/result.md
+++ b/frameworks/rooch-nursery/doc/result.md
@@ -11,7 +11,7 @@
 -  [Function `is_ok`](#0xa_result_is_ok)
 -  [Function `get`](#0xa_result_get)
 -  [Function `err`](#0xa_result_err)
--  [Function `err_string`](#0xa_result_err_string)
+-  [Function `err_str`](#0xa_result_err_str)
 -  [Function `is_err`](#0xa_result_is_err)
 -  [Function `get_err`](#0xa_result_get_err)
 -  [Function `as_err`](#0xa_result_as_err)
@@ -38,7 +38,7 @@ Most of the time, we do not need the Result type in smart contract, we can direc
 But in some cases, we need to return a result to ensure the caller can handle the error.
 
 
-<pre><code><b>struct</b> <a href="result.md#0xa_result_Result">Result</a>&lt;T&gt; <b>has</b> <b>copy</b>, drop
+<pre><code><b>struct</b> <a href="result.md#0xa_result_Result">Result</a>&lt;T, E&gt; <b>has</b> <b>copy</b>, drop
 </code></pre>
 
 
@@ -74,7 +74,7 @@ Expected the result is ok but the result is err.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_ok">ok</a>&lt;T&gt;(value: T): <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_ok">ok</a>&lt;T, E&gt;(value: T): <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;
 </code></pre>
 
 
@@ -85,7 +85,7 @@ Expected the result is ok but the result is err.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_is_ok">is_ok</a>&lt;T&gt;(<a href="result.md#0xa_result">result</a>: &<a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_is_ok">is_ok</a>&lt;T, E&gt;(<a href="result.md#0xa_result">result</a>: &<a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;): bool
 </code></pre>
 
 
@@ -96,7 +96,7 @@ Expected the result is ok but the result is err.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_get">get</a>&lt;T&gt;(<a href="result.md#0xa_result">result</a>: &<a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;): &<a href="_Option">option::Option</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_get">get</a>&lt;T, E&gt;(<a href="result.md#0xa_result">result</a>: &<a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;): &<a href="_Option">option::Option</a>&lt;T&gt;
 </code></pre>
 
 
@@ -107,18 +107,20 @@ Expected the result is ok but the result is err.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_err">err</a>&lt;T&gt;(err: <a href="">vector</a>&lt;u8&gt;): <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_err">err</a>&lt;T, E&gt;(err: E): <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;
 </code></pre>
 
 
 
-<a name="0xa_result_err_string"></a>
+<a name="0xa_result_err_str"></a>
 
-## Function `err_string`
+## Function `err_str`
+
+A shortcut to create a Result<T, String> with an error String with
+err_str(b"msg").
 
 
-
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_err_string">err_string</a>&lt;T&gt;(err: <a href="_String">string::String</a>): <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_err_str">err_str</a>&lt;T&gt;(err: <a href="">vector</a>&lt;u8&gt;): <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, <a href="_String">string::String</a>&gt;
 </code></pre>
 
 
@@ -129,7 +131,7 @@ Expected the result is ok but the result is err.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_is_err">is_err</a>&lt;T&gt;(<a href="result.md#0xa_result">result</a>: &<a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_is_err">is_err</a>&lt;T, E&gt;(<a href="result.md#0xa_result">result</a>: &<a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;): bool
 </code></pre>
 
 
@@ -140,7 +142,7 @@ Expected the result is ok but the result is err.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_get_err">get_err</a>&lt;T&gt;(<a href="result.md#0xa_result">result</a>: &<a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;): <a href="_Option">option::Option</a>&lt;<a href="_String">string::String</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_get_err">get_err</a>&lt;T, E&gt;(<a href="result.md#0xa_result">result</a>: &<a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;): &<a href="_Option">option::Option</a>&lt;E&gt;
 </code></pre>
 
 
@@ -149,10 +151,10 @@ Expected the result is ok but the result is err.
 
 ## Function `as_err`
 
-Convert an error Result<T> to error Result<U>.
+Convert an error Result<T, String> to error Result<U, String>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_as_err">as_err</a>&lt;U, T&gt;(self: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;): <a href="result.md#0xa_result_Result">result::Result</a>&lt;U&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_as_err">as_err</a>&lt;U, T&gt;(self: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, <a href="_String">string::String</a>&gt;): <a href="result.md#0xa_result_Result">result::Result</a>&lt;U, <a href="_String">string::String</a>&gt;
 </code></pre>
 
 
@@ -163,7 +165,7 @@ Convert an error Result<T> to error Result<U>.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_unpack">unpack</a>&lt;T&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;): (<a href="_Option">option::Option</a>&lt;T&gt;, <a href="_Option">option::Option</a>&lt;<a href="_String">string::String</a>&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_unpack">unpack</a>&lt;T, E&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;): (<a href="_Option">option::Option</a>&lt;T&gt;, <a href="_Option">option::Option</a>&lt;E&gt;)
 </code></pre>
 
 
@@ -174,7 +176,7 @@ Convert an error Result<T> to error Result<U>.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_and_then">and_then</a>&lt;U, T&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;U&gt;, f: |U|<a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;): <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_and_then">and_then</a>&lt;U, T, E&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;U, E&gt;, f: |U|<a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;): <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;
 </code></pre>
 
 
@@ -185,7 +187,7 @@ Convert an error Result<T> to error Result<U>.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_unwrap">unwrap</a>&lt;T&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;): T
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_unwrap">unwrap</a>&lt;T, E: drop&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;): T
 </code></pre>
 
 
@@ -196,7 +198,7 @@ Convert an error Result<T> to error Result<U>.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_unwrap_err">unwrap_err</a>&lt;T&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;): <a href="_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_unwrap_err">unwrap_err</a>&lt;T, E&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;): E
 </code></pre>
 
 
@@ -211,7 +213,7 @@ This function is inline, so it will be expanded in the caller.
 This ensures the abort_code is the caller's location.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_assert_ok">assert_ok</a>&lt;T&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;, abort_code: u64): T
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_assert_ok">assert_ok</a>&lt;T, E&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;, abort_code: u64): T
 </code></pre>
 
 
@@ -222,5 +224,5 @@ This ensures the abort_code is the caller's location.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_assert_err">assert_err</a>&lt;T&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T&gt;, abort_code: u64): <a href="_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="result.md#0xa_result_assert_err">assert_err</a>&lt;T, E&gt;(<a href="result.md#0xa_result">result</a>: <a href="result.md#0xa_result_Result">result::Result</a>&lt;T, E&gt;, abort_code: u64): E
 </code></pre>

--- a/frameworks/rooch-nursery/doc/tick_info.md
+++ b/frameworks/rooch-nursery/doc/tick_info.md
@@ -184,7 +184,7 @@ Check if the tick is deployed.
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tick_info.md#0xa_tick_info_mint_on_bitcoin">mint_on_bitcoin</a>(metaprotocol: <a href="_String">string::String</a>, tick: <a href="_String">string::String</a>, amount: u64): <a href="result.md#0xa_result_Result">result::Result</a>&lt;<a href="_Object">object::Object</a>&lt;<a href="bitseed.md#0xa_bitseed_Bitseed">bitseed::Bitseed</a>&gt;&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tick_info.md#0xa_tick_info_mint_on_bitcoin">mint_on_bitcoin</a>(metaprotocol: <a href="_String">string::String</a>, tick: <a href="_String">string::String</a>, amount: u64): <a href="result.md#0xa_result_Result">result::Result</a>&lt;<a href="_Object">object::Object</a>&lt;<a href="bitseed.md#0xa_bitseed_Bitseed">bitseed::Bitseed</a>&gt;, <a href="_String">string::String</a>&gt;
 </code></pre>
 
 

--- a/frameworks/rooch-nursery/sources/tick_info.move
+++ b/frameworks/rooch-nursery/sources/tick_info.move
@@ -14,7 +14,7 @@ module rooch_nursery::tick_info {
     
     use bitcoin_move::ord::{Self, InscriptionID};
     use rooch_nursery::bitseed::{Self, Bitseed};
-    use rooch_nursery::result::{Result, ok, err};
+    use rooch_nursery::result::{Result, ok, err_str};
 
     const ErrorMetaprotocolNotFound: u64 = 1;
     const ErrorTickNotFound: u64 = 2;
@@ -162,11 +162,11 @@ module rooch_nursery::tick_info {
         bitseed
     }
 
-    public(friend) fun mint_on_bitcoin(metaprotocol: String, tick: String, amount: u64) : Result<Object<Bitseed>>{
+    public(friend) fun mint_on_bitcoin(metaprotocol: String, tick: String, amount: u64) : Result<Object<Bitseed>,String>{
         let tick = string_utils::to_lower_case(&tick);
         let tick_info = borrow_mut_tick_info(metaprotocol, tick);
         if (tick_info.supply + amount > tick_info.max){
-            return err(b"maximum supply exceeded")
+            return err_str(b"maximum supply exceeded")
         };
         let bid = tx_context::fresh_address();
         let bitseed = bitseed::new(metaprotocol, tick, bid, amount, option::none(), vector::empty());

--- a/frameworks/rooch-nursery/tests/result_tests.move
+++ b/frameworks/rooch-nursery/tests/result_tests.move
@@ -3,13 +3,14 @@
 
 module rooch_nursery::result_test {
 
-    use rooch_nursery::result::{Self, Result, ok, err, assert_ok};
+    use std::string::String;
+    use rooch_nursery::result::{Self, Result, ok, err_str, assert_ok};
 
     const ErrorForTest: u64 = 1;
 
     #[test]
     public fun test_result() {
-        let result: Result<u64> = ok(1);
+        let result: Result<u64, String> = ok(1);
         let value = assert_ok(result, ErrorForTest);
         assert!(value == 1, 1);
     }
@@ -17,17 +18,17 @@ module rooch_nursery::result_test {
     #[test]
     #[expected_failure(abort_code = ErrorForTest, location = Self)]
     public fun test_result_err() {
-        let result: Result<u64> = err(b"error");
+        let result: Result<u64, String> = err_str(b"error");
         let _value = assert_ok(result, ErrorForTest);
     }
 
-    fun test_return_result() : Result<u64> {
+    fun test_return_result() : Result<u64, String> {
         ok(1)
     }
 
     #[test]
     public fun test_and_then() {
-        let result: Result<u64> = test_return_result();
+        let result = test_return_result();
         let result2 = result::and_then(result, |value| {
             ok(value + 1)
         });


### PR DESCRIPTION
## Summary

Follow #2197, refactor `Result<T>` to `Result<T, E>`, and allow any type as the error type.

cc @yubing744  