### PR TITLE
[bitcoin] Improve the block 790964 testcase

### DIFF
--- a/crates/rooch-benchmarks/src/tx_exec.rs
+++ b/crates/rooch-benchmarks/src/tx_exec.rs
@@ -117,8 +117,12 @@ pub fn tx_exec_benchmark(c: &mut Criterion) {
                         .execute_l1_block(l1_block_with_body.clone())
                         .unwrap();
                 }
-                LedgerTxData::L1Tx(tx) => binding_test.execute_l1_tx(tx).unwrap(),
-                LedgerTxData::L2Tx(tx) => binding_test.execute(tx).unwrap(),
+                LedgerTxData::L1Tx(tx) => {
+                    binding_test.execute_l1_tx(tx).unwrap();
+                }
+                LedgerTxData::L2Tx(tx) => {
+                    binding_test.execute(tx).unwrap();
+                }
             }
         });
     });

--- a/crates/rooch-framework-tests/README.md
+++ b/crates/rooch-framework-tests/README.md
@@ -4,5 +4,5 @@
 ## How to build a bitcoin block tester genesis?
 
 ```bash
-cargo run -p rooch-framework-tests --  --btc-rpc-url http://localhost:9332 --btc-rpc-username your_username --btc-rpc-password your_pwd --block-hash 000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506
+cargo run -p rooch-framework-tests --  --btc-rpc-url http://localhost:9332 --btc-rpc-username your_username --btc-rpc-password your_pwd --blocks 790964 --blocks 855396
 ```

--- a/crates/rooch-framework-tests/src/binding_test.rs
+++ b/crates/rooch-framework-tests/src/binding_test.rs
@@ -140,7 +140,7 @@ impl RustBindingTest {
     }
 
     //TODO let the module bundle to execute the function
