### PR TITLE
[CLI] Implement rooch bitcoin command to suppor taproot multisign and bump bitcoin to 0.32.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,12 +1170,6 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-
-[[package]]
-name = "bitcoin_hashes"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
@@ -5160,9 +5154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -6106,16 +6097,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniscript"
-version = "12.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add2d4aee30e4291ce5cffa3a322e441ff4d4bc57b38c8d9bf0e94faa50ab626"
-dependencies = [
- "bech32 0.11.0",
- "bitcoin 0.32.2",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -7115,21 +7096,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
-name = "musig2"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed08befaac75bfb31ca5e87678c4e8490bcd21d0c98ccb4f12f4065a7567e83"
-dependencies = [
- "base16ct 0.2.0",
- "hmac",
- "once_cell",
- "secp",
- "secp256k1 0.28.2",
- "sha2 0.10.8",
- "subtle",
-]
-
-[[package]]
 name = "named-lock"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7256,29 +7222,6 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
-
-[[package]]
-name = "nostr"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38ff6fec17be97b6ea1e30a4913618c8e02b2e555b5188d01668f2e4fa09507"
-dependencies = [
- "aes",
- "base64 0.21.7",
- "bech32 0.9.1",
- "bip39",
- "bitcoin 0.30.2",
- "bitcoin_hashes 0.12.0",
- "cbc",
- "getrandom 0.2.15",
- "instant",
- "log",
- "reqwest 0.11.27",
- "secp256k1 0.27.0",
- "serde 1.0.210",
- "serde_json",
- "url",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -9025,7 +8968,6 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
- "tokio-socks",
  "tokio-util",
  "tower-service",
  "url",
@@ -9539,7 +9481,6 @@ dependencies = [
  "moveos",
  "moveos-stdlib",
  "moveos-types",
- "musig2",
  "rooch-types",
  "smallvec",
  "tracing",
@@ -9561,13 +9502,11 @@ dependencies = [
  "hex",
  "include_dir",
  "metrics",
- "miniscript",
  "move-core-types",
  "moveos-config",
  "moveos-eventbus",
  "moveos-store",
  "moveos-types",
- "musig2",
  "rand 0.8.5",
  "rooch-config",
  "rooch-db",
@@ -9720,7 +9659,6 @@ dependencies = [
  "moveos-stdlib",
  "moveos-types",
  "moveos-wasm",
- "musig2",
  "rooch-framework",
  "rooch-types",
  "serde_json",
@@ -9894,7 +9832,6 @@ dependencies = [
  "move-core-types",
  "move-resource-viewer",
  "moveos-types",
- "nostr",
  "rooch-open-rpc",
  "rooch-open-rpc-macros",
  "rooch-types",
@@ -10053,14 +9990,12 @@ dependencies = [
  "framework-builder",
  "framework-types",
  "hex",
- "miniscript",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
  "move-resource-viewer",
  "move-vm-types",
  "moveos-types",
- "nostr",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -10570,18 +10505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4754628ff9006f80c6abd1cd1e88c5ca6f5a60eab151ad2e16268aab3514d0"
-dependencies = [
- "base16ct 0.2.0",
- "once_cell",
- "secp256k1 0.28.2",
- "subtle",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10620,15 +10543,6 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
@@ -12049,18 +11963,6 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls 0.23.10",
  "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-socks"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
-dependencies = [
- "either",
- "futures-util",
- "thiserror",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
  "bitcoin_hashes 0.14.0",
 ]
 
@@ -926,12 +926,6 @@ name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
-name = "bech32"
-version = "0.10.0-beta"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bech32"
@@ -1101,13 +1095,14 @@ checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
 dependencies = [
  "base58ck",
  "bech32 0.11.0",
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes 0.14.0",
- "hex-conservative 0.2.1",
+ "hex-conservative",
  "hex_lit",
  "secp256k1 0.29.0",
+ "serde 1.0.208",
 ]
 
 [[package]]
@@ -1124,6 +1119,9 @@ name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde 1.0.208",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -1137,7 +1135,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "brotli 3.5.0",
  "hex",
  "move-binary-format",
@@ -1166,7 +1164,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
+ "serde 1.0.208",
 ]
 
 [[package]]
@@ -1203,14 +1202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative 0.2.1",
+ "hex-conservative",
+ "serde 1.0.208",
 ]
 
 [[package]]
 name = "bitcoincore-rpc"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb70725a621848c83b3809913d5314c0d20ca84877d99dd909504b564edab00"
+checksum = "aedd23ae0fd321affb4bbbc36126c6f49a32818dc6b979395d24da8c9d4e80ee"
 dependencies = [
  "bitcoincore-rpc-json",
  "jsonrpc",
@@ -1226,6 +1226,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "856ffbee2e492c23bca715d72ea34aae80d58400f2bda26a82015d6bc2ec3662"
 dependencies = [
  "bitcoin 0.31.2",
+ "serde 1.0.210",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
+dependencies = [
+ "bitcoin 0.32.2",
+ "serde 1.0.210",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
+dependencies = [
+ "bitcoin 0.32.2",
  "serde 1.0.210",
  "serde_json",
 ]
@@ -4628,12 +4650,6 @@ dependencies = [
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
-
-[[package]]
-name = "hex-conservative"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
@@ -5328,11 +5344,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.14.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8128f36b47411cd3f044be8c1f5cc0c9e24d1d1bfdc45f0a57897b32513053f2"
+checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
  "base64 0.13.1",
+ "minreq",
  "serde 1.0.210",
  "serde_json",
 ]
@@ -6107,6 +6124,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "minreq"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763d142cdff44aaadd9268bebddb156ef6c65a0e13486bb81673cf2d8739f9b0"
+dependencies = [
+ "log",
+ "serde 1.0.208",
+ "serde_json",
 ]
 
 [[package]]
@@ -9235,7 +9263,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "bitcoin-move",
  "chrono",
  "clap 4.5.13",
@@ -9324,7 +9352,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "bcs",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
  "clap 4.5.13",
@@ -9500,7 +9528,7 @@ name = "rooch-framework"
 version = "0.7.0"
 dependencies = [
  "bcs",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=56f6223b84ada922b6cb2c672c69db2ea3dc6a13)",
  "hex",
  "move-binary-format",
@@ -9523,7 +9551,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "bcs",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "bitcoin-move",
  "clap 4.5.13",
  "coerce",
@@ -9677,7 +9705,7 @@ name = "rooch-nursery"
 version = "0.7.0"
 dependencies = [
  "bcs",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "ciborium",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=56f6223b84ada922b6cb2c672c69db2ea3dc6a13)",
  "hex",
@@ -9759,7 +9787,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "bitcoincore-rpc",
  "chrono",
  "coerce",
@@ -9829,7 +9857,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "bitcoincore-rpc",
  "chrono",
  "coerce",
@@ -9858,7 +9886,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "bcs",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "ethers",
  "hex",
  "jsonrpsee 0.23.2",
@@ -10011,7 +10039,7 @@ dependencies = [
  "argon2",
  "bcs",
  "bech32 0.11.0",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.2",
  "bitcoincore-rpc",
  "bs58 0.5.1",
  "chacha20poly1305",
@@ -10570,8 +10598,6 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
- "bitcoin_hashes 0.13.0",
- "rand 0.8.5",
  "secp256k1-sys 0.9.2",
  "serde 1.0.210",
 ]
@@ -10585,6 +10611,7 @@ dependencies = [
  "bitcoin_hashes 0.14.0",
  "rand 0.8.5",
  "secp256k1-sys 0.10.0",
+ "serde 1.0.208",
 ]
 
 [[package]]
@@ -11248,7 +11275,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "bcs",
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes 0.14.0",
  "byteorder",
  "bytes",
  "function_name",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes 0.14.0",
+ "bitcoinconsensus",
  "hex-conservative",
  "hex_lit",
  "secp256k1 0.29.0",
@@ -1151,6 +1152,15 @@ dependencies = [
  "bitcoin-io",
  "hex-conservative",
  "serde 1.0.210",
+]
+
+[[package]]
+name = "bitcoinconsensus"
+version = "0.105.0+25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f260ac8fb2c621329013fc0ed371c940fcc512552dcbcb9095ed0179098c9e18"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -9941,6 +9951,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9911,6 +9911,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "bitcoin 0.32.2",
  "futures",
  "hex",
  "jsonrpsee 0.23.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,17 +1034,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bip39"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
-dependencies = [
- "bitcoin_hashes 0.11.0",
- "serde 1.0.210",
- "unicode-normalization",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,21 +1063,6 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
-dependencies = [
- "bech32 0.10.0-beta",
- "bitcoin-internals 0.2.0",
- "bitcoin_hashes 0.13.0",
- "hex-conservative 0.1.2",
- "hex_lit",
- "secp256k1 0.28.2",
- "serde 1.0.210",
-]
-
-[[package]]
-name = "bitcoin"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
@@ -1102,15 +1076,6 @@ dependencies = [
  "hex-conservative",
  "hex_lit",
  "secp256k1 0.29.0",
- "serde 1.0.208",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
-dependencies = [
  "serde 1.0.210",
 ]
 
@@ -1120,7 +1085,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -1165,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
  "bitcoin-internals",
- "serde 1.0.208",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -1175,18 +1140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
- "serde 1.0.210",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals 0.2.0",
- "hex-conservative 0.1.2",
- "serde 1.0.210",
 ]
 
 [[package]]
@@ -1197,7 +1150,7 @@ checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
- "serde 1.0.208",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -1209,28 +1162,6 @@ dependencies = [
  "bitcoincore-rpc-json",
  "jsonrpc",
  "log",
- "serde 1.0.210",
- "serde_json",
-]
-
-[[package]]
-name = "bitcoincore-rpc-json"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856ffbee2e492c23bca715d72ea34aae80d58400f2bda26a82015d6bc2ec3662"
-dependencies = [
- "bitcoin 0.31.2",
- "serde 1.0.210",
- "serde_json",
-]
-
-[[package]]
-name = "bitcoincore-rpc-json"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
-dependencies = [
- "bitcoin 0.32.2",
  "serde 1.0.210",
  "serde_json",
 ]
@@ -6114,7 +6045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "763d142cdff44aaadd9268bebddb156ef6c65a0e13486bb81673cf2d8739f9b0"
 dependencies = [
  "log",
- "serde 1.0.208",
+ "serde 1.0.210",
  "serde_json",
 ]
 
@@ -9862,6 +9793,7 @@ dependencies = [
  "serde 1.0.210",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -10513,17 +10445,6 @@ dependencies = [
  "bitcoin_hashes 0.12.0",
  "rand 0.8.5",
  "secp256k1-sys 0.8.1",
- "serde 1.0.210",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
-dependencies = [
- "secp256k1-sys 0.9.2",
- "serde 1.0.210",
 ]
 
 [[package]]
@@ -10535,7 +10456,7 @@ dependencies = [
  "bitcoin_hashes 0.14.0",
  "rand 0.8.5",
  "secp256k1-sys 0.10.0",
- "serde 1.0.208",
+ "serde 1.0.210",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,7 +243,6 @@ hyper = { version = "1.0.0", features = ["full"] }
 num_enum = "0.7.3"
 libc = "^0.2"
 include_dir = { version = "0.6.2" }
-nostr = "0.22"
 serde-reflection = "0.3.6"
 serde-generate = "0.25.1"
 bcs-ext = { path = "moveos/moveos-commons/bcs_ext" }
@@ -336,8 +335,6 @@ rustc-hash = { version = "2.0.0" }
 xorf = { version = "0.11.0" }
 vergen-git2 = { version = "1.0.0", features = ["build", "cargo", "rustc"] }
 vergen-pretty = "0.3.4"
-musig2 = { version = "0.0.11" }
-miniscript = "12.2.0"
 crossbeam-channel = "0.5.13"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ bcs = "0.1.3"
 bytes = "1.7.1"
 bech32 = "0.11.0"
 better_any = "0.1.1"
-bitcoin = { version = "0.32.2", features = ["rand-std"] }
+bitcoin = { version = "0.32.2", features = ["rand-std", "bitcoinconsensus"] }
 bitcoin_hashes = { version = "0.14.0", features = ["serde"] }
 bitcoincore-rpc = "0.19.0"
 bitcoincore-rpc-json = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,9 +149,10 @@ bcs = "0.1.3"
 bytes = "1.7.1"
 bech32 = "0.11.0"
 better_any = "0.1.1"
-bitcoin = { version = "0.31.0", features = ["rand-std"] }
-bitcoin_hashes = { version = "0.13.0", features = ["serde-std"]}
-bitcoincore-rpc = "0.18.0"
+bitcoin = { version = "0.32.2", features = ["rand-std"] }
+bitcoin_hashes = { version = "0.14.0", features = ["serde"] }
+bitcoincore-rpc = "0.19.0"
+bitcoincore-rpc-json = "0.19.0"
 bip32 = "0.4.0"
 byteorder = "1.4.3"
 clap = { version = "4.5.13", features = ["derive", "env"] }
@@ -316,7 +317,6 @@ pprof = { version = "0.13.0", features = ["flamegraph", "criterion", "cpp", "fra
 celestia-rpc = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "129272e8d926b4c7badf27a26dea915323dd6489" }
 celestia-types = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "129272e8d926b4c7badf27a26dea915323dd6489" }
 opendal = { version = "0.47.3", features = ["services-fs", "services-gcs"] }
-bitcoincore-rpc-json = "0.18.0"
 toml = "0.8.19"
 csv = "1.2.1"
 revm-precompile = "7.0.0"

--- a/crates/rooch-framework-tests/Cargo.toml
+++ b/crates/rooch-framework-tests/Cargo.toml
@@ -25,8 +25,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tempfile = { workspace = true }
 include_dir = { workspace = true }
-musig2 = { workspace = true }
-miniscript = { workspace = true }
 coerce = { workspace = true }
 tokio = { workspace = true }
 clap = { features = ["derive", ], workspace = true }

--- a/crates/rooch-framework-tests/src/bitcoin_block_tester.rs
+++ b/crates/rooch-framework-tests/src/bitcoin_block_tester.rs
@@ -141,7 +141,7 @@ impl BitcoinBlockTester {
         let mut utxo_set = HashMap::<OutPoint, TxOut>::new();
         let block_data = self.executed_block.as_ref().unwrap();
         for tx in block_data.block.txdata.as_slice() {
-            let txid = tx.txid();
+            let txid = tx.compute_txid();
             for (index, tx_out) in tx.output.iter().enumerate() {
                 let vout = index as u32;
                 let out_point = OutPoint::new(txid, vout);
@@ -486,7 +486,7 @@ impl TesterGenesisBuilder {
         );
 
         for tx in &block.txdata {
-            self.block_txids.insert(tx.txid());
+            self.block_txids.insert(tx.compute_txid());
         }
 
         let depdent_txids = block

--- a/crates/rooch-framework-tests/src/tests/bitcoin_test.rs
+++ b/crates/rooch-framework-tests/src/tests/bitcoin_test.rs
@@ -100,7 +100,8 @@ fn check_utxo(txs: Vec<Transaction>, binding_test: &binding_test::RustBindingTes
     for tx in txs.as_slice() {
         for (index, tx_out) in tx.output.iter().enumerate() {
             let vout = index as u32;
-            let out_point = OutPoint::new(tx.txid(), vout);
+            let txid = tx.compute_txid();
+            let out_point = OutPoint::new(txid, vout);
             utxo_set.insert(out_point, tx_out.clone());
         }
         for tx_in in tx.input.iter() {
@@ -147,7 +148,7 @@ fn check_utxo(txs: Vec<Transaction>, binding_test: &binding_test::RustBindingTes
     let inscriptions = txs
         .iter()
         .flat_map(|tx| {
-            let txid = tx.txid();
+            let txid = tx.compute_txid();
             let rooch_btc_tx = rooch_types::bitcoin::types::Transaction::from(tx.clone());
             ord_module
                 .parse_inscription_from_tx(&rooch_btc_tx)

--- a/crates/rooch-framework-tests/src/tests/brc20_test.rs
+++ b/crates/rooch-framework-tests/src/tests/brc20_test.rs
@@ -9,7 +9,8 @@ fn decode_tx(btx_tx_hex: &str) {
     let btc_tx_bytes = Vec::from_hex(btx_tx_hex).unwrap();
     let btc_tx: bitcoin::Transaction =
         Decodable::consensus_decode(&mut btc_tx_bytes.as_slice()).unwrap();
-    debug!("tx_id: {}", btc_tx.txid());
+    let txid = btc_tx.compute_txid();
+    debug!("tx_id: {}", txid);
     for (i, input) in btc_tx.input.iter().enumerate() {
         debug!("{}. input: {:?}", i, input.previous_output);
     }

--- a/crates/rooch-framework-tests/src/tests/ord_test.rs
+++ b/crates/rooch-framework-tests/src/tests/ord_test.rs
@@ -17,7 +17,8 @@ fn decode_inscription(
     binding_test: &mut binding_test::RustBindingTest,
     btc_tx: Transaction,
 ) -> Vec<Envelope<InscriptionRecord>> {
-    debug!("tx_id: {}", btc_tx.txid());
+    let txid = btc_tx.compute_txid();
+    debug!("tx_id: {}", txid);
     for (i, input) in btc_tx.input.iter().enumerate() {
         debug!("{}. input: {:?}", i, input.previous_output);
     }

--- a/crates/rooch-key/src/keystore/account_keystore.rs
+++ b/crates/rooch-key/src/keystore/account_keystore.rs
@@ -90,7 +90,20 @@ pub trait AccountKeystore {
         Ok(())
     }
 
+    /// Get all local accounts
+    //TODO refactor the keystore, save the public key out of the encryption data, so that we don't need to require password to get the public key
     fn get_accounts(&self, password: Option<String>) -> Result<Vec<LocalAccount>, anyhow::Error>;
+
+    /// Get local account by address
+    fn get_account(
+        &self,
+        address: &RoochAddress,
+        password: Option<String>,
+    ) -> Result<Option<LocalAccount>, anyhow::Error> {
+        let accounts = self.get_accounts(password)?;
+        let account = accounts.iter().find(|account| account.address == *address);
+        Ok(account.cloned())
+    }
 
     fn contains_address(&self, address: &RoochAddress) -> bool;
 

--- a/crates/rooch-key/src/keystore/base_keystore.rs
+++ b/crates/rooch-key/src/keystore/base_keystore.rs
@@ -6,6 +6,7 @@ use crate::keystore::account_keystore::AccountKeystore;
 use anyhow::{ensure, Ok};
 use rooch_types::framework::session_key::SessionKey;
 use rooch_types::key_struct::{MnemonicData, MnemonicResult};
+use rooch_types::to_bech32::ToBech32;
 use rooch_types::{
     address::RoochAddress,
     authentication_key::AuthenticationKey,
@@ -74,7 +75,7 @@ impl AccountKeystore for BaseKeyStore {
             let keypair: RoochKeyPair = encryption.decrypt_with_type(password.clone())?;
             let public_key = keypair.public();
             let bitcoin_address = public_key.bitcoin_address()?;
-            let nostr_bech32_public_key = public_key.nostr_bech32_public_key()?;
+            let nostr_bech32_public_key = public_key.xonly_public_key()?.to_bech32()?;
             let has_session_key = self.session_keys.contains_key(address);
             let local_account = LocalAccount {
                 address: *address,

--- a/crates/rooch-key/src/keystore/base_keystore.rs
+++ b/crates/rooch-key/src/keystore/base_keystore.rs
@@ -103,10 +103,9 @@ impl AccountKeystore for BaseKeyStore {
             let keypair: RoochKeyPair = encryption.decrypt_with_type::<RoochKeyPair>(password)?;
             Ok(keypair)
         } else {
-            Err(anyhow::Error::new(RoochError::SignMessageError(format!(
-                "Cannot find key for address: [{:?}]",
-                address
-            ))))
+            Err(anyhow::Error::new(RoochError::CommandArgumentError(
+                format!("Cannot find key for address: [{:?}]", address),
+            )))
         }
     }
 

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -910,7 +910,7 @@
         ],
         "properties": {
           "txid": {
-            "$ref": "#/components/schemas/bitcoin::hash_types::newtypes::Txid"
+            "$ref": "#/components/schemas/bitcoin::blockdata::transaction::Txid"
           },
           "vout": {
             "type": "integer",
@@ -3104,7 +3104,7 @@
             "description": "The txid of the UTXO",
             "allOf": [
               {
-                "$ref": "#/components/schemas/bitcoin::hash_types::newtypes::Txid"
+                "$ref": "#/components/schemas/bitcoin::blockdata::transaction::Txid"
               }
             ]
           },
@@ -3248,7 +3248,7 @@
       "alloc::vec::Vec<u8>": {
         "type": "string"
       },
-      "bitcoin::hash_types::newtypes::Txid": {
+      "bitcoin::blockdata::transaction::Txid": {
         "type": "string"
       },
       "move_binary_format::file_format::Ability": {

--- a/crates/rooch-rpc-api/Cargo.toml
+++ b/crates/rooch-rpc-api/Cargo.toml
@@ -23,7 +23,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 schemars = { workspace = true }
 bitcoin = { workspace = true }
-nostr = { workspace = true }
 
 move-core-types = { workspace = true }
 move-resource-viewer = { workspace = true }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/address.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/address.rs
@@ -66,6 +66,7 @@ impl From<RoochAddressView> for AccountAddress {
     }
 }
 
+//TODO directly use UnitedAddress and remove UnitedAddressView
 #[derive(Debug, Clone)]
 pub struct UnitedAddress {
     pub rooch_address: RoochAddress,
@@ -163,5 +164,36 @@ impl TryFrom<UnitedAddressView> for NostrPublicKey {
             Some(nostr_public_key) => Ok(nostr_public_key),
             None => Err(anyhow::anyhow!("No Nostr public key found")),
         }
+    }
+}
+
+impl From<BitcoinAddress> for UnitedAddressView {
+    fn from(value: BitcoinAddress) -> Self {
+        StrView(UnitedAddress {
+            rooch_address: value.to_rooch_address(),
+            bitcoin_address: Some(value),
+            nostr_public_key: None,
+        })
+    }
+}
+
+impl From<RoochAddress> for UnitedAddressView {
+    fn from(value: RoochAddress) -> Self {
+        StrView(UnitedAddress {
+            rooch_address: value,
+            bitcoin_address: None,
+            nostr_public_key: None,
+        })
+    }
+}
+
+impl From<bitcoin::Address> for UnitedAddressView {
+    fn from(value: bitcoin::Address) -> Self {
+        let value = BitcoinAddress::from(value);
+        StrView(UnitedAddress {
+            rooch_address: value.to_rooch_address(),
+            bitcoin_address: Some(value),
+            nostr_public_key: None,
+        })
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/address.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/address.rs
@@ -3,11 +3,12 @@
 
 use crate::jsonrpc_types::StrView;
 use anyhow::Result;
+use bitcoin::XOnlyPublicKey;
 use move_core_types::account_address::AccountAddress;
-use nostr::{key::XOnlyPublicKey, prelude::FromBech32};
 use rooch_types::{
     address::{BitcoinAddress, NostrPublicKey, RoochAddress},
     bitcoin::network::Network,
+    to_bech32::FromBech32,
 };
 use std::str::FromStr;
 
@@ -91,6 +92,7 @@ impl std::fmt::Display for UnitedAddressView {
 impl FromStr for UnitedAddressView {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        //TODO use the prefix to determine the type of address
         match RoochAddress::from_str(s) {
             Ok(rooch_address) => Ok(StrView(UnitedAddress {
                 rooch_address,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/btc/transaction.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/btc/transaction.rs
@@ -3,7 +3,6 @@
 
 use crate::jsonrpc_types::StrView;
 use anyhow::Result;
-use bitcoin::hashes::Hash;
 use bitcoin::Txid;
 use std::fmt;
 use std::str::FromStr;
@@ -11,9 +10,8 @@ use std::str::FromStr;
 pub type TxidView = StrView<Txid>;
 
 impl fmt::Display for TxidView {
-    //TODO check display format
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:x}", self.0)
+        write!(f, "{}", self.0)
     }
 }
 
@@ -30,12 +28,6 @@ impl From<TxidView> for Txid {
     }
 }
 
-pub fn hex_to_txid(hex_string: &str) -> Result<Txid> {
-    let mut bytes = hex::decode(hex_string)?;
-    bytes.reverse();
-    Ok(Txid::from_slice(&bytes)?)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -44,8 +36,10 @@ mod test {
     #[test]
     fn test_txid() -> Result<()> {
         let txid_str = "5fddcbdc3eb21a93e8dd1dd3f9087c3677f422b82d5ba39a6b1ec37338154af6";
-        let txid = hex_to_txid(txid_str)?;
+        let txid_view = TxidView::from_str(txid_str)?;
+        let txid = Txid::from_str(txid_str)?;
         let txid_str2 = txid.to_string();
+        assert!(txid_view.0 == txid);
         assert!(txid_str == txid_str2);
 
         Ok(())

--- a/crates/rooch-rpc-client/Cargo.toml
+++ b/crates/rooch-rpc-client/Cargo.toml
@@ -23,6 +23,7 @@ jsonrpsee = { workspace = true }
 serde_json = { workspace = true }
 log = { workspace = true }
 hex = { workspace = true }
+bitcoin = { workspace = true }
 
 move-core-types = { workspace = true }
 

--- a/crates/rooch-rpc-client/Cargo.toml
+++ b/crates/rooch-rpc-client/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 log = { workspace = true }
 hex = { workspace = true }
 bitcoin = { workspace = true }
+tracing = { workspace = true }
 
 move-core-types = { workspace = true }
 

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -94,7 +94,7 @@ impl WalletContext {
         parsed_address: ParsedAddress,
     ) -> RoochResult<RoochAddress> {
         match parsed_address {
-            ParsedAddress::Numerical(address) => Ok(address.into()),
+            ParsedAddress::Numerical(address) => Ok(address),
             ParsedAddress::Named(name) => self
                 .address_mapping
                 .get(&name)

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -225,6 +225,7 @@ pub async fn run_start_server(opt: RoochOpt, server_opt: ServerOpt) -> Result<Se
         let rooch_dao_bitcoin_address = network.mock_genesis_account(&sequencer_keypair)?;
         let rooch_dao_address = rooch_dao_bitcoin_address.to_rooch_address();
         println!("Rooch DAO address: {:?}", rooch_dao_address);
+        println!("Rooch DAO Bitcoin address: {}", rooch_dao_bitcoin_address);
     } else {
         ensure!(
             network.genesis_config.sequencer_account == sequencer_bitcoin_address,

--- a/crates/rooch-types/Cargo.toml
+++ b/crates/rooch-types/Cargo.toml
@@ -35,13 +35,11 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 schemars = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-nostr = { workspace = true }
 clap = { workspace = true }
 sha3 = { workspace = true }
 bs58 = { workspace = true, features = ["check"] }
 chacha20poly1305 = { workspace = true }
 argon2 = { workspace = true }
-miniscript = { workspace = true }
 
 move-core-types = { workspace = true }
 move-vm-types = { workspace = true }

--- a/crates/rooch-types/Cargo.toml
+++ b/crates/rooch-types/Cargo.toml
@@ -40,6 +40,7 @@ sha3 = { workspace = true }
 bs58 = { workspace = true, features = ["check"] }
 chacha20poly1305 = { workspace = true }
 argon2 = { workspace = true }
+tracing = { workspace = true }
 
 move-core-types = { workspace = true }
 move-vm-types = { workspace = true }

--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -575,7 +575,7 @@ impl TryFrom<u8> for BitcoinAddressPayloadType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 #[serde_as]
 pub struct BitcoinAddress {
     bytes: Vec<u8>,
@@ -606,6 +606,12 @@ impl<'de> Deserialize<'de> for BitcoinAddress {
             let bytes = Vec::<u8>::deserialize(deserializer)?;
             Ok(Self { bytes })
         }
+    }
+}
+
+impl fmt::Debug for BitcoinAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/crates/rooch-types/src/address.rs
+++ b/crates/rooch-types/src/address.rs
@@ -1234,7 +1234,7 @@ mod test {
         let address_str = bitcoin_address.format(network::Network::Bitcoin)?;
         let btc_address = bitcoin::Address::from_str(&address_str).unwrap();
         let btc_address = btc_address.assume_checked();
-        let btc_address2 = bitcoin_address.to_bitcoin_address(bitcoin::Network::Regtest)?;
+        let btc_address2 = bitcoin_address.to_bitcoin_address(network::Network::Bitcoin)?;
         assert_eq!(btc_address, btc_address2);
         println!(
             "test_convert_bitcoin_address bitcoin address {} ",

--- a/crates/rooch-types/src/bitcoin/multisign_account.rs
+++ b/crates/rooch-types/src/bitcoin/multisign_account.rs
@@ -113,10 +113,6 @@ pub fn generate_multisign_address(
     // Sort public keys to ensure the same script is generated for the same set of keys
     x_only_public_keys.sort();
 
-    // let x_only_public_keys = x_only_public_keys
-    //     .into_iter()
-    //     .map(|pk| XOnlyPublicKey::from_slice(&pk))
-    //     .collect::<Result<Vec<_>, bitcoin::secp256k1::Error>>()?;
     let multisig_script = create_multisig_script(threshold, &x_only_public_keys);
 
     let builder = TaprootBuilder::new().add_leaf(0, multisig_script)?;

--- a/crates/rooch-types/src/bitcoin/network.rs
+++ b/crates/rooch-types/src/bitcoin/network.rs
@@ -23,16 +23,14 @@ pub enum Network {
     Regtest = 4,
 }
 
-impl TryFrom<u8> for Network {
-    type Error = anyhow::Error;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
+impl From<u8> for Network {
+    fn from(value: u8) -> Self {
         match value {
-            1 => Ok(Network::Bitcoin),
-            2 => Ok(Network::Testnet),
-            3 => Ok(Network::Signet),
-            4 => Ok(Network::Regtest),
-            _ => Err(anyhow::anyhow!("Bitcoin network {} is invalid", value)),
+            1 => Network::Bitcoin,
+            2 => Network::Testnet,
+            3 => Network::Signet,
+            4 => Network::Regtest,
+            _ => Network::Bitcoin,
         }
     }
 }

--- a/crates/rooch-types/src/bitcoin/network.rs
+++ b/crates/rooch-types/src/bitcoin/network.rs
@@ -62,12 +62,12 @@ impl std::fmt::Display for Network {
 }
 
 impl Network {
-    pub fn bech32_hrp(&self) -> bitcoin::bech32::Hrp {
+    pub fn bech32_hrp(&self) -> bech32::Hrp {
         match self {
-            Network::Bitcoin => bitcoin::bech32::hrp::BC,
-            Network::Testnet => bitcoin::bech32::hrp::TB,
-            Network::Signet => bitcoin::bech32::hrp::TB,
-            Network::Regtest => bitcoin::bech32::hrp::BCRT,
+            Network::Bitcoin => bech32::hrp::BC,
+            Network::Testnet => bech32::hrp::TB,
+            Network::Signet => bech32::hrp::TB,
+            Network::Regtest => bech32::hrp::BCRT,
         }
     }
 

--- a/crates/rooch-types/src/bitcoin/types.rs
+++ b/crates/rooch-types/src/bitcoin/types.rs
@@ -169,7 +169,7 @@ pub struct Transaction {
 impl From<bitcoin::Transaction> for Transaction {
     fn from(tx: bitcoin::Transaction) -> Self {
         Self {
-            id: tx.txid().into_address(),
+            id: tx.compute_txid().into_address(),
             version: tx.version.0 as u32,
             lock_time: tx.lock_time.to_consensus_u32(),
             input: tx.input.into_iter().map(|tx_in| tx_in.into()).collect(),

--- a/crates/rooch-types/src/bitcoin/types.rs
+++ b/crates/rooch-types/src/bitcoin/types.rs
@@ -312,6 +312,15 @@ impl From<bitcoin::OutPoint> for OutPoint {
     }
 }
 
+impl From<OutPoint> for bitcoin::OutPoint {
+    fn from(out_point: OutPoint) -> Self {
+        Self {
+            txid: Txid::from_address(out_point.txid),
+            vout: out_point.vout,
+        }
+    }
+}
+
 impl MoveStructType for OutPoint {
     const MODULE_NAME: &'static IdentStr = MODULE_NAME;
     const STRUCT_NAME: &'static IdentStr = ident_str!("OutPoint");

--- a/crates/rooch-types/src/bitcoin/utxo.rs
+++ b/crates/rooch-types/src/bitcoin/utxo.rs
@@ -3,7 +3,9 @@
 
 use super::types;
 use crate::addresses::BITCOIN_MOVE_ADDRESS;
+use crate::into_address::FromAddress;
 use anyhow::Result;
+use bitcoin::{Amount, Txid};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::object::{self, ObjectMeta};
@@ -103,6 +105,18 @@ impl UTXO {
 
     pub fn object_id(&self) -> ObjectID {
         derive_utxo_id(&types::OutPoint::new(self.txid, self.vout))
+    }
+
+    pub fn amount(&self) -> Amount {
+        Amount::from_sat(self.value)
+    }
+
+    pub fn txid(&self) -> Txid {
+        Txid::from_address(self.txid)
+    }
+
+    pub fn outpoint(&self) -> types::OutPoint {
+        types::OutPoint::new(self.txid, self.vout)
     }
 }
 

--- a/crates/rooch-types/src/crypto.rs
+++ b/crates/rooch-types/src/crypto.rs
@@ -367,6 +367,10 @@ impl PublicKey {
 
     pub fn from_hex(hex: &str) -> Result<Self, anyhow::Error> {
         let bytes = hex::decode(hex.strip_prefix("0x").unwrap_or(hex))?;
+        Self::from_bytes(&bytes)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, anyhow::Error> {
         match SignatureScheme::from_flag_byte(
             *bytes
                 .first()
@@ -392,6 +396,12 @@ impl PublicKey {
             },
             Err(e) => Err(anyhow!("Invalid bytes :{}", e)),
         }
+    }
+
+    pub fn from_bitcoin_pubkey(pk: &bitcoin::PublicKey) -> Result<Self, anyhow::Error> {
+        let bytes = pk.to_bytes();
+        let pk = Secp256k1PublicKey::from_bytes(&bytes)?;
+        Ok(PublicKey::Secp256k1((&pk).into()))
     }
 }
 

--- a/crates/rooch-types/src/crypto.rs
+++ b/crates/rooch-types/src/crypto.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail};
 use bech32::{encode, Bech32, EncodeError};
+use bitcoin::secp256k1::SecretKey;
 use derive_more::{AsMut, AsRef, From};
 pub use enum_dispatch::enum_dispatch;
 use eyre::eyre;
@@ -37,7 +38,6 @@ use fastcrypto::{
     secp256k1::{Secp256k1PublicKey, Secp256k1Signature, Secp256k1SignatureAsBytes},
 };
 use moveos_types::serde::Readable;
-use nostr::prelude::ToBech32;
 use schemars::JsonSchema;
 use serde::ser::Serializer;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -132,6 +132,33 @@ impl RoochKeyPair {
         match self {
             RoochKeyPair::Ed25519(kp) => kp.as_bytes(),
             RoochKeyPair::Secp256k1(kp) => kp.as_bytes(),
+        }
+    }
+
+    /// Get the secp256k1 keypair
+    pub fn secp256k1_keypair(&self) -> Option<bitcoin::key::Keypair> {
+        match self.secp256k1_secret_key() {
+            Some(sk) => {
+                let keypair = bitcoin::key::Keypair::from_secret_key(
+                    &bitcoin::secp256k1::Secp256k1::new(),
+                    &sk,
+                );
+                Some(keypair)
+            }
+            None => None,
+        }
+    }
+
+    /// Get the secp256k1 private key
+    pub fn secp256k1_secret_key(&self) -> Option<SecretKey> {
+        match self {
+            RoochKeyPair::Secp256k1(kp) => {
+                SecretKey::from_slice(kp.secret.as_bytes()).ok()
+                //The bitcoin and fastcrypto dependent on different version secp256k1 library
+                //So we cannot directly return the private key
+                //Some(&kp.secret.privkey)
+            }
+            _ => None,
         }
     }
 
@@ -345,15 +372,14 @@ impl PublicKey {
         }
     }
 
-    pub fn nostr_bech32_public_key(&self) -> Result<String, anyhow::Error> {
+    pub fn xonly_public_key(&self) -> Result<bitcoin::XOnlyPublicKey, anyhow::Error> {
         match self {
             PublicKey::Secp256k1(pk) => {
-                let xonly_pubkey = nostr::secp256k1::XOnlyPublicKey::from(
-                    nostr::secp256k1::PublicKey::from_slice(&pk.0)?,
-                );
-                Ok(xonly_pubkey.to_bech32()?)
+                let xonly_pubkey =
+                    bitcoin::XOnlyPublicKey::from(bitcoin::PublicKey::from_slice(&pk.0)?);
+                Ok(xonly_pubkey)
             }
-            _ => bail!("Only secp256k1 public key can be converted to nostr bech32 public key"),
+            _ => bail!("Only secp256k1 public key can be converted to xonly public key"),
         }
     }
 

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -156,6 +156,12 @@ impl From<io::Error> for RoochError {
     }
 }
 
+impl From<bitcoin::io::Error> for RoochError {
+    fn from(e: bitcoin::io::Error) -> Self {
+        RoochError::IOError(e.to_string())
+    }
+}
+
 impl From<VMError> for RoochError {
     fn from(e: VMError) -> Self {
         RoochError::VMError(e)
@@ -165,6 +171,18 @@ impl From<VMError> for RoochError {
 impl From<serde_json::Error> for RoochError {
     fn from(e: serde_json::Error) -> Self {
         RoochError::UnexpectedError(e.to_string())
+    }
+}
+
+impl From<bitcoin::psbt::Error> for RoochError {
+    fn from(e: bitcoin::psbt::Error) -> Self {
+        RoochError::CommandArgumentError(e.to_string())
+    }
+}
+
+impl From<hex::FromHexError> for RoochError {
+    fn from(e: hex::FromHexError) -> Self {
+        RoochError::CommandArgumentError(e.to_string())
     }
 }
 

--- a/crates/rooch-types/src/lib.rs
+++ b/crates/rooch-types/src/lib.rs
@@ -24,4 +24,5 @@ pub mod rooch_signature;
 pub mod sequencer;
 pub mod service_status;
 pub mod test_utils;
+pub mod to_bech32;
 pub mod transaction;

--- a/crates/rooch-types/src/to_bech32.rs
+++ b/crates/rooch-types/src/to_bech32.rs
@@ -1,0 +1,45 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Error;
+use bech32::Hrp;
+use bitcoin::XOnlyPublicKey;
+
+pub const PREFIX_BECH32_PUBLIC_KEY: &str = "npub";
+pub const NPUB: Hrp = Hrp::parse_unchecked(PREFIX_BECH32_PUBLIC_KEY);
+
+pub trait ToBech32 {
+    type Err;
+    fn to_bech32(&self) -> Result<String, Self::Err>;
+}
+
+impl ToBech32 for XOnlyPublicKey {
+    type Err = Error;
+
+    fn to_bech32(&self) -> Result<String, Self::Err> {
+        let data = self.serialize();
+        Ok(bech32::encode::<bech32::Bech32>(NPUB, &data)?)
+    }
+}
+
+pub trait FromBech32: Sized {
+    type Err;
+    fn from_bech32<S>(s: S) -> Result<Self, Self::Err>
+    where
+        S: Into<String>;
+}
+
+impl FromBech32 for XOnlyPublicKey {
+    type Err = Error;
+
+    fn from_bech32<S>(s: S) -> Result<Self, Self::Err>
+    where
+        S: Into<String>,
+    {
+        let (hrp, data) = bech32::decode(&s.into())?;
+        if hrp != NPUB {
+            return Err(Error::msg("Invalid HRP"));
+        }
+        Ok(XOnlyPublicKey::from_slice(&data)?)
+    }
+}

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -51,6 +51,7 @@ vergen-pretty = { workspace = true }
 prometheus = { workspace = true }
 lazy_static = { workspace = true }
 schemars = { workspace = true }
+bitcoin = { workspace = true }
 
 move-bytecode-utils = { workspace = true }
 move-binary-format = { workspace = true }
@@ -86,7 +87,6 @@ framework-builder = { workspace = true }
 framework-types = { workspace = true }
 raw-store = { workspace = true }
 smt = { workspace = true }
-bitcoin = { workspace = true }
 bitcoin-move = { workspace = true }
 
 rooch-key = { workspace = true }

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -199,7 +199,7 @@ async fn get_total_utxo_value(
 
         for utxo in page.data {
             total_value = total_value
-                .checked_add(utxo.value.get_value())
+                .checked_add(utxo.value.value())
                 .ok_or_else(|| anyhow::anyhow!("UTXO value overflow"))?;
         }
 

--- a/crates/rooch/src/commands/bitcoin/broadcast_tx.rs
+++ b/crates/rooch/src/commands/bitcoin/broadcast_tx.rs
@@ -1,0 +1,20 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use async_trait::async_trait;
+use clap::Parser;
+use rooch_types::error::RoochResult;
+
+#[derive(Debug, Parser)]
+pub struct BroadcastTx {
+    input_file: String,
+}
+
+#[async_trait]
+impl CommandAction<String> for BroadcastTx {
+    async fn execute(self) -> RoochResult<String> {
+        // Implement broadcast-tx logic here
+        Ok(format!("Broadcasted transaction from {}", self.input_file))
+    }
+}

--- a/crates/rooch/src/commands/bitcoin/broadcast_tx.rs
+++ b/crates/rooch/src/commands/bitcoin/broadcast_tx.rs
@@ -1,20 +1,28 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli_types::CommandAction;
+use crate::cli_types::{CommandAction, FileOrHexInput, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
 use rooch_types::error::RoochResult;
 
 #[derive(Debug, Parser)]
 pub struct BroadcastTx {
-    input_file: String,
+    /// The input tx file path or hex string
+    input: FileOrHexInput,
+    #[clap(flatten)]
+    pub(crate) context_options: WalletContextOptions,
 }
 
 #[async_trait]
 impl CommandAction<String> for BroadcastTx {
     async fn execute(self) -> RoochResult<String> {
-        // Implement broadcast-tx logic here
-        Ok(format!("Broadcasted transaction from {}", self.input_file))
+        let context = self.context_options.build()?;
+        let client = context.get_client().await?;
+
+        Ok(client
+            .rooch
+            .broadcast_bitcoin_tx(self.input.data.into(), None)
+            .await?)
     }
 }

--- a/crates/rooch/src/commands/bitcoin/build_tx.rs
+++ b/crates/rooch/src/commands/bitcoin/build_tx.rs
@@ -1,0 +1,168 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use super::transaction_builder::TransactionBuilder;
+use crate::cli_types::{CommandAction, WalletContextOptions};
+use anyhow::ensure;
+use async_trait::async_trait;
+use bitcoin::absolute::LockTime;
+use bitcoin::{Amount, FeeRate, OutPoint};
+use clap::Parser;
+use moveos_types::moveos_std::object::ObjectID;
+use rooch_types::address::ParsedAddress;
+use rooch_types::bitcoin::utxo::derive_utxo_id;
+use rooch_types::error::{RoochError, RoochResult};
+use std::str::FromStr;
+use tracing::info;
+
+#[derive(Debug, Clone)]
+pub enum ParsedInput {
+    /// Input is an UTXO ObjectID
+    ObjectID(ObjectID),
+    /// Input is an OutPoint
+    OutPoint(OutPoint),
+}
+
+impl FromStr for ParsedInput {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains(":") {
+            let outpoint = OutPoint::from_str(s)?;
+            Ok(ParsedInput::OutPoint(outpoint))
+        } else {
+            let object_id = ObjectID::from_str(s)?;
+            Ok(ParsedInput::ObjectID(object_id))
+        }
+    }
+}
+
+impl ParsedInput {
+    pub fn into_object_id(self) -> ObjectID {
+        match self {
+            ParsedInput::ObjectID(object_id) => object_id,
+            ParsedInput::OutPoint(outpoint) => derive_utxo_id(&outpoint.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedOutput {
+    pub address: ParsedAddress,
+    pub amount: Amount,
+}
+
+impl FromStr for ParsedOutput {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(':').collect();
+        ensure!(parts.len() == 2, "Invalid output format: {}", s);
+        let address = ParsedAddress::parse(parts[0])?;
+        let amount = Amount::from_str(parts[1])?;
+        Ok(ParsedOutput { address, amount })
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct BuildTx {
+    /// The sender address of the transaction, if not specified, the active address will be used
+    #[clap(long, short = 's', value_parser=ParsedAddress::parse, default_value = "default")]
+    sender: ParsedAddress,
+
+    /// The inputs of the transaction, if not specified, the UTXOs of the sender will be used
+    /// The format of the input is <object_id> or <txid>:<vout>
+    #[clap(long, short = 'i')]
+    inputs: Vec<ParsedInput>,
+
+    /// The to address of the transaction, if not specified, the outputs will be used
+    #[clap(long, short = 't', conflicts_with = "outputs", group = "to", value_parser=ParsedAddress::parse)]
+    to: Option<ParsedAddress>,
+
+    /// The amount of the transaction, if not specified, the amount will be calculated automatically
+    #[clap(long, short = 'a', conflicts_with = "outputs", group = "to")]
+    amount: Option<Amount>,
+
+    #[clap(long, short = 'o')]
+    outputs: Vec<ParsedOutput>,
+
+    /// The fee rate of the transaction, if not specified, the fee will be calculated automatically
+    #[clap(long)]
+    fee_rate: Option<FeeRate>,
+
+    /// The lock time of the transaction, if not specified, the lock time will be 0
+    #[clap(long)]
+    lock_time: Option<LockTime>,
+
+    /// The change address of the transaction, if not specified, the change address will be the sender's address
+    #[clap(long, value_parser=ParsedAddress::parse)]
+    change_address: Option<ParsedAddress>,
+
+    /// Skip check seal of the UTXOs, default is false
+    /// If set to true, some UTXO which carries other asserts, such as Inscription, maybe unexpected spent.
+    #[clap(long)]
+    skip_check_seal: bool,
+
+    #[clap(long, default_value = "unsigned_tx.json")]
+    output_file: String,
+
+    #[clap(flatten)]
+    pub(crate) context_options: WalletContextOptions,
+}
+
+#[async_trait]
+impl CommandAction<String> for BuildTx {
+    async fn execute(self) -> RoochResult<String> {
+        let context = self.context_options.build()?;
+        let client = context.get_client().await?;
+
+        let bitcoin_network = context.get_bitcoin_network().await?;
+
+        let sender = context.resolve_bitcoin_address(self.sender).await?;
+
+        let inputs = self
+            .inputs
+            .into_iter()
+            .map(|input| input.into_object_id())
+            .collect();
+        let mut tx_builder = TransactionBuilder::new(
+            client,
+            sender.to_bitcoin_address(bitcoin_network)?,
+            inputs,
+            self.skip_check_seal,
+        )
+        .await?;
+
+        if let Some(fee_rate) = self.fee_rate {
+            tx_builder = tx_builder.with_fee_rate(fee_rate);
+        }
+        if let Some(lock_time) = self.lock_time {
+            tx_builder = tx_builder.with_lock_time(lock_time);
+        }
+        if let Some(change_address) = self.change_address {
+            let change_address = context.resolve_bitcoin_address(change_address).await?;
+            tx_builder =
+                tx_builder.with_change_address(change_address.to_bitcoin_address(bitcoin_network)?);
+        }
+        let psbt = if let Some(to) = self.to {
+            let amount = self.amount.ok_or_else(|| {
+                RoochError::CommandArgumentError("Amount is required".to_string())
+            })?;
+            let to = context.resolve_bitcoin_address(to).await?;
+            tx_builder
+                .build_transfer(to.to_bitcoin_address(bitcoin_network)?, amount)
+                .await?
+        } else {
+            let mut outputs = Vec::new();
+            for output in self.outputs.iter() {
+                let address = context
+                    .resolve_bitcoin_address(output.address.clone())
+                    .await?;
+                outputs.push((address.to_bitcoin_address(bitcoin_network)?, output.amount));
+            }
+            tx_builder.build(outputs).await?
+        };
+        info!("PSBT: {}", serde_json::to_string_pretty(&psbt).unwrap());
+        Ok(psbt.serialize_hex())
+    }
+}

--- a/crates/rooch/src/commands/bitcoin/build_tx.rs
+++ b/crates/rooch/src/commands/bitcoin/build_tx.rs
@@ -27,7 +27,7 @@ impl FromStr for ParsedInput {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.contains(":") {
+        if s.contains(':') {
             let outpoint = OutPoint::from_str(s)?;
             Ok(ParsedInput::OutPoint(outpoint))
         } else {

--- a/crates/rooch/src/commands/bitcoin/mod.rs
+++ b/crates/rooch/src/commands/bitcoin/mod.rs
@@ -21,6 +21,7 @@ pub struct Bitcoin {
     cmd: BitcoinCommands,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
 pub enum BitcoinCommands {
     BuildTx(BuildTx),

--- a/crates/rooch/src/commands/bitcoin/mod.rs
+++ b/crates/rooch/src/commands/bitcoin/mod.rs
@@ -2,17 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::cli_types::CommandAction;
+use anyhow::Result;
 use async_trait::async_trait;
+use bitcoin::{consensus::Encodable, Psbt, Transaction, Txid};
 use broadcast_tx::BroadcastTx;
 use build_tx::BuildTx;
 use clap::{Parser, Subcommand};
 use rooch_types::error::RoochResult;
+use serde::{Deserialize, Serialize};
 use sign_tx::SignTx;
+use std::{env, fs::File, io::Write, path::PathBuf};
+use transfer::Transfer;
 
 pub mod broadcast_tx;
 pub mod build_tx;
 pub mod sign_tx;
 pub mod transaction_builder;
+pub mod transfer;
 pub mod utxo_selector;
 
 #[derive(Debug, Parser)]
@@ -27,15 +33,83 @@ pub enum BitcoinCommands {
     BuildTx(BuildTx),
     SignTx(SignTx),
     BroadcastTx(BroadcastTx),
+    Transfer(Transfer),
 }
 
 #[async_trait]
 impl CommandAction<String> for Bitcoin {
     async fn execute(self) -> RoochResult<String> {
         match self.cmd {
-            BitcoinCommands::BuildTx(build_tx) => build_tx.execute().await,
-            BitcoinCommands::SignTx(sign_tx) => sign_tx.execute().await,
-            BitcoinCommands::BroadcastTx(broadcast_tx) => broadcast_tx.execute().await,
+            BitcoinCommands::BuildTx(build_tx) => build_tx.execute_serialized().await,
+            BitcoinCommands::SignTx(sign_tx) => sign_tx.execute_serialized().await,
+            BitcoinCommands::BroadcastTx(broadcast_tx) => broadcast_tx.execute_serialized().await,
+            BitcoinCommands::Transfer(transfer) => transfer.execute_serialized().await,
         }
+    }
+}
+
+pub(crate) enum FileOutputData {
+    Psbt(Psbt),
+    Tx(Transaction),
+}
+
+impl FileOutputData {
+    pub fn txid(&self) -> Txid {
+        match self {
+            FileOutputData::Psbt(psbt) => psbt.unsigned_tx.compute_txid(),
+            FileOutputData::Tx(tx) => tx.compute_txid(),
+        }
+    }
+
+    pub fn file_suffix(&self) -> &str {
+        match self {
+            FileOutputData::Psbt(_) => "psbt",
+            FileOutputData::Tx(_) => "tx",
+        }
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        match self {
+            FileOutputData::Psbt(psbt) => psbt.serialize(),
+            FileOutputData::Tx(tx) => {
+                let mut buf = Vec::new();
+                tx.consensus_encode(&mut buf)
+                    .expect("encode tx should success");
+                buf
+            }
+        }
+    }
+
+    pub fn default_output_file_path(&self) -> Result<PathBuf> {
+        let temp_dir = env::temp_dir();
+        let tx_hash = self.txid();
+        let file_name = format!("{}.{}", hex::encode(&tx_hash[..8]), self.file_suffix());
+        Ok(temp_dir.join(file_name))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct FileOutput {
+    pub content: String,
+    pub output_type: String,
+    pub path: String,
+}
+
+impl FileOutput {
+    pub fn write_to_file(data: FileOutputData, output_path: Option<String>) -> Result<Self> {
+        let path = match output_path {
+            Some(path) => PathBuf::from(path),
+            None => data.default_output_file_path()?,
+        };
+        let mut file = File::create(&path)?;
+        // we write the hex encoded data to the file
+        // not the binary data, for better readability
+        let hex = hex::encode(data.encode());
+        file.write_all(hex.as_bytes())?;
+        Ok(FileOutput {
+            content: hex,
+            output_type: data.file_suffix().to_string(),
+            path: path.to_string_lossy().to_string(),
+        })
     }
 }

--- a/crates/rooch/src/commands/bitcoin/mod.rs
+++ b/crates/rooch/src/commands/bitcoin/mod.rs
@@ -1,0 +1,40 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use async_trait::async_trait;
+use broadcast_tx::BroadcastTx;
+use build_tx::BuildTx;
+use clap::{Parser, Subcommand};
+use rooch_types::error::RoochResult;
+use sign_tx::SignTx;
+
+pub mod broadcast_tx;
+pub mod build_tx;
+pub mod sign_tx;
+pub mod transaction_builder;
+pub mod utxo_selector;
+
+#[derive(Debug, Parser)]
+pub struct Bitcoin {
+    #[clap(subcommand)]
+    cmd: BitcoinCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum BitcoinCommands {
+    BuildTx(BuildTx),
+    SignTx(SignTx),
+    BroadcastTx(BroadcastTx),
+}
+
+#[async_trait]
+impl CommandAction<String> for Bitcoin {
+    async fn execute(self) -> RoochResult<String> {
+        match self.cmd {
+            BitcoinCommands::BuildTx(build_tx) => build_tx.execute().await,
+            BitcoinCommands::SignTx(sign_tx) => sign_tx.execute().await,
+            BitcoinCommands::BroadcastTx(broadcast_tx) => broadcast_tx.execute().await,
+        }
+    }
+}

--- a/crates/rooch/src/commands/bitcoin/sign_tx.rs
+++ b/crates/rooch/src/commands/bitcoin/sign_tx.rs
@@ -181,15 +181,8 @@ pub(crate) async fn sign_psbt(
                     debug!("Collected signatures: {:?}", ordered_signatures);
 
                     let mut witness = Witness::new();
-                    //let mut valid_sig_count:u64 = 0;
                     for sig in ordered_signatures {
-                        // if !sig.is_empty() {
-                        //     valid_sig_count += 1;
-                        // }
                         witness.push(sig);
-                        // if valid_sig_count >= account_info.threshold {
-                        //     break;
-                        // }
                     }
 
                     witness.push(multisig_script.as_bytes());

--- a/crates/rooch/src/commands/bitcoin/sign_tx.rs
+++ b/crates/rooch/src/commands/bitcoin/sign_tx.rs
@@ -1,22 +1,55 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli_types::CommandAction;
+use crate::{
+    cli_types::{CommandAction, WalletContextOptions},
+    commands::transaction::commands::is_file_path,
+};
 use async_trait::async_trait;
+use bitcoin::{consensus::Encodable, key::Secp256k1};
 use clap::Parser;
+use rooch_rpc_client::wallet_context::WalletContext;
 use rooch_types::error::RoochResult;
 
 #[derive(Debug, Parser)]
 pub struct SignTx {
-    input_file: String,
+    input: String,
     #[clap(long)]
     output_file: Option<String>,
+
+    #[clap(flatten)]
+    pub(crate) context_options: WalletContextOptions,
 }
 
 #[async_trait]
 impl CommandAction<String> for SignTx {
     async fn execute(self) -> RoochResult<String> {
-        // Implement sign-tx logic here
-        Ok(format!("Signed transaction from {}", self.input_file))
+        let context = self.context_options.build_require_password()?;
+        let _client = context.get_client().await?;
+
+        let bytes = if is_file_path(&self.input) {
+            std::fs::read(self.input)?
+        } else {
+            let hex = self.input.strip_prefix("0x").unwrap_or(&self.input);
+            hex::decode(hex)?
+        };
+
+        let psbt = bitcoin::Psbt::deserialize(&bytes)?;
+
+        let tx = sign_tx(psbt, &context)?;
+        let mut bytes = vec![];
+        tx.consensus_encode(&mut bytes)?;
+        let signed_tx_hex = hex::encode(bytes);
+        Ok(signed_tx_hex)
     }
+}
+
+fn sign_tx(
+    mut psbt: bitcoin::Psbt,
+    context: &WalletContext,
+) -> Result<bitcoin::Transaction, anyhow::Error> {
+    let secp = Secp256k1::new();
+    psbt.sign(context, &secp)
+        .map_err(|_e| anyhow::anyhow!("Sign psbt errror"))?;
+    Ok(psbt.extract_tx()?)
 }

--- a/crates/rooch/src/commands/bitcoin/sign_tx.rs
+++ b/crates/rooch/src/commands/bitcoin/sign_tx.rs
@@ -1,26 +1,35 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
-
 use crate::{
-    cli_types::{CommandAction, WalletContextOptions},
-    commands::transaction::commands::is_file_path,
+    cli_types::{CommandAction, FileOrHexInput, WalletContextOptions},
+    commands::bitcoin::{FileOutput, FileOutputData},
 };
+use anyhow::bail;
 use async_trait::async_trait;
-use bitcoin::{consensus::Encodable, key::Secp256k1};
+use bitcoin::{
+    key::{Keypair, Secp256k1, TapTweak},
+    sighash::{Prevouts, SighashCache},
+    Psbt, TapLeafHash, TapSighashType, Witness,
+};
 use clap::Parser;
 use moveos_types::module_binding::MoveFunctionCaller;
+use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_rpc_client::{wallet_context::WalletContext, Client};
 use rooch_types::{
-    address::BitcoinAddress,
-    bitcoin::multisign_account::{self, MultisignAccountModule},
-    error::RoochResult,
+    address::{BitcoinAddress, RoochAddress},
+    bitcoin::multisign_account::MultisignAccountModule,
+    error::{RoochError, RoochResult},
 };
+use tracing::debug;
 
 #[derive(Debug, Parser)]
 pub struct SignTx {
-    input: String,
+    /// The input psbt file path or hex string
+    input: FileOrHexInput,
+
+    /// The output file path
+    /// If not provided, the file will be written to temp directory
     #[clap(long)]
     output_file: Option<String>,
 
@@ -28,56 +37,171 @@ pub struct SignTx {
     pub(crate) context_options: WalletContextOptions,
 }
 
+#[derive(Debug, Clone)]
+pub enum SignOutput {
+    Psbt(Psbt),
+    Tx(bitcoin::Transaction),
+}
+
 #[async_trait]
-impl CommandAction<String> for SignTx {
-    async fn execute(self) -> RoochResult<String> {
+impl CommandAction<FileOutput> for SignTx {
+    async fn execute(self) -> RoochResult<FileOutput> {
         let context = self.context_options.build_require_password()?;
         let client = context.get_client().await?;
 
-        let bytes = if is_file_path(&self.input) {
-            std::fs::read(self.input)?
-        } else {
-            let hex = self.input.strip_prefix("0x").unwrap_or(&self.input);
-            hex::decode(hex)?
+        let psbt = Psbt::deserialize(&self.input.data)?;
+        debug!("psbt before sign: {:?}", psbt);
+        let output = sign_psbt(psbt, &context, &client).await?;
+        debug!("sign output: {:?}", output);
+
+        let file_output_data = match output {
+            SignOutput::Psbt(psbt) => FileOutputData::Psbt(psbt),
+            SignOutput::Tx(tx) => FileOutputData::Tx(tx),
         };
-
-        let psbt = bitcoin::Psbt::deserialize(&bytes)?;
-
-        let tx = sign_tx(psbt, &context, &client).await?;
-        let mut bytes = vec![];
-        tx.consensus_encode(&mut bytes)?;
-        let signed_tx_hex = hex::encode(bytes);
-        Ok(signed_tx_hex)
+        let output = FileOutput::write_to_file(file_output_data, self.output_file)?;
+        Ok(output)
     }
 }
 
-async fn sign_tx(
-    mut psbt: bitcoin::Psbt,
+pub(crate) async fn sign_psbt(
+    mut psbt: Psbt,
     context: &WalletContext,
     client: &Client,
-) -> Result<bitcoin::Transaction, anyhow::Error> {
+) -> Result<SignOutput, anyhow::Error> {
     let secp = Secp256k1::new();
 
     let multisign_account_module = client.as_module_binding::<MultisignAccountModule>();
 
-    let mut multisign_addresses = HashSet::new();
-    for input in psbt.inputs.iter_mut() {
+    let spend_utxos = (0..psbt.inputs.len())
+        .map(|i| psbt.spend_utxo(i).ok().cloned())
+        .collect::<Vec<_>>();
+
+    if !spend_utxos.iter().all(Option::is_some) {
+        bail!("Missing spend utxo");
+    }
+
+    let all_spend_utxos = spend_utxos.into_iter().flatten().collect::<Vec<_>>();
+    let prevouts = Prevouts::All(&all_spend_utxos);
+
+    let mut sighash_cache = SighashCache::new(&psbt.unsigned_tx);
+
+    for (idx, input) in psbt.inputs.iter_mut().enumerate() {
         if let Some(utxo) = input.witness_utxo.as_ref() {
             let addr = BitcoinAddress::from(&utxo.script_pubkey);
             let rooch_addr = addr.to_rooch_address();
             if multisign_account_module.is_multisign_account(rooch_addr.into())? {
-                multisign_addresses.insert(rooch_addr);
+                let account_info = client.rooch.get_multisign_account_info(rooch_addr).await?;
+
+                let (control_block, (multisig_script, leaf_version)) = input
+                    .tap_scripts
+                    .iter()
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("No tap script found for input {}", idx))?;
+
+                let tap_leaf_hash = TapLeafHash::from_script(multisig_script, *leaf_version);
+
+                let hash_ty = TapSighashType::Default;
+
+                let sighash = sighash_cache.taproot_script_spend_signature_hash(
+                    idx,
+                    &prevouts,
+                    tap_leaf_hash,
+                    hash_ty,
+                )?;
+
+                for participant in account_info.participants.values() {
+                    let participant_addr: RoochAddress = participant.participant_address.into();
+                    if context.keystore.contains_address(&participant_addr) {
+                        debug!("Signing for participant: {}", participant_addr);
+                        let kp = context.get_key_pair(&participant_addr)?;
+                        let our_pubkey = kp.public().xonly_public_key()?;
+
+                        let sk = kp.secp256k1_secret_key().expect("should have secret key");
+                        let key_pair = Keypair::from_secret_key(&secp, &sk);
+
+                        let signature = secp.sign_schnorr(&sighash.into(), &key_pair);
+
+                        input.tap_script_sigs.insert(
+                            (our_pubkey, tap_leaf_hash),
+                            bitcoin::taproot::Signature {
+                                signature,
+                                sighash_type: hash_ty,
+                            },
+                        );
+                    }
+                }
+
+                //Try to finalize the psbt
+                if input.tap_script_sigs.len() >= account_info.threshold as usize {
+                    let mut signatures = Vec::new();
+
+                    //TODO handle multiple tap_leaf case
+                    //make sure the signature order same as the public key order
+
+                    for participant in account_info.participants.values() {
+                        let xonly_pubkey = participant.x_only_public_key()?;
+                        if let Some(sig) =
+                            input.tap_script_sigs.remove(&(xonly_pubkey, tap_leaf_hash))
+                        {
+                            signatures.push(sig.to_vec());
+                        }
+                    }
+
+                    debug!("Signatures: {:?}", signatures.len());
+
+                    let mut witness = Witness::new();
+
+                    for sig in signatures.iter().take(account_info.threshold as usize) {
+                        witness.push(sig);
+                    }
+
+                    witness.push(multisig_script.as_bytes());
+                    witness.push(control_block.serialize());
+                    input.final_script_witness = Some(witness);
+                }
+            } else {
+                let kp = context.get_key_pair(&rooch_addr)?;
+                let sk = kp.secp256k1_secret_key().expect("should have secret key");
+
+                let key_pair = Keypair::from_secret_key(&secp, &sk)
+                    .tap_tweak(&secp, input.tap_merkle_root)
+                    .to_inner();
+
+                let sighash = sighash_cache.taproot_key_spend_signature_hash(
+                    idx,
+                    &prevouts,
+                    TapSighashType::Default,
+                )?;
+                debug!("Calculated sighash: {:?}", sighash);
+
+                let signature = secp.sign_schnorr(&sighash.into(), &key_pair);
+                debug!("Created signature: {:?}", signature);
+                let tap_key_sig = bitcoin::taproot::Signature {
+                    signature,
+                    sighash_type: TapSighashType::Default,
+                };
+
+                let witness = Witness::from_slice(&[tap_key_sig.to_vec()]);
+                input.tap_key_sig = Some(tap_key_sig);
+                input.final_script_witness = Some(witness);
             }
         }
     }
 
-    for rooch_addr in multisign_addresses {
-        let kp = context.get_key_pair(&rooch_addr)?;
-        multisign_account::sign_taproot_multisig(&mut psbt, &kp)?;
-    }
+    let sign_output = if is_psbt_finalized(&psbt) {
+        let tx = psbt.extract_tx().map_err(|e| {
+            RoochError::CommandArgumentError(format!("Failed to extract tx from psbt: {}", e))
+        })?;
+        SignOutput::Tx(tx)
+    } else {
+        SignOutput::Psbt(psbt)
+    };
 
-    psbt.sign(context, &secp)
-        .map_err(|_e| anyhow::anyhow!("Sign psbt errror"))?;
+    Ok(sign_output)
+}
 
-    Ok(psbt.extract_tx()?)
+fn is_psbt_finalized(psbt: &Psbt) -> bool {
+    psbt.inputs
+        .iter()
+        .all(|input| input.final_script_sig.is_some() || input.final_script_witness.is_some())
 }

--- a/crates/rooch/src/commands/bitcoin/sign_tx.rs
+++ b/crates/rooch/src/commands/bitcoin/sign_tx.rs
@@ -1,6 +1,8 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use crate::{
     cli_types::{CommandAction, WalletContextOptions},
     commands::transaction::commands::is_file_path,
@@ -8,8 +10,13 @@ use crate::{
 use async_trait::async_trait;
 use bitcoin::{consensus::Encodable, key::Secp256k1};
 use clap::Parser;
-use rooch_rpc_client::wallet_context::WalletContext;
-use rooch_types::error::RoochResult;
+use moveos_types::module_binding::MoveFunctionCaller;
+use rooch_rpc_client::{wallet_context::WalletContext, Client};
+use rooch_types::{
+    address::BitcoinAddress,
+    bitcoin::multisign_account::{self, MultisignAccountModule},
+    error::RoochResult,
+};
 
 #[derive(Debug, Parser)]
 pub struct SignTx {
@@ -25,7 +32,7 @@ pub struct SignTx {
 impl CommandAction<String> for SignTx {
     async fn execute(self) -> RoochResult<String> {
         let context = self.context_options.build_require_password()?;
-        let _client = context.get_client().await?;
+        let client = context.get_client().await?;
 
         let bytes = if is_file_path(&self.input) {
             std::fs::read(self.input)?
@@ -36,7 +43,7 @@ impl CommandAction<String> for SignTx {
 
         let psbt = bitcoin::Psbt::deserialize(&bytes)?;
 
-        let tx = sign_tx(psbt, &context)?;
+        let tx = sign_tx(psbt, &context, &client).await?;
         let mut bytes = vec![];
         tx.consensus_encode(&mut bytes)?;
         let signed_tx_hex = hex::encode(bytes);
@@ -44,12 +51,33 @@ impl CommandAction<String> for SignTx {
     }
 }
 
-fn sign_tx(
+async fn sign_tx(
     mut psbt: bitcoin::Psbt,
     context: &WalletContext,
+    client: &Client,
 ) -> Result<bitcoin::Transaction, anyhow::Error> {
     let secp = Secp256k1::new();
+
+    let multisign_account_module = client.as_module_binding::<MultisignAccountModule>();
+
+    let mut multisign_addresses = HashSet::new();
+    for input in psbt.inputs.iter_mut() {
+        if let Some(utxo) = input.witness_utxo.as_ref() {
+            let addr = BitcoinAddress::from(&utxo.script_pubkey);
+            let rooch_addr = addr.to_rooch_address();
+            if multisign_account_module.is_multisign_account(rooch_addr.into())? {
+                multisign_addresses.insert(rooch_addr);
+            }
+        }
+    }
+
+    for rooch_addr in multisign_addresses {
+        let kp = context.get_key_pair(&rooch_addr)?;
+        multisign_account::sign_taproot_multisig(&mut psbt, &kp)?;
+    }
+
     psbt.sign(context, &secp)
         .map_err(|_e| anyhow::anyhow!("Sign psbt errror"))?;
+
     Ok(psbt.extract_tx()?)
 }

--- a/crates/rooch/src/commands/bitcoin/sign_tx.rs
+++ b/crates/rooch/src/commands/bitcoin/sign_tx.rs
@@ -1,0 +1,22 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::CommandAction;
+use async_trait::async_trait;
+use clap::Parser;
+use rooch_types::error::RoochResult;
+
+#[derive(Debug, Parser)]
+pub struct SignTx {
+    input_file: String,
+    #[clap(long)]
+    output_file: Option<String>,
+}
+
+#[async_trait]
+impl CommandAction<String> for SignTx {
+    async fn execute(self) -> RoochResult<String> {
+        // Implement sign-tx logic here
+        Ok(format!("Signed transaction from {}", self.input_file))
+    }
+}

--- a/crates/rooch/src/commands/bitcoin/transaction_builder.rs
+++ b/crates/rooch/src/commands/bitcoin/transaction_builder.rs
@@ -1,0 +1,171 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use super::utxo_selector::UTXOSelector;
+use anyhow::{anyhow, bail, Result};
+use bitcoin::{
+    absolute::LockTime, transaction::Version, Address, Amount, FeeRate, OutPoint, Psbt, ScriptBuf,
+    Sequence, Transaction, TxIn, TxOut, Witness,
+};
+use moveos_types::moveos_std::object::ObjectID;
+use rooch_rpc_client::Client;
+use rooch_types::bitcoin::utxo::UTXO;
+
+#[derive(Debug)]
+pub struct TransactionBuilder {
+    utxo_selector: UTXOSelector,
+    fee_rate: FeeRate,
+    change_address: Address,
+    lock_time: Option<LockTime>,
+}
+
+impl TransactionBuilder {
+    const ADDITIONAL_INPUT_VBYTES: usize = 58;
+    const ADDITIONAL_OUTPUT_VBYTES: usize = 43;
+    const SCHNORR_SIGNATURE_SIZE: usize = 64;
+
+    pub async fn new(
+        client: Client,
+        sender: Address,
+        inputs: Vec<ObjectID>,
+        skip_seal_check: bool,
+    ) -> Result<Self> {
+        let utxo_selector =
+            UTXOSelector::new(client, sender.clone(), inputs, skip_seal_check).await?;
+        Ok(Self {
+            utxo_selector,
+            fee_rate: FeeRate::from_sat_per_vb(10).unwrap(),
+            change_address: sender,
+            lock_time: None,
+        })
+    }
+
+    pub fn with_fee_rate(mut self, fee_rate: FeeRate) -> Self {
+        self.fee_rate = fee_rate;
+        self
+    }
+
+    pub fn with_lock_time(mut self, locktime: LockTime) -> Self {
+        self.lock_time = Some(locktime);
+        self
+    }
+
+    pub fn with_change_address(mut self, change_address: Address) -> Self {
+        self.change_address = change_address;
+        self
+    }
+
+    fn estimate_vbytes_with(inputs: usize, outputs: Vec<Address>) -> usize {
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: (0..inputs)
+                .map(|_| TxIn {
+                    previous_output: OutPoint::null(),
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                    witness: Witness::from_slice(&[&[0; Self::SCHNORR_SIGNATURE_SIZE]]),
+                })
+                .collect(),
+            output: outputs
+                .into_iter()
+                .map(|address| TxOut {
+                    value: Amount::from_sat(0),
+                    script_pubkey: address.script_pubkey(),
+                })
+                .collect(),
+        }
+        .vsize()
+    }
+
+    pub async fn build_transfer(self, receipient: Address, amount: Amount) -> Result<Psbt> {
+        self.build(vec![(receipient, amount)]).await
+    }
+
+    pub async fn build(mut self, outputs: Vec<(Address, Amount)>) -> Result<Psbt> {
+        let total_output = outputs.iter().map(|(_, amount)| *amount).sum::<Amount>();
+        let output_address = outputs
+            .iter()
+            .map(|(address, _)| address.clone())
+            .collect::<Vec<_>>();
+        let estimate_inputs = if self.utxo_selector.specific_utxos().is_empty() {
+            1
+        } else {
+            self.utxo_selector.specific_utxos().len()
+        };
+        let estimate_fee = self
+            .fee_rate
+            .fee_vb(
+                (Self::estimate_vbytes_with(estimate_inputs, output_address)
+                    + Self::ADDITIONAL_INPUT_VBYTES
+                    + Self::ADDITIONAL_OUTPUT_VBYTES) as u64,
+            )
+            .ok_or_else(|| anyhow!("Failed to estimate fee: {}", self.fee_rate))?;
+        let utxos = self.select_utxos(total_output + estimate_fee).await?;
+        let mut tx_inputs = vec![];
+        let mut total_input = Amount::from_sat(0);
+        for utxo in utxos {
+            tx_inputs.push(Self::utxo_to_txin(&utxo));
+            total_input += utxo.amount();
+        }
+
+        let tx_outputs = outputs
+            .into_iter()
+            .map(|(address, amount)| TxOut {
+                value: amount,
+                script_pubkey: address.script_pubkey(),
+            })
+            .collect::<Vec<_>>();
+
+        let mut tx = Transaction {
+            version: Version::TWO,
+            lock_time: self.lock_time.unwrap_or(LockTime::ZERO),
+            input: tx_inputs,
+            output: tx_outputs,
+        };
+        let fee = self
+            .fee_rate
+            .fee_vb(tx.vsize() as u64)
+            .ok_or_else(|| anyhow!("Failed to estimate fee: {}", self.fee_rate))?;
+        if fee > estimate_fee && total_input < total_output + fee {
+            //we need to add more inputs
+            let utxos = self.select_utxos(total_output + fee - total_input).await?;
+            tx.input.extend(utxos.iter().map(Self::utxo_to_txin));
+            total_input += utxos.iter().map(|utxo| utxo.amount()).sum::<Amount>();
+        }
+
+        let change = total_input - total_output - fee;
+        if change > Amount::from_sat(0) {
+            tx.output.push(TxOut {
+                value: change,
+                script_pubkey: self.change_address.script_pubkey(),
+            });
+        }
+        let psbt = Psbt::from_unsigned_tx(tx)?;
+        Ok(psbt)
+    }
+
+    async fn select_utxos(&mut self, expected_amount: Amount) -> Result<Vec<UTXO>> {
+        let mut utxos = vec![];
+        let mut total_input = Amount::from_sat(0);
+        while total_input < expected_amount {
+            let utxo = self.utxo_selector.next_utxo().await?;
+            if utxo.is_none() {
+                bail!("not enough BTC funds");
+            }
+            let utxo = utxo.unwrap();
+            total_input += utxo.amount();
+            utxos.push(utxo);
+        }
+        Ok(utxos)
+    }
+
+    fn utxo_to_txin(utxo: &UTXO) -> TxIn {
+        TxIn {
+            previous_output: utxo.outpoint().into(),
+            script_sig: ScriptBuf::default(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::default(),
+        }
+    }
+}

--- a/crates/rooch/src/commands/bitcoin/transaction_builder.rs
+++ b/crates/rooch/src/commands/bitcoin/transaction_builder.rs
@@ -16,6 +16,7 @@ use rooch_types::{
     address::BitcoinAddress,
     bitcoin::multisign_account::{self},
 };
+use tracing::debug;
 
 #[derive(Debug)]
 pub struct TransactionBuilder<'a> {
@@ -201,6 +202,7 @@ impl<'a> TransactionBuilder<'a> {
                     .rooch
                     .get_multisign_account_info(rooch_addr)
                     .await?;
+                debug!("Multisign account: {:?}", account_info);
                 multisign_account::update_multisig_psbt(input, &account_info)?;
             } else {
                 let kp = self.wallet_context.get_key_pair(&rooch_addr)?;

--- a/crates/rooch/src/commands/bitcoin/transfer.rs
+++ b/crates/rooch/src/commands/bitcoin/transfer.rs
@@ -1,0 +1,89 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use super::sign_tx::SignOutput;
+use super::transaction_builder::TransactionBuilder;
+use crate::cli_types::{CommandAction, WalletContextOptions};
+use crate::commands::bitcoin::sign_tx::sign_psbt;
+use async_trait::async_trait;
+use bitcoin::consensus::Encodable;
+use bitcoin::{Amount, FeeRate};
+use clap::Parser;
+use rooch_types::address::ParsedAddress;
+use rooch_types::error::{RoochError, RoochResult};
+use tracing::debug;
+
+#[derive(Debug, Parser)]
+pub struct Transfer {
+    /// The sender address of the transaction, if not specified, the active address will be used
+    #[clap(long, short = 's', default_value = "default")]
+    sender: ParsedAddress,
+
+    /// The receiver address of the BTC
+    #[clap(long, short = 't')]
+    to: ParsedAddress,
+
+    /// The BTC amount in satoshi to transfer
+    #[clap(long, short = 'a')]
+    amount: u64,
+
+    /// The fee rate of the transaction, if not specified, the fee will be calculated automatically
+    #[clap(long)]
+    fee_rate: Option<FeeRate>,
+
+    /// Skip check seal of the UTXOs, default is false
+    /// If set to true, some UTXO which carries other asserts, such as Inscription, maybe unexpected spent.
+    #[clap(long)]
+    skip_check_seal: bool,
+
+    #[clap(flatten)]
+    pub(crate) context_options: WalletContextOptions,
+}
+
+#[async_trait]
+impl CommandAction<String> for Transfer {
+    async fn execute(self) -> RoochResult<String> {
+        let context = self.context_options.build_require_password()?;
+        let client = context.get_client().await?;
+
+        let bitcoin_network = context.get_bitcoin_network().await?;
+
+        let sender = context.resolve_bitcoin_address(self.sender).await?;
+        let to = context.resolve_bitcoin_address(self.to).await?;
+        let amount = Amount::from_sat(self.amount);
+
+        let mut tx_builder = TransactionBuilder::new(
+            &context,
+            client.clone(),
+            sender.to_bitcoin_address(bitcoin_network)?,
+            vec![],
+            self.skip_check_seal,
+        )
+        .await?;
+
+        if let Some(fee_rate) = self.fee_rate {
+            tx_builder = tx_builder.with_fee_rate(fee_rate);
+        }
+
+        let psbt = tx_builder
+            .build_transfer(to.to_bitcoin_address(bitcoin_network)?, amount)
+            .await?;
+        debug!("PSBT: {}", serde_json::to_string_pretty(&psbt).unwrap());
+        let sign_out = sign_psbt(psbt, &context, &client).await?;
+        match sign_out {
+            SignOutput::Psbt(_psbt) => {
+                return Err(RoochError::CommandArgumentError(
+                    "The sender address should not be a multisig address".to_string(),
+                ))
+            }
+            SignOutput::Tx(tx) => {
+                let mut raw_tx = vec![];
+                tx.consensus_encode(&mut raw_tx)?;
+                Ok(client
+                    .rooch
+                    .broadcast_bitcoin_tx(raw_tx.into(), None)
+                    .await?)
+            }
+        }
+    }
+}

--- a/crates/rooch/src/commands/bitcoin/transfer.rs
+++ b/crates/rooch/src/commands/bitcoin/transfer.rs
@@ -69,7 +69,7 @@ impl CommandAction<String> for Transfer {
             .build_transfer(to.to_bitcoin_address(bitcoin_network)?, amount)
             .await?;
         debug!("PSBT: {}", serde_json::to_string_pretty(&psbt).unwrap());
-        let sign_out = sign_psbt(psbt, &context, &client).await?;
+        let sign_out = sign_psbt(psbt, None, &context, &client).await?;
         match sign_out {
             SignOutput::Psbt(_psbt) => {
                 return Err(RoochError::CommandArgumentError(

--- a/crates/rooch/src/commands/bitcoin/utxo_selector.rs
+++ b/crates/rooch/src/commands/bitcoin/utxo_selector.rs
@@ -1,0 +1,111 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use bitcoin::Address;
+use moveos_types::{moveos_std::object::ObjectID, state::ObjectState};
+use rooch_rpc_api::jsonrpc_types::{btc::utxo::UTXOFilterView, IndexerStateIDView};
+use rooch_rpc_client::Client;
+use rooch_types::bitcoin::utxo::UTXO;
+use tracing::debug;
+
+#[derive(Debug)]
+pub struct UTXOSelector {
+    client: Client,
+    sender: Address,
+    specific_utxos: Vec<ObjectID>,
+    loaded_page: Option<(Option<IndexerStateIDView>, bool)>,
+    candidate_utxos: Vec<UTXO>,
+    skip_seal_check: bool,
+}
+
+impl UTXOSelector {
+    pub async fn new(
+        client: Client,
+        sender: Address,
+        specific_utxos: Vec<ObjectID>,
+        skip_seal_check: bool,
+    ) -> Result<Self> {
+        let mut selector = Self {
+            client,
+            sender,
+            specific_utxos,
+            loaded_page: None,
+            candidate_utxos: vec![],
+            skip_seal_check,
+        };
+        selector.load_specific_utxos().await?;
+        Ok(selector)
+    }
+
+    async fn load_specific_utxos(&mut self) -> Result<()> {
+        let utxos_objs = self
+            .client
+            .rooch
+            .get_object_states(self.specific_utxos.clone(), None)
+            .await?;
+        for (utxo_id, utxo_obj) in self.specific_utxos.iter().zip(utxos_objs) {
+            if let Some(utxo_obj_view) = utxo_obj {
+                let utxo_obj: ObjectState = utxo_obj_view.into();
+                let utxo = utxo_obj.value_as::<UTXO>()?;
+                if !self.skip_seal_check {
+                    if !utxo.seals.is_empty() {
+                        bail!("UTXO {} is has seals: {:?}, please use --skip-seal-check to skip this check", utxo.outpoint(), utxo.seals);
+                    }
+                    let dust_value = self.sender.script_pubkey().dust_value();
+                    if utxo.amount() <= dust_value {
+                        bail!("UTXO {} is less than dust value: {}, please use --skip-dust-check to skip this check", utxo.outpoint(), dust_value);
+                    }
+                }
+                self.candidate_utxos.push(utxo);
+            } else {
+                bail!("UTXO not found: {}", utxo_id);
+            }
+        }
+        Ok(())
+    }
+
+    async fn load_utxos(&mut self) -> Result<()> {
+        let (next_cursor, has_next_page) = self.loaded_page.unwrap_or((None, true));
+        if !has_next_page {
+            return Ok(());
+        }
+        let utxo_page = self
+            .client
+            .rooch
+            .query_utxos(
+                UTXOFilterView::owner(self.sender.clone()),
+                next_cursor.map(Into::into),
+                None,
+                None,
+            )
+            .await?;
+        debug!("loaded utxos: {:?}", utxo_page.data.len());
+        let dust_value = self.sender.script_pubkey().dust_value();
+        for utxo_view in utxo_page.data {
+            let utxo: UTXO = utxo_view.value.into();
+            if !self.skip_seal_check {
+                if !utxo.seals.is_empty() {
+                    continue;
+                }
+                if utxo.amount() <= dust_value {
+                    continue;
+                }
+            }
+            self.candidate_utxos.push(utxo);
+        }
+        self.loaded_page = Some((utxo_page.next_cursor, utxo_page.has_next_page));
+        Ok(())
+    }
+    /// Get the next utxo from the candidate utxos
+    pub async fn next_utxo(&mut self) -> Result<Option<UTXO>> {
+        if self.candidate_utxos.is_empty() {
+            self.load_utxos().await?;
+        }
+        Ok(self.candidate_utxos.pop())
+    }
+
+    pub fn specific_utxos(&self) -> &[ObjectID] {
+        &self.specific_utxos
+    }
+}

--- a/crates/rooch/src/commands/bitcoin/utxo_selector.rs
+++ b/crates/rooch/src/commands/bitcoin/utxo_selector.rs
@@ -52,7 +52,7 @@ impl UTXOSelector {
                     if !utxo.seals.is_empty() {
                         bail!("UTXO {} is has seals: {:?}, please use --skip-seal-check to skip this check", utxo.outpoint(), utxo.seals);
                     }
-                    let dust_value = self.sender.script_pubkey().dust_value();
+                    let dust_value = self.sender.script_pubkey().minimal_non_dust();
                     if utxo.amount() <= dust_value {
                         bail!("UTXO {} is less than dust value: {}, please use --skip-dust-check to skip this check", utxo.outpoint(), dust_value);
                     }
@@ -81,7 +81,7 @@ impl UTXOSelector {
             )
             .await?;
         debug!("loaded utxos: {:?}", utxo_page.data.len());
-        let dust_value = self.sender.script_pubkey().dust_value();
+        let dust_value = self.sender.script_pubkey().minimal_non_dust();
         for utxo_view in utxo_page.data {
             let utxo: UTXO = utxo_view.value.into();
             if !self.skip_seal_check {

--- a/crates/rooch/src/commands/bitcoin/utxo_selector.rs
+++ b/crates/rooch/src/commands/bitcoin/utxo_selector.rs
@@ -41,6 +41,9 @@ impl UTXOSelector {
     }
 
     async fn load_specific_utxos(&mut self) -> Result<()> {
+        if self.specific_utxos.is_empty() {
+            return Ok(());
+        }
         let utxos_objs = self
             .client
             .rooch
@@ -84,7 +87,7 @@ impl UTXOSelector {
                 UTXOFilterView::owner(self.sender.clone()),
                 next_cursor.map(Into::into),
                 None,
-                None,
+                Some(false),
             )
             .await?;
         debug!("loaded utxos: {:?}", utxo_page.data.len());

--- a/crates/rooch/src/commands/bitcoin/utxo_selector.rs
+++ b/crates/rooch/src/commands/bitcoin/utxo_selector.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
-use bitcoin::Address;
-use moveos_types::{moveos_std::object::ObjectID, state::ObjectState};
-use rooch_rpc_api::jsonrpc_types::{btc::utxo::UTXOFilterView, IndexerStateIDView};
+use bitcoin::{Address, Amount};
+use moveos_types::moveos_std::object::{ObjectID, GENESIS_STATE_ROOT};
+use rooch_rpc_api::jsonrpc_types::{
+    btc::utxo::{UTXOFilterView, UTXOStateView, UTXOView},
+    IndexerStateIDView, ObjectMetaView,
+};
 use rooch_rpc_client::Client;
-use rooch_types::bitcoin::utxo::UTXO;
 use tracing::debug;
 
 #[derive(Debug)]
@@ -15,7 +17,7 @@ pub struct UTXOSelector {
     sender: Address,
     specific_utxos: Vec<ObjectID>,
     loaded_page: Option<(Option<IndexerStateIDView>, bool)>,
-    candidate_utxos: Vec<UTXO>,
+    candidate_utxos: Vec<(ObjectMetaView, UTXOView)>,
     skip_seal_check: bool,
 }
 
@@ -42,25 +44,30 @@ impl UTXOSelector {
         let utxos_objs = self
             .client
             .rooch
-            .get_object_states(self.specific_utxos.clone(), None)
+            .query_utxos(
+                UTXOFilterView::object_ids(self.specific_utxos.clone()),
+                None,
+                None,
+                None,
+            )
             .await?;
-        for (utxo_id, utxo_obj) in self.specific_utxos.iter().zip(utxos_objs) {
-            if let Some(utxo_obj_view) = utxo_obj {
-                let utxo_obj: ObjectState = utxo_obj_view.into();
-                let utxo = utxo_obj.value_as::<UTXO>()?;
-                if !self.skip_seal_check {
-                    if !utxo.seals.is_empty() {
-                        bail!("UTXO {} is has seals: {:?}, please use --skip-seal-check to skip this check", utxo.outpoint(), utxo.seals);
-                    }
-                    let dust_value = self.sender.script_pubkey().minimal_non_dust();
-                    if utxo.amount() <= dust_value {
-                        bail!("UTXO {} is less than dust value: {}, please use --skip-dust-check to skip this check", utxo.outpoint(), dust_value);
-                    }
+        for utxo_state_view in utxos_objs.data {
+            let utxo = &utxo_state_view.value;
+            if !self.skip_seal_check {
+                let minimal_non_dust = self.sender.script_pubkey().minimal_non_dust();
+                if skip_utxo(&utxo_state_view, minimal_non_dust) {
+                    bail!("UTXO {} has seal or tempstate attachment: {:?}, please use --skip-seal-check to skip this check", utxo_state_view.value.outpoint(), utxo_state_view);
                 }
-                self.candidate_utxos.push(utxo);
-            } else {
-                bail!("UTXO not found: {}", utxo_id);
             }
+            if utxo_state_view.metadata.owner_bitcoin_address.is_none() {
+                bail!(
+                    "Can not recognize the owner of UTXO {}, metadata: {:?}",
+                    utxo.outpoint(),
+                    utxo_state_view.metadata
+                );
+            }
+            self.candidate_utxos
+                .push((utxo_state_view.metadata, utxo_state_view.value));
         }
         Ok(())
     }
@@ -81,24 +88,28 @@ impl UTXOSelector {
             )
             .await?;
         debug!("loaded utxos: {:?}", utxo_page.data.len());
-        let dust_value = self.sender.script_pubkey().minimal_non_dust();
+        let minimal_non_dust = self.sender.script_pubkey().minimal_non_dust();
         for utxo_view in utxo_page.data {
-            let utxo: UTXO = utxo_view.value.into();
-            if !self.skip_seal_check {
-                if !utxo.seals.is_empty() {
-                    continue;
-                }
-                if utxo.amount() <= dust_value {
-                    continue;
-                }
+            let utxo = &utxo_view.value;
+            if !self.skip_seal_check && skip_utxo(&utxo_view, minimal_non_dust) {
+                continue;
             }
-            self.candidate_utxos.push(utxo);
+            if utxo_view.metadata.owner_bitcoin_address.is_none() {
+                debug!(
+                    "Can not recognize the owner of UTXO {}, metadata: {:?}, skip.",
+                    utxo.outpoint(),
+                    utxo_view.metadata
+                );
+                continue;
+            }
+            self.candidate_utxos
+                .push((utxo_view.metadata, utxo_view.value));
         }
         self.loaded_page = Some((utxo_page.next_cursor, utxo_page.has_next_page));
         Ok(())
     }
     /// Get the next utxo from the candidate utxos
-    pub async fn next_utxo(&mut self) -> Result<Option<UTXO>> {
+    pub async fn next_utxo(&mut self) -> Result<Option<(ObjectMetaView, UTXOView)>> {
         if self.candidate_utxos.is_empty() {
             self.load_utxos().await?;
         }
@@ -108,4 +119,31 @@ impl UTXOSelector {
     pub fn specific_utxos(&self) -> &[ObjectID] {
         &self.specific_utxos
     }
+}
+
+fn skip_utxo(utxo_state_view: &UTXOStateView, minimal_non_dust: Amount) -> bool {
+    let utxo = &utxo_state_view.value;
+    if !utxo.seals.is_empty() {
+        debug!(
+            "UTXO {} is has seals: {:?}, skip.",
+            utxo.outpoint(),
+            utxo.seals
+        );
+        return true;
+    }
+    if utxo.amount() <= minimal_non_dust {
+        debug!(
+            "UTXO {} is less than dust value: {}, skip.",
+            utxo.outpoint(),
+            minimal_non_dust
+        );
+        return true;
+    }
+    if utxo_state_view.metadata.state_root.is_some()
+        && utxo_state_view.metadata.state_root.as_ref().unwrap().0 != *GENESIS_STATE_ROOT
+    {
+        debug!("UTXO {} is contains tempstate, skip.", utxo.outpoint());
+        return true;
+    }
+    false
 }

--- a/crates/rooch/src/commands/mod.rs
+++ b/crates/rooch/src/commands/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod abi;
 pub mod account;
+pub mod bitcoin;
 pub mod db;
 pub mod dynamic_field;
 pub mod env;

--- a/crates/rooch/src/commands/object.rs
+++ b/crates/rooch/src/commands/object.rs
@@ -133,7 +133,12 @@ impl CommandAction<String> for ObjectCommand {
                 };
                 let result = client
                     .rooch
-                    .query_utxos(utxo_fitler, None, self.limit, Some(query_options))
+                    .query_utxos(
+                        utxo_fitler,
+                        None,
+                        self.limit,
+                        Some(query_options.descending),
+                    )
                     .await?;
                 serde_json::to_string_pretty(&result).unwrap()
             }

--- a/crates/rooch/src/commands/transaction/commands/mod.rs
+++ b/crates/rooch/src/commands/transaction/commands/mod.rs
@@ -16,10 +16,6 @@ pub mod query;
 pub mod sign;
 pub mod submit;
 
-pub(crate) fn is_file_path(s: &str) -> bool {
-    s.contains('/') || s.contains('\\') || s.contains('.')
-}
-
 pub(crate) enum FileOutputData {
     RoochTransactionData(RoochTransactionData),
     SignedRoochTransaction(RoochTransaction),

--- a/crates/rooch/src/commands/transaction/commands/submit.rs
+++ b/crates/rooch/src/commands/transaction/commands/submit.rs
@@ -1,21 +1,19 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use super::is_file_path;
-use crate::cli_types::{CommandAction, WalletContextOptions};
+use crate::cli_types::{CommandAction, FileOrHexInput, WalletContextOptions};
 use async_trait::async_trait;
 use rooch_rpc_api::jsonrpc_types::ExecuteTransactionResponseView;
 use rooch_types::{
     error::{RoochError, RoochResult},
     transaction::RoochTransaction,
 };
-use std::{fs::File, io::Read};
 
 /// Get transactions by order
 #[derive(Debug, clap::Parser)]
 pub struct SubmitCommand {
     /// Transaction data hex or file location to be used for submitting
-    input: String,
+    input: FileOrHexInput,
 
     #[clap(flatten)]
     context: WalletContextOptions,
@@ -30,34 +28,11 @@ impl CommandAction<ExecuteTransactionResponseView> for SubmitCommand {
     async fn execute(self) -> RoochResult<ExecuteTransactionResponseView> {
         let context = self.context.build()?;
 
-        let tx_hex = if is_file_path(&self.input) {
-            let mut file = File::open(&self.input).map_err(|e| {
-                RoochError::CommandArgumentError(format!(
-                    "Failed to open file: {}, err:{:?}",
-                    self.input, e
-                ))
-            })?;
-            let mut hex_str = String::new();
-            file.read_to_string(&mut hex_str).map_err(|e| {
-                RoochError::CommandArgumentError(format!(
-                    "Failed to read file: {}, err:{:?}",
-                    self.input, e
-                ))
-            })?;
-            hex_str
-        } else {
-            self.input
-        };
-        let tx_bytes = hex::decode(tx_hex.strip_prefix("0x").unwrap_or(&tx_hex)).map_err(|e| {
+        let signed_tx = bcs::from_bytes::<RoochTransaction>(&self.input.data).map_err(|e| {
             RoochError::CommandArgumentError(format!(
                 "Invalid signed transaction hex, err: {:?}, hex: {}",
-                e, tx_hex
-            ))
-        })?;
-        let signed_tx = bcs::from_bytes::<RoochTransaction>(&tx_bytes).map_err(|e| {
-            RoochError::CommandArgumentError(format!(
-                "Invalid signed transaction hex, err: {:?}, hex: {}",
-                e, tx_hex
+                e,
+                hex::encode(&self.input.data)
             ))
         })?;
 

--- a/crates/rooch/src/lib.rs
+++ b/crates/rooch/src/lib.rs
@@ -11,10 +11,10 @@ use clap::builder::{
 };
 use cli_types::CommandAction;
 use commands::{
-    abi::ABI, account::Account, dynamic_field::DynamicField, env::Env, genesis::Genesis,
-    init::Init, move_cli::MoveCli, object::ObjectCommand, resource::ResourceCommand, rpc::Rpc,
-    server::Server, session_key::SessionKey, state::StateCommand, transaction::Transaction,
-    upgrade::Upgrade, util::Util, version::Version,
+    abi::ABI, account::Account, bitcoin::Bitcoin, dynamic_field::DynamicField, env::Env,
+    genesis::Genesis, init::Init, move_cli::MoveCli, object::ObjectCommand,
+    resource::ResourceCommand, rpc::Rpc, server::Server, session_key::SessionKey,
+    state::StateCommand, transaction::Transaction, upgrade::Upgrade, util::Util, version::Version,
 };
 use once_cell::sync::Lazy;
 use rooch_types::error::RoochResult;
@@ -46,6 +46,7 @@ static LONG_VERSION: Lazy<String> = Lazy::new(|| {
 pub enum Command {
     Version(Version),
     Account(Account),
+    Bitcoin(Bitcoin),
     Init(Init),
     Move(MoveCli),
     Server(Server),
@@ -72,6 +73,7 @@ pub async fn run_cli(opt: RoochCli) -> RoochResult<String> {
     match opt.cmd {
         Command::Version(version) => version.execute().await,
         Command::Account(account) => account.execute().await,
+        Command::Bitcoin(bitcoin) => bitcoin.execute().await,
         Command::Move(move_cli) => move_cli.execute().await,
         Command::Server(server) => server.execute().await,
         Command::Init(init) => init.execute_serialized().await,

--- a/crates/testsuite/features/multisign.feature
+++ b/crates/testsuite/features/multisign.feature
@@ -40,16 +40,15 @@ Feature: Rooch CLI multisign integration tests
       # l1 transaction
       Then cmd: "bitcoin build-tx --sender {{$.account[-1].multisign_bitcoin_address}} -o {{$.account[-2].account0.bitcoin_address}}:100000000"
       Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
-      Then cmd: "bitcoin sign-tx {{$.bitcoin[-1].path}}"
+      Then cmd: "bitcoin sign-tx -s {{$.account[-1].participants[0].participant_address}}   {{$.bitcoin[-1].path}}"
+      Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
+      Then cmd: "bitcoin sign-tx -s {{$.account[-1].participants[2].participant_address}}   {{$.bitcoin[-1].path}}"
       Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
       Then cmd: "bitcoin broadcast-tx {{$.bitcoin[-1].path}}"
       Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
 
       Then cmd bitcoin-cli: "generatetoaddress 1 {{$.getnewaddress[-1]}}"
       Then sleep: "10" # wait for the transaction to be confirmed
-      
-      Then cmd bitcoin-cli: "gettransaction {{$.bitcoin[-1]}}"
-      Then assert: "{{$.gettransaction[-1].confirmations}} == 1"
 
       Then cmd: "account balance -a {{$.account[-2].account0.address}} --json"
       Then assert: "{{$.account[-1].Bitcoin.balance}} == 100000000"

--- a/crates/testsuite/features/multisign.feature
+++ b/crates/testsuite/features/multisign.feature
@@ -3,6 +3,7 @@ Feature: Rooch CLI multisign integration tests
    
     @serial
     Scenario: multisign_account
+      Given a bitcoind server for multisign_account
       Given a server for multisign_account
 
       Then cmd: "account create"
@@ -14,19 +15,59 @@ Feature: Rooch CLI multisign integration tests
       Then cmd: "account create-multisign -t 2 -p {{$.account[-1].account0.public_key}} -p {{$.account[-1].account1.public_key}} -p {{$.account[-1].account2.public_key}} --json"
       Then assert: "'{{$.account[-1]}}' not_contains error"
 
-      #transfer some gas to multisign account
-      Then cmd: "account transfer --to {{$.account[-1].multisign_address}} --amount 10000000000 --coin-type rooch_framework::gas_coin::RGas"
-      Then assert: "{{$.account[-1].execution_info.status.type}} == executed"  
+      # Create and load a wallet
+      Then cmd bitcoin-cli: "createwallet \"test_wallet\""
+      Then cmd bitcoin-cli: "loadwallet \"test_wallet\""
 
-      # transaction
-      Then cmd: "tx build --sender {{$.account[-2].multisign_address}}  --function rooch_framework::empty::empty --json"
+      # Prepare funds
+      Then cmd bitcoin-cli: "getnewaddress"
+      
+      # mint btc
+      Then cmd bitcoin-cli: "generatetoaddress 101 {{$.getnewaddress[-1]}}"
+
+      # Get UTXO for transaction input
+      Then cmd bitcoin-cli: "listunspent 1 9999999 [\"{{$.getnewaddress[-1]}}\"] true"
+
+      # Create a Bitcoin transaction transfer to multisign account
+      Then cmd bitcoin-cli: "createrawtransaction [{\"txid\":\"{{$.listunspent[-1][0].txid}}\",\"vout\":{{$.listunspent[-1][0].vout}}}] {\"{{$.account[-1].multisign_bitcoin_address}}\":49.999}"
+      Then cmd bitcoin-cli: "signrawtransactionwithwallet {{$.createrawtransaction[-1]}}"
+      Then cmd: "bitcoin broadcast-tx {{$.signrawtransactionwithwallet[-1].hex}}"
+      Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
+
+      Then cmd bitcoin-cli: "generatetoaddress 1 {{$.getnewaddress[-1]}}"
+      Then sleep: "20" # wait for the transaction to be confirmed
+
+      # l1 transaction
+      Then cmd: "bitcoin build-tx --sender {{$.account[-1].multisign_bitcoin_address}} -o {{$.account[-2].account0.bitcoin_address}}:100000000"
+      Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
+      Then cmd: "bitcoin sign-tx {{$.bitcoin[-1].path}}"
+      Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
+      Then cmd: "bitcoin broadcast-tx {{$.bitcoin[-1].path}}"
+      Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
+
+      Then cmd bitcoin-cli: "generatetoaddress 1 {{$.getnewaddress[-1]}}"
+      Then sleep: "10" # wait for the transaction to be confirmed
+      
+      Then cmd bitcoin-cli: "gettransaction {{$.bitcoin[-1]}}"
+      Then assert: "{{$.gettransaction[-1].confirmations}} == 1"
+
+      Then cmd: "account balance -a {{$.account[-2].account0.address}} --json"
+      Then assert: "{{$.account[-1].Bitcoin.balance}} == 100000000"
+
+      #transfer some gas to multisign account
+      Then cmd: "account transfer --to {{$.account[-2].multisign_address}} --amount 10000000000 --coin-type rooch_framework::gas_coin::RGas"
+      Then assert: "{{$.account[-1].execution_info.status.type}} == executed"
+
+      # l2 transaction
+      Then cmd: "tx build --sender {{$.account[-3].multisign_address}}  --function rooch_framework::empty::empty --json"
       Then assert: "'{{$.tx[-1]}}' not_contains error"
-      Then cmd: "tx sign {{$.tx[-1].path}} -s {{$.account[-2].participants[0].participant_address}}  --json"
+      Then cmd: "tx sign {{$.tx[-1].path}} -s {{$.account[-3].participants[0].participant_address}}  --json"
       Then assert: "'{{$.tx[-1]}}' not_contains error"
-      Then cmd: "tx sign {{$.tx[-1].path}} -s {{$.account[-2].participants[1].participant_address}}  --json"
+      Then cmd: "tx sign {{$.tx[-1].path}} -s {{$.account[-3].participants[1].participant_address}}  --json"
       Then assert: "'{{$.tx[-1]}}' not_contains error"
       Then cmd: "tx submit {{$.tx[-1].path}} --json"
       Then assert: "{{$.tx[-1].execution_info.status.type}} == executed"
 
 
       Then stop the server
+      Then stop the bitcoind server 

--- a/frameworks/rooch-framework/Cargo.toml
+++ b/frameworks/rooch-framework/Cargo.toml
@@ -20,7 +20,6 @@ smallvec = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 bitcoin = { workspace = true }
-musig2 = { workspace = true }
 
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }

--- a/frameworks/rooch-nursery/Cargo.toml
+++ b/frameworks/rooch-nursery/Cargo.toml
@@ -20,7 +20,6 @@ smallvec = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 bitcoin = { workspace = true }
-musig2 = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
 ciborium = { workspace = true }

--- a/moveos/moveos-types/src/moveos_std/simple_map.rs
+++ b/moveos/moveos-types/src/moveos_std/simple_map.rs
@@ -31,6 +31,10 @@ impl<Key, Value> SimpleMap<Key, Value> {
         Self { data: vec![] }
     }
 
+    pub fn keys(&self) -> Vec<&Key> {
+        self.data.iter().map(|element| &element.key).collect()
+    }
+
     pub fn values(&self) -> Vec<&Value> {
         self.data.iter().map(|element| &element.value).collect()
     }

--- a/moveos/moveos-types/src/moveos_std/simple_map.rs
+++ b/moveos/moveos-types/src/moveos_std/simple_map.rs
@@ -30,6 +30,10 @@ impl<Key, Value> SimpleMap<Key, Value> {
     pub fn create() -> Self {
         Self { data: vec![] }
     }
+
+    pub fn values(&self) -> Vec<&Value> {
+        self.data.iter().map(|element| &element.value).collect()
+    }
 }
 
 impl<Key, Value> SimpleMap<Key, Value>

--- a/moveos/moveos-types/src/moveos_std/simple_multimap.rs
+++ b/moveos/moveos-types/src/moveos_std/simple_multimap.rs
@@ -117,3 +117,20 @@ where
         ))])
     }
 }
+
+impl<Key, Value> From<SimpleMultiMap<Key, Value>> for Vec<(Key, Vec<Value>)> {
+    fn from(map: SimpleMultiMap<Key, Value>) -> Self {
+        map.data.into_iter().map(|e| (e.key, e.value)).collect()
+    }
+}
+
+impl<Key, Value> From<Vec<(Key, Vec<Value>)>> for SimpleMultiMap<Key, Value> {
+    fn from(data: Vec<(Key, Vec<Value>)>) -> Self {
+        SimpleMultiMap {
+            data: data
+                .into_iter()
+                .map(|(key, value)| Element { key, value })
+                .collect(),
+        }
+    }
+}

--- a/moveos/smt/src/jellyfish_merkle/hash.rs
+++ b/moveos/smt/src/jellyfish_merkle/hash.rs
@@ -1,9 +1,8 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use bitcoin_hashes::{sha256t_hash_newtype, HashEngine};
+use bitcoin_hashes::{hex::FromHex, sha256t_hash_newtype, HashEngine};
 use bytes::Bytes;
-use hex::FromHex;
 use more_asserts::debug_assert_lt;
 use once_cell::sync::Lazy;
 use primitive_types::H256;
@@ -145,7 +144,7 @@ impl SMTNodeHash {
     }
 
     /// Parse a given hex string to a hash value.
-    pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, HashParseError> {
+    pub fn from_hex(hex: &str) -> Result<Self, HashParseError> {
         <[u8; Self::LEN]>::from_hex(hex)
             .map_err(|_| HashParseError)
             .map(Self::new)
@@ -169,18 +168,7 @@ impl SMTNodeHash {
             return Err(HashParseError);
         }
         let literal = literal.strip_prefix("0x").unwrap_or(literal);
-        let hex_len = literal.len();
-        // If the string is too short, pad it
-        if hex_len < Self::LEN * 2 {
-            let mut hex_str = String::with_capacity(Self::LEN * 2);
-            for _ in 0..Self::LEN * 2 - hex_len {
-                hex_str.push('0');
-            }
-            hex_str.push_str(literal);
-            Self::from_hex(hex_str)
-        } else {
-            Self::from_hex(literal)
-        }
+        Self::from_hex(literal)
     }
 }
 

--- a/scripts/bitcoin/README.md
+++ b/scripts/bitcoin/README.md
@@ -13,11 +13,11 @@ This directory contains scripts for setting up a local development environment f
 
 ## Development on rooch
 
-1. Run `rooch server start --btc-rpc-url http://127.0.0.1:18443 --btc-rpc-username roochuser --btc-rpc-password roochpass`
+1. Run `rooch server start -n local --btc-sync-block-interval 1 --btc-rpc-url http://127.0.0.1:18443 --btc-rpc-username roochuser --btc-rpc-password roochpass`
 2. Run `rooch account list --json` to get the `bitcoin_address`
 3. Run `bitcoin-cli generatetoaddress 101 <bitcoin_address>` to generate 101 blocks to the address
-2. Run `rooch rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x4::utxo::UTXO"},  null, "2", {"descending": true,"showDisplay":false}]'` to query the UTXO set
-3. Run `rooch rpc request --method rooch_queryObjectStates --params '[{"object_type":"0x4::ord::Inscription"},  null, "2", {"descending": true,"showDisplay":false}]'` to query the Inscription set
+2. Run `rooch rpc request --method btc_queryUTXOs --params '["all",  null, "2", true]'` to query the UTXO set
+3. Run `rooch rpc request --method btc_queryInscriptions --params '["all",  null, "2", true]'` to query the Inscription set
 
 ## Usage
 


### PR DESCRIPTION
## Summary

1. Implement `rooch bitcoin` command
2. bump bitcoin to 0.32.2, and remove nostr


close #2414 and close #2581 

Usage:

1. Create multisign

```bash
rooch account create-multisign -t 2 -p $Pubkey1 -p $Pubkey2 -p $Pubkey3
```

Got the multisign_bitcoin_address

2. Build tx

```bash
rooch bitcoin build-tx --sender $multisign_bitcoin_address -o $to_address:amount_sats
```

```json
{
  "content": "hex content",
  "output_type": "psbt",
  "path": "/tmp/xxxxx.psbt"
}
```

3. Sign tx

```bash
rooch bitcoin sign-tx -s $Pubkey1_address /tmp/xxxxx.psbt
```

```bash
rooch bitcoin sign-tx -s $Pubkey2_address /tmp/xxxxx.psbt
```
Got xxxxx.tx

4. Broadcast tx

```bash
rooch bitcoin broadcast-tx /tmp/xxxxx.tx
```

Note: the taproot multisign signature order in the witness should be reversed with the public key order in the script. Thanks to https://github.com/rust-bitcoin/rust-bitcoin/issues/2241