### PR TITLE
[gh-2471] add tx build command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9708,6 +9708,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "futures",
+ "hex",
  "jsonrpsee 0.23.2",
  "log",
  "move-core-types",

--- a/crates/rooch-rpc-client/Cargo.toml
+++ b/crates/rooch-rpc-client/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true }
 jsonrpsee = { workspace = true }
 serde_json = { workspace = true }
 log = { workspace = true }
+hex = { workspace = true }
 
 move-core-types = { workspace = true }
 

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Ok, Result};
-use hex::ToHex;
 use jsonrpsee::http_client::HttpClient;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::account::Account;
-use moveos_types::transaction::MoveAction;
 use moveos_types::{access_path::AccessPath, state::ObjectState, transaction::FunctionCall};
 use rooch_rpc_api::api::rooch_api::RoochAPIClient;
 use rooch_rpc_api::jsonrpc_types::{
@@ -15,8 +13,7 @@ use rooch_rpc_api::jsonrpc_types::{
 };
 use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, EventOptions, EventPageView,
-    FieldKeyView, ObjectIDView, RoochAddressView, StateOptions, StatePageView, StrView,
-    StructTagView,
+    FieldKeyView, ObjectIDView, RoochAddressView, StateOptions, StatePageView, StructTagView,
 };
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, ObjectStateView};
 use rooch_rpc_api::jsonrpc_types::{

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Ok, Result};
+use hex::ToHex;
 use jsonrpsee::http_client::HttpClient;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::account::Account;
+use moveos_types::transaction::MoveAction;
 use moveos_types::{access_path::AccessPath, state::ObjectState, transaction::FunctionCall};
 use rooch_rpc_api::api::rooch_api::RoochAPIClient;
 use rooch_rpc_api::jsonrpc_types::{
@@ -13,7 +15,8 @@ use rooch_rpc_api::jsonrpc_types::{
 };
 use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, EventOptions, EventPageView,
-    FieldKeyView, ObjectIDView, RoochAddressView, StateOptions, StatePageView, StructTagView,
+    FieldKeyView, ObjectIDView, RoochAddressView, StateOptions, StatePageView, StrView,
+    StructTagView,
 };
 use rooch_rpc_api::jsonrpc_types::{ExecuteTransactionResponseView, ObjectStateView};
 use rooch_rpc_api::jsonrpc_types::{

--- a/crates/rooch/src/commands/transaction/commands/build.rs
+++ b/crates/rooch/src/commands/transaction/commands/build.rs
@@ -1,0 +1,59 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::{CommandAction, TransactionOptions, WalletContextOptions};
+use async_trait::async_trait;
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use moveos_types::{move_types::FunctionId, transaction::MoveAction};
+use rooch_framework::MOVEOS_STD_ADDRESS;
+use rooch_rpc_api::jsonrpc_types::TransactionWithInfoPageView;
+use rooch_rpc_client::wallet_context;
+use rooch_types::{error::RoochResult, transaction::RoochTransactionData};
+
+/// Get transactions by order
+#[derive(Debug, clap::Parser)]
+pub struct BuildCommand {
+    /// Transaction's hash
+    #[clap(long)]
+    pub cursor: Option<u64>,
+
+    #[clap(long)]
+    pub limit: Option<u64>,
+
+    /// descending order
+    #[clap(short = 'd', long)]
+    descending_order: Option<bool>,
+
+    #[clap(flatten)]
+    tx_options: TransactionOptions,
+
+    #[clap(flatten)]
+    context: WalletContextOptions,
+}
+
+#[async_trait]
+impl CommandAction<RoochTransactionData> for BuildCommand {
+    async fn execute(self) -> RoochResult<RoochTransactionData> {
+        let context = self.context.build()?;
+        let sender = context.resolve_address(self.tx_options.sender)?.into();
+        let max_gas_amount = self.tx_options.max_gas_amount;
+
+        // TODO: actions for building a tx data
+        let mut bundles: Vec<Vec<u8>> = vec![];
+        let args = bcs::to_bytes(&bundles).unwrap();
+        let action = MoveAction::new_function_call(
+            FunctionId::new(
+                ModuleId::new(
+                    MOVEOS_STD_ADDRESS,
+                    Identifier::new("module_store".to_owned()).unwrap(),
+                ),
+                Identifier::new("publish_modules_entry".to_owned()).unwrap(),
+            ),
+            vec![],
+            vec![args],
+        );
+
+        let tx_data = context.build_tx_data(sender, action, max_gas_amount);
+        Ok(tx_data)
+    }
+}

--- a/crates/rooch/src/commands/transaction/commands/build.rs
+++ b/crates/rooch/src/commands/transaction/commands/build.rs
@@ -10,7 +10,7 @@ use move_command_line_common::types::ParsedStructType;
 use move_core_types::language_storage::TypeTag;
 use moveos_types::transaction::MoveAction;
 use rooch_types::{
-    error::{RoochError, RoochResult},
+    error::RoochResult,
     function_arg::{parse_function_arg, FunctionArg, ParsedFunctionId},
 };
 

--- a/crates/rooch/src/commands/transaction/commands/build.rs
+++ b/crates/rooch/src/commands/transaction/commands/build.rs
@@ -50,9 +50,9 @@ pub struct BuildCommand {
     #[clap(long, default_value = "false")]
     output: bool,
 
-    /// File location for the file being written
+    /// File destination for the file being written
     #[clap(long)]
-    file_location: Option<String>,
+    file_destination: Option<String>,
 
     /// Return command outputs in json format
     #[clap(long, default_value = "false")]
@@ -100,18 +100,16 @@ impl CommandAction<Option<String>> for BuildCommand {
 
                 Ok(None)
             }
-        } else {
-            if let Some(file_location) = self.file_location {
-                let mut file = File::create(file_location)?;
-                file.write_all(&tx_data.encode())?;
-                println!("Write encoded tx data succeeded in the designated location");
+        } else if let Some(file_destination) = self.file_destination {
+            let mut file = File::create(file_destination)?;
+            file.write_all(&tx_data.encode())?;
+            println!("Write encoded tx data succeeded in the destination");
 
-                Ok(None)
-            } else {
-                return Err(RoochError::CommandArgumentError(format!(
-                    "Argument --file-location is not provided",
-                )));
-            }
+            Ok(None)
+        } else {
+            return Err(RoochError::CommandArgumentError(
+                "Argument --file-destination is not provided".to_owned(),
+            ));
         }
     }
 }