-    pub fn execute(&mut self, tx: RoochTransaction) -> Result<()> {
+    pub fn execute(&mut self, tx: RoochTransaction) -> Result<ExecuteTransactionResult> {
         let execute_result = self.execute_as_result(tx)?;
         if execute_result.transaction_info.status != KeptVMStatus::Executed {
             bail!(
@@ -148,7 +148,7 @@ impl RustBindingTest {
                 execute_result.transaction_info.status
             );
         }
-        Ok(())
+        Ok(execute_result)
     }
 
     pub fn execute_l1_block_and_tx(&mut self, l1_block: L1BlockWithBody) -> Result<()> {

--- a/crates/rooch-framework-tests/src/binding_test.rs
+++ b/crates/rooch-framework-tests/src/binding_test.rs
@@ -33,6 +33,7 @@ use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
+use tracing::info;
 
 pub fn get_data_dir() -> DataDirPath {
     match env::var("ROOCH_TEST_DATA_DIR") {
@@ -152,9 +153,17 @@ impl RustBindingTest {
 
     pub fn execute_l1_block_and_tx(&mut self, l1_block: L1BlockWithBody) -> Result<()> {
         let l1_txs = self.execute_l1_block(l1_block.clone())?;
+        let tx_len = l1_txs.len();
+        let mut total_gas_used = 0;
         for l1_tx in l1_txs {
-            self.execute_l1_tx(l1_tx)?;
+            let resut = self.execute_l1_tx(l1_tx)?;
+            total_gas_used += resut.output.gas_used;
         }
+        let avg_gas_used = total_gas_used / tx_len as u64;
+        info!(
+            "execute l1 block total gas used: {}, avg gas used: {}",
+            total_gas_used, avg_gas_used
+        );
         Ok(())
     }
 
@@ -186,7 +195,7 @@ impl RustBindingTest {
         }
     }
 
-    pub fn execute_l1_tx(&mut self, l1_tx: L1Transaction) -> Result<()> {
+    pub fn execute_l1_tx(&mut self, l1_tx: L1Transaction) -> Result<ExecuteTransactionResult> {
         let verified_tx = self.executor.validate_l1_tx(l1_tx)?;
         self.execute_verified_tx(verified_tx)
     }
@@ -196,7 +205,10 @@ impl RustBindingTest {
         self.execute_verified_tx_as_result(verified_tx)
     }
 
-    pub fn execute_verified_tx(&mut self, tx: VerifiedMoveOSTransaction) -> Result<()> {
+    pub fn execute_verified_tx(
+        &mut self,
+        tx: VerifiedMoveOSTransaction,
+    ) -> Result<ExecuteTransactionResult> {
         let execute_result = self.execute_verified_tx_as_result(tx)?;
         if execute_result.transaction_info.status != KeptVMStatus::Executed {
             bail!(
@@ -204,7 +216,7 @@ impl RustBindingTest {
                 execute_result.transaction_info.status
             );
         }
-        Ok(())
+        Ok(execute_result)
     }
 
     pub fn execute_verified_tx_as_result(

--- a/crates/rooch-framework-tests/src/bitcoin_block_tester.rs
+++ b/crates/rooch-framework-tests/src/bitcoin_block_tester.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::binding_test::RustBindingTest;
-use anyhow::{anyhow, ensure, Result};
-use bitcoin::{hashes::Hash, Block, BlockHash, Txid};
+use anyhow::{anyhow, bail, ensure, Result};
+use bitcoin::{hashes::Hash, Block, TxOut, Txid, OutPoint};
 use framework_builder::stdlib_version::StdlibVersion;
 use moveos_types::{
     moveos_std::{
@@ -17,7 +17,7 @@ use rooch_relayer::actor::bitcoin_client_proxy::BitcoinClientProxy;
 use rooch_types::{
     bitcoin::{
         ord::InscriptionID,
-        utxo::{BitcoinUTXOStore, UTXO},
+        utxo::{self, BitcoinUTXOStore, UTXO},
     },
     genesis_config,
     into_address::IntoAddress,
@@ -37,6 +37,7 @@ use tracing::{debug, info};
 pub struct BitcoinBlockTester {
     genesis: BitcoinTesterGenesis,
     binding_test: RustBindingTest,
+    executed_block: Option<Block>,
 }
 
 impl BitcoinBlockTester {
@@ -49,19 +50,61 @@ impl BitcoinBlockTester {
         Ok(Self {
             genesis,
             binding_test,
+            executed_block: None,
         })
     }
 
+    /// Execute one block from genesis blocks
     pub fn execute(&mut self) -> Result<()> {
-        for (height, block) in &self.genesis.blocks {
-            let l1_block = L1BlockWithBody::new_bitcoin_block(*height as u64, block.clone());
-            self.binding_test.execute_l1_block_and_tx(l1_block)?;
+        if self.genesis.blocks.is_empty() {
+            bail!("No block to execute");
         }
+        let (height, block) = self.genesis.blocks.remove(0);
+        info!("Execute block: {}", height);
+        let l1_block = L1BlockWithBody::new_bitcoin_block(height as u64, block.clone());
+        self.binding_test.execute_l1_block_and_tx(l1_block)?;
+        self.executed_block = Some(block);
         Ok(())
     }
 
     pub fn verify_utxo(&self) -> Result<()> {
-        //TODO verify utxo in state with block output
+        ensure!(
+            self.executed_block.is_some(),
+            "No block executed, please execute block first"
+        );
+        let mut utxo_set = HashMap::<OutPoint, TxOut>::new();
+        let block = self.executed_block.as_ref().unwrap();
+        for tx in block.txdata.as_slice() {
+            let txid = tx.txid();
+            for (index, tx_out) in tx.output.iter().enumerate() {
+                let vout = index as u32;
+                let out_point = OutPoint::new(txid, vout);
+                utxo_set.insert(out_point, tx_out.clone());
+            }
+            //remove spent utxo
+            for tx_in in tx.input.iter() {
+                utxo_set.remove(&tx_in.previous_output);
+            }
+        }
+
+        for (outpoint, tx_out) in utxo_set.into_iter() {
+            let utxo_object_id = utxo::derive_utxo_id(&outpoint.into());
+            let utxo_obj = self.binding_test.get_object(&utxo_object_id)?;
+            ensure!(
+                utxo_obj.is_some(),
+                "Missing utxo object: {}, {}",
+                utxo_object_id,
+                outpoint
+            );
+            let utxo_obj = utxo_obj.unwrap();
+            let utxo_state = utxo_obj.value_as::<UTXO>()?;
+            ensure!(
+                utxo_state.value == tx_out.value.to_sat(),
+                "UTXO not match: {:?}, {:?}",
+                utxo_state,
+                tx_out
+            );
+        }
         Ok(())
     }
 
@@ -119,13 +162,14 @@ impl TesterGenesisBuilder {
         })
     }
 
-    pub async fn add_block(mut self, block_hash: BlockHash) -> Result<Self> {
+    pub async fn add_block(mut self, block_height: u64) -> Result<Self> {
+        let block_hash = self.bitcoin_client.get_block_hash(block_height).await?;
         let block = self.bitcoin_client.get_block(block_hash).await?;
         let block_header_result = self
             .bitcoin_client
             .get_block_header_info(block_hash)
             .await?;
-        debug!("Add block: {:?}", block_header_result);
+        info!("Add block: {:?}", block_header_result);
         if !self.blocks.is_empty() {
             let last_block = self.blocks.last().unwrap();
             ensure!(
@@ -159,7 +203,7 @@ impl TesterGenesisBuilder {
             if self.block_txids.contains(&txid) {
                 continue;
             }
-            debug!("Get tx: {:?}", txid);
+            info!("Get tx: {:?}", txid);
             let tx = self.bitcoin_client.get_raw_transaction(txid).await?;
             depdent_txs.insert(txid, tx);
         }
@@ -193,7 +237,7 @@ impl TesterGenesisBuilder {
                     SimpleMultiMap::create(),
                 );
                 let object_id = utxo.object_id();
-                debug!("Add utxo: {}, {:?}", object_id, utxo);
+                info!("Add utxo: {}, {:?}", object_id, utxo);
                 let mut object_meta = ObjectMeta::genesis_meta(object_id, UTXO::type_tag());
                 object_meta.owner = rooch_pre_output.recipient_address.to_rooch_address().into();
                 let utxo_obj = ObjectState::new_with_struct(object_meta, utxo)?;

--- a/crates/rooch-framework-tests/src/bitcoin_block_tester.rs
+++ b/crates/rooch-framework-tests/src/bitcoin_block_tester.rs
@@ -3,7 +3,7 @@
 
 use crate::binding_test::RustBindingTest;
 use anyhow::{anyhow, bail, ensure, Result};
-use bitcoin::{hashes::Hash, Block, TxOut, Txid, OutPoint};
+use bitcoin::{hashes::Hash, Block, OutPoint, TxOut, Txid};
 use framework_builder::stdlib_version::StdlibVersion;
 use moveos_types::{
     moveos_std::{

--- a/crates/rooch-types/src/bitcoin/ord.rs
+++ b/crates/rooch-types/src/bitcoin/ord.rs
@@ -295,6 +295,33 @@ impl MoveStructState for SatPoint {
     }
 }
 
+impl FromStr for SatPoint {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let mut parts = s.split(':');
+        let txid = parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("missing txid"))?;
+        let vout = parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("missing vout"))?;
+        let offset = parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("missing offset"))?;
+        let txid = bitcoin::Txid::from_str(txid)?;
+        let vout = u32::from_str(vout)?;
+        let offset = u64::from_str(offset)?;
+        Ok(SatPoint {
+            outpoint: OutPoint {
+                txid: txid.into_address(),
+                vout,
+            },
+            offset,
+        })
+    }
+}
+
 /// Rust bindings for BitcoinMove ord module
 pub struct OrdModule<'a> {
     caller: &'a dyn MoveFunctionCaller,

--- a/crates/rooch-types/src/bitcoin/types.rs
+++ b/crates/rooch-types/src/bitcoin/types.rs
@@ -4,6 +4,7 @@
 use crate::into_address::FromAddress;
 use crate::{address::BitcoinAddress, addresses::BITCOIN_MOVE_ADDRESS, into_address::IntoAddress};
 use anyhow::Result;
+use bitcoin::Txid;
 use bitcoin::{hashes::Hash, BlockHash};
 use bitcoincore_rpc::bitcoincore_rpc_json::GetBlockHeaderResult;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
@@ -274,7 +275,7 @@ impl MoveStructState for Witness {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Ord, PartialOrd, PartialEq, Eq, Hash)]
 pub struct OutPoint {
     /// The referenced transaction's txid.
     /// Use address to represent sha256d hash
@@ -327,7 +328,9 @@ impl MoveStructState for OutPoint {
 
 impl Display for OutPoint {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}:{}", self.txid, self.vout)
+        //We use bitcoin txid hex to display
+        let txid = Txid::from_address(self.txid);
+        write!(f, "{}:{}", txid, self.vout)
     }
 }
 


### PR DESCRIPTION
## Summary

Verify the spend as fee case https://ordiscan.com/inscription/8706753

Print the l1 block execution gas used info in the binding test


Before #2500 (v0.6.9 tag)

execute l1 block total gas used: 114858924818, avg gas used: 18875747

After the insctiption_updater refactor:

execute l1 block total gas used: 121341117932, avg gas used: 19941021

cc @steelgeek091  