### PR TITLE
feat(statedb/export): export indexer from source file directly

### DIFF
--- a/crates/rooch/src/commands/statedb/commands/export.rs
+++ b/crates/rooch/src/commands/statedb/commands/export.rs
@@ -287,8 +287,10 @@ impl ExportCommand {
                 .ord_source_path
                 .clone()
                 .expect("ord source path must be existed if utxo path is provided");
-            let outpoint_inscriptions_map_path =
-                ord_path.with_extension("outpoint_inscriptions_map");
+            let outpoint_inscriptions_map_path = self
+                .outpoint_inscriptions_map_path
+                .clone()
+                .expect("outpoint_inscriptions_map path must be existed if utxo path is provided");
             let utxo_store_object_id = BitcoinUTXOStore::object_id();
             let utxo_store_state_root = get_state_root(
                 moveos_store,

--- a/crates/rooch/src/commands/statedb/commands/export.rs
+++ b/crates/rooch/src/commands/statedb/commands/export.rs
@@ -2,28 +2,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Display;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Result;
 use clap::Parser;
-use csv::Writer;
 use serde::{Deserialize, Serialize};
 
 use moveos_store::MoveOSStore;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::object::ObjectID;
 use moveos_types::state::FieldKey;
-use moveos_types::state_resolver::{StateKV, StatelessResolver};
+use moveos_types::state_resolver::StatelessResolver;
 use rooch_config::R_OPT_NET_HELP;
 use rooch_types::bitcoin::ord::InscriptionStore;
 use rooch_types::bitcoin::utxo::BitcoinUTXOStore;
-use rooch_types::error::{RoochError, RoochResult};
+use rooch_types::error::RoochResult;
 use rooch_types::framework::address_mapping::RoochToBitcoinAddressMapping;
 use rooch_types::rooch_network::RoochChainID;
 
-use crate::commands::statedb::commands::{init_job, GLOBAL_STATE_TYPE_ROOT};
+use crate::commands::statedb::commands::inscription::{
+    gen_inscription_id_update, InscriptionSource,
+};
+use crate::commands::statedb::commands::utxo::UTXORawData;
+use crate::commands::statedb::commands::{init_job, ExportWriter, OutpointInscriptionsMap};
 
 /// Export statedb
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
@@ -33,8 +39,7 @@ pub enum ExportMode {
     Genesis, // dump InscriptionStore, BitcoinUTXOStore, RoochToBitcoinAddressMapping for genesis start-up
     Full,
     Snapshot,
-    FullIndexer, // dump Full Objects, include InscriptionStore, BitcoinUTXOStore for rebuild indexer
-    Indexer,     // dump InscriptionStore, BitcoinUTXOStore for rebuild indexer
+    Indexer, // dump Full Objects, include InscriptionStore, BitcoinUTXOStore for rebuild indexer
     Object,
 }
 
@@ -44,7 +49,6 @@ impl Display for ExportMode {
             ExportMode::Genesis => write!(f, "genesis"),
             ExportMode::Full => write!(f, "full"),
             ExportMode::Snapshot => write!(f, "snapshot"),
-            ExportMode::FullIndexer => write!(f, "fullindexer"),
             ExportMode::Indexer => write!(f, "indexer"),
             ExportMode::Object => write!(f, "object"),
         }
@@ -59,7 +63,6 @@ impl FromStr for ExportMode {
             "genesis" => Ok(ExportMode::Genesis),
             "full" => Ok(ExportMode::Full),
             "snapshot" => Ok(ExportMode::Snapshot),
-            "fullindexer" => Ok(ExportMode::FullIndexer),
             "indexer" => Ok(ExportMode::Indexer),
             "object" => Ok(ExportMode::Object),
             _ => Err("export-mode no match"),
@@ -203,6 +206,15 @@ pub struct ExportCommand {
     /// Path to data dir, this dir is base dir, the final data_dir is base_dir/chain_network_name
     pub base_data_dir: Option<PathBuf>,
 
+    #[clap(long, help = "path to ord source path")]
+    pub ord_source_path: Option<PathBuf>,
+
+    #[clap(long, help = "path to utxo source path")]
+    pub utxo_source_path: Option<PathBuf>,
+
+    #[clap(long, help = "path to outpoint_inscriptions_map path")]
+    pub outpoint_inscriptions_map_path: Option<PathBuf>,
+
     // #[serde(skip_serializing_if = "Option::is_none")]
     #[clap(long, short = 'm')]
     /// statedb export mode, default is genesis mode
@@ -226,21 +238,14 @@ impl ExportCommand {
         let (root, moveos_store, start_time) =
             init_job(self.base_data_dir.clone(), self.chain_id.clone());
 
-        let file_name = self.output.display().to_string();
-        let mut writer_builder = csv::WriterBuilder::new();
-        let writer_builder = writer_builder
-            .delimiter(b',')
-            .double_quote(false)
-            .buffer_capacity(1 << 23);
-        let mut writer = writer_builder.from_path(file_name).map_err(|e| {
-            RoochError::from(anyhow::Error::msg(format!("Invalid output path: {}", e)))
-        })?;
+        let output = self.output.clone();
+        let mut writer = ExportWriter::new(Some(output));
         let root_state_root = self.state_root.unwrap_or(root.state_root());
 
         let mode = self.mode.unwrap_or_default();
         match mode {
             ExportMode::Genesis => {
-                Self::export_genesis(&moveos_store, root_state_root, &mut writer)?;
+                todo!()
             }
             ExportMode::Full => {
                 todo!()
@@ -248,11 +253,8 @@ impl ExportCommand {
             ExportMode::Snapshot => {
                 todo!()
             }
-            ExportMode::FullIndexer => {
-                Self::export_full_indexer(&moveos_store, root_state_root, &mut writer)?;
-            }
             ExportMode::Indexer => {
-                Self::export_indexer(&moveos_store, root_state_root, &mut writer)?;
+                self.export_indexer(&moveos_store, root_state_root, &mut writer)?;
             }
             ExportMode::Object => {
                 let obj_id: ObjectID = self.object_id.unwrap_or_else(|| {
@@ -265,68 +267,177 @@ impl ExportCommand {
             }
         }
 
+        writer.flush()?;
         log::info!("Done in {:?}.", start_time.elapsed(),);
         Ok(())
     }
 
-    /// Field state must be export first, and then object state
-    fn export_genesis<W: std::io::Write>(
+    fn export_indexer(
+        &self,
         moveos_store: &MoveOSStore,
         root_state_root: H256,
-        writer: &mut Writer<W>,
+        writer: &mut ExportWriter,
     ) -> Result<()> {
-        let utxo_store_id = BitcoinUTXOStore::object_id();
-        let inscription_store_id = InscriptionStore::object_id();
-        let rooch_to_bitcoin_address_mapping_id = RoochToBitcoinAddressMapping::object_id();
-        let genesis_object_ids_field_keys = vec![
-            utxo_store_id.clone().field_key(),
-            inscription_store_id.clone().field_key(),
-            rooch_to_bitcoin_address_mapping_id.clone().field_key(),
-        ];
+        // export root_object's top level fields
+        let mut object_ids = vec![ObjectID::root()];
 
-        Self::export_genesis_fields(
-            moveos_store,
-            root_state_root,
-            writer,
-            genesis_object_ids_field_keys,
-        )
+        // export utxo_store, inscription_store's top level fields
+        if let Some(utxo_path) = self.utxo_source_path.clone() {
+            let ord_path = self
+                .ord_source_path
+                .clone()
+                .expect("ord source path must be existed if utxo path is provided");
+            let outpoint_inscriptions_map_path =
+                ord_path.with_extension("outpoint_inscriptions_map");
+            let utxo_store_object_id = BitcoinUTXOStore::object_id();
+            let utxo_store_state_root = get_state_root(
+                moveos_store,
+                root_state_root,
+                utxo_store_object_id.field_key(),
+            );
+            Self::export_utxo_store(
+                utxo_path,
+                ord_path.clone(),
+                outpoint_inscriptions_map_path,
+                utxo_store_state_root,
+                writer,
+            )?;
+            let inscription_store_object_id = InscriptionStore::object_id();
+            let inscription_store_state_root = get_state_root(
+                moveos_store,
+                root_state_root,
+                inscription_store_object_id.field_key(),
+            );
+            Self::export_ord_store(ord_path, inscription_store_state_root, writer)?;
+        } else {
+            object_ids.push(BitcoinUTXOStore::object_id());
+            object_ids.push(InscriptionStore::object_id());
+        }
+
+        self.internal_export_indexer(moveos_store, root_state_root, writer, object_ids)?;
+        Ok(())
     }
 
-    fn export_full_indexer<W: std::io::Write>(
-        moveos_store: &MoveOSStore,
-        root_state_root: H256,
-        writer: &mut Writer<W>,
+    fn export_ord_store(
+        ord_path: PathBuf,
+        obj_state_root: H256,
+        writer: &mut ExportWriter,
     ) -> Result<()> {
-        // export root object, utxo, inscription store object, exclude dynamic filed objects
-        let object_ids = vec![
-            ObjectID::root(),
-            BitcoinUTXOStore::object_id(),
-            InscriptionStore::object_id(),
-        ];
+        let start_time = Instant::now();
 
-        Self::internal_export_indexer(moveos_store, root_state_root, writer, object_ids)?;
-        writer.flush()?;
+        let mut reader = BufReader::with_capacity(8 * 1024 * 1024, File::open(ord_path).unwrap());
+        let mut is_title_line = true;
+
+        let object_id = InscriptionStore::object_id();
+        let object_name = ExportObjectName::from_object_id(object_id.clone()).to_string();
+
+        let mut loop_time = Instant::now();
+        let mut sequence_number = 0;
+        for line in reader.by_ref().lines() {
+            let line = line.unwrap();
+
+            if is_title_line {
+                is_title_line = false;
+                if line.starts_with("# export at") {
+                    // skip block height info
+                    continue;
+                }
+            }
+
+            let source = InscriptionSource::from_str(&line);
+            let (key, state, inscription_id) = source.gen_update();
+            writer.write_record(&key, &state)?;
+
+            let (k2, v2) = gen_inscription_id_update(sequence_number, inscription_id);
+            writer.write_record(&k2, &v2)?;
+
+            sequence_number += 1;
+            if sequence_number % 1_000_000 == 0 {
+                println!(
+                    "exporting top_level_fields of object_id: {:?}({}), exported count: {}. cost: {:?}",
+                    object_id, object_name, sequence_number*2, loop_time.elapsed()
+                );
+                loop_time = Instant::now();
+            }
+        }
+
+        println!(
+            "Done. export_top_level_fields of object_id: {:?}({}), state_root: {:?}, exported count: {}. cost: {:?}",
+            object_id,
+            object_name,
+            obj_state_root,
+            sequence_number*2,
+            start_time.elapsed()
+        );
 
         Ok(())
     }
 
-    fn export_indexer<W: std::io::Write>(
-        moveos_store: &MoveOSStore,
-        root_state_root: H256,
-        writer: &mut Writer<W>,
+    fn export_utxo_store(
+        utxo_path: PathBuf,
+        ord_path: PathBuf,
+        outpoint_inscriptions_map_path: PathBuf,
+        obj_state_root: H256,
+        writer: &mut ExportWriter,
     ) -> Result<()> {
-        // export utxo, inscription store object
-        let object_ids = vec![BitcoinUTXOStore::object_id(), InscriptionStore::object_id()];
+        let start_time = Instant::now();
 
-        Self::internal_export_indexer(moveos_store, root_state_root, writer, object_ids)?;
-        writer.flush()?;
+        let mut reader = BufReader::with_capacity(8 * 1024 * 1024, File::open(utxo_path).unwrap());
+        let mut is_title_line = true;
+        let mut max_height = 0;
+        let mut count: u64 = 0;
+
+        let outpoint_inscriptions_map =
+            OutpointInscriptionsMap::load_or_index(outpoint_inscriptions_map_path, ord_path);
+        let outpoint_inscriptions_map = Some(Arc::new(outpoint_inscriptions_map));
+
+        let object_id = BitcoinUTXOStore::object_id();
+        let object_name = ExportObjectName::from_object_id(object_id.clone()).to_string();
+
+        let mut loop_time = Instant::now();
+        for line in reader.by_ref().lines() {
+            let line = line.unwrap();
+            if is_title_line {
+                is_title_line = false;
+                if line.starts_with("count") {
+                    continue;
+                }
+            }
+
+            let mut utxo_raw = UTXORawData::from_str(&line);
+            let (key, state) = utxo_raw.gen_utxo_update(outpoint_inscriptions_map.clone());
+            writer.write_record(&key, &state)?;
+            if utxo_raw.height > max_height {
+                max_height = utxo_raw.height;
+            }
+
+            count += 1;
+            if count % 1_000_000 == 0 {
+                println!(
+                    "exporting top_level_fields of object_id: {:?}({}), exported count: {}. cost: {:?}",
+                    object_id, object_name, count, loop_time.elapsed()
+                );
+                loop_time = Instant::now();
+            }
+        }
+
+        println!("utxo max_height: {}", max_height);
+        println!(
+            "Done. export_top_level_fields of object_id: {:?}({}), state_root: {:?}, exported count: {}. cost: {:?}",
+            object_id,
+            object_name,
+            obj_state_root,
+            count,
+            start_time.elapsed()
+        );
         Ok(())
     }
 
-    fn internal_export_indexer<W: std::io::Write>(
+    fn internal_export_indexer(
+        &self,
         moveos_store: &MoveOSStore,
         root_state_root: H256,
-        writer: &mut Writer<W>,
+        writer: &mut ExportWriter,
         object_ids: Vec<ObjectID>,
     ) -> Result<()> {
         for obj_id in object_ids.into_iter() {
@@ -340,13 +451,28 @@ impl ExportCommand {
         Ok(())
     }
 
+    fn export_object(
+        moveos_store: &MoveOSStore,
+        root_state_root: H256,
+        object_id: ObjectID,
+        writer: &mut ExportWriter,
+    ) -> Result<()> {
+        let state_root = if object_id == ObjectID::root() {
+            root_state_root
+        } else {
+            get_state_root(moveos_store, root_state_root, object_id.field_key())
+        };
+        Self::export_top_level_fields(moveos_store, state_root, object_id, None, writer)?;
+        Ok(())
+    }
+
     // export top level fields of an object, no recursive export child field
-    fn export_top_level_fields<W: std::io::Write>(
+    fn export_top_level_fields(
         moveos_store: &MoveOSStore,
         obj_state_root: H256,
         object_id: ObjectID,
         object_name: Option<String>, // human-readable object name for debug
-        writer: &mut Writer<W>,
+        writer: &mut ExportWriter,
     ) -> Result<()> {
         let start_time = Instant::now();
 
@@ -363,7 +489,7 @@ impl ExportCommand {
         let mut loop_time = Instant::now();
         for item in iter {
             let (k, v) = item?;
-            writer.write_record([k.to_string().as_str(), v.to_string().as_str()])?;
+            writer.write_record(&k, &v)?;
             count += 1;
             if count % 1_000_000 == 0 {
                 println!(
@@ -384,59 +510,6 @@ impl ExportCommand {
         );
         Ok(())
     }
-
-    fn export_genesis_fields<W: std::io::Write>(
-        moveos_store: &MoveOSStore,
-        root_state_root: H256,
-        writer: &mut Writer<W>,
-        field_keys: Vec<FieldKey>,
-    ) -> Result<()> {
-        let genesis_states = get_object_states(moveos_store, root_state_root, field_keys);
-        // write root state
-        {
-            let root_export_id =
-                ExportID::new(ObjectID::root(), root_state_root, root_state_root, 0);
-            writer.write_record([GLOBAL_STATE_TYPE_ROOT, root_export_id.to_string().as_str()])?;
-        }
-        for (k, v) in genesis_states.into_iter() {
-            writer.write_record([k.to_string().as_str(), v.to_string().as_str()])?;
-        }
-
-        writer.flush()?;
-        Ok(())
-    }
-
-    fn export_object<W: std::io::Write>(
-        moveos_store: &MoveOSStore,
-        root_state_root: H256,
-        object_id: ObjectID,
-        writer: &mut Writer<W>,
-    ) -> Result<()> {
-        let state_root = if object_id == ObjectID::root() {
-            root_state_root
-        } else {
-            get_state_root(moveos_store, root_state_root, object_id.field_key())
-        };
-        Self::export_top_level_fields(moveos_store, state_root, object_id, None, writer)?;
-        writer.flush()?;
-        Ok(())
-    }
-}
-
-fn get_object_states(
-    moveos_store: &MoveOSStore,
-    state_root: H256,
-    object_field_keys: Vec<FieldKey>,
-) -> Vec<StateKV> {
-    let mut kvs: Vec<StateKV> = Vec::with_capacity(object_field_keys.len());
-    for object_field_key in object_field_keys.into_iter() {
-        let state = moveos_store
-            .get_field_at(state_root, &object_field_key)
-            .unwrap()
-            .expect("state must be existed.");
-        kvs.push((object_field_key, state));
-    }
-    kvs
 }
 
 fn get_state_root(

--- a/crates/rooch/src/commands/statedb/commands/genesis_verify.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_verify.rs
@@ -148,12 +148,10 @@ impl OrdCases {
 
 impl GenesisVerifyCommand {
     pub async fn execute(self) -> RoochResult<()> {
-        let (root, moveos_store, start_time) =
-            init_job(self.base_data_dir.clone(), self.chain_id.clone());
+        let (root, moveos_store, _) = init_job(self.base_data_dir.clone(), self.chain_id.clone());
         let outpoint_inscriptions_map = OutpointInscriptionsMap::load_or_index(
             self.outpoint_inscriptions_map_dump_path,
             self.ord_source.clone(),
-            start_time,
         );
         let outpoint_inscriptions_map = Arc::new(outpoint_inscriptions_map);
         let random_mode = self.random_mode;

--- a/crates/rooch/src/commands/statedb/commands/mod.rs
+++ b/crates/rooch/src/commands/statedb/commands/mod.rs
@@ -322,7 +322,8 @@ impl OutpointInscriptionsMap {
         OutpointInscriptionsMap::new(items, true)
     }
 
-    fn load_or_index(path: PathBuf, inscriptions_path: PathBuf, start_time: Instant) -> Self {
+    fn load_or_index(path: PathBuf, inscriptions_path: PathBuf) -> Self {
+        let start_time = Instant::now();
         let map_existed = path.exists();
         if map_existed {
             log::info!("load outpoint_inscriptions_map...");
@@ -390,12 +391,11 @@ where
     None
 }
 
-#[allow(dead_code)]
+// ExportWriter is a helper struct to write FieldKey:ObjectState pairs to a csv file
 struct ExportWriter {
-    writer: Option<Writer<File>>,
+    writer: Option<Writer<File>>, // option here for nop writer
 }
 
-#[allow(dead_code)]
 impl ExportWriter {
     fn new(output: Option<PathBuf>) -> Self {
         let writer = match output {
@@ -413,9 +413,17 @@ impl ExportWriter {
         };
         ExportWriter { writer }
     }
-    fn write(&mut self, k: &FieldKey, v: &ObjectState) -> anyhow::Result<()> {
+    fn write_record(&mut self, k: &FieldKey, v: &ObjectState) -> anyhow::Result<()> {
         if let Some(writer) = &mut self.writer {
             writer.write_record([k.to_string().as_str(), v.to_string().as_str()])?;
+            Ok(())
+        } else {
+            Ok(())
+        }
+    }
+    fn flush(&mut self) -> Result<()> {
+        if let Some(writer) = &mut self.writer {
+            writer.flush()?;
             Ok(())
         } else {
             Ok(())


### PR DESCRIPTION
## Summary

original way is getting FieldKey, ObjectState from Iter generated by Object's StateRoot.

In this PR, generate data from source files directly just like what we've done in statedb/genesis. 

Result:

230G(output for indexer)

+100x faster: 

1. Oringal: 55hours+ (never finished yet, ~600s/1M fields, 180M utxo+ 78M inscription+78M inscription_id)
2. Present:  1757s

Test:

I've checked output written by these way approach, all matched for data set.
