### PR TITLE
new framework upgrade function and `UpgradeCap`

### DIFF
--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -286,11 +286,14 @@ impl RoochGenesis {
     }
 
     /// Load the genesis from binary, if not exist, build the genesis, only support the builtin chain id
-    pub fn load(chain_id: BuiltinChainID) -> Result<Self> {
+    pub fn load(chain_id: BuiltinChainID, network: Option<RoochNetwork>) -> Result<Self> {
         let genesis = load_genesis_from_binary(chain_id)?;
         match genesis {
             Some(genesis) => Ok(genesis),
-            None => Self::build(RoochNetwork::builtin(chain_id)),
+            None => {
+                let network = network.unwrap_or(RoochNetwork::builtin(chain_id));
+                Self::build(network)
+            }
         }
     }
 
@@ -325,7 +328,7 @@ impl RoochGenesis {
             Some(genesis_info_from_store) => {
                 //if the chain_id is builtin, we should check the genesis version between the store and the binary
                 if let Some(builtin_id) = network.chain_id.to_builtin() {
-                    let genesis_from_binary = Self::load(builtin_id)?;
+                    let genesis_from_binary = Self::load(builtin_id, Some(network.clone()))?;
                     let genesis_info_from_binary = genesis_from_binary.genesis_info();
                     if genesis_info_from_store.root != genesis_info_from_binary.root {
                         return Err(GenesisError::GenesisVersionMismatch {
@@ -340,7 +343,7 @@ impl RoochGenesis {
             None => {
                 //if the chain_id is builtin, we should load the released genesis from binary
                 let genesis = if let Some(builtin_id) = network.chain_id.to_builtin() {
-                    Self::load(builtin_id)?
+                    Self::load(builtin_id, Some(network))?
                 } else {
                     Self::build(network)?
                 };
@@ -610,22 +613,22 @@ mod tests {
         let _ = tracing_subscriber::fmt::try_init();
         {
             let network = BuiltinChainID::Local.into();
-            let genesis = RoochGenesis::load(BuiltinChainID::Local).unwrap();
+            let genesis = RoochGenesis::load(BuiltinChainID::Local, None).unwrap();
             genesis_init_test_case(network, genesis);
         }
         {
             let network = BuiltinChainID::Dev.into();
-            let genesis = RoochGenesis::load(BuiltinChainID::Dev).unwrap();
+            let genesis = RoochGenesis::load(BuiltinChainID::Dev, None).unwrap();
             genesis_init_test_case(network, genesis);
         }
         {
             let network = BuiltinChainID::Test.into();
-            let genesis = RoochGenesis::load(BuiltinChainID::Test).unwrap();
+            let genesis = RoochGenesis::load(BuiltinChainID::Test, None).unwrap();
             genesis_init_test_case(network, genesis);
         }
         {
             let network = BuiltinChainID::Main.into();
-            let genesis = RoochGenesis::load(BuiltinChainID::Main).unwrap();
+            let genesis = RoochGenesis::load(BuiltinChainID::Main, None).unwrap();
             genesis_init_test_case(network, genesis);
         }
     }

--- a/frameworks/rooch-framework/doc/genesis.md
+++ b/frameworks/rooch-framework/doc/genesis.md
@@ -23,6 +23,7 @@
 <b>use</b> <a href="gas_coin.md#0x3_gas_coin">0x3::gas_coin</a>;
 <b>use</b> <a href="onchain_config.md#0x3_onchain_config">0x3::onchain_config</a>;
 <b>use</b> <a href="transaction_fee.md#0x3_transaction_fee">0x3::transaction_fee</a>;
+<b>use</b> <a href="upgrade.md#0x3_upgrade">0x3::upgrade</a>;
 </code></pre>
 
 

--- a/frameworks/rooch-framework/doc/upgrade.md
+++ b/frameworks/rooch-framework/doc/upgrade.md
@@ -5,18 +5,64 @@
 
 
 
+-  [Struct `StdlibPackage`](#0x3_upgrade_StdlibPackage)
+-  [Struct `Stdlib`](#0x3_upgrade_Stdlib)
+-  [Resource `UpgradeCap`](#0x3_upgrade_UpgradeCap)
 -  [Struct `FrameworkUpgradeEvent`](#0x3_upgrade_FrameworkUpgradeEvent)
 -  [Constants](#@Constants_0)
+-  [Function `genesis_init`](#0x3_upgrade_genesis_init)
+-  [Function `new_upgrade_cap_for_upgrade`](#0x3_upgrade_new_upgrade_cap_for_upgrade)
 -  [Function `upgrade_entry`](#0x3_upgrade_upgrade_entry)
+-  [Function `upgrade_v2_entry`](#0x3_upgrade_upgrade_v2_entry)
 -  [Function `upgrade_gas_schedule`](#0x3_upgrade_upgrade_gas_schedule)
 
 
-<pre><code><b>use</b> <a href="">0x2::account</a>;
+<pre><code><b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="">0x2::account</a>;
+<b>use</b> <a href="">0x2::bcs</a>;
 <b>use</b> <a href="">0x2::event</a>;
 <b>use</b> <a href="">0x2::gas_schedule</a>;
 <b>use</b> <a href="">0x2::module_store</a>;
+<b>use</b> <a href="">0x2::object</a>;
 <b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="onchain_config.md#0x3_onchain_config">0x3::onchain_config</a>;
+</code></pre>
+
+
+
+<a name="0x3_upgrade_StdlibPackage"></a>
+
+## Struct `StdlibPackage`
+
+
+
+<pre><code>#[data_struct]
+<b>struct</b> <a href="upgrade.md#0x3_upgrade_StdlibPackage">StdlibPackage</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<a name="0x3_upgrade_Stdlib"></a>
+
+## Struct `Stdlib`
+
+Collection of framework packages. The struct must keep the same with the Rust definition.
+
+
+<pre><code>#[data_struct]
+<b>struct</b> <a href="upgrade.md#0x3_upgrade_Stdlib">Stdlib</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<a name="0x3_upgrade_UpgradeCap"></a>
+
+## Resource `UpgradeCap`
+
+Upgrade capability
+
+
+<pre><code><b>struct</b> <a href="upgrade.md#0x3_upgrade_UpgradeCap">UpgradeCap</a> <b>has</b> store, key
 </code></pre>
 
 
@@ -56,6 +102,24 @@ Event for framework upgrades
 
 
 
+<a name="0x3_upgrade_ErrorCapabilityAlreadyExists"></a>
+
+
+
+<pre><code><b>const</b> <a href="upgrade.md#0x3_upgrade_ErrorCapabilityAlreadyExists">ErrorCapabilityAlreadyExists</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x3_upgrade_ErrorNoAccess"></a>
+
+
+
+<pre><code><b>const</b> <a href="upgrade.md#0x3_upgrade_ErrorNoAccess">ErrorNoAccess</a>: u64 = 3;
+</code></pre>
+
+
+
 <a name="0x3_upgrade_MoveStdAccount"></a>
 
 
@@ -83,6 +147,31 @@ Event for framework upgrades
 
 
 
+<a name="0x3_upgrade_genesis_init"></a>
+
+## Function `genesis_init`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="upgrade.md#0x3_upgrade_genesis_init">genesis_init</a>(sequencer: <b>address</b>)
+</code></pre>
+
+
+
+<a name="0x3_upgrade_new_upgrade_cap_for_upgrade"></a>
+
+## Function `new_upgrade_cap_for_upgrade`
+
+Aqcuires the upgrade capability for the sequencer.
+Only used for framework upgrading.
+TODO: remove this function when reset genesis.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="upgrade.md#0x3_upgrade_new_upgrade_cap_for_upgrade">new_upgrade_cap_for_upgrade</a>(sequencer: &<a href="">signer</a>)
+</code></pre>
+
+
+
 <a name="0x3_upgrade_upgrade_entry"></a>
 
 ## Function `upgrade_entry`
@@ -90,6 +179,19 @@ Event for framework upgrades
 
 
 <pre><code>entry <b>fun</b> <a href="upgrade.md#0x3_upgrade_upgrade_entry">upgrade_entry</a>(<a href="">account</a>: &<a href="">signer</a>, move_std_bundles: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, moveos_std_bundles: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, rooch_framework_bundles: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, bitcoin_move_bundles: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;)
+</code></pre>
+
+
+
+<a name="0x3_upgrade_upgrade_v2_entry"></a>
+
+## Function `upgrade_v2_entry`
+
+Upgrade the framework package
+<code>package_bytes</code> is the serialized <code><a href="upgrade.md#0x3_upgrade_StdlibPackage">StdlibPackage</a></code>
+
+
+<pre><code>entry <b>fun</b> <a href="upgrade.md#0x3_upgrade_upgrade_v2_entry">upgrade_v2_entry</a>(<a href="">account</a>: &<a href="">signer</a>, package_bytes: <a href="">vector</a>&lt;u8&gt;)
 </code></pre>
 
 

--- a/frameworks/rooch-framework/sources/genesis.move
+++ b/frameworks/rooch-framework/sources/genesis.move
@@ -16,6 +16,7 @@ module rooch_framework::genesis {
     use rooch_framework::address_mapping;
     use rooch_framework::onchain_config;
     use rooch_framework::bitcoin_address::{Self, BitcoinAddress};
+    use rooch_framework::upgrade;
 
 
     const ErrorGenesisInit: u64 = 1;
@@ -42,6 +43,7 @@ module rooch_framework::genesis {
         address_mapping::genesis_init(genesis_account);
         let sequencer_addr = bitcoin_address::to_rooch_address(&genesis_context.sequencer);
         onchain_config::genesis_init(genesis_account, sequencer_addr);
+        upgrade::genesis_init(sequencer_addr);
 
         // Some test cases use framework account as sequencer, it may already exist
         if(!moveos_std::account::exists_at(sequencer_addr)){

--- a/frameworks/rooch-framework/sources/upgrade.move
+++ b/frameworks/rooch-framework/sources/upgrade.move
@@ -2,28 +2,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module rooch_framework::upgrade {
+    use std::vector;
 
     use moveos_std::gas_schedule::update_gas_schedule;
     use moveos_std::signer::module_signer;
     use moveos_std::signer;
     use moveos_std::event;
-    
+    use moveos_std::bcs;
     use moveos_std::account::create_signer_for_system;
     use moveos_std::module_store;
+    use moveos_std::object;
     use rooch_framework::onchain_config;
 
+    friend rooch_framework::genesis;
+
     const ErrorNotSequencer: u64 = 1;
+    const ErrorCapabilityAlreadyExists: u64 = 2;
+    const ErrorNoAccess: u64 = 3;
 
     const MoveStdAccount: address = @0x1;
     const MoveosStdAccount: address = @0x2;
     const RoochFrameworkAccount: address = @rooch_framework;
     const BitcoinMoveAccount: address = @0x4;
 
+    #[data_struct]
+    struct StdlibPackage has store, copy, drop {
+        package_name: std::string::String,
+        genesis_account: address,
+        modules: vector<vector<u8>>,
+    }
+
+    #[data_struct]
+    /// Collection of framework packages. The struct must keep the same with the Rust definition.
+    struct Stdlib has store, copy, drop {
+        packages: vector<StdlibPackage>,
+    }
+
+    /// Upgrade capability
+    struct UpgradeCap has key, store {}
+
     /// Event for framework upgrades
     struct FrameworkUpgradeEvent has drop, store, copy {
         version: u64,
     }
 
+    public(friend) fun genesis_init(sequencer: address){
+        let cap_obj = object::new_named_object(UpgradeCap{});
+        object::transfer(cap_obj, sequencer);
+    }
+
+    /// Aqcuires the upgrade capability for the sequencer.
+    /// Only used for framework upgrading.
+    /// TODO: remove this function when reset genesis.
+    public fun new_upgrade_cap_for_upgrade(sequencer: &signer) {
+        let sender_address = signer::address_of(sequencer);
+        assert!(sender_address == onchain_config::sequencer(), ErrorNotSequencer);
+        let id = object::named_object_id<UpgradeCap>();
+        assert!(!object::exists_object(id), ErrorCapabilityAlreadyExists);
+        genesis_init(sender_address);
+    }
+
+    fun has_upgrade_access(account: address): bool {
+        let id = object::named_object_id<UpgradeCap>();
+        if (!object::exists_object(id)) {
+            return false
+        };
+        let cap = object::borrow_object<UpgradeCap>(id);
+        object::owner(cap) == account
+    }
+
+    // Deprecated upgrade function. 
+    // TODO: remove this function when reset genesis, and rename the following function to `upgrade_v2_entry` to `upgrade_entry`.
     entry fun upgrade_entry(account: &signer, 
         move_std_bundles: vector<vector<u8>>,
         moveos_std_bundles: vector<vector<u8>>,
@@ -45,6 +94,32 @@ module rooch_framework::upgrade {
 
         let bitcoin_move_signer = create_signer_for_system(&system, BitcoinMoveAccount);
         module_store::publish_modules_entry(&bitcoin_move_signer, bitcoin_move_bundles);
+
+        onchain_config::update_framework_version();
+        event::emit<FrameworkUpgradeEvent>(FrameworkUpgradeEvent { version: onchain_config::framework_version() });
+    }
+
+    /// Upgrade the framework package
+    /// `package_bytes` is the serialized `StdlibPackage`
+    entry fun upgrade_v2_entry(account: &signer, package_bytes: vector<u8>) {
+        let sender_address = signer::address_of(account);
+        assert!(has_upgrade_access(sender_address), ErrorNoAccess);
+        let system = module_signer<FrameworkUpgradeEvent>();
+
+        let stdlib = bcs::from_bytes<Stdlib>(package_bytes);
+        let len = vector::length(&stdlib.packages);
+        while (len > 0) {
+            let package = vector::pop_back(&mut stdlib.packages);
+            if (package.genesis_account == MoveStdAccount || 
+                package.genesis_account == MoveosStdAccount ||
+                package.genesis_account == RoochFrameworkAccount ||
+                package.genesis_account == BitcoinMoveAccount) 
+            {
+                let package_signer = create_signer_for_system(&system, package.genesis_account);
+                module_store::publish_modules_entry(&package_signer, package.modules);
+            };
+            len = len - 1;
+        };
 
         onchain_config::update_framework_version();
         event::emit<FrameworkUpgradeEvent>(FrameworkUpgradeEvent { version: onchain_config::framework_version() });


### PR DESCRIPTION

## Summary

1. resolve #2493 
2. Add `upgrade_v2_entry` function, which has `vector<u8>` argument used to deserialize to stdlib packages.
3. Add `UpgradeCap`. Owner who has `UpgradeCap` object can upgrade the framework. part of #2463 

- Closes #2493 