### PR TITLE
[moveos_std] Improve the event queue, trigger OffChainEvent sametime

### DIFF
--- a/frameworks/moveos-stdlib/doc/event_queue.md
+++ b/frameworks/moveos-stdlib/doc/event_queue.md
@@ -7,6 +7,7 @@
 
 -  [Resource `EventQueue`](#0x2_event_queue_EventQueue)
 -  [Struct `OnChainEvent`](#0x2_event_queue_OnChainEvent)
+-  [Struct `OffChainEvent`](#0x2_event_queue_OffChainEvent)
 -  [Resource `Subscriber`](#0x2_event_queue_Subscriber)
 -  [Constants](#@Constants_0)
 -  [Function `emit`](#0x2_event_queue_emit)
@@ -18,6 +19,7 @@
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="timestamp.md#0x2_timestamp">0x2::timestamp</a>;
 </code></pre>
@@ -42,6 +44,19 @@
 
 
 <pre><code><b>struct</b> <a href="event_queue.md#0x2_event_queue_OnChainEvent">OnChainEvent</a>&lt;E&gt; <b>has</b> drop, store
+</code></pre>
+
+
+
+<a name="0x2_event_queue_OffChainEvent"></a>
+
+## Struct `OffChainEvent`
+
+The off-chain event
+Every on-chain event also trigger an off-chain event
+
+
+<pre><code><b>struct</b> <a href="event_queue.md#0x2_event_queue_OffChainEvent">OffChainEvent</a>&lt;E&gt; <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -76,6 +91,15 @@
 
 
 <pre><code><b>const</b> <a href="event_queue.md#0x2_event_queue_ErrorEventNotFound">ErrorEventNotFound</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_event_queue_ErrorEventQueueNotFound"></a>
+
+
+
+<pre><code><b>const</b> <a href="event_queue.md#0x2_event_queue_ErrorEventQueueNotFound">ErrorEventQueueNotFound</a>: u64 = 5;
 </code></pre>
 
 


### PR DESCRIPTION
## Summary

follow #2476 

1. Only create the event queue when the first subscriber subscribes to it to reduce the number of EventQueue objects.
2. Trigger an OffChainEvent when OnChainEvent emits; the developer can merge OnChain and OffChain events.

Leave a break change to #2402 