### PR TITLE
[CLI] add a command to rollback state to a specific tx order

### DIFF
--- a/crates/rooch/src/commands/db/commands/mod.rs
+++ b/crates/rooch/src/commands/db/commands/mod.rs
@@ -1,3 +1,5 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
+
 pub mod revert_tx;
+pub mod rollback;

--- a/crates/rooch/src/commands/db/mod.rs
+++ b/crates/rooch/src/commands/db/mod.rs
@@ -1,13 +1,12 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use async_trait::async_trait;
-use clap::Parser;
-
-use rooch_types::error::RoochResult;
-
 use crate::cli_types::CommandAction;
 use crate::commands::db::commands::revert_tx::RevertTxCommand;
+use async_trait::async_trait;
+use clap::Parser;
+use commands::rollback::RollbackCommand;
+use rooch_types::error::RoochResult;
 
 pub mod commands;
 
@@ -25,6 +24,9 @@ impl CommandAction<String> for DB {
             DBCommand::RevertTx(revert_tx) => revert_tx.execute().await.map(|resp| {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
             }),
+            DBCommand::Rollback(rollback) => rollback.execute().await.map(|resp| {
+                serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
+            }),
         }
     }
 }
@@ -33,4 +35,5 @@ impl CommandAction<String> for DB {
 #[clap(name = "db")]
 pub enum DBCommand {
     RevertTx(RevertTxCommand),
+    Rollback(RollbackCommand),
 }

--- a/moveos/moveos-store/src/lib.rs
+++ b/moveos/moveos-store/src/lib.rs
@@ -260,6 +260,11 @@ impl TransactionStore for MoveOSStore {
         self.get_transaction_store()
             .multi_get_tx_execution_infos(tx_hashes)
     }
+
+    fn remove_tx_execution_info(&self, tx_hash: H256) -> Result<()> {
+        self.get_transaction_store()
+            .remove_tx_execution_info(tx_hash)
+    }
 }
 
 impl ConfigStore for MoveOSStore {

--- a/moveos/moveos-store/src/transaction_store/mod.rs
+++ b/moveos/moveos-store/src/transaction_store/mod.rs
@@ -23,6 +23,7 @@ pub trait TransactionStore {
         &self,
         tx_hashes: Vec<H256>,
     ) -> Result<Vec<Option<TransactionExecutionInfo>>>;
+    fn remove_tx_execution_info(&self, tx_hash: H256) -> Result<()>;
 }
 
 impl TransactionStore for TransactionDBStore {
@@ -39,5 +40,9 @@ impl TransactionStore for TransactionDBStore {
         tx_hashes: Vec<H256>,
     ) -> Result<Vec<Option<TransactionExecutionInfo>>> {
         self.multiple_get(tx_hashes)
+    }
+
+    fn remove_tx_execution_info(&self, tx_hash: H256) -> Result<()> {
+        self.remove(tx_hash)
     }
 }


### PR DESCRIPTION
## Summary

Add a command to rollback state to a specific tx order.

If the Bitcoin network reorg > 3 blocks, we need to roll back the L2 txs.