### PR TITLE
[framework] Refactor the auth payload encoding and implement bitcoin multisign validator

### DIFF
--- a/crates/rooch-framework-tests/src/tests/bitcoin_multisign_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/bitcoin_multisign_validator_tests.rs
@@ -7,20 +7,18 @@ use moveos_types::module_binding::MoveFunctionCaller;
 use moveos_types::state::MoveStructType;
 use moveos_types::transaction::{MoveAction, MoveOSTransaction};
 use rooch_types::crypto::{RoochKeyPair, RoochSignature};
-use rooch_types::framework::auth_payload::SignData;
+use rooch_types::framework::auth_payload::{MultisignAuthPayload, SignData};
 use rooch_types::framework::auth_validator::BuiltinAuthValidator;
 use rooch_types::framework::empty::Empty;
 use rooch_types::framework::gas_coin::GasCoin;
 use rooch_types::framework::transfer::TransferModule;
-use rooch_types::nursery::bitcoin_multisign_validator::{
-    AuthPayload, BitcoinMultisignValidatorModule,
-};
+use rooch_types::nursery::bitcoin_multisign_validator::BitcoinMultisignValidatorModule;
 use rooch_types::nursery::multisign_account::{self, MultisignAccountModule};
 use rooch_types::transaction::rooch::RoochTransactionData;
 use rooch_types::transaction::{Authenticator, RoochTransaction};
 
