### PR TITLE
[panic] Fix null object id panic

### DIFF
--- a/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/move_types.rs
@@ -83,6 +83,7 @@ impl FromStr for ObjectIDVecView {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let ids = s
             .split(',')
+            .filter(|s| !s.is_empty())
             .map(ObjectID::from_str)
             .collect::<Result<Vec<_>, _>>()?;
         Ok(StrView(ids))


### PR DESCRIPTION
#2602

```
rooch rpc request --method btc_queryUTXOs --params '[{"object_id":""}, null, null, null]'
{
  "data": [],
  "next_cursor": null,
  "has_next_page": false
}
```
