### PR TITLE
[portal] add csp rule

### DIFF
--- a/infra/rooch-portal-v2/next.config.mjs
+++ b/infra/rooch-portal-v2/next.config.mjs
@@ -4,25 +4,6 @@
 
 const isStaticExport = 'false';
 
-const isProduction = process.env.NODE_ENV === 'production';
-
-const iconDomains = ['https://api.unisvg.com', 'https://api.iconify.design', 'https://api.simplesvg.com'];
-const apiDomains = ['https://dev-seed.rooch.network', 'https://test-seed.rooch.network'];
-
-const cspHeader = `
-    default-src 'self';
-    script-src 'self' ${isProduction ? '' : "'unsafe-eval' 'unsafe-inline'"};
-    style-src 'self' 'unsafe-inline';
-    img-src 'self' blob: data: ${iconDomains.join(' ')};
-    font-src 'self';
-    object-src 'none';
-    base-uri 'self';
-    form-action 'self';
-    frame-ancestors 'none';
-    upgrade-insecure-requests;
-    connect-src 'self' ${apiDomains.join(' ')} ${iconDomains.join(' ')};
-`;
-
 const nextConfig = {
   compiler: {
     removeConsole: true,
@@ -42,19 +23,6 @@ const nextConfig = {
     '@mui/lab': {
       transform: '@mui/lab/{{member}}',
     },
-  },
-  async headers() {
-    return [
-      {
-        source: '/(.*)',
-        headers: [
-          {
-            key: 'Content-Security-Policy',
-            value: cspHeader.replace(/\n/g, ''),
-          },
-        ],
-      },
-    ];
   },
   webpack(config) {
     config.module.rules.push({

--- a/infra/rooch-portal-v2/next.config.mjs
+++ b/infra/rooch-portal-v2/next.config.mjs
@@ -4,6 +4,25 @@
 
 const isStaticExport = 'false';
 
+const isProduction = process.env.NODE_ENV === 'production';
+
+const iconDomains = ['https://api.unisvg.com', 'https://api.iconify.design', 'https://api.simplesvg.com'];
+const apiDomains = ['https://dev-seed.rooch.network', 'https://test-seed.rooch.network'];
+
+const cspHeader = `
+    default-src 'self';
+    script-src 'self' ${isProduction ? '' : "'unsafe-eval' 'unsafe-inline'"};
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' blob: data: ${iconDomains.join(' ')};
+    font-src 'self';
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    upgrade-insecure-requests;
+    connect-src 'self' ${apiDomains.join(' ')} ${iconDomains.join(' ')};
+`;
+
 const nextConfig = {
   compiler: {
     removeConsole: true,
@@ -23,6 +42,19 @@ const nextConfig = {
     '@mui/lab': {
       transform: '@mui/lab/{{member}}',
     },
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: cspHeader.replace(/\n/g, ''),
+          },
+        ],
+      },
+    ];
   },
   webpack(config) {
     config.module.rules.push({

--- a/infra/rooch-portal-v2/src/app/layout.tsx
+++ b/infra/rooch-portal-v2/src/app/layout.tsx
@@ -10,7 +10,8 @@ import '@fontsource-variable/red-hat-mono';
 import { primary } from 'src/theme/core/palette';
 import { DashboardLayout } from 'src/layouts/dashboard';
 import { ThemeProvider } from 'src/theme/theme-provider';
-import { getInitColorSchemeScript } from 'src/theme/color-scheme-script';
+import { schemeConfig } from 'src/theme/color-scheme-script';
+import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
 
 import { Snackbar } from 'src/components/snackbar';
 import { ProgressBar } from 'src/components/progress-bar';
@@ -40,7 +41,7 @@ export default async function RootLayout({ children }: Props) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
-        {getInitColorSchemeScript}
+        <InitColorSchemeScript {...schemeConfig} nonce={nonce} />
         <RoochDappProvider>
           <SettingsProvider settings={settings} caches="localStorage">
             <ThemeProvider nonce={nonce}>

--- a/infra/rooch-portal-v2/src/app/layout.tsx
+++ b/infra/rooch-portal-v2/src/app/layout.tsx
@@ -3,6 +3,7 @@ import '@fontsource-variable/raleway/wght.css';
 import '@fontsource-variable/plus-jakarta-sans/wght.css';
 
 import type { Viewport } from 'next';
+import { headers } from 'next/headers';
 
 import '@fontsource-variable/red-hat-mono';
 
@@ -18,6 +19,8 @@ import { SettingsDrawer, defaultSettings, SettingsProvider } from 'src/component
 
 import RoochDappProvider from './rooch-dapp-provider';
 
+export const dynamic = 'force-dynamic';
+
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
@@ -32,13 +35,15 @@ export default async function RootLayout({ children }: Props) {
   // const settings = CONFIG.isStaticExport ? defaultSettings : await detectSettings();
   const settings = defaultSettings;
 
+  const nonce = headers().get('x-nonce') || '';
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
         {getInitColorSchemeScript}
         <RoochDappProvider>
           <SettingsProvider settings={settings} caches="localStorage">
-            <ThemeProvider>
+            <ThemeProvider nonce={nonce}>
               <MotionLazy>
                 <Snackbar />
                 <ProgressBar />

--- a/infra/rooch-portal-v2/src/middleware.ts
+++ b/infra/rooch-portal-v2/src/middleware.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const iconDomains = [
+  'https://api.unisvg.com',
+  'https://api.iconify.design',
+  'https://api.simplesvg.com',
+];
+const apiDomains = ['https://dev-seed.rooch.network', 'https://test-seed.rooch.network'];
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+export function middleware(request: NextRequest) {
+  const nonce = crypto.randomUUID();
+
+  const csp = [
+    { name: 'default-src', values: ["'self'"] },
+    {
+      name: 'script-src',
+      values: isProduction
+        ? ["'self'", `'nonce-${nonce}'`, "'strict-dynamic'"]
+        : ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
+    },
+    {
+      name: 'style-src',
+      values: ["'self'", `'nonce-${nonce}'`],
+    },
+    { name: 'img-src', values: ["'self'", 'data:', 'blob:'] },
+    { name: 'font-src', values: ["'self'", 'data:'] },
+    { name: 'object-src', values: ["'none'"] },
+    { name: 'base-uri', values: ["'self'"] },
+    { name: 'form-action', values: ["'self'"] },
+    { name: 'frame-ancestors', values: ["'none'"] },
+    {
+      name: 'connect-src',
+      values: ["'self'", ...apiDomains, ...iconDomains],
+    },
+    { name: 'upgrade-insecure-requests', values: [] },
+  ];
+
+  const contentSecurityPolicyHeaderValue = csp
+    .map((directive) => {
+      return `${directive.name} ${directive.values.join(' ')}`;
+    })
+    .join('; ');
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set('Content-Security-Policy', contentSecurityPolicyHeaderValue);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set('Content-Security-Policy', contentSecurityPolicyHeaderValue);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+};

--- a/infra/rooch-portal-v2/src/middleware.ts
+++ b/infra/rooch-portal-v2/src/middleware.ts
@@ -22,7 +22,7 @@ export function middleware(request: NextRequest) {
     },
     {
       name: 'style-src',
-      values: ["'self'", `'nonce-${nonce}'`],
+      values: ["'self'", "'unsafe-inline'"],
     },
     { name: 'img-src', values: ["'self'", 'data:', 'blob:'] },
     { name: 'font-src', values: ["'self'", 'data:'] },

--- a/infra/rooch-portal-v2/src/middleware.ts
+++ b/infra/rooch-portal-v2/src/middleware.ts
@@ -22,7 +22,7 @@ export function middleware(request: NextRequest) {
     },
     {
       name: 'style-src',
-      values: ["'self'", "'unsafe-inline'"],
+      values: ["'self'", `'nonce-${nonce}'`],
     },
     { name: 'img-src', values: ["'self'", 'data:', 'blob:'] },
     { name: 'font-src', values: ["'self'", 'data:'] },
@@ -38,9 +38,7 @@ export function middleware(request: NextRequest) {
   ];
 
   const contentSecurityPolicyHeaderValue = csp
-    .map((directive) => {
-      return `${directive.name} ${directive.values.join(' ')}`;
-    })
+    .map((directive) => `${directive.name} ${directive.values.join(' ')}`)
     .join('; ');
 
   const requestHeaders = new Headers(request.headers);

--- a/infra/rooch-portal-v2/src/theme/color-scheme-script.ts
+++ b/infra/rooch-portal-v2/src/theme/color-scheme-script.ts
@@ -1,10 +1,6 @@
 'use client';
 
-import { getInitColorSchemeScript as _getInitColorSchemeScript } from '@mui/material/styles';
-
 export const schemeConfig = {
   modeStorageKey: 'theme-mode',
   defaultMode: 'light' as const,
 };
-
-export const getInitColorSchemeScript = _getInitColorSchemeScript(schemeConfig);

--- a/infra/rooch-portal-v2/src/theme/theme-provider.tsx
+++ b/infra/rooch-portal-v2/src/theme/theme-provider.tsx
@@ -17,16 +17,17 @@ import { RTL } from './with-settings/right-to-left';
 import { schemeConfig } from './color-scheme-script';
 
 type Props = {
+  nonce: string;
   children: React.ReactNode;
 };
 
-export function ThemeProvider({ children }: Props) {
+export function ThemeProvider({ nonce, children }: Props) {
   const settings = useSettingsContext();
 
   const theme = createTheme(settings);
 
   return (
-    <AppRouterCacheProvider options={{ key: 'css' }}>
+    <AppRouterCacheProvider options={{ key: 'css', nonce }}>
       <CssVarsProvider
         theme={theme}
         defaultMode={schemeConfig.defaultMode}


### PR DESCRIPTION
## Summary

Related with #1958 

Add strict CSP rules to the Rooch Portal to prevent potential XSS attacks.

**Disadvantage**: it will cause all pages to be SSR. But this should be acceptable.

## Test Result

### Attempting to load script from a third-party domain

Example:

```jsx
<Script src="https://unpkg.com/react@16.7.0/umd/react.production.min.js" />
```

The application will refuse the connection:

> Refused to load the script 'https://unpkg.com/react@16.7.0/umd/react.production.min.js' because it violates the following Content Security Policy directive: "script-src 'self' 'unsafe-eval' 'unsafe-inline'". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.

### Attempting to use inline script

Example:

```html
<button onclick="alert('you are hacked')" />
```

The application will refuse to exec:

> Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution. Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present.

### Attempting to use `eval` to execute concatenated code

Example:

```js
eval(location.hash.substring(1))
```

The application will refuse to exec:

> Uncaught EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".