-#[test]
-fn test_validate() {
+#[tokio::test]
+async fn test_validate() {
     let mut binding_test = binding_test::RustBindingTest::new().unwrap();
     let root = binding_test.root().clone();
 
@@ -79,7 +77,7 @@ fn test_validate() {
     let signature2 = kp2.sign(data_hash.as_bytes());
 
     let message_info = sign_data.message_info_without_tx_hash();
-    let payload = AuthPayload {
+    let payload = MultisignAuthPayload {
         signatures: vec![
             signature1.signature_bytes().to_vec(),
             signature2.signature_bytes().to_vec(),

--- a/crates/rooch-framework-tests/src/tests/bitcoin_multisign_validator_tests.rs
+++ b/crates/rooch-framework-tests/src/tests/bitcoin_multisign_validator_tests.rs
@@ -1,0 +1,88 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::binding_test;
+use moveos_types::module_binding::MoveFunctionCaller;
+use moveos_types::transaction::{MoveAction, MoveOSTransaction};
+use rooch_types::crypto::{RoochKeyPair, RoochSignature};
+use rooch_types::framework::auth_payload::SignData;
+use rooch_types::framework::auth_validator::BuiltinAuthValidator;
+use rooch_types::framework::empty::Empty;
+use rooch_types::nursery::bitcoin_multisign_validator::{
+    AuthPayload, BitcoinMultisignValidatorModule,
+};
+use rooch_types::nursery::multisign_account::{self, MultisignAccountModule};
+use rooch_types::transaction::rooch::RoochTransactionData;
+use rooch_types::transaction::{Authenticator, RoochTransaction};
+
+#[test]
+fn test_validate() {
+    let mut binding_test = binding_test::RustBindingTest::new().unwrap();
+    let root = binding_test.root().clone();
+
+    let kp1 = RoochKeyPair::generate_secp256k1();
+    let kp2 = RoochKeyPair::generate_secp256k1();
+    let kp3 = RoochKeyPair::generate_secp256k1();
+
+    let u1 = kp1.public().bitcoin_address().unwrap().to_rooch_address();
+    //let u2 = kp2.public().bitcoin_address().unwrap().to_rooch_address();
+    //let u3 = kp3.public().bitcoin_address().unwrap().to_rooch_address();
+
+    let pubkeys = vec![
+        kp1.bitcoin_public_key().unwrap(),
+        kp2.bitcoin_public_key().unwrap(),
+        kp3.bitcoin_public_key().unwrap(),
+    ];
+
+    let pubkeys = pubkeys
+        .into_iter()
+        .map(|pk| pk.to_bytes())
+        .collect::<Vec<_>>();
+
+    let bitcoin_address_from_rust =
+        multisign_account::generate_multisign_address(2, pubkeys.clone()).unwrap();
+    //println!("bitcoin_address_from_rust: {}", bitcoin_address_from_rust);
+
+    //Initialize the multisign account
+    let action = MultisignAccountModule::initialize_multisig_account_action(2, pubkeys.to_vec());
+    let tx_data = RoochTransactionData::new_for_test(u1, 0, action);
+    let tx = tx_data.sign(&kp1);
+    binding_test.execute(tx).unwrap();
+
+    let sender = bitcoin_address_from_rust.to_rooch_address();
+    let sequence_number = 0;
+    let action = MoveAction::new_function_call(Empty::empty_function_id(), vec![], vec![]);
+    let tx_data = RoochTransactionData::new_for_test(sender, sequence_number, action);
+
+    let sign_data = SignData::new_with_default(&tx_data);
+    let data_hash = sign_data.data_hash();
+
+    let signature1 = kp1.sign(data_hash.as_bytes());
+    let signature2 = kp2.sign(data_hash.as_bytes());
+
+    let message_info = sign_data.message_info_without_tx_hash();
+    let payload = AuthPayload {
+        signatures: vec![
+            signature1.signature_bytes().to_vec(),
+            signature2.signature_bytes().to_vec(),
+        ],
+        message_prefix: sign_data.message_prefix,
+        message_info,
+        public_keys: pubkeys[0..2].to_vec(),
+    };
+
+    let authenticator = Authenticator::new(
+        BuiltinAuthValidator::BitcoinMultisign.flag().into(),
+        bcs::to_bytes(&payload).unwrap(),
+    );
+
+    let tx = RoochTransaction::new(tx_data, authenticator);
+
+    let auth_info = tx.authenticator_info();
+
+    let move_tx: MoveOSTransaction = tx.into_moveos_transaction(root);
+
+    let validator_caller = binding_test.as_module_binding::<BitcoinMultisignValidatorModule>();
+    let result = validator_caller.validate(&move_tx.ctx, auth_info.authenticator.payload);
+    assert!(result.is_ok());
+}

--- a/crates/rooch-framework-tests/src/tests/mod.rs
+++ b/crates/rooch-framework-tests/src/tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+mod bitcoin_multisign_validator_tests;
 mod bitcoin_test;
 mod bitcoin_validator_tests;
 mod brc20_test;

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -632,7 +632,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_custom_genesis_init() {
-        let network = RoochNetwork::new(100.into(), BuiltinChainID::Local.genesis_config().clone());
+        let network = RoochNetwork::new(100.into(), BuiltinChainID::Test.genesis_config().clone());
         let genesis = RoochGenesis::build(network.clone()).unwrap();
         genesis_init_test_case(network, genesis);
     }

--- a/crates/rooch-types/src/framework/auth_payload.rs
+++ b/crates/rooch-types/src/framework/auth_payload.rs
@@ -141,6 +141,43 @@ impl AuthPayload {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultisignAuthPayload {
+    pub signatures: Vec<Vec<u8>>,
+    pub message_prefix: Vec<u8>,
+    pub message_info: Vec<u8>,
+    pub public_keys: Vec<Vec<u8>>,
+}
+
+impl MoveStructType for MultisignAuthPayload {
+    const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("MultisignAuthPayload");
+}
+
+impl MoveStructState for MultisignAuthPayload {
+    fn struct_layout() -> move_core_types::value::MoveStructLayout {
+        move_core_types::value::MoveStructLayout::new(vec![
+            move_core_types::value::MoveTypeLayout::Vector(Box::new(
+                move_core_types::value::MoveTypeLayout::Vector(Box::new(
+                    move_core_types::value::MoveTypeLayout::U8,
+                )),
+            )),
+            move_core_types::value::MoveTypeLayout::Vector(Box::new(
+                move_core_types::value::MoveTypeLayout::U8,
+            )),
+            move_core_types::value::MoveTypeLayout::Vector(Box::new(
+                move_core_types::value::MoveTypeLayout::U8,
+            )),
+            move_core_types::value::MoveTypeLayout::Vector(Box::new(
+                move_core_types::value::MoveTypeLayout::Vector(Box::new(
+                    move_core_types::value::MoveTypeLayout::U8,
+                )),
+            )),
+        ])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rooch-types/src/framework/auth_payload.rs
+++ b/crates/rooch-types/src/framework/auth_payload.rs
@@ -5,6 +5,7 @@ use crate::{
     crypto::{RoochSignature, Signature, SignatureScheme},
     transaction::RoochTransactionData,
 };
+use anyhow::Result;
 use fastcrypto::{
     hash::Sha256,
     secp256k1::{Secp256k1PublicKey, Secp256k1Signature},
@@ -20,38 +21,48 @@ use serde::{Deserialize, Serialize};
 
 pub const MODULE_NAME: &IdentStr = ident_str!("auth_payload");
 
-const MESSAGE_INFO_PREFIX: &[u8] = b"\x18Bitcoin Signed Message:\n";
+/// The original message prefix of the Bitcoin wallet includes the length of the message `x18`
+/// We remove the length because the bcs serialization format already contains the length information
+const MESSAGE_INFO_PREFIX: &[u8] = b"Bitcoin Signed Message:\n";
 const MESSAGE_INFO: &[u8] = b"Rooch Transaction:\n";
+
+const TX_HASH_HEX_LENGTH: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SignData {
     pub message_prefix: Vec<u8>,
     pub message_info: Vec<u8>,
-    pub tx_hash_hex: Vec<u8>,
 }
 
 impl SignData {
-    pub fn new(tx_data: &RoochTransactionData) -> Self {
-        let tx_hash_hex = hex::encode(tx_data.tx_hash().as_bytes()).into_bytes();
-        let message_info = MESSAGE_INFO.to_vec();
-
-        // We simulate the format of the Bitcoin wallet, append the length of message info and tx hash to the prefix
-        let mut encode_message_prefix = MESSAGE_INFO_PREFIX.to_vec();
-        encode_message_prefix.push((message_info.len() + tx_hash_hex.len()) as u8);
-
+    pub fn new(
+        message_prefix: Vec<u8>,
+        message_info_without_tx_hash: Vec<u8>,
+        tx_data: &RoochTransactionData,
+    ) -> Self {
+        let message_info = {
+            let tx_hash_hex = hex::encode(tx_data.tx_hash().as_bytes()).into_bytes();
+            let mut message_info = message_info_without_tx_hash;
+            message_info.extend_from_slice(&tx_hash_hex);
+            message_info
+        };
         SignData {
-            message_prefix: encode_message_prefix,
+            message_prefix,
             message_info,
-            tx_hash_hex,
         }
     }
 
+    pub fn new_with_default(tx_data: &RoochTransactionData) -> Self {
+        Self::new(MESSAGE_INFO_PREFIX.to_vec(), MESSAGE_INFO.to_vec(), tx_data)
+    }
+
     pub fn encode(&self) -> Vec<u8> {
-        let mut data = Vec::new();
-        data.extend_from_slice(&self.message_prefix);
-        data.extend_from_slice(&self.message_info);
-        data.extend_from_slice(&self.tx_hash_hex);
-        data
+        bcs::to_bytes(self).expect("Serialize SignData should success")
+    }
+
+    /// The message info without tx hash, the verifier should append the tx hash to the message info
+    pub fn message_info_without_tx_hash(&self) -> Vec<u8> {
+        self.message_info[..self.message_info.len() - TX_HASH_HEX_LENGTH].to_vec()
     }
 
     pub fn data_hash(&self) -> H256 {
@@ -66,7 +77,7 @@ pub struct AuthPayload {
     pub signature: Vec<u8>,
     // Some wallets add magic prefixes, such as unisat adding 'Bitcoin Signed Message:\n'
     pub message_prefix: Vec<u8>,
-    // Description of a user-defined signature
+    // Description of a user-defined signature, the message info does not include the tx hash
     pub message_info: Vec<u8>,
     // Public key of address
     pub public_key: Vec<u8>,
@@ -105,24 +116,23 @@ impl MoveStructState for AuthPayload {
 impl AuthPayload {
     pub fn new(sign_data: SignData, signature: Signature, bitcoin_address: String) -> Self {
         debug_assert_eq!(signature.scheme(), SignatureScheme::Secp256k1);
-
+        let message_info = sign_data.message_info_without_tx_hash();
         AuthPayload {
             signature: signature.signature_bytes().to_vec(),
             message_prefix: sign_data.message_prefix,
-            message_info: sign_data.message_info,
+            message_info,
             public_key: signature.public_key_bytes().to_vec(),
             from_address: bitcoin_address.into_bytes(),
         }
     }
 
-    pub fn verify(&self, tx_data: &RoochTransactionData) -> Result<(), anyhow::Error> {
+    pub fn verify(&self, tx_data: &RoochTransactionData) -> Result<()> {
         let pk = Secp256k1PublicKey::from_bytes(&self.public_key)?;
-        let tx_hash_hex = hex::encode(tx_data.tx_hash().as_bytes()).into_bytes();
-        let sign_data = SignData {
-            message_prefix: self.message_prefix.clone(),
-            message_info: self.message_info.clone(),
-            tx_hash_hex,
-        };
+        let sign_data = SignData::new(
+            self.message_prefix.clone(),
+            self.message_info.clone(),
+            tx_data,
+        );
         let message = sign_data.encode();
         let message_hash = sha2_256_of(&message).0.to_vec();
         let signature = Secp256k1Signature::from_bytes(&self.signature)?;

--- a/crates/rooch-types/src/framework/auth_validator.rs
+++ b/crates/rooch-types/src/framework/auth_validator.rs
@@ -4,7 +4,7 @@
 use crate::address::{BitcoinAddress, RoochSupportedAddress};
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
 use crate::error::RoochError;
-use anyhow::{ensure, Result};
+use anyhow::Result;
 use clap::ValueEnum;
 use framework_types::addresses::ROOCH_NURSERY_ADDRESS;
 use move_core_types::value::MoveValue;
@@ -231,12 +231,6 @@ impl<'a> AuthValidatorCaller<'a> {
         );
         self.caller
             .call_function(ctx, auth_validator_call)?
-            .decode(|values| {
-                ensure!(
-                    !values.is_empty(),
-                    "Unexpect validate function return values"
-                );
-                Ok(())
-            })
+            .decode(|_values| Ok(()))
     }
 }

--- a/crates/rooch-types/src/framework/auth_validator.rs
+++ b/crates/rooch-types/src/framework/auth_validator.rs
@@ -47,19 +47,22 @@ pub const MODULE_NAME: &IdentStr = ident_str!("auth_validator");
 pub enum BuiltinAuthValidator {
     Rooch,
     Bitcoin,
+    BitcoinMultisign,
     Ethereum,
 }
 
 impl BuiltinAuthValidator {
     const ROOCH_FLAG: u8 = 0x00;
     const BITCOIN_FLAG: u8 = 0x01;
-    const ETHEREUM_FLAG: u8 = 0x02;
+    const BITCOIN_MULTISIGN: u8 = 0x02;
+    const ETHEREUM_FLAG: u8 = 0x03;
 
     pub fn flag(&self) -> u8 {
         match self {
             BuiltinAuthValidator::Rooch => Self::ROOCH_FLAG,
-            BuiltinAuthValidator::Ethereum => Self::ETHEREUM_FLAG,
             BuiltinAuthValidator::Bitcoin => Self::BITCOIN_FLAG,
+            BuiltinAuthValidator::BitcoinMultisign => Self::BITCOIN_MULTISIGN,
+            BuiltinAuthValidator::Ethereum => Self::ETHEREUM_FLAG,
         }
     }
 
@@ -74,6 +77,7 @@ impl BuiltinAuthValidator {
         match byte_int {
             Self::ROOCH_FLAG => Ok(BuiltinAuthValidator::Rooch),
             Self::BITCOIN_FLAG => Ok(BuiltinAuthValidator::Bitcoin),
+            Self::BITCOIN_MULTISIGN => Ok(BuiltinAuthValidator::BitcoinMultisign),
             Self::ETHEREUM_FLAG => Ok(BuiltinAuthValidator::Ethereum),
             _ => Err(RoochError::KeyConversionError(
                 "Invalid key auth validator".to_owned(),
@@ -92,6 +96,12 @@ impl BuiltinAuthValidator {
                 id: self.flag().into(),
                 module_address: ROOCH_FRAMEWORK_ADDRESS,
                 module_name: MoveString::from_str("bitcoin_validator").expect("Should be valid"),
+            },
+            BuiltinAuthValidator::BitcoinMultisign => AuthValidator {
+                id: self.flag().into(),
+                module_address: ROOCH_NURSERY_ADDRESS,
+                module_name: MoveString::from_str("bitcoin_multisign_validator")
+                    .expect("Should be valid"),
             },
             BuiltinAuthValidator::Ethereum => AuthValidator {
                 id: self.flag().into(),

--- a/crates/rooch-types/src/framework/bitcoin_validator.rs
+++ b/crates/rooch-types/src/framework/bitcoin_validator.rs
@@ -3,18 +3,10 @@
 
 use super::auth_validator::BuiltinAuthValidator;
 use crate::addresses::ROOCH_FRAMEWORK_ADDRESS;
-use anyhow::Result;
-use move_core_types::{
-    account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
-};
-use moveos_types::{
-    module_binding::{ModuleBinding, MoveFunctionCaller},
-    moveos_std::tx_context::TxContext,
-    state::MoveStructType,
-    transaction::{FunctionCall, MoveAction},
-};
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use moveos_types::state::MoveStructType;
 
-const MODULE_NAME: &'static IdentStr = ident_str!("bitcoin_validator");
+const MODULE_NAME: &IdentStr = ident_str!("bitcoin_validator");
 
 /// Bitcoin Auth Validator
 pub struct BitcoinValidator {}
@@ -29,41 +21,4 @@ impl MoveStructType for BitcoinValidator {
     const ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
     const MODULE_NAME: &'static IdentStr = MODULE_NAME;
     const STRUCT_NAME: &'static IdentStr = ident_str!("BitcoinValidator");
-}
-
-/// Rust bindings for RoochFramework bitcoin_validator module
-pub struct BitcoinValidatorModule<'a> {
-    caller: &'a dyn MoveFunctionCaller,
-}
-
-impl<'a> BitcoinValidatorModule<'a> {
-    const VALIDATE_FUNCTION_NAME: &'static IdentStr = ident_str!("validate");
-
-    fn validate(&self, ctx: &TxContext, payload: Vec<u8>) -> Result<()> {
-        let auth_validator_call = FunctionCall::new(
-            Self::function_id(Self::VALIDATE_FUNCTION_NAME),
-            vec![],
-            vec![MoveValue::vector_u8(payload).simple_serialize().unwrap()],
-        );
-        self.caller
-            .call_function(ctx, auth_validator_call)?
-            .into_result()
-            .map(|values| {
-                debug_assert!(values.is_empty(), "should not have return values");
-            })?;
-        Ok(())
-    }
-
-}
-
-impl<'a> ModuleBinding<'a> for NativeValidatorModule<'a> {
-    
-    const MODULE_ADDRESS: AccountAddress = ROOCH_FRAMEWORK_ADDRESS;
-
-    fn new(caller: &'a impl MoveFunctionCaller) -> Self
-    where
-        Self: Sized,
-    {
-        Self { caller }
-    }
 }

--- a/crates/rooch-types/src/framework/mod.rs
+++ b/crates/rooch-types/src/framework/mod.rs
@@ -12,6 +12,7 @@ pub mod account_coin_store;
 pub mod address_mapping;
 pub mod auth_payload;
 pub mod auth_validator;
+pub mod bitcoin_validator;
 pub mod chain_id;
 pub mod coin;
 pub mod coin_store;

--- a/crates/rooch-types/src/nursery/bitcoin_multisign_validator.rs
+++ b/crates/rooch-types/src/nursery/bitcoin_multisign_validator.rs
@@ -1,0 +1,77 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::framework::auth_validator::BuiltinAuthValidator;
+use anyhow::Result;
+use framework_types::addresses::ROOCH_NURSERY_ADDRESS;
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
+};
+use moveos_types::{
+    module_binding::{ModuleBinding, MoveFunctionCaller},
+    moveos_std::tx_context::TxContext,
+    state::MoveStructType,
+    transaction::FunctionCall,
+};
+use serde::{Deserialize, Serialize};
+
+const MODULE_NAME: &IdentStr = ident_str!("bitcoin_multisign_validator");
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthPayload {
+    pub signatures: Vec<Vec<u8>>,
+    pub message_prefix: Vec<u8>,
+    pub message_info: Vec<u8>,
+    pub public_keys: Vec<Vec<u8>>,
+}
+
+/// Bitcoin Multisign Auth Validator
+pub struct BitcoinMultisignValidator {}
+
+impl BitcoinMultisignValidator {
+    pub fn auth_validator_id() -> u64 {
+        BuiltinAuthValidator::BitcoinMultisign.flag().into()
+    }
+}
+
+impl MoveStructType for BitcoinMultisignValidator {
+    const ADDRESS: AccountAddress = ROOCH_NURSERY_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = ident_str!("BitcoinMultisignValidator");
+}
+
+/// Rust bindings for RoochFramework bitcoin_validator module
+pub struct BitcoinMultisignValidatorModule<'a> {
+    caller: &'a dyn MoveFunctionCaller,
+}
+
+impl<'a> BitcoinMultisignValidatorModule<'a> {
+    const VALIDATE_FUNCTION_NAME: &'static IdentStr = ident_str!("validate");
+
+    pub fn validate(&self, ctx: &TxContext, payload: Vec<u8>) -> Result<()> {
+        let auth_validator_call = FunctionCall::new(
+            Self::function_id(Self::VALIDATE_FUNCTION_NAME),
+            vec![],
+            vec![MoveValue::vector_u8(payload).simple_serialize().unwrap()],
+        );
+        self.caller
+            .call_function(ctx, auth_validator_call)?
+            .into_result()
+            .map(|values| {
+                debug_assert!(values.is_empty(), "should not have return values");
+            })?;
+        Ok(())
+    }
+}
+
+impl<'a> ModuleBinding<'a> for BitcoinMultisignValidatorModule<'a> {
+    const MODULE_ADDRESS: AccountAddress = ROOCH_NURSERY_ADDRESS;
+    const MODULE_NAME: &'static IdentStr = MODULE_NAME;
+
+    fn new(caller: &'a impl MoveFunctionCaller) -> Self
+    where
+        Self: Sized,
+    {
+        Self { caller }
+    }
+}

--- a/crates/rooch-types/src/nursery/bitcoin_multisign_validator.rs
+++ b/crates/rooch-types/src/nursery/bitcoin_multisign_validator.rs
@@ -13,17 +13,8 @@ use moveos_types::{
     state::MoveStructType,
     transaction::FunctionCall,
 };
-use serde::{Deserialize, Serialize};
 
 const MODULE_NAME: &IdentStr = ident_str!("bitcoin_multisign_validator");
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthPayload {
-    pub signatures: Vec<Vec<u8>>,
-    pub message_prefix: Vec<u8>,
-    pub message_info: Vec<u8>,
-    pub public_keys: Vec<Vec<u8>>,
-}
 
 /// Bitcoin Multisign Auth Validator
 pub struct BitcoinMultisignValidator {}

--- a/crates/rooch-types/src/nursery/mod.rs
+++ b/crates/rooch-types/src/nursery/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod bitcoin_multisign_validator;
 pub mod multisign_account;

--- a/crates/rooch-types/src/transaction/authenticator.rs
+++ b/crates/rooch-types/src/transaction/authenticator.rs
@@ -140,7 +140,7 @@ impl Authenticator {
     /// We simulate the Bitcoin Wallet message signature
     pub fn bitcoin(kp: &RoochKeyPair, tx_data: &RoochTransactionData) -> Self {
         debug_assert_eq!(kp.public().scheme(), SignatureScheme::Secp256k1);
-        let sign_data = SignData::new(tx_data);
+        let sign_data = SignData::new_with_default(tx_data);
         //The Bitcoin wallet uses sha2_256 twice, the Secp256k1 sign method will hash the data again
         let data_hash = sign_data.data_hash();
         let signature = kp.sign(data_hash.as_bytes());

--- a/frameworks/rooch-framework/doc/auth_payload.md
+++ b/frameworks/rooch-framework/doc/auth_payload.md
@@ -6,8 +6,10 @@
 
 
 -  [Struct `AuthPayload`](#0x3_auth_payload_AuthPayload)
+-  [Struct `MultisignAuthPayload`](#0x3_auth_payload_MultisignAuthPayload)
 -  [Struct `SignData`](#0x3_auth_payload_SignData)
 -  [Constants](#@Constants_0)
+-  [Function `new_sign_data`](#0x3_auth_payload_new_sign_data)
 -  [Function `from_bytes`](#0x3_auth_payload_from_bytes)
 -  [Function `encode_full_message`](#0x3_auth_payload_encode_full_message)
 -  [Function `signature`](#0x3_auth_payload_signature)
@@ -15,6 +17,12 @@
 -  [Function `message_info`](#0x3_auth_payload_message_info)
 -  [Function `public_key`](#0x3_auth_payload_public_key)
 -  [Function `from_address`](#0x3_auth_payload_from_address)
+-  [Function `multisign_from_bytes`](#0x3_auth_payload_multisign_from_bytes)
+-  [Function `multisign_signatures`](#0x3_auth_payload_multisign_signatures)
+-  [Function `multisign_message_prefix`](#0x3_auth_payload_multisign_message_prefix)
+-  [Function `multisign_message_info`](#0x3_auth_payload_multisign_message_info)
+-  [Function `multisign_public_keys`](#0x3_auth_payload_multisign_public_keys)
+-  [Function `multisign_encode_full_message`](#0x3_auth_payload_multisign_encode_full_message)
 
 
 <pre><code><b>use</b> <a href="">0x1::string</a>;
@@ -37,13 +45,26 @@
 
 
 
+<a name="0x3_auth_payload_MultisignAuthPayload"></a>
+
+## Struct `MultisignAuthPayload`
+
+
+
+<pre><code>#[data_struct]
+<b>struct</b> <a href="auth_payload.md#0x3_auth_payload_MultisignAuthPayload">MultisignAuthPayload</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
 <a name="0x3_auth_payload_SignData"></a>
 
 ## Struct `SignData`
 
 
 
-<pre><code><b>struct</b> <a href="auth_payload.md#0x3_auth_payload_SignData">SignData</a> <b>has</b> <b>copy</b>, drop
+<pre><code>#[data_struct]
+<b>struct</b> <a href="auth_payload.md#0x3_auth_payload_SignData">SignData</a> <b>has</b> <b>copy</b>, drop
 </code></pre>
 
 
@@ -76,6 +97,17 @@
 
 
 <pre><code><b>const</b> <a href="auth_payload.md#0x3_auth_payload_MessagePrefix">MessagePrefix</a>: <a href="">vector</a>&lt;u8&gt; = [66, 105, 116, 99, 111, 105, 110, 32, 83, 105, 103, 110, 101, 100, 32, 77, 101, 115, 115, 97, 103, 101, 58, 10];
+</code></pre>
+
+
+
+<a name="0x3_auth_payload_new_sign_data"></a>
+
+## Function `new_sign_data`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_payload.md#0x3_auth_payload_new_sign_data">new_sign_data</a>(message_prefix: <a href="">vector</a>&lt;u8&gt;, message_info: <a href="">vector</a>&lt;u8&gt;): <a href="auth_payload.md#0x3_auth_payload_SignData">auth_payload::SignData</a>
 </code></pre>
 
 
@@ -153,4 +185,70 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="auth_payload.md#0x3_auth_payload_from_address">from_address</a>(payload: <a href="auth_payload.md#0x3_auth_payload_AuthPayload">auth_payload::AuthPayload</a>): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a name="0x3_auth_payload_multisign_from_bytes"></a>
+
+## Function `multisign_from_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_payload.md#0x3_auth_payload_multisign_from_bytes">multisign_from_bytes</a>(bytes: <a href="">vector</a>&lt;u8&gt;): <a href="auth_payload.md#0x3_auth_payload_MultisignAuthPayload">auth_payload::MultisignAuthPayload</a>
+</code></pre>
+
+
+
+<a name="0x3_auth_payload_multisign_signatures"></a>
+
+## Function `multisign_signatures`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_payload.md#0x3_auth_payload_multisign_signatures">multisign_signatures</a>(payload: &<a href="auth_payload.md#0x3_auth_payload_MultisignAuthPayload">auth_payload::MultisignAuthPayload</a>): &<a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<a name="0x3_auth_payload_multisign_message_prefix"></a>
+
+## Function `multisign_message_prefix`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_payload.md#0x3_auth_payload_multisign_message_prefix">multisign_message_prefix</a>(payload: &<a href="auth_payload.md#0x3_auth_payload_MultisignAuthPayload">auth_payload::MultisignAuthPayload</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<a name="0x3_auth_payload_multisign_message_info"></a>
+
+## Function `multisign_message_info`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_payload.md#0x3_auth_payload_multisign_message_info">multisign_message_info</a>(payload: &<a href="auth_payload.md#0x3_auth_payload_MultisignAuthPayload">auth_payload::MultisignAuthPayload</a>): &<a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<a name="0x3_auth_payload_multisign_public_keys"></a>
+
+## Function `multisign_public_keys`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_payload.md#0x3_auth_payload_multisign_public_keys">multisign_public_keys</a>(payload: &<a href="auth_payload.md#0x3_auth_payload_MultisignAuthPayload">auth_payload::MultisignAuthPayload</a>): &<a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<a name="0x3_auth_payload_multisign_encode_full_message"></a>
+
+## Function `multisign_encode_full_message`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_payload.md#0x3_auth_payload_multisign_encode_full_message">multisign_encode_full_message</a>(self: &<a href="auth_payload.md#0x3_auth_payload_MultisignAuthPayload">auth_payload::MultisignAuthPayload</a>, tx_hash: <a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;
 </code></pre>

--- a/frameworks/rooch-framework/doc/auth_payload.md
+++ b/frameworks/rooch-framework/doc/auth_payload.md
@@ -6,6 +6,7 @@
 
 
 -  [Struct `AuthPayload`](#0x3_auth_payload_AuthPayload)
+-  [Struct `SignData`](#0x3_auth_payload_SignData)
 -  [Constants](#@Constants_0)
 -  [Function `from_bytes`](#0x3_auth_payload_from_bytes)
 -  [Function `encode_full_message`](#0x3_auth_payload_encode_full_message)
@@ -36,6 +37,17 @@
 
 
 
+<a name="0x3_auth_payload_SignData"></a>
+
+## Struct `SignData`
+
+
+
+<pre><code><b>struct</b> <a href="auth_payload.md#0x3_auth_payload_SignData">SignData</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
 <a name="@Constants_0"></a>
 
 ## Constants
@@ -50,11 +62,20 @@
 
 
 
-<a name="0x3_auth_payload_MessgaeInfoPrefix"></a>
+<a name="0x3_auth_payload_MessageInfoPrefix"></a>
 
 
 
-<pre><code><b>const</b> <a href="auth_payload.md#0x3_auth_payload_MessgaeInfoPrefix">MessgaeInfoPrefix</a>: <a href="">vector</a>&lt;u8&gt; = [82, 111, 111, 99, 104, 32, 84, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 58, 10];
+<pre><code><b>const</b> <a href="auth_payload.md#0x3_auth_payload_MessageInfoPrefix">MessageInfoPrefix</a>: <a href="">vector</a>&lt;u8&gt; = [82, 111, 111, 99, 104, 32, 84, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 58, 10];
+</code></pre>
+
+
+
+<a name="0x3_auth_payload_MessagePrefix"></a>
+
+
+
+<pre><code><b>const</b> <a href="auth_payload.md#0x3_auth_payload_MessagePrefix">MessagePrefix</a>: <a href="">vector</a>&lt;u8&gt; = [66, 105, 116, 99, 111, 105, 110, 32, 83, 105, 103, 110, 101, 100, 32, 77, 101, 115, 115, 97, 103, 101, 58, 10];
 </code></pre>
 
 

--- a/frameworks/rooch-framework/doc/builtin_validators.md
+++ b/frameworks/rooch-framework/doc/builtin_validators.md
@@ -31,6 +31,34 @@
 
 
 
+<a name="0x3_builtin_validators_SESSION_VALIDATOR_ID"></a>
+
+
+
+<pre><code><b>const</b> <a href="builtin_validators.md#0x3_builtin_validators_SESSION_VALIDATOR_ID">SESSION_VALIDATOR_ID</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x3_builtin_validators_BITCOIN_MULTISIGN_VALIDATOR_ID"></a>
+
+Bitcoin multisign validator is defined in bitcoin_move framework.
+
+
+<pre><code><b>const</b> <a href="builtin_validators.md#0x3_builtin_validators_BITCOIN_MULTISIGN_VALIDATOR_ID">BITCOIN_MULTISIGN_VALIDATOR_ID</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x3_builtin_validators_BITCOIN_VALIDATOR_ID"></a>
+
+
+
+<pre><code><b>const</b> <a href="builtin_validators.md#0x3_builtin_validators_BITCOIN_VALIDATOR_ID">BITCOIN_VALIDATOR_ID</a>: u64 = 1;
+</code></pre>
+
+
+
 <a name="0x3_builtin_validators_genesis_init"></a>
 
 ## Function `genesis_init`

--- a/frameworks/rooch-framework/doc/transaction_validator.md
+++ b/frameworks/rooch-framework/doc/transaction_validator.md
@@ -25,6 +25,7 @@
 <b>use</b> <a href="auth_validator_registry.md#0x3_auth_validator_registry">0x3::auth_validator_registry</a>;
 <b>use</b> <a href="bitcoin_address.md#0x3_bitcoin_address">0x3::bitcoin_address</a>;
 <b>use</b> <a href="bitcoin_validator.md#0x3_bitcoin_validator">0x3::bitcoin_validator</a>;
+<b>use</b> <a href="builtin_validators.md#0x3_builtin_validators">0x3::builtin_validators</a>;
 <b>use</b> <a href="chain_id.md#0x3_chain_id">0x3::chain_id</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
 <b>use</b> <a href="gas_coin.md#0x3_gas_coin">0x3::gas_coin</a>;

--- a/frameworks/rooch-framework/sources/auth_validator/builtin_validators.move
+++ b/frameworks/rooch-framework/sources/auth_validator/builtin_validators.move
@@ -11,6 +11,11 @@ module rooch_framework::builtin_validators{
 
     const ErrorGenesisInit: u64 = 1;
 
+    const SESSION_VALIDATOR_ID: u64 = 0;
+    const BITCOIN_VALIDATOR_ID: u64 = 1;
+    /// Bitcoin multisign validator is defined in bitcoin_move framework.
+    const BITCOIN_MULTISIGN_VALIDATOR_ID: u64 = 2;
+
     public(friend) fun genesis_init(_genesis_account: &signer) {
         // NATIVE_AUTH_VALIDATOR_ID: u64 = 0;
         let id = auth_validator_registry::register_internal<session_validator::SessionValidator>();
@@ -22,7 +27,8 @@ module rooch_framework::builtin_validators{
     }
 
     public fun is_builtin_auth_validator(auth_validator_id: u64): bool {
-        auth_validator_id == session_validator::auth_validator_id()
-        || auth_validator_id == bitcoin_validator::auth_validator_id()
+        auth_validator_id == SESSION_VALIDATOR_ID || 
+        auth_validator_id == BITCOIN_VALIDATOR_ID || 
+        auth_validator_id == BITCOIN_MULTISIGN_VALIDATOR_ID
     }
 }

--- a/frameworks/rooch-framework/sources/transaction_validator.move
+++ b/frameworks/rooch-framework/sources/transaction_validator.move
@@ -22,6 +22,7 @@ module rooch_framework::transaction_validator {
     use rooch_framework::bitcoin_validator;
     use rooch_framework::address_mapping;
     use rooch_framework::account_coin_store;
+    use rooch_framework::builtin_validators;
 
     const MAX_U64: u128 = 18446744073709551615;
 
@@ -98,7 +99,7 @@ module rooch_framework::transaction_validator {
             let auth_validator = auth_validator_registry::borrow_validator(auth_validator_id);
             let validator_id = auth_validator::validator_id(auth_validator);
             // The third-party auth validator must be installed to the sender's account
-            assert!(account_authentication::is_auth_validator_installed(sender, validator_id),
+            assert!(builtin_validators::is_builtin_auth_validator(validator_id) || account_authentication::is_auth_validator_installed(sender, validator_id),
                     auth_validator::error_validate_not_installed_auth_validator());
             let bitcoin_address = address_mapping::resolve_bitcoin(sender);
             (bitcoin_address, option::none(), option::some(*auth_validator))

--- a/frameworks/rooch-nursery/doc/README.md
+++ b/frameworks/rooch-nursery/doc/README.md
@@ -21,6 +21,7 @@ This is the reference documentation of the Rooch Nursery Framework.
 -  [`0xa::inscribe_factory`](inscribe_factory.md#0xa_inscribe_factory)
 -  [`0xa::mint_get_factory`](mint_get_factory.md#0xa_mint_get_factory)
 -  [`0xa::multisign_account`](multisign_account.md#0xa_multisign_account)
+-  [`0xa::multisign_wallet`](multisign_wallet.md#0xa_multisign_wallet)
 -  [`0xa::tick_info`](tick_info.md#0xa_tick_info)
 
 

--- a/frameworks/rooch-nursery/doc/README.md
+++ b/frameworks/rooch-nursery/doc/README.md
@@ -12,6 +12,7 @@ This is the reference documentation of the Rooch Nursery Framework.
 ## Index
 
 
+-  [`0xa::bitcoin_multisign_validator`](bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator)
 -  [`0xa::bitseed`](bitseed.md#0xa_bitseed)
 -  [`0xa::brc20`](brc20.md#0xa_brc20)
 -  [`0xa::ethereum`](ethereum.md#0xa_ethereum)

--- a/frameworks/rooch-nursery/doc/bitcoin_multisign_validator.md
+++ b/frameworks/rooch-nursery/doc/bitcoin_multisign_validator.md
@@ -6,19 +6,15 @@
 
 
 -  [Struct `BitcoinMultisignValidator`](#0xa_bitcoin_multisign_validator_BitcoinMultisignValidator)
--  [Struct `AuthPayload`](#0xa_bitcoin_multisign_validator_AuthPayload)
--  [Struct `SignData`](#0xa_bitcoin_multisign_validator_SignData)
 -  [Constants](#@Constants_0)
 -  [Function `auth_validator_id`](#0xa_bitcoin_multisign_validator_auth_validator_id)
 -  [Function `genesis_init`](#0xa_bitcoin_multisign_validator_genesis_init)
 -  [Function `validate`](#0xa_bitcoin_multisign_validator_validate)
 
 
-<pre><code><b>use</b> <a href="">0x1::vector</a>;
-<b>use</b> <a href="">0x2::bcs</a>;
-<b>use</b> <a href="">0x2::hash</a>;
-<b>use</b> <a href="">0x2::hex</a>;
+<pre><code><b>use</b> <a href="">0x2::hash</a>;
 <b>use</b> <a href="">0x2::tx_context</a>;
+<b>use</b> <a href="">0x3::auth_payload</a>;
 <b>use</b> <a href="">0x3::auth_validator</a>;
 <b>use</b> <a href="">0x3::auth_validator_registry</a>;
 <b>use</b> <a href="">0x3::ecdsa_k1</a>;
@@ -34,29 +30,6 @@
 
 
 <pre><code><b>struct</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_BitcoinMultisignValidator">BitcoinMultisignValidator</a> <b>has</b> drop, store
-</code></pre>
-
-
-
-<a name="0xa_bitcoin_multisign_validator_AuthPayload"></a>
-
-## Struct `AuthPayload`
-
-
-
-<pre><code>#[data_struct]
-<b>struct</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_AuthPayload">AuthPayload</a> <b>has</b> <b>copy</b>, drop, store
-</code></pre>
-
-
-
-<a name="0xa_bitcoin_multisign_validator_SignData"></a>
-
-## Struct `SignData`
-
-
-
-<pre><code><b>struct</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_SignData">SignData</a> <b>has</b> <b>copy</b>, drop
 </code></pre>
 
 

--- a/frameworks/rooch-nursery/doc/bitcoin_multisign_validator.md
+++ b/frameworks/rooch-nursery/doc/bitcoin_multisign_validator.md
@@ -66,12 +66,12 @@
 ## Constants
 
 
-<a name="0xa_bitcoin_multisign_validator_BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID"></a>
+<a name="0xa_bitcoin_multisign_validator_BITCOIN_MULTISIGN_VALIDATOR_ID"></a>
 
 there defines auth validator id for each auth validator
 
 
-<pre><code><b>const</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID">BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID</a>: u64 = 2;
+<pre><code><b>const</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_BITCOIN_MULTISIGN_VALIDATOR_ID">BITCOIN_MULTISIGN_VALIDATOR_ID</a>: u64 = 2;
 </code></pre>
 
 

--- a/frameworks/rooch-nursery/doc/bitcoin_multisign_validator.md
+++ b/frameworks/rooch-nursery/doc/bitcoin_multisign_validator.md
@@ -1,0 +1,117 @@
+
+<a name="0xa_bitcoin_multisign_validator"></a>
+
+# Module `0xa::bitcoin_multisign_validator`
+
+
+
+-  [Struct `BitcoinMultisignValidator`](#0xa_bitcoin_multisign_validator_BitcoinMultisignValidator)
+-  [Struct `AuthPayload`](#0xa_bitcoin_multisign_validator_AuthPayload)
+-  [Struct `SignData`](#0xa_bitcoin_multisign_validator_SignData)
+-  [Constants](#@Constants_0)
+-  [Function `auth_validator_id`](#0xa_bitcoin_multisign_validator_auth_validator_id)
+-  [Function `genesis_init`](#0xa_bitcoin_multisign_validator_genesis_init)
+-  [Function `validate`](#0xa_bitcoin_multisign_validator_validate)
+
+
+<pre><code><b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="">0x2::bcs</a>;
+<b>use</b> <a href="">0x2::hash</a>;
+<b>use</b> <a href="">0x2::hex</a>;
+<b>use</b> <a href="">0x2::tx_context</a>;
+<b>use</b> <a href="">0x3::auth_validator</a>;
+<b>use</b> <a href="">0x3::auth_validator_registry</a>;
+<b>use</b> <a href="">0x3::ecdsa_k1</a>;
+<b>use</b> <a href="multisign_account.md#0xa_multisign_account">0xa::multisign_account</a>;
+</code></pre>
+
+
+
+<a name="0xa_bitcoin_multisign_validator_BitcoinMultisignValidator"></a>
+
+## Struct `BitcoinMultisignValidator`
+
+
+
+<pre><code><b>struct</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_BitcoinMultisignValidator">BitcoinMultisignValidator</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<a name="0xa_bitcoin_multisign_validator_AuthPayload"></a>
+
+## Struct `AuthPayload`
+
+
+
+<pre><code>#[data_struct]
+<b>struct</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_AuthPayload">AuthPayload</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<a name="0xa_bitcoin_multisign_validator_SignData"></a>
+
+## Struct `SignData`
+
+
+
+<pre><code><b>struct</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_SignData">SignData</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0xa_bitcoin_multisign_validator_BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID"></a>
+
+there defines auth validator id for each auth validator
+
+
+<pre><code><b>const</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID">BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0xa_bitcoin_multisign_validator_ErrorGenesisInitError"></a>
+
+
+
+<pre><code><b>const</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_ErrorGenesisInitError">ErrorGenesisInitError</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0xa_bitcoin_multisign_validator_auth_validator_id"></a>
+
+## Function `auth_validator_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_auth_validator_id">auth_validator_id</a>(): u64
+</code></pre>
+
+
+
+<a name="0xa_bitcoin_multisign_validator_genesis_init"></a>
+
+## Function `genesis_init`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_genesis_init">genesis_init</a>()
+</code></pre>
+
+
+
+<a name="0xa_bitcoin_multisign_validator_validate"></a>
+
+## Function `validate`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator_validate">validate</a>(authenticator_payload: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>

--- a/frameworks/rooch-nursery/doc/genesis.md
+++ b/frameworks/rooch-nursery/doc/genesis.md
@@ -9,6 +9,7 @@
 
 
 <pre><code><b>use</b> <a href="">0x3::chain_id</a>;
+<b>use</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator">0xa::bitcoin_multisign_validator</a>;
 <b>use</b> <a href="ethereum.md#0xa_ethereum">0xa::ethereum</a>;
 <b>use</b> <a href="tick_info.md#0xa_tick_info">0xa::tick_info</a>;
 </code></pre>

--- a/frameworks/rooch-nursery/doc/genesis.md
+++ b/frameworks/rooch-nursery/doc/genesis.md
@@ -5,6 +5,7 @@
 
 
 
+-  [Struct `GenesisContext`](#0xa_genesis_GenesisContext)
 -  [Constants](#@Constants_0)
 
 
@@ -12,6 +13,17 @@
 <b>use</b> <a href="bitcoin_multisign_validator.md#0xa_bitcoin_multisign_validator">0xa::bitcoin_multisign_validator</a>;
 <b>use</b> <a href="ethereum.md#0xa_ethereum">0xa::ethereum</a>;
 <b>use</b> <a href="tick_info.md#0xa_tick_info">0xa::tick_info</a>;
+</code></pre>
+
+
+
+<a name="0xa_genesis_GenesisContext"></a>
+
+## Struct `GenesisContext`
+
+
+
+<pre><code><b>struct</b> <a href="genesis.md#0xa_genesis_GenesisContext">GenesisContext</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 

--- a/frameworks/rooch-nursery/doc/multisign_account.md
+++ b/frameworks/rooch-nursery/doc/multisign_account.md
@@ -15,7 +15,10 @@ Bitcoin multisign account module
 -  [Function `initialize_multisig_account`](#0xa_multisign_account_initialize_multisig_account)
 -  [Function `generate_multisign_address`](#0xa_multisign_account_generate_multisign_address)
 -  [Function `is_participant`](#0xa_multisign_account_is_participant)
+-  [Function `is_participant_via_public_key`](#0xa_multisign_account_is_participant_via_public_key)
+-  [Function `is_multisign_account`](#0xa_multisign_account_is_multisign_account)
 -  [Function `bitcoin_address`](#0xa_multisign_account_bitcoin_address)
+-  [Function `threshold`](#0xa_multisign_account_threshold)
 -  [Function `submit_bitcoin_proposal`](#0xa_multisign_account_submit_bitcoin_proposal)
 -  [Function `sign_bitcoin_proposal`](#0xa_multisign_account_sign_bitcoin_proposal)
 
@@ -28,7 +31,7 @@ Bitcoin multisign account module
 <b>use</b> <a href="">0x2::object</a>;
 <b>use</b> <a href="">0x2::result</a>;
 <b>use</b> <a href="">0x2::signer</a>;
-<b>use</b> <a href="">0x2::table</a>;
+<b>use</b> <a href="">0x2::simple_map</a>;
 <b>use</b> <a href="">0x2::table_vec</a>;
 <b>use</b> <a href="">0x3::bitcoin_address</a>;
 <b>use</b> <a href="">0x3::ecdsa_k1</a>;
@@ -56,7 +59,7 @@ Bitcoin multisign account module
 
 
 
-<pre><code><b>struct</b> <a href="multisign_account.md#0xa_multisign_account_ParticipantInfo">ParticipantInfo</a> <b>has</b> store
+<pre><code><b>struct</b> <a href="multisign_account.md#0xa_multisign_account_ParticipantInfo">ParticipantInfo</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -269,6 +272,28 @@ If the multisign account already exists, we will init the MultisignAccountInfo i
 
 
 
+<a name="0xa_multisign_account_is_participant_via_public_key"></a>
+
+## Function `is_participant_via_public_key`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multisign_account.md#0xa_multisign_account_is_participant_via_public_key">is_participant_via_public_key</a>(multisign_address: <b>address</b>, public_key: &<a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<a name="0xa_multisign_account_is_multisign_account"></a>
+
+## Function `is_multisign_account`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multisign_account.md#0xa_multisign_account_is_multisign_account">is_multisign_account</a>(multisign_address: <b>address</b>): bool
+</code></pre>
+
+
+
 <a name="0xa_multisign_account_bitcoin_address"></a>
 
 ## Function `bitcoin_address`
@@ -280,13 +305,24 @@ If the multisign account already exists, we will init the MultisignAccountInfo i
 
 
 
+<a name="0xa_multisign_account_threshold"></a>
+
+## Function `threshold`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multisign_account.md#0xa_multisign_account_threshold">threshold</a>(multisign_address: <b>address</b>): u64
+</code></pre>
+
+
+
 <a name="0xa_multisign_account_submit_bitcoin_proposal"></a>
 
 ## Function `submit_bitcoin_proposal`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="multisign_account.md#0xa_multisign_account_submit_bitcoin_proposal">submit_bitcoin_proposal</a>(sender: &<a href="">signer</a>, multisign_address: <b>address</b>, tx_id: <b>address</b>, tx_data: <a href="">vector</a>&lt;u8&gt;, participants: <a href="">vector</a>&lt;<b>address</b>&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="multisign_account.md#0xa_multisign_account_submit_bitcoin_proposal">submit_bitcoin_proposal</a>(sender: &<a href="">signer</a>, multisign_address: <b>address</b>, tx_id: <b>address</b>, tx_data: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 

--- a/frameworks/rooch-nursery/doc/multisign_account.md
+++ b/frameworks/rooch-nursery/doc/multisign_account.md
@@ -8,8 +8,6 @@ Bitcoin multisign account module
 
 -  [Resource `MultisignAccountInfo`](#0xa_multisign_account_MultisignAccountInfo)
 -  [Struct `ParticipantInfo`](#0xa_multisign_account_ParticipantInfo)
--  [Struct `BitcoinProposal`](#0xa_multisign_account_BitcoinProposal)
--  [Struct `RoochProposal`](#0xa_multisign_account_RoochProposal)
 -  [Constants](#@Constants_0)
 -  [Function `initialize_multisig_account_entry`](#0xa_multisign_account_initialize_multisig_account_entry)
 -  [Function `initialize_multisig_account`](#0xa_multisign_account_initialize_multisig_account)
@@ -19,8 +17,8 @@ Bitcoin multisign account module
 -  [Function `is_multisign_account`](#0xa_multisign_account_is_multisign_account)
 -  [Function `bitcoin_address`](#0xa_multisign_account_bitcoin_address)
 -  [Function `threshold`](#0xa_multisign_account_threshold)
--  [Function `submit_bitcoin_proposal`](#0xa_multisign_account_submit_bitcoin_proposal)
--  [Function `sign_bitcoin_proposal`](#0xa_multisign_account_sign_bitcoin_proposal)
+-  [Function `participant_public_key`](#0xa_multisign_account_participant_public_key)
+-  [Function `participant_bitcoin_address`](#0xa_multisign_account_participant_bitcoin_address)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -32,7 +30,6 @@ Bitcoin multisign account module
 <b>use</b> <a href="">0x2::result</a>;
 <b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="">0x2::simple_map</a>;
-<b>use</b> <a href="">0x2::table_vec</a>;
 <b>use</b> <a href="">0x3::address_mapping</a>;
 <b>use</b> <a href="">0x3::bitcoin_address</a>;
 <b>use</b> <a href="">0x3::ecdsa_k1</a>;
@@ -61,28 +58,6 @@ Bitcoin multisign account module
 
 
 <pre><code><b>struct</b> <a href="multisign_account.md#0xa_multisign_account_ParticipantInfo">ParticipantInfo</a> <b>has</b> <b>copy</b>, drop, store
-</code></pre>
-
-
-
-<a name="0xa_multisign_account_BitcoinProposal"></a>
-
-## Struct `BitcoinProposal`
-
-
-
-<pre><code><b>struct</b> <a href="multisign_account.md#0xa_multisign_account_BitcoinProposal">BitcoinProposal</a> <b>has</b> store
-</code></pre>
-
-
-
-<a name="0xa_multisign_account_RoochProposal"></a>
-
-## Struct `RoochProposal`
-
-
-
-<pre><code><b>struct</b> <a href="multisign_account.md#0xa_multisign_account_RoochProposal">RoochProposal</a> <b>has</b> store
 </code></pre>
 
 
@@ -317,22 +292,22 @@ If the multisign account already exists, we will init the MultisignAccountInfo i
 
 
 
-<a name="0xa_multisign_account_submit_bitcoin_proposal"></a>
+<a name="0xa_multisign_account_participant_public_key"></a>
 
-## Function `submit_bitcoin_proposal`
+## Function `participant_public_key`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="multisign_account.md#0xa_multisign_account_submit_bitcoin_proposal">submit_bitcoin_proposal</a>(sender: &<a href="">signer</a>, multisign_address: <b>address</b>, tx_id: <b>address</b>, tx_data: <a href="">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="multisign_account.md#0xa_multisign_account_participant_public_key">participant_public_key</a>(multisign_address: <b>address</b>, participant_address: <b>address</b>): <a href="">vector</a>&lt;u8&gt;
 </code></pre>
 
 
 
-<a name="0xa_multisign_account_sign_bitcoin_proposal"></a>
+<a name="0xa_multisign_account_participant_bitcoin_address"></a>
 
-## Function `sign_bitcoin_proposal`
+## Function `participant_bitcoin_address`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="multisign_account.md#0xa_multisign_account_sign_bitcoin_proposal">sign_bitcoin_proposal</a>(sender: &<a href="">signer</a>, multisign_address: <b>address</b>, proposal_id: u64, signature: <a href="">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="multisign_account.md#0xa_multisign_account_participant_bitcoin_address">participant_bitcoin_address</a>(multisign_address: <b>address</b>, participant_address: <b>address</b>): <a href="_BitcoinAddress">bitcoin_address::BitcoinAddress</a>
 </code></pre>

--- a/frameworks/rooch-nursery/doc/multisign_account.md
+++ b/frameworks/rooch-nursery/doc/multisign_account.md
@@ -33,6 +33,7 @@ Bitcoin multisign account module
 <b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="">0x2::simple_map</a>;
 <b>use</b> <a href="">0x2::table_vec</a>;
+<b>use</b> <a href="">0x3::address_mapping</a>;
 <b>use</b> <a href="">0x3::bitcoin_address</a>;
 <b>use</b> <a href="">0x3::ecdsa_k1</a>;
 <b>use</b> <a href="">0x4::opcode</a>;

--- a/frameworks/rooch-nursery/doc/multisign_wallet.md
+++ b/frameworks/rooch-nursery/doc/multisign_wallet.md
@@ -1,0 +1,219 @@
+
+<a name="0xa_multisign_wallet"></a>
+
+# Module `0xa::multisign_wallet`
+
+Bitcoin multisign account wallet to manage the multisign tx on Bitcoin and Rooch
+
+
+-  [Resource `MultisignWallet`](#0xa_multisign_wallet_MultisignWallet)
+-  [Struct `BitcoinProposal`](#0xa_multisign_wallet_BitcoinProposal)
+-  [Struct `RoochProposal`](#0xa_multisign_wallet_RoochProposal)
+-  [Constants](#@Constants_0)
+-  [Function `submit_bitcoin_proposal`](#0xa_multisign_wallet_submit_bitcoin_proposal)
+-  [Function `sign_bitcoin_proposal`](#0xa_multisign_wallet_sign_bitcoin_proposal)
+
+
+<pre><code><b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="">0x2::bcs</a>;
+<b>use</b> <a href="">0x2::object</a>;
+<b>use</b> <a href="">0x2::signer</a>;
+<b>use</b> <a href="">0x2::table_vec</a>;
+<b>use</b> <a href="">0x3::ecdsa_k1</a>;
+<b>use</b> <a href="multisign_account.md#0xa_multisign_account">0xa::multisign_account</a>;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_MultisignWallet"></a>
+
+## Resource `MultisignWallet`
+
+
+
+<pre><code><b>struct</b> <a href="multisign_wallet.md#0xa_multisign_wallet_MultisignWallet">MultisignWallet</a> <b>has</b> key
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_BitcoinProposal"></a>
+
+## Struct `BitcoinProposal`
+
+
+
+<pre><code><b>struct</b> <a href="multisign_wallet.md#0xa_multisign_wallet_BitcoinProposal">BitcoinProposal</a> <b>has</b> store
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_RoochProposal"></a>
+
+## Struct `RoochProposal`
+
+
+
+<pre><code><b>struct</b> <a href="multisign_wallet.md#0xa_multisign_wallet_RoochProposal">RoochProposal</a> <b>has</b> store
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0xa_multisign_wallet_ErrorInvalidPublicKey"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorInvalidPublicKey">ErrorInvalidPublicKey</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_ErrorInvalidThreshold"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorInvalidThreshold">ErrorInvalidThreshold</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_ErrorInvalidSignature"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorInvalidSignature">ErrorInvalidSignature</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_BITCOIN_COMPRESSED_PUBLIC_KEY_LEN"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_BITCOIN_COMPRESSED_PUBLIC_KEY_LEN">BITCOIN_COMPRESSED_PUBLIC_KEY_LEN</a>: u64 = 33;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_ErrorInvalidParticipant"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorInvalidParticipant">ErrorInvalidParticipant</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_ErrorInvalidProposal"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorInvalidProposal">ErrorInvalidProposal</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_ErrorInvalidProposalStatus"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorInvalidProposalStatus">ErrorInvalidProposalStatus</a>: u64 = 9;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_ErrorMultisignAccountNotFound"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorMultisignAccountNotFound">ErrorMultisignAccountNotFound</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_ErrorParticipantAlreadyJoined"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorParticipantAlreadyJoined">ErrorParticipantAlreadyJoined</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_ErrorParticipantMustHasBitcoinAddress"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorParticipantMustHasBitcoinAddress">ErrorParticipantMustHasBitcoinAddress</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_ErrorProposalAlreadySigned"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_ErrorProposalAlreadySigned">ErrorProposalAlreadySigned</a>: u64 = 8;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_PROPOSAL_STATUS_APPROVED"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_PROPOSAL_STATUS_APPROVED">PROPOSAL_STATUS_APPROVED</a>: u8 = 1;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_PROPOSAL_STATUS_PENDING"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_PROPOSAL_STATUS_PENDING">PROPOSAL_STATUS_PENDING</a>: u8 = 0;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_PROPOSAL_STATUS_REJECTED"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_PROPOSAL_STATUS_REJECTED">PROPOSAL_STATUS_REJECTED</a>: u8 = 2;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_X_ONLY_PUBLIC_KEY_LEN"></a>
+
+
+
+<pre><code><b>const</b> <a href="multisign_wallet.md#0xa_multisign_wallet_X_ONLY_PUBLIC_KEY_LEN">X_ONLY_PUBLIC_KEY_LEN</a>: u64 = 32;
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_submit_bitcoin_proposal"></a>
+
+## Function `submit_bitcoin_proposal`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multisign_wallet.md#0xa_multisign_wallet_submit_bitcoin_proposal">submit_bitcoin_proposal</a>(sender: &<a href="">signer</a>, multisign_address: <b>address</b>, tx_id: <b>address</b>, tx_data: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<a name="0xa_multisign_wallet_sign_bitcoin_proposal"></a>
+
+## Function `sign_bitcoin_proposal`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="multisign_wallet.md#0xa_multisign_wallet_sign_bitcoin_proposal">sign_bitcoin_proposal</a>(sender: &<a href="">signer</a>, multisign_address: <b>address</b>, proposal_id: u64, signature: <a href="">vector</a>&lt;u8&gt;)
+</code></pre>

--- a/frameworks/rooch-nursery/sources/bitcoin_multisign_validator.move
+++ b/frameworks/rooch-nursery/sources/bitcoin_multisign_validator.move
@@ -1,0 +1,111 @@
+module rooch_nursery::bitcoin_multisign_validator{
+
+    use std::vector;
+    use moveos_std::bcs;
+    use moveos_std::tx_context;
+    use moveos_std::hash;
+    use moveos_std::hex;
+    use rooch_framework::ecdsa_k1;
+    use rooch_framework::auth_validator_registry;
+    use rooch_framework::auth_validator;
+    use rooch_nursery::multisign_account;
+
+    friend rooch_nursery::genesis;
+
+    const ErrorGenesisInitError: u64 = 1;
+
+    /// there defines auth validator id for each auth validator
+    const BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID: u64 = 2;
+
+    struct BitcoinMultisignValidator has store, drop {}
+
+    #[data_struct]
+    struct AuthPayload has copy, store, drop {
+        // Message signature
+        signatures: vector<vector<u8>>,
+        // Some wallets add magic prefixes, such as unisat adding 'Bitcoin Signed Message:\n'
+        message_prefix: vector<u8>,
+        // Description of a user-defined signature, without the tx_hash hex
+        message_info: vector<u8>,
+        // Public key of address
+        public_keys: vector<vector<u8>>,
+    }
+
+    struct SignData has copy, drop {
+        message_prefix: vector<u8>,
+        // Description of a user-defined signature, include the tx_hash hex
+        message_info: vector<u8>,
+    }
+
+    public fun auth_validator_id(): u64 {
+        BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID
+    }
+
+    public(friend) fun genesis_init(){
+        let id = auth_validator_registry::register<BitcoinMultisignValidator>();
+        assert!(id == BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID, ErrorGenesisInitError);
+    }
+
+    fun encode_full_message(self: &AuthPayload, tx_hash: vector<u8>): vector<u8> {
+        let tx_hex = hex::encode(tx_hash);
+        let message_info = self.message_info;
+        vector::append(&mut message_info, tx_hex);
+        let sign_data = SignData {
+            message_prefix: self.message_prefix,
+            message_info: message_info,
+        };
+        bcs::to_bytes(&sign_data)
+    }
+
+    /// Only validate the authenticator's signature.
+    fun validate_signatures(payload: &AuthPayload, tx_hash: vector<u8>) {
+        assert!(
+            vector::length(&payload.signatures) == vector::length(&payload.public_keys),
+            auth_validator::error_validate_invalid_authenticator()
+        );
+
+        let message = encode_full_message(payload, tx_hash);
+
+        // The Bitcoin wallet uses sha2_256 twice, the `ecdsa_k1::verify` function also does sha2_256 once
+        let message_hash = hash::sha2_256(message);
+        let i = 0;
+        while (i < vector::length(&payload.signatures)) {
+            assert!(
+                ecdsa_k1::verify(
+                    vector::borrow(&payload.signatures,i),
+                    vector::borrow(&payload.public_keys,i),
+                    &message_hash,
+                    ecdsa_k1::sha256()
+                ),
+                auth_validator::error_validate_invalid_authenticator()
+            );
+            i = i + 1;
+        }
+    }
+
+    fun validate_multisign_account(multisign_address: address, public_keys: &vector<vector<u8>>) {
+        assert!(
+            multisign_account::is_multisign_account(multisign_address),
+            auth_validator::error_validate_invalid_authenticator()
+        );
+        let pubkey_len = vector::length(public_keys);
+        assert!(pubkey_len >= multisign_account::threshold(multisign_address), auth_validator::error_validate_invalid_authenticator());
+        let i = 0;
+        while (i < pubkey_len) {
+            assert!(
+                multisign_account::is_participant_via_public_key(multisign_address, vector::borrow(public_keys,i)),
+                auth_validator::error_validate_invalid_authenticator()
+            );
+            i = i + 1;
+        }    
+    }
+
+    public fun validate(authenticator_payload: vector<u8>) {
+        let sender = tx_context::sender();
+        let tx_hash = tx_context::tx_hash();
+        let payload = bcs::from_bytes<AuthPayload>(authenticator_payload);
+        validate_multisign_account(sender, &payload.public_keys);
+        validate_signatures(&payload, tx_hash);
+    }
+
+}

--- a/frameworks/rooch-nursery/sources/bitcoin_multisign_validator.move
+++ b/frameworks/rooch-nursery/sources/bitcoin_multisign_validator.move
@@ -1,13 +1,12 @@
 module rooch_nursery::bitcoin_multisign_validator{
 
     use std::vector;
-    use moveos_std::bcs;
     use moveos_std::tx_context;
     use moveos_std::hash;
-    use moveos_std::hex;
     use rooch_framework::ecdsa_k1;
     use rooch_framework::auth_validator_registry;
     use rooch_framework::auth_validator;
+    use rooch_framework::auth_payload;
     use rooch_nursery::multisign_account;
 
     friend rooch_nursery::genesis;
@@ -19,23 +18,6 @@ module rooch_nursery::bitcoin_multisign_validator{
 
     struct BitcoinMultisignValidator has store, drop {}
 
-    #[data_struct]
-    struct AuthPayload has copy, store, drop {
-        // Message signature
-        signatures: vector<vector<u8>>,
-        // Some wallets add magic prefixes, such as unisat adding 'Bitcoin Signed Message:\n'
-        message_prefix: vector<u8>,
-        // Description of a user-defined signature, without the tx_hash hex
-        message_info: vector<u8>,
-        // Public key of address
-        public_keys: vector<vector<u8>>,
-    }
-
-    struct SignData has copy, drop {
-        message_prefix: vector<u8>,
-        // Description of a user-defined signature, include the tx_hash hex
-        message_info: vector<u8>,
-    }
 
     public fun auth_validator_id(): u64 {
         BITCOIN_MULTISIGN_VALIDATOR_ID
@@ -46,34 +28,23 @@ module rooch_nursery::bitcoin_multisign_validator{
         assert!(id == BITCOIN_MULTISIGN_VALIDATOR_ID, ErrorGenesisInitError);
     }
 
-    fun encode_full_message(self: &AuthPayload, tx_hash: vector<u8>): vector<u8> {
-        let tx_hex = hex::encode(tx_hash);
-        let message_info = self.message_info;
-        vector::append(&mut message_info, tx_hex);
-        let sign_data = SignData {
-            message_prefix: self.message_prefix,
-            message_info: message_info,
-        };
-        bcs::to_bytes(&sign_data)
-    }
-
     /// Only validate the authenticator's signature.
-    fun validate_signatures(payload: &AuthPayload, tx_hash: vector<u8>) {
+    fun validate_signatures(signatures: &vector<vector<u8>>, public_keys: &vector<vector<u8>>, message: vector<u8>) {
+        
+        let signature_len = vector::length(signatures);
         assert!(
-            vector::length(&payload.signatures) == vector::length(&payload.public_keys),
+            signature_len == vector::length(public_keys),
             auth_validator::error_validate_invalid_authenticator()
         );
-
-        let message = encode_full_message(payload, tx_hash);
 
         // The Bitcoin wallet uses sha2_256 twice, the `ecdsa_k1::verify` function also does sha2_256 once
         let message_hash = hash::sha2_256(message);
         let i = 0;
-        while (i < vector::length(&payload.signatures)) {
+        while (i < signature_len) {
             assert!(
                 ecdsa_k1::verify(
-                    vector::borrow(&payload.signatures,i),
-                    vector::borrow(&payload.public_keys,i),
+                    vector::borrow(signatures,i),
+                    vector::borrow(public_keys,i),
                     &message_hash,
                     ecdsa_k1::sha256()
                 ),
@@ -103,9 +74,12 @@ module rooch_nursery::bitcoin_multisign_validator{
     public fun validate(authenticator_payload: vector<u8>) {
         let sender = tx_context::sender();
         let tx_hash = tx_context::tx_hash();
-        let payload = bcs::from_bytes<AuthPayload>(authenticator_payload);
-        validate_multisign_account(sender, &payload.public_keys);
-        validate_signatures(&payload, tx_hash);
+        let payload = auth_payload::multisign_from_bytes(authenticator_payload);
+        let message = auth_payload::multisign_encode_full_message(&payload, tx_hash);
+        let signatures = auth_payload::multisign_signatures(&payload);
+        let public_keys = auth_payload::multisign_public_keys(&payload);
+        validate_multisign_account(sender, public_keys);
+        validate_signatures(signatures, public_keys, message);
     }
 
 }

--- a/frameworks/rooch-nursery/sources/bitcoin_multisign_validator.move
+++ b/frameworks/rooch-nursery/sources/bitcoin_multisign_validator.move
@@ -15,7 +15,7 @@ module rooch_nursery::bitcoin_multisign_validator{
     const ErrorGenesisInitError: u64 = 1;
 
     /// there defines auth validator id for each auth validator
-    const BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID: u64 = 2;
+    const BITCOIN_MULTISIGN_VALIDATOR_ID: u64 = 2;
 
     struct BitcoinMultisignValidator has store, drop {}
 
@@ -38,12 +38,12 @@ module rooch_nursery::bitcoin_multisign_validator{
     }
 
     public fun auth_validator_id(): u64 {
-        BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID
+        BITCOIN_MULTISIGN_VALIDATOR_ID
     }
 
     public(friend) fun genesis_init(){
         let id = auth_validator_registry::register<BitcoinMultisignValidator>();
-        assert!(id == BITCOIN_MULTISIGN_AUTH_VALIDATOR_ID, ErrorGenesisInitError);
+        assert!(id == BITCOIN_MULTISIGN_VALIDATOR_ID, ErrorGenesisInitError);
     }
 
     fun encode_full_message(self: &AuthPayload, tx_hash: vector<u8>): vector<u8> {

--- a/frameworks/rooch-nursery/sources/genesis.move
+++ b/frameworks/rooch-nursery/sources/genesis.move
@@ -5,6 +5,7 @@ module rooch_nursery::genesis {
     use rooch_framework::chain_id;
     use rooch_nursery::ethereum;
     use rooch_nursery::tick_info;
+    use rooch_nursery::bitcoin_multisign_validator;
 
     const ErrorInvalidChainId: u64 = 1;
 
@@ -13,6 +14,7 @@ module rooch_nursery::genesis {
         // nursery can running on a local or dev chain or custom chain
         assert!(!chain_id::is_test() && !chain_id::is_main(), ErrorInvalidChainId);
         ethereum::genesis_init(genesis_account);
+        bitcoin_multisign_validator::genesis_init();
         tick_info::genesis_init();
     }
 }

--- a/frameworks/rooch-nursery/sources/genesis.move
+++ b/frameworks/rooch-nursery/sources/genesis.move
@@ -9,6 +9,9 @@ module rooch_nursery::genesis {
 
     const ErrorInvalidChainId: u64 = 1;
 
+    struct GenesisContext has copy,store,drop{
+    }
+
     fun init(genesis_account: &signer){
         // Ensure the nursery is not running on test or main chain.
         // nursery can running on a local or dev chain or custom chain
@@ -16,5 +19,13 @@ module rooch_nursery::genesis {
         ethereum::genesis_init(genesis_account);
         bitcoin_multisign_validator::genesis_init();
         tick_info::genesis_init();
+    }
+
+    #[test_only]
+    /// init the genesis context for test
+    public fun init_for_test(){
+        rooch_framework::genesis::init_for_test();
+        let genesis_account = moveos_std::signer::module_signer<GenesisContext>();
+        init(&genesis_account);
     }
 }

--- a/frameworks/rooch-nursery/sources/multisign_wallet.move
+++ b/frameworks/rooch-nursery/sources/multisign_wallet.move
@@ -1,0 +1,177 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+/// Bitcoin multisign account wallet to manage the multisign tx on Bitcoin and Rooch
+module rooch_nursery::multisign_wallet{
+
+    use std::vector;
+    use moveos_std::signer;
+    use moveos_std::object;
+    use moveos_std::table_vec::{Self, TableVec};
+    use moveos_std::bcs;
+    use rooch_nursery::multisign_account;
+    use rooch_framework::ecdsa_k1;
+
+    const PROPOSAL_STATUS_PENDING: u8 = 0;
+    const PROPOSAL_STATUS_APPROVED: u8 = 1;
+    const PROPOSAL_STATUS_REJECTED: u8 = 2;
+
+    const X_ONLY_PUBLIC_KEY_LEN: u64 = 32;
+    const BITCOIN_COMPRESSED_PUBLIC_KEY_LEN: u64 = 33;
+
+    const ErrorInvalidThreshold: u64 = 1;
+    const ErrorMultisignAccountNotFound: u64 = 2;
+    const ErrorInvalidParticipant: u64 = 3;
+    const ErrorParticipantMustHasBitcoinAddress: u64 = 4;
+    const ErrorParticipantAlreadyJoined: u64 = 5;
+    const ErrorInvalidPublicKey: u64 = 6;
+    const ErrorInvalidProposal: u64 = 7;
+    const ErrorProposalAlreadySigned: u64 = 8;
+    const ErrorInvalidProposalStatus: u64 = 9;
+    const ErrorInvalidSignature: u64 = 10; 
+
+    struct MultisignWallet has key {
+        bitcoin_proposals: TableVec<BitcoinProposal>,
+        rooch_proposals: TableVec<RoochProposal>,
+    }
+
+    struct BitcoinProposal has store {
+        /// The multisign account address
+        multisign_address: address,
+        /// The proposal id
+        proposal_id: u64,
+        /// The proposal transaction id
+        tx_id: address,
+        /// The proposal transaction data to be signed
+        tx_data: vector<u8>,
+        /// The proposal status
+        status: u8,
+        /// The proposal result
+        result: u8,
+        /// The proposal participants
+        participants: vector<address>,
+        /// The proposal signatures
+        signatures: vector<vector<u8>>,
+    }
+
+    struct RoochProposal has store {
+        /// The multisign account address
+        multisign_address: address,
+        /// The proposal id
+        proposal_id: u64,
+        /// The proposal transaction id
+        tx_id: address,
+        /// The proposal transaction data
+        /// The signer will sign the sign_message + tx_id
+        /// We keep the tx_data here for the verify the tx_id and display to the user
+        tx_data: vector<u8>,
+        /// The sign message to be signed
+        sign_message: vector<u8>,
+        /// The proposal status
+        status: u8,
+        /// The proposal result
+        result: u8,
+        /// The proposal participants
+        participants: vector<address>,
+        /// The proposal signatures
+        signatures: vector<vector<u8>>,
+    }
+
+    fun create_or_borrow_mut_wallet(multisign_address: address) : &mut MultisignWallet {
+        let wallet_id = object::account_named_object_id<MultisignWallet>(multisign_address);
+        if (!object::exists_object(wallet_id)){
+            let wallet = MultisignWallet {
+                bitcoin_proposals: table_vec::new(),
+                rooch_proposals: table_vec::new(),
+            };
+            let wallet_obj = object::new_account_named_object(multisign_address, wallet);
+            object::transfer_extend(wallet_obj, multisign_address);
+        };
+        let wallet_obj = object::borrow_mut_object_extend<MultisignWallet>(wallet_id);
+        object::borrow_mut(wallet_obj)
+    }
+
+    public fun submit_bitcoin_proposal(
+        sender: &signer,
+        multisign_address: address,
+        tx_id: address,
+        tx_data: vector<u8>,
+    ){
+        assert!(multisign_account::is_multisign_account(multisign_address), ErrorMultisignAccountNotFound);
+        
+        let sender_addr = signer::address_of(sender);
+        assert!(multisign_account::is_participant(multisign_address, sender_addr), ErrorInvalidParticipant);
+
+        let wallet = create_or_borrow_mut_wallet(multisign_address);
+
+        let proposal_id = table_vec::length(&wallet.bitcoin_proposals);
+        let proposal = BitcoinProposal {
+            multisign_address,
+            proposal_id,
+            tx_id,
+            tx_data,
+            status: 0,
+            result: 0,
+            participants: vector::empty(),
+            signatures: vector::empty(),
+        };
+        table_vec::push_back(&mut wallet.bitcoin_proposals, proposal);
+    }
+
+    public fun sign_bitcoin_proposal(
+        sender: &signer,
+        multisign_address: address,
+        proposal_id: u64,
+        signature: vector<u8>,
+    ){
+        assert!(multisign_account::is_multisign_account(multisign_address), ErrorMultisignAccountNotFound);
+        
+        let sender_addr = signer::address_of(sender);
+        assert!(multisign_account::is_participant(multisign_address, sender_addr), ErrorInvalidParticipant);
+
+        let wallet = create_or_borrow_mut_wallet(multisign_address);
+
+        assert!(table_vec::contains(&wallet.bitcoin_proposals, proposal_id), ErrorInvalidProposal);
+        
+        let proposal = table_vec::borrow_mut(&mut wallet.bitcoin_proposals, proposal_id);
+        assert!(proposal.status == PROPOSAL_STATUS_PENDING, ErrorInvalidProposalStatus);
+        assert!(!vector::contains(&proposal.participants, &sender_addr), ErrorProposalAlreadySigned);
+
+        let participant_public_key = multisign_account::participant_public_key(multisign_address, sender_addr);
+        verify_bitcoin_signature(proposal.tx_id, &signature, &participant_public_key);
+        let threshold = multisign_account::threshold(multisign_address);
+        vector::push_back(&mut proposal.signatures, signature);
+        if(vector::length(&proposal.signatures) >= threshold){
+            proposal.status = PROPOSAL_STATUS_APPROVED;
+        }
+    }
+
+
+    fun verify_bitcoin_signature(tx_id: address, signature: &vector<u8>, public_key: &vector<u8>) {
+        assert!(
+            ecdsa_k1::verify(
+                signature,
+                public_key,
+                &bcs::to_bytes(&tx_id),
+                ecdsa_k1::sha256()
+            ),
+            ErrorInvalidSignature
+        );
+    }
+
+    fun check_public_keys(public_keys: &vector<vector<u8>>) {
+        let idx = 0;
+        let len = vector::length(public_keys);
+        while(idx < len){
+            let public_key = vector::borrow(public_keys, idx);
+            check_public_key(public_key);
+            idx = idx + 1;
+        };
+    }
+
+    fun check_public_key(public_key: &vector<u8>) {
+        let public_key_len = vector::length(public_key);
+        assert!(public_key_len == BITCOIN_COMPRESSED_PUBLIC_KEY_LEN, ErrorInvalidPublicKey);
+    }
+
+}

--- a/frameworks/rooch-nursery/tests/multisign_account_test.move
+++ b/frameworks/rooch-nursery/tests/multisign_account_test.move
@@ -4,9 +4,11 @@ module rooch_nursery::multisign_account_test{
     use std::string::{utf8};
     use rooch_framework::bitcoin_address;
     use rooch_nursery::multisign_account;
+    use rooch_nursery::genesis;
 
     #[test]
     public fun test_multisign_account(){
+        genesis::init_for_test();
         let u1 = @0x09d7a0b046555338a1f4e62d4597d94dd7a70eb2084083cd82adf1669521e1f3;
         let u2 = @0x364611452c544b067d6d0541f239adf8067f51c6150335fb60de468051b47d88;
         let u3 = @0x49f56b4d1d0ad7320f69fe97b325c74fd9f572d395cd44d5187c457c12f969ef;
@@ -22,7 +24,7 @@ module rooch_nursery::multisign_account_test{
         vector::push_back(&mut public_keys, pk2);
         vector::push_back(&mut public_keys, pk3);
         let multisign_addr_result = multisign_account::initialize_multisig_account(threshold, public_keys);
-        //std::debug::print(&multisign_addr_result);
+        std::debug::print(&multisign_addr_result);
         assert!(multisign_addr == multisign_addr_result, 1001);
         assert!(multisign_account::is_participant(multisign_addr, u1), 1002);
         assert!(multisign_account::is_participant(multisign_addr, u2), 1003);

--- a/frameworks/rooch-nursery/tests/multisign_account_test.move
+++ b/frameworks/rooch-nursery/tests/multisign_account_test.move
@@ -24,7 +24,7 @@ module rooch_nursery::multisign_account_test{
         vector::push_back(&mut public_keys, pk2);
         vector::push_back(&mut public_keys, pk3);
         let multisign_addr_result = multisign_account::initialize_multisig_account(threshold, public_keys);
-        std::debug::print(&multisign_addr_result);
+        //std::debug::print(&multisign_addr_result);
         assert!(multisign_addr == multisign_addr_result, 1001);
         assert!(multisign_account::is_participant(multisign_addr, u1), 1002);
         assert!(multisign_account::is_participant(multisign_addr, u2), 1003);


### PR DESCRIPTION
## Summary

1. Remove the length in the message prefix and directly use the bcs serialize. The bcs length serialize is the same as bitcoin var int.
2. Implement the Bitcoin multisign validator and enable the multisign address to execute tx on Rooch.

TODO:
1. Migrate the Bitcoin multisign validator to `bitcoin-move`.
2. CLI support send multisign tx( build tx, sign tx, submit tx).