### PR TITLE
[bitcoin-move] Support TempStateDropEvent for UTXO and Inscription

### DIFF
--- a/frameworks/bitcoin-move/doc/README.md
+++ b/frameworks/bitcoin-move/doc/README.md
@@ -24,6 +24,7 @@ This is the reference documentation of the Bitcoin Move Framework.
 -  [`0x4::pending_block`](pending_block.md#0x4_pending_block)
 -  [`0x4::script_buf`](script_buf.md#0x4_script_buf)
 -  [`0x4::taproot_builder`](taproot_builder.md#0x4_taproot_builder)
+-  [`0x4::temp_state`](temp_state.md#0x4_temp_state)
 -  [`0x4::types`](types.md#0x4_types)
 -  [`0x4::utxo`](utxo.md#0x4_utxo)
 

--- a/frameworks/bitcoin-move/doc/ord.md
+++ b/frameworks/bitcoin-move/doc/ord.md
@@ -15,6 +15,7 @@
 -  [Struct `MetaprotocolValidity`](#0x4_ord_MetaprotocolValidity)
 -  [Resource `InscriptionStore`](#0x4_ord_InscriptionStore)
 -  [Struct `InscriptionEvent`](#0x4_ord_InscriptionEvent)
+-  [Struct `TempStateDropEvent`](#0x4_ord_TempStateDropEvent)
 -  [Struct `InscriptionCharm`](#0x4_ord_InscriptionCharm)
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x4_ord_genesis_init)
@@ -108,6 +109,7 @@
 -  [Function `unpack_inscription_event`](#0x4_ord_unpack_inscription_event)
 -  [Function `inscription_event_type_new`](#0x4_ord_inscription_event_type_new)
 -  [Function `inscription_event_type_burn`](#0x4_ord_inscription_event_type_burn)
+-  [Function `unpack_temp_state_drop_event`](#0x4_ord_unpack_temp_state_drop_event)
 -  [Function `charm_coin_flag`](#0x4_ord_charm_coin_flag)
 -  [Function `charm_cursed_flag`](#0x4_ord_charm_cursed_flag)
 -  [Function `charm_epic_flag`](#0x4_ord_charm_epic_flag)
@@ -138,6 +140,7 @@
 <b>use</b> <a href="">0x2::string_utils</a>;
 <b>use</b> <a href="">0x2::type_info</a>;
 <b>use</b> <a href="bitcoin_hash.md#0x4_bitcoin_hash">0x4::bitcoin_hash</a>;
+<b>use</b> <a href="temp_state.md#0x4_temp_state">0x4::temp_state</a>;
 <b>use</b> <a href="types.md#0x4_types">0x4::types</a>;
 </code></pre>
 
@@ -261,6 +264,20 @@ Compared to the events in inscription_updater, the main differences are:
 
 
 <pre><code><b>struct</b> <a href="ord.md#0x4_ord_InscriptionEvent">InscriptionEvent</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<a name="0x4_ord_TempStateDropEvent"></a>
+
+## Struct `TempStateDropEvent`
+
+Event emitted when the temporary state of an Inscription is dropped
+The temporary state is dropped when the inscription is transferred
+The event is onchain event, and the event_queue name is type_name of the temporary state
+
+
+<pre><code><b>struct</b> <a href="ord.md#0x4_ord_TempStateDropEvent">TempStateDropEvent</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -1490,6 +1507,17 @@ Get the MetaprotocolValidity's invalid_reason
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_inscription_event_type_burn">inscription_event_type_burn</a>(): u8
+</code></pre>
+
+
+
+<a name="0x4_ord_unpack_temp_state_drop_event"></a>
+
+## Function `unpack_temp_state_drop_event`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ord.md#0x4_ord_unpack_temp_state_drop_event">unpack_temp_state_drop_event</a>(<a href="">event</a>: <a href="ord.md#0x4_ord_TempStateDropEvent">ord::TempStateDropEvent</a>): (<a href="_ObjectID">object::ObjectID</a>, <a href="ord.md#0x4_ord_InscriptionID">ord::InscriptionID</a>)
 </code></pre>
 
 

--- a/frameworks/bitcoin-move/doc/temp_state.md
+++ b/frameworks/bitcoin-move/doc/temp_state.md
@@ -7,6 +7,7 @@ This module is used to store temporary states for UTXO and Inscription.
 
 
 -  [Struct `TempState`](#0x4_temp_state_TempState)
+-  [Constants](#@Constants_0)
 -  [Function `new`](#0x4_temp_state_new)
 -  [Function `add_state`](#0x4_temp_state_add_state)
 -  [Function `borrow_state`](#0x4_temp_state_borrow_state)
@@ -17,6 +18,7 @@ This module is used to store temporary states for UTXO and Inscription.
 
 
 <pre><code><b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="">0x1::vector</a>;
 <b>use</b> <a href="">0x2::bag</a>;
 <b>use</b> <a href="">0x2::type_info</a>;
 </code></pre>
@@ -30,6 +32,38 @@ This module is used to store temporary states for UTXO and Inscription.
 
 
 <pre><code><b>struct</b> <a href="temp_state.md#0x4_temp_state_TempState">TempState</a> <b>has</b> store
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x4_temp_state_ErrorMaxTempStateExceeded"></a>
+
+
+
+<pre><code><b>const</b> <a href="temp_state.md#0x4_temp_state_ErrorMaxTempStateExceeded">ErrorMaxTempStateExceeded</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x4_temp_state_ErrorTempStateNotFound"></a>
+
+
+
+<pre><code><b>const</b> <a href="temp_state.md#0x4_temp_state_ErrorTempStateNotFound">ErrorTempStateNotFound</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x4_temp_state_MAX_TEMP_STATES"></a>
+
+
+
+<pre><code><b>const</b> <a href="temp_state.md#0x4_temp_state_MAX_TEMP_STATES">MAX_TEMP_STATES</a>: u64 = 20;
 </code></pre>
 
 

--- a/frameworks/bitcoin-move/doc/temp_state.md
+++ b/frameworks/bitcoin-move/doc/temp_state.md
@@ -1,0 +1,110 @@
+
+<a name="0x4_temp_state"></a>
+
+# Module `0x4::temp_state`
+
+This module is used to store temporary states for UTXO and Inscription.
+
+
+-  [Struct `TempState`](#0x4_temp_state_TempState)
+-  [Function `new`](#0x4_temp_state_new)
+-  [Function `add_state`](#0x4_temp_state_add_state)
+-  [Function `borrow_state`](#0x4_temp_state_borrow_state)
+-  [Function `borrow_mut_state`](#0x4_temp_state_borrow_mut_state)
+-  [Function `remove_state`](#0x4_temp_state_remove_state)
+-  [Function `contains_state`](#0x4_temp_state_contains_state)
+-  [Function `remove`](#0x4_temp_state_remove)
+
+
+<pre><code><b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="">0x2::bag</a>;
+<b>use</b> <a href="">0x2::type_info</a>;
+</code></pre>
+
+
+
+<a name="0x4_temp_state_TempState"></a>
+
+## Struct `TempState`
+
+
+
+<pre><code><b>struct</b> <a href="temp_state.md#0x4_temp_state_TempState">TempState</a> <b>has</b> store
+</code></pre>
+
+
+
+<a name="0x4_temp_state_new"></a>
+
+## Function `new`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="temp_state.md#0x4_temp_state_new">new</a>(): <a href="temp_state.md#0x4_temp_state_TempState">temp_state::TempState</a>
+</code></pre>
+
+
+
+<a name="0x4_temp_state_add_state"></a>
+
+## Function `add_state`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="temp_state.md#0x4_temp_state_add_state">add_state</a>&lt;T: drop, store&gt;(self: &<b>mut</b> <a href="temp_state.md#0x4_temp_state_TempState">temp_state::TempState</a>, value: T)
+</code></pre>
+
+
+
+<a name="0x4_temp_state_borrow_state"></a>
+
+## Function `borrow_state`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="temp_state.md#0x4_temp_state_borrow_state">borrow_state</a>&lt;T: drop, store&gt;(self: &<a href="temp_state.md#0x4_temp_state_TempState">temp_state::TempState</a>): &T
+</code></pre>
+
+
+
+<a name="0x4_temp_state_borrow_mut_state"></a>
+
+## Function `borrow_mut_state`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="temp_state.md#0x4_temp_state_borrow_mut_state">borrow_mut_state</a>&lt;T: drop, store&gt;(self: &<b>mut</b> <a href="temp_state.md#0x4_temp_state_TempState">temp_state::TempState</a>): &<b>mut</b> T
+</code></pre>
+
+
+
+<a name="0x4_temp_state_remove_state"></a>
+
+## Function `remove_state`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="temp_state.md#0x4_temp_state_remove_state">remove_state</a>&lt;T: drop, store&gt;(self: &<b>mut</b> <a href="temp_state.md#0x4_temp_state_TempState">temp_state::TempState</a>): T
+</code></pre>
+
+
+
+<a name="0x4_temp_state_contains_state"></a>
+
+## Function `contains_state`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="temp_state.md#0x4_temp_state_contains_state">contains_state</a>&lt;T: drop, store&gt;(self: &<a href="temp_state.md#0x4_temp_state_TempState">temp_state::TempState</a>): bool
+</code></pre>
+
+
+
+<a name="0x4_temp_state_remove"></a>
+
+## Function `remove`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="temp_state.md#0x4_temp_state_remove">remove</a>(self: <a href="temp_state.md#0x4_temp_state_TempState">temp_state::TempState</a>): <a href="">vector</a>&lt;<a href="_String">string::String</a>&gt;
+</code></pre>

--- a/frameworks/bitcoin-move/doc/utxo.md
+++ b/frameworks/bitcoin-move/doc/utxo.md
@@ -10,6 +10,7 @@
 -  [Struct `SealOut`](#0x4_utxo_SealOut)
 -  [Struct `SpendUTXOEvent`](#0x4_utxo_SpendUTXOEvent)
 -  [Struct `ReceiveUTXOEvent`](#0x4_utxo_ReceiveUTXOEvent)
+-  [Struct `TempStateDropEvent`](#0x4_utxo_TempStateDropEvent)
 -  [Resource `BitcoinUTXOStore`](#0x4_utxo_BitcoinUTXOStore)
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x4_utxo_genesis_init)
@@ -43,17 +44,18 @@
 -  [Function `check_utxo_input`](#0x4_utxo_check_utxo_input)
 -  [Function `unpack_spend_utxo_event`](#0x4_utxo_unpack_spend_utxo_event)
 -  [Function `unpack_receive_utxo_event`](#0x4_utxo_unpack_receive_utxo_event)
+-  [Function `unpack_temp_state_drop_event`](#0x4_utxo_unpack_temp_state_drop_event)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::string</a>;
 <b>use</b> <a href="">0x2::address</a>;
-<b>use</b> <a href="">0x2::bag</a>;
 <b>use</b> <a href="">0x2::event_queue</a>;
 <b>use</b> <a href="">0x2::object</a>;
 <b>use</b> <a href="">0x2::simple_multimap</a>;
 <b>use</b> <a href="">0x2::type_info</a>;
 <b>use</b> <a href="">0x3::chain_id</a>;
+<b>use</b> <a href="temp_state.md#0x4_temp_state">0x4::temp_state</a>;
 <b>use</b> <a href="types.md#0x4_types">0x4::types</a>;
 </code></pre>
 
@@ -121,6 +123,20 @@ However, for simplifying payment scenarios, we define sender and receiver as fol
 
 
 <pre><code><b>struct</b> <a href="utxo.md#0x4_utxo_ReceiveUTXOEvent">ReceiveUTXOEvent</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<a name="0x4_utxo_TempStateDropEvent"></a>
+
+## Struct `TempStateDropEvent`
+
+Event emitted when the temporary state of a UTXO is dropped
+The temporary state is dropped when the UTXO is spent
+The event is onchain event, and the event_queue name is type_name of the temporary state
+
+
+<pre><code><b>struct</b> <a href="utxo.md#0x4_utxo_TempStateDropEvent">TempStateDropEvent</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -502,4 +518,15 @@ Get the UTXO's vout
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="utxo.md#0x4_utxo_unpack_receive_utxo_event">unpack_receive_utxo_event</a>(<a href="">event</a>: <a href="utxo.md#0x4_utxo_ReceiveUTXOEvent">utxo::ReceiveUTXOEvent</a>): (<b>address</b>, <a href="_Option">option::Option</a>&lt;<b>address</b>&gt;, <b>address</b>, u64)
+</code></pre>
+
+
+
+<a name="0x4_utxo_unpack_temp_state_drop_event"></a>
+
+## Function `unpack_temp_state_drop_event`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="utxo.md#0x4_utxo_unpack_temp_state_drop_event">unpack_temp_state_drop_event</a>(<a href="">event</a>: <a href="utxo.md#0x4_utxo_TempStateDropEvent">utxo::TempStateDropEvent</a>): (<a href="_ObjectID">object::ObjectID</a>, <a href="types.md#0x4_types_OutPoint">types::OutPoint</a>, u64)
 </code></pre>

--- a/frameworks/bitcoin-move/sources/ord.move
+++ b/frameworks/bitcoin-move/sources/ord.move
@@ -13,9 +13,11 @@ module bitcoin_move::ord {
     use moveos_std::simple_map::{Self, SimpleMap};
     use moveos_std::string_utils;
     use moveos_std::type_info;
+    use moveos_std::event_queue;
 
     use bitcoin_move::bitcoin_hash;
     use bitcoin_move::types::{Self, Transaction, Witness, OutPoint};
+    use bitcoin_move::temp_state;
 
     friend bitcoin_move::genesis;
     friend bitcoin_move::bitcoin;
@@ -131,6 +133,14 @@ module bitcoin_move::ord {
         inscription_obj_id: ObjectID,
         event_type: u8,
     }
+
+    /// Event emitted when the temporary state of an Inscription is dropped
+    /// The temporary state is dropped when the inscription is transferred
+    /// The event is onchain event, and the event_queue name is type_name of the temporary state
+    struct TempStateDropEvent has drop, store, copy {
+        inscription_obj_id: ObjectID,
+        inscription_id: InscriptionID,
+    } 
 
     public(friend) fun genesis_init() {
         let store = InscriptionStore {
@@ -644,52 +654,58 @@ module bitcoin_move::ord {
     #[private_generics(S)]
     public fun add_temp_state<S: store + drop>(inscription: &mut Object<Inscription>, state: S) {
         if (object::contains_field(inscription, TEMPORARY_AREA)) {
-            let bag = object::borrow_mut_field(inscription, TEMPORARY_AREA);
-            let name = type_info::type_name<S>();
-            bag::add_dropable(bag, name, state);
+            let temp_state = object::borrow_mut_field(inscription, TEMPORARY_AREA);
+            temp_state::add_state(temp_state, state);
         }else {
-            let bag = bag::new_dropable();
-            let name = type_info::type_name<S>();
-            bag::add_dropable(&mut bag, name, state);
-            object::add_field(inscription, TEMPORARY_AREA, bag);
+            let temp_state = temp_state::new();
+            temp_state::add_state(&mut temp_state, state);
+            object::add_field(inscription, TEMPORARY_AREA, temp_state);
         }
     }
 
     public fun contains_temp_state<S: store + drop>(inscription: &Object<Inscription>): bool {
         if (object::contains_field(inscription, TEMPORARY_AREA)) {
-            let bag = object::borrow_field(inscription, TEMPORARY_AREA);
-            let name = type_info::type_name<S>();
-            bag::contains(bag, name)
+            let temp_state = object::borrow_field(inscription, TEMPORARY_AREA);
+            temp_state::contains_state<S>(temp_state)
         }else {
             false
         }
     }
 
     public fun borrow_temp_state<S: store + drop>(inscription: &Object<Inscription>): &S {
-        let bag = object::borrow_field(inscription, TEMPORARY_AREA);
-        let name = type_info::type_name<S>();
-        bag::borrow(bag, name)
+        let temp_state = object::borrow_field(inscription, TEMPORARY_AREA);
+        temp_state::borrow_state(temp_state)
     }
 
     #[private_generics(S)]
     public fun borrow_mut_temp_state<S: store + drop>(inscription: &mut Object<Inscription>): &mut S {
-        let bag = object::borrow_mut_field(inscription, TEMPORARY_AREA);
-        let name = type_info::type_name<S>();
-        bag::borrow_mut(bag, name)
+        let temp_state = object::borrow_mut_field(inscription, TEMPORARY_AREA);
+        temp_state::borrow_mut_state(temp_state)
     }
 
     #[private_generics(S)]
     public fun remove_temp_state<S: store + drop>(inscription: &mut Object<Inscription>): S {
-        let bag = object::borrow_mut_field(inscription, TEMPORARY_AREA);
-        let name = type_info::type_name<S>();
-        bag::remove(bag, name)
+        let temp_state = object::borrow_mut_field(inscription, TEMPORARY_AREA);
+        temp_state::remove_state(temp_state)
     }
 
     /// Drop the bag, whether it's empty or not
     public(friend) fun drop_temp_area(inscription: &mut Object<Inscription>) {
         if (object::contains_field(inscription, TEMPORARY_AREA)) {
-            let bag = object::remove_field(inscription, TEMPORARY_AREA);
-            bag::drop(bag);
+            let inscription_obj_id = object::id(inscription);
+            let inscription_id = object::borrow(inscription).id;
+            let temp_state = object::remove_field(inscription, TEMPORARY_AREA);
+            let state_type_names = temp_state::remove(temp_state);
+            let idx = 0;
+            let len = vector::length(&state_type_names);
+            while(idx < len){
+                let state_type_name = vector::pop_back(&mut state_type_names);
+                event_queue::emit(state_type_name, TempStateDropEvent{
+                    inscription_obj_id,
+                    inscription_id,
+                });
+                idx = idx + 1;
+            };
         }
     }
 
@@ -845,6 +861,11 @@ module bitcoin_move::ord {
 
     public fun inscription_event_type_burn(): u8 {
         InscriptionEventTypeBurn
+    }
+
+    public fun unpack_temp_state_drop_event(event: TempStateDropEvent): (ObjectID, InscriptionID) {
+        let TempStateDropEvent { inscription_obj_id, inscription_id } = event;
+        (inscription_obj_id, inscription_id)
     }
 
     // ==== Inscription Charm ==== //
@@ -1131,7 +1152,7 @@ module bitcoin_move::ord {
     }
 
     #[test_only]
-    struct TempState has store, copy, drop {
+    struct TestTempState has store, copy, drop {
         value: u64,
     }
 
@@ -1152,16 +1173,16 @@ module bitcoin_move::ord {
             vector[],
             option::none(),
         );
-        add_temp_state(&mut inscription_obj, TempState { value: 10 });
-        assert!(contains_temp_state<TempState>(&inscription_obj), 1);
-        assert!(borrow_temp_state<TempState>(&inscription_obj).value == 10, 2);
+        add_temp_state(&mut inscription_obj, TestTempState { value: 10 });
+        assert!(contains_temp_state<TestTempState>(&inscription_obj), 1);
+        assert!(borrow_temp_state<TestTempState>(&inscription_obj).value == 10, 2);
         {
-            let state = borrow_mut_temp_state<TempState>(&mut inscription_obj);
+            let state = borrow_mut_temp_state<TestTempState>(&mut inscription_obj);
             state.value = 20;
         };
-        let state = remove_temp_state<TempState>(&mut inscription_obj);
+        let state = remove_temp_state<TestTempState>(&mut inscription_obj);
         assert!(state.value == 20, 1);
-        assert!(!contains_temp_state<TempState>(&inscription_obj), 3);
+        assert!(!contains_temp_state<TestTempState>(&inscription_obj), 3);
 
         drop_temp_area(&mut inscription_obj);
         drop_inscription_object_for_test(inscription_obj);
@@ -1191,8 +1212,9 @@ module bitcoin_move::ord {
             vector[],
             option::none(),
         );
-
-        add_temp_state(&mut inscription_obj, TempState { value: 10 });
+        let state_type_name = type_info::type_name<TestTempState>();
+        let subscriber = event_queue::subscribe<TempStateDropEvent>(state_type_name);
+        add_temp_state(&mut inscription_obj, TestTempState { value: 10 });
         add_permanent_state(&mut inscription_obj, PermanentState { value: 10 });
         let object_id = object::id(&inscription_obj);
 
@@ -1202,8 +1224,17 @@ module bitcoin_move::ord {
         };
 
         let inscription_obj = object::borrow_object<Inscription>(object_id);
-        assert!(!contains_temp_state<TempState>(inscription_obj), 1);
-        assert!(contains_permanent_state<PermanentState>(inscription_obj), 2);
+        assert!(!contains_temp_state<TestTempState>(inscription_obj), 1);
+
+        let event_option = event_queue::consume<TempStateDropEvent>(&mut subscriber);
+        assert!(option::is_some(&event_option), 2);
+        let event = option::destroy_some(event_option);
+        assert!(event.inscription_obj_id == object_id, 3);
+        assert!(event.inscription_id == id, 4);
+
+        assert!(contains_permanent_state<PermanentState>(inscription_obj), 5);
+
+        event_queue::unsubscribe(subscriber);
     }
 
 

--- a/frameworks/bitcoin-move/sources/temp_state.move
+++ b/frameworks/bitcoin-move/sources/temp_state.move
@@ -1,0 +1,69 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module is used to store temporary states for UTXO and Inscription.
+module bitcoin_move::temp_state {
+
+    use std::string::String;
+    use std::vector;
+    use moveos_std::type_info;
+    use moveos_std::bag::{Self, Bag};
+
+    friend bitcoin_move::utxo;
+    friend bitcoin_move::ord;
+
+    const MAX_TEMP_STATES: u64 = 20;
+
+    const ErrorMaxTempStateExceeded: u64 = 1;
+    const ErrorTempStateNotFound: u64 = 2;
+
+    struct TempState has store {
+        names: vector<String>,
+        states: Bag,
+    }
+
+    public(friend) fun new(): TempState {
+        TempState{
+            names: vector::empty(),
+            states: bag::new_dropable(),
+        }
+    }
+
+    public(friend) fun add_state<T: drop + store>(self: &mut TempState, value: T) {
+        assert!(vector::length(&self.names) < MAX_TEMP_STATES, ErrorMaxTempStateExceeded);
+        let key = type_info::type_name<T>();
+        bag::add_dropable(&mut self.states, key, value);
+        vector::push_back(&mut self.names, key);
+    }
+
+    public(friend) fun borrow_state<T: drop + store>(self: &TempState): &T {
+        assert!(contains_state<T>(self), ErrorTempStateNotFound);
+        let key = type_info::type_name<T>();
+        bag::borrow(&self.states, key)
+    }
+
+    public(friend) fun borrow_mut_state<T: drop + store>(self: &mut TempState): &mut T {
+        assert!(contains_state<T>(self), ErrorTempStateNotFound);
+        let key = type_info::type_name<T>();
+        bag::borrow_mut(&mut self.states, key)
+    }
+
+    public(friend) fun remove_state<T: drop + store>(self: &mut TempState): T {
+        assert!(contains_state<T>(self), ErrorTempStateNotFound);
+        let key = type_info::type_name<T>();
+        self.names = vector::remove_value(&mut self.names, &key);
+        bag::remove(&mut self.states, key)
+    }
+
+    public(friend) fun contains_state<T: drop + store>(self: &TempState): bool {
+        let key = type_info::type_name<T>();
+        bag::contains(&self.states, key)
+    }
+
+    public(friend) fun remove(self: TempState) : vector<String> {
+        let TempState{names, states} = self;
+        bag::drop(states);
+        names
+    }
+
+}


### PR DESCRIPTION
## Summary

Support TempStateDropEvent for UTXO and Inscription

The application can subscribe to the TempStateDropEvent on-chain event and implement business logic. 

close #2542 