### PR TITLE
workflow(issue): add GitHub issue templates for bugs and proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug.yml
@@ -1,0 +1,47 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+name: Bugs
+description: The rooch command, framework, or anything else
+title: "commands/rpc: issue title"
+labels: [ "bug" ]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve! 🙏 Please answer these questions and provide as much information as possible about your problem.
+
+  - type: input
+    id: rooch-version
+    attributes:
+      label: Rooch version
+      description: |
+        What version of Rooch are you using (`rooch --version`)?
+
+      placeholder: ex. rooch --version rooch 0.6.8 (git commit a3d8e1987562d29673bfa29e1a8b23ddc9ac8967)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-did-you-do
+    attributes:
+      label: "What did you do?"
+      description: "If possible, provide a recipe for reproducing the error. A complete runnable program is good."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: "What did you see happen?"
+      description: Command invocations and their associated output, functions with their arguments and return results, full stacktraces for panics (upload a file if it is very long), etc. Prefer copying text output over using screenshots.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "What did you expect to see?"
+      description: Why is the current output incorrect, and any additional context we may need to understand the issue.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/10-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/10-proposal.yml
@@ -1,0 +1,15 @@
+name: Proposals
+description: New external API or other notable changes
+title: "proposal: commands/rpc: proposal title"
+labels: [ "proposal" ]
+body:
+  - type: markdown
+    attributes:
+      value: "Thanks for helping us improve! 🙏 Please answer these questions and provide as much information as possible about your proposal."
+  - type: textarea
+    id: proposal-details
+    attributes:
+      label: "Proposal Details"
+      description: "Please provide the details of your proposal here."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "Documentation"
+    url: "https://rooch.network/learn/welcome
+    about: "Learn more about Rooch Network"


### PR DESCRIPTION
## Summary

Created new issue templates for "Bugs" and "Proposals" to standardize issue reporting. These templates include guided fields to help users provide detailed and useful information for accurate problem-solving and proposal evaluation. A config file for issue templates was also added.