--- a/crates/rooch/src/commands/transaction/commands/mod.rs
+++ b/crates/rooch/src/commands/transaction/commands/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod build;
 pub mod get_transactions_by_hash;
 pub mod get_transactions_by_order;

--- a/crates/rooch/src/commands/transaction/mod.rs
+++ b/crates/rooch/src/commands/transaction/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::cli_types::CommandAction;
 use crate::commands::transaction::commands::{
-    get_transactions_by_hash::GetTransactionsByHashCommand,
+    build::BuildCommand, get_transactions_by_hash::GetTransactionsByHashCommand,
     get_transactions_by_order::GetTransactionsByOrderCommand,
 };
 use async_trait::async_trait;
@@ -25,12 +25,14 @@ impl CommandAction<String> for Transaction {
         match self.cmd {
             TransactionCommand::GetTransactionsByOrder(cmd) => cmd.execute_serialized().await,
             TransactionCommand::GetTransactionsByHash(cmd) => cmd.execute_serialized().await,
+            TransactionCommand::Build(cmd) => cmd.execute_serialized().await,
         }
     }
 }
 
 #[derive(Subcommand)]
 pub enum TransactionCommand {
+    Build(BuildCommand),
     GetTransactionsByOrder(GetTransactionsByOrderCommand),
     GetTransactionsByHash(GetTransactionsByHashCommand),
 }

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -67,7 +67,7 @@ Feature: Rooch CLI integration tests
       # transaction
       Then cmd: "transaction get-transactions-by-order --cursor 0 --limit 1 --descending-order false"
       Then cmd: "transaction get-transactions-by-hash --hashes {{$.transaction[-1].data[0].execution_info.tx_hash}}"
-      Then cmd: "transaction build --module-address 0000000000000000000000000000000000000000000000000000000000000003 --module-name empty --function-name empty --json --output"
+      Then cmd: "transaction build --function rooch_framework::empty::empty --json --output"
 
       # alias tx for transaction
       Then cmd: "tx get-transactions-by-order --cursor 1 --limit 2 --descending-order true"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -67,7 +67,7 @@ Feature: Rooch CLI integration tests
       # transaction
       Then cmd: "transaction get-transactions-by-order --cursor 0 --limit 1 --descending-order false"
       Then cmd: "transaction get-transactions-by-hash --hashes {{$.transaction[-1].data[0].execution_info.tx_hash}}"
-      Then cmd: "transaction build --module-address 0000000000000000000000000000000000000000000000000000000000000003 --module-name empty --function-name empty --json"
+      Then cmd: "transaction build --module-address 0000000000000000000000000000000000000000000000000000000000000003 --module-name empty --function-name empty --json --output"
 
       # alias tx for transaction
       Then cmd: "tx get-transactions-by-order --cursor 1 --limit 2 --descending-order true"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -67,7 +67,7 @@ Feature: Rooch CLI integration tests
       # transaction
       Then cmd: "transaction get-transactions-by-order --cursor 0 --limit 1 --descending-order false"
       Then cmd: "transaction get-transactions-by-hash --hashes {{$.transaction[-1].data[0].execution_info.tx_hash}}"
-      Then cmd: "transaction build --function rooch_framework::empty::empty --json --output"
+      Then cmd: "transaction build --function rooch_framework::empty::empty --json"
 
       # alias tx for transaction
       Then cmd: "tx get-transactions-by-order --cursor 1 --limit 2 --descending-order true"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -67,6 +67,7 @@ Feature: Rooch CLI integration tests
       # transaction
       Then cmd: "transaction get-transactions-by-order --cursor 0 --limit 1 --descending-order false"
       Then cmd: "transaction get-transactions-by-hash --hashes {{$.transaction[-1].data[0].execution_info.tx_hash}}"
+      Then cmd: "transaction build --module-address 0000000000000000000000000000000000000000000000000000000000000003 --module-name empty --function-name empty --json"
 
       # alias tx for transaction
       Then cmd: "tx get-transactions-by-order --cursor 1 --limit 2 --descending-order true"


### PR DESCRIPTION
## Summary

Add `build` subcommand for `rooch tx` and `rooch transaction`.

Example output (if writing to a file):

```zsh
rooch transaction build --function rooch_framework::empty::empty --json --file-location ~/text.txt
Write encoded tx data succeeded in the designated location

cat ~/text.txt                                                                                    
??U?J?LԌj?&?F?^m????3???VW??emptyempty% 
```

Example output (if outputting a hex):

```zsh
rooch transaction build --function rooch_framework::empty::empty --json --output
"0ea3bb55c14aec8e074cd48c6a850526aa46965e176df53fadb433adeeeb56570000000000000000040000000000000000e1f5050000000001000000000000000000000000000000000000000000000000000000000000000305656d70747905656d7074790000"
```

- Closes #2471 