### PR TITLE
[State] Support state sync and provide RPC to sync state

### DIFF
--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -10,7 +10,7 @@ use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::event::{AnnotatedEvent, Event, EventID};
 use moveos_types::moveos_std::object::ObjectMeta;
-use moveos_types::state::{AnnotatedState, FieldKey, ObjectState};
+use moveos_types::state::{AnnotatedState, FieldKey, ObjectState, StateChangeSetExt};
 use moveos_types::state_resolver::{AnnotatedStateKV, StateKV};
 use moveos_types::transaction::TransactionExecutionInfo;
 use moveos_types::transaction::TransactionOutput;
@@ -212,4 +212,14 @@ pub struct GetRootMessage {}
 
 impl Message for GetRootMessage {
     type Result = Result<ObjectState>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SaveStateChangeSetMessage {
+    pub tx_order: u64,
+    pub state_change_set: StateChangeSetExt,
+}
+
+impl Message for SaveStateChangeSetMessage {
+    type Result = Result<()>;
 }

--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -223,3 +223,12 @@ pub struct SaveStateChangeSetMessage {
 impl Message for SaveStateChangeSetMessage {
     type Result = Result<()>;
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetStateChangeSetsMessage {
+    pub tx_orders: Vec<u64>,
+}
+
+impl Message for GetStateChangeSetsMessage {
+    type Result = Result<Vec<Option<StateChangeSetExt>>>;
+}

--- a/crates/rooch-executor/src/actor/reader_executor.rs
+++ b/crates/rooch-executor/src/actor/reader_executor.rs
@@ -3,8 +3,8 @@
 
 use super::messages::{
     AnnotatedStatesMessage, ExecuteViewFunctionMessage, GetAnnotatedEventsByEventHandleMessage,
-    GetAnnotatedEventsByEventIDsMessage, GetEventsByEventHandleMessage, RefreshStateMessage,
-    StatesMessage,
+    GetAnnotatedEventsByEventIDsMessage, GetEventsByEventHandleMessage, GetStateChangeSetsMessage,
+    RefreshStateMessage, StatesMessage,
 };
 use crate::actor::messages::{
     GetEventsByEventIDsMessage, GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage,
@@ -24,7 +24,7 @@ use moveos_types::function_return_value::AnnotatedFunctionReturnValue;
 use moveos_types::moveos_std::event::EventHandle;
 use moveos_types::moveos_std::event::{AnnotatedEvent, Event};
 use moveos_types::moveos_std::object::ObjectMeta;
-use moveos_types::state::{AnnotatedState, ObjectState};
+use moveos_types::state::{AnnotatedState, ObjectState, StateChangeSetExt};
 use moveos_types::state_resolver::RootObjectResolver;
 use moveos_types::state_resolver::{AnnotatedStateKV, AnnotatedStateReader, StateKV, StateReader};
 use moveos_types::transaction::TransactionExecutionInfo;
@@ -321,5 +321,19 @@ impl Handler<EventData> for ReaderExecutorActor {
             )?;
         }
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<GetStateChangeSetsMessage> for ReaderExecutorActor {
+    async fn handle(
+        &mut self,
+        msg: GetStateChangeSetsMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<Vec<Option<StateChangeSetExt>>> {
+        let GetStateChangeSetsMessage { tx_orders } = msg;
+        self.rooch_store
+            .state_store
+            .multi_get_state_change_set(tx_orders)
     }
 }

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -3,9 +3,9 @@
 
 use crate::actor::messages::{
     ConvertL2TransactionData, DryRunTransactionResult, GetAnnotatedEventsByEventIDsMessage,
-    GetEventsByEventHandleMessage, GetEventsByEventIDsMessage, GetTxExecutionInfosByHashMessage,
-    ListAnnotatedStatesMessage, ListStatesMessage, RefreshStateMessage, SaveStateChangeSetMessage,
-    ValidateL1BlockMessage, ValidateL1TxMessage,
+    GetEventsByEventHandleMessage, GetEventsByEventIDsMessage, GetStateChangeSetsMessage,
+    GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage, ListStatesMessage,
+    RefreshStateMessage, SaveStateChangeSetMessage, ValidateL1BlockMessage, ValidateL1TxMessage,
 };
 use crate::actor::reader_executor::ReaderExecutorActor;
 use crate::actor::{
@@ -249,6 +249,15 @@ impl ExecutorProxy {
             })
             .await
             .map_err(|e| anyhow!(format!("Save state change set error: {:?}", e)))
+    }
+
+    pub async fn get_state_change_sets(
+        &self,
+        tx_orders: Vec<u64>,
+    ) -> Result<Vec<Option<StateChangeSetExt>>> {
+        self.reader_actor
+            .send(GetStateChangeSetsMessage { tx_orders })
+            .await?
     }
 
     pub async fn chain_id(&self) -> Result<ChainID> {

--- a/crates/rooch-indexer/src/actor/indexer.rs
+++ b/crates/rooch-indexer/src/actor/indexer.rs
@@ -237,15 +237,12 @@ impl Handler<IndexerRevertMessage> for IndexerActor {
     async fn handle(&mut self, msg: IndexerRevertMessage, _ctx: &mut ActorContext) -> Result<()> {
         let IndexerRevertMessage {
             revert_tx_order,
-            // revert_ledger_tx,
-            // revert_execution_info,
             revert_state_change_set,
             root,
             object_mapping,
         } = msg;
 
         self.root = root;
-        // let tx_order = ledger_transaction.sequence_info.tx_order;
 
         // 1. revert indexer transaction
         self.indexer_store
@@ -259,14 +256,6 @@ impl Handler<IndexerRevertMessage> for IndexerActor {
         let mut state_index_generator = IndexerObjectStatesIndexGenerator::default();
         let mut indexer_object_state_change_set = IndexerObjectStateChangeSet::default();
 
-        // // set genesis tx_order and state_index_generator for new indexer revert
-        // let tx_order: u64 = 0;
-        // let last_state_index = self
-        //     .query_last_state_index_by_tx_order(tx_order, state_type.clone())
-        //     .await?;
-        // let mut state_index_generator = last_state_index.map_or(0, |x| x + 1);
-
-        // let object_mapping = HashMap::<ObjectID, ObjectMeta>::new();
         for (_feild_key, object_change) in revert_state_change_set.state_change_set.changes {
             let _ = handle_revert_object_change(
                 &mut state_index_generator,
@@ -279,7 +268,6 @@ impl Handler<IndexerRevertMessage> for IndexerActor {
         self.indexer_store
             .apply_object_states(indexer_object_state_change_set)?;
 
-        // self.indexer_store.revert_states(object_state_change_set)?;
         Ok(())
     }
 }

--- a/crates/rooch-indexer/src/actor/messages.rs
+++ b/crates/rooch-indexer/src/actor/messages.rs
@@ -16,6 +16,7 @@ use rooch_types::indexer::state::{
 use rooch_types::indexer::transaction::{IndexerTransaction, TransactionFilter};
 use rooch_types::transaction::LedgerTransaction;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Indexer write Message
 #[derive(Debug, Clone)]
@@ -150,14 +151,15 @@ impl Message for IndexerApplyObjectStatesMessage {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct IndexerRevertStatesMessage {
+pub struct IndexerRevertMessage {
     pub revert_tx_order: u64,
-    pub revert_ledger_tx: LedgerTransaction,
-    pub revert_execution_info: TransactionExecutionInfo,
+    // pub revert_ledger_tx: LedgerTransaction,
+    // pub revert_execution_info: TransactionExecutionInfo,
     pub revert_state_change_set: StateChangeSetExt,
     pub root: ObjectMeta,
+    pub object_mapping: HashMap<ObjectID, ObjectMeta>,
 }
 
-impl Message for IndexerRevertStatesMessage {
+impl Message for IndexerRevertMessage {
     type Result = Result<()>;
 }

--- a/crates/rooch-indexer/src/actor/messages.rs
+++ b/crates/rooch-indexer/src/actor/messages.rs
@@ -6,7 +6,7 @@ use coerce::actor::message::Message;
 use moveos_types::moveos_std::event::Event;
 use moveos_types::moveos_std::object::{ObjectID, ObjectMeta};
 use moveos_types::moveos_std::tx_context::TxContext;
-use moveos_types::state::StateChangeSet;
+use moveos_types::state::{StateChangeSet, StateChangeSetExt};
 use moveos_types::transaction::{MoveAction, TransactionExecutionInfo, VerifiedMoveOSTransaction};
 use rooch_types::indexer::event::{EventFilter, IndexerEvent, IndexerEventID};
 use rooch_types::indexer::state::{
@@ -146,5 +146,18 @@ pub struct IndexerApplyObjectStatesMessage {
 }
 
 impl Message for IndexerApplyObjectStatesMessage {
+    type Result = Result<()>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IndexerRevertStatesMessage {
+    pub revert_tx_order: u64,
+    pub revert_ledger_tx: LedgerTransaction,
+    pub revert_execution_info: TransactionExecutionInfo,
+    pub revert_state_change_set: StateChangeSetExt,
+    pub root: ObjectMeta,
+}
+
+impl Message for IndexerRevertStatesMessage {
     type Result = Result<()>;
 }

--- a/crates/rooch-indexer/src/actor/messages.rs
+++ b/crates/rooch-indexer/src/actor/messages.rs
@@ -153,8 +153,6 @@ impl Message for IndexerApplyObjectStatesMessage {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexerRevertMessage {
     pub revert_tx_order: u64,
-    // pub revert_ledger_tx: LedgerTransaction,
-    // pub revert_execution_info: TransactionExecutionInfo,
     pub revert_state_change_set: StateChangeSetExt,
     pub root: ObjectMeta,
     pub object_mapping: HashMap<ObjectID, ObjectMeta>,

--- a/crates/rooch-indexer/src/lib.rs
+++ b/crates/rooch-indexer/src/lib.rs
@@ -212,6 +212,16 @@ impl IndexerStoreTrait for IndexerStore {
         self.get_sqlite_store(INDEXER_EVENTS_TABLE_NAME)?
             .persist_events(events)
     }
+
+    fn delete_transactions(&self, tx_orders: Vec<u64>) -> Result<(), IndexerError> {
+        self.get_sqlite_store(INDEXER_TRANSACTIONS_TABLE_NAME)?
+            .delete_transactions(tx_orders)
+    }
+
+    fn delete_events(&self, tx_orders: Vec<u64>) -> Result<(), IndexerError> {
+        self.get_sqlite_store(INDEXER_EVENTS_TABLE_NAME)?
+            .delete_events(tx_orders)
+    }
 }
 
 impl IndexerStore {

--- a/crates/rooch-indexer/src/models/events.rs
+++ b/crates/rooch-indexer/src/models/events.rs
@@ -3,11 +3,11 @@
 
 use crate::schema::events;
 use diesel::prelude::*;
+use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::StructTag;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::event::EventID;
 use moveos_types::moveos_std::object::ObjectID;
-use rooch_types::address::RoochAddress;
 use rooch_types::indexer::event::{IndexerEvent, IndexerEventID};
 use std::str::FromStr;
 
@@ -60,7 +60,7 @@ impl From<IndexerEvent> for StoredEvent {
 impl StoredEvent {
     pub fn try_into_indexer_event(&self) -> Result<IndexerEvent, anyhow::Error> {
         let event_handle_id = ObjectID::from_str(self.event_handle_id.as_str())?;
-        let sender = RoochAddress::from_str(self.sender.as_str())?;
+        let sender = AccountAddress::from_str(self.sender.as_str())?;
         let tx_hash = H256::from_str(self.tx_hash.as_str())?;
         let event_type = StructTag::from_str(self.event_type.as_str())?;
 

--- a/crates/rooch-indexer/src/models/transactions.rs
+++ b/crates/rooch-indexer/src/models/transactions.rs
@@ -4,8 +4,8 @@
 use crate::schema::transactions;
 use crate::utils::escape_sql_string;
 use diesel::prelude::*;
+use move_core_types::account_address::AccountAddress;
 use moveos_types::h256::H256;
-use rooch_types::address::RoochAddress;
 use rooch_types::indexer::transaction::IndexerTransaction;
 use std::str::FromStr;
 
@@ -58,7 +58,7 @@ impl TryFrom<StoredTransaction> for IndexerTransaction {
     type Error = anyhow::Error;
 
     fn try_from(transaction: StoredTransaction) -> Result<Self, Self::Error> {
-        let sender = RoochAddress::from_hex_literal(transaction.sender.as_str())?;
+        let sender = AccountAddress::from_str(transaction.sender.as_str())?;
         let tx_hash = H256::from_str(transaction.tx_hash.as_str())?;
 
         let indexer_transaction = IndexerTransaction {

--- a/crates/rooch-indexer/src/proxy/mod.rs
+++ b/crates/rooch-indexer/src/proxy/mod.rs
@@ -214,8 +214,6 @@ impl IndexerProxy {
     pub async fn revert_indexer(
         &self,
         revert_tx_order: u64,
-        // revert_ledger_tx: LedgerTransaction,
-        // revert_execution_info: TransactionExecutionInfo,
         revert_state_change_set: StateChangeSetExt,
         root: ObjectMeta,
         object_mapping: HashMap<ObjectID, ObjectMeta>,
@@ -223,8 +221,6 @@ impl IndexerProxy {
         self.actor
             .notify(IndexerRevertMessage {
                 revert_tx_order,
-                // revert_ledger_tx,
-                // revert_execution_info,
                 revert_state_change_set,
                 root,
                 object_mapping,

--- a/crates/rooch-indexer/src/proxy/mod.rs
+++ b/crates/rooch-indexer/src/proxy/mod.rs
@@ -4,9 +4,9 @@
 use crate::actor::indexer::IndexerActor;
 use crate::actor::messages::{
     IndexerApplyObjectStatesMessage, IndexerDeleteAnyObjectStatesMessage, IndexerEventsMessage,
-    IndexerPersistOrUpdateAnyObjectStatesMessage, IndexerStatesMessage, IndexerTransactionMessage,
-    QueryIndexerEventsMessage, QueryIndexerObjectIdsMessage, QueryIndexerTransactionsMessage,
-    QueryLastStateIndexByTxOrderMessage, UpdateIndexerMessage,
+    IndexerPersistOrUpdateAnyObjectStatesMessage, IndexerRevertMessage, IndexerStatesMessage,
+    IndexerTransactionMessage, QueryIndexerEventsMessage, QueryIndexerObjectIdsMessage,
+    QueryIndexerTransactionsMessage, QueryLastStateIndexByTxOrderMessage, UpdateIndexerMessage,
 };
 use crate::actor::reader_indexer::IndexerReaderActor;
 use anyhow::{Ok, Result};
@@ -14,7 +14,7 @@ use coerce::actor::ActorRef;
 use moveos_types::moveos_std::event::Event;
 use moveos_types::moveos_std::object::{ObjectID, ObjectMeta};
 use moveos_types::moveos_std::tx_context::TxContext;
-use moveos_types::state::StateChangeSet;
+use moveos_types::state::{StateChangeSet, StateChangeSetExt};
 use moveos_types::transaction::{MoveAction, TransactionExecutionInfo, VerifiedMoveOSTransaction};
 use rooch_types::indexer::event::{EventFilter, IndexerEvent, IndexerEventID};
 use rooch_types::indexer::state::{
@@ -23,6 +23,7 @@ use rooch_types::indexer::state::{
 };
 use rooch_types::indexer::transaction::{IndexerTransaction, TransactionFilter};
 use rooch_types::transaction::LedgerTransaction;
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct IndexerProxy {
@@ -208,5 +209,27 @@ impl IndexerProxy {
                 state_type,
             })
             .await?
+    }
+
+    pub async fn revert_indexer(
+        &self,
+        revert_tx_order: u64,
+        // revert_ledger_tx: LedgerTransaction,
+        // revert_execution_info: TransactionExecutionInfo,
+        revert_state_change_set: StateChangeSetExt,
+        root: ObjectMeta,
+        object_mapping: HashMap<ObjectID, ObjectMeta>,
+    ) -> Result<()> {
+        self.actor
+            .notify(IndexerRevertMessage {
+                revert_tx_order,
+                // revert_ledger_tx,
+                // revert_execution_info,
+                revert_state_change_set,
+                root,
+                object_mapping,
+            })
+            .await?;
+        Ok(())
     }
 }

--- a/crates/rooch-indexer/src/store/sqlite_store.rs
+++ b/crates/rooch-indexer/src/store/sqlite_store.rs
@@ -346,6 +346,32 @@ impl SqliteIndexerStore {
     }
 
     #[named]
+    pub fn delete_transactions(&self, tx_orders: Vec<u64>) -> Result<(), IndexerError> {
+        if tx_orders.is_empty() {
+            return Ok(());
+        }
+
+        let fn_name = function_name!();
+        let _timer = self
+            .db_metrics
+            .indexer_store_metrics
+            .indexer_persist_or_update_or_delete_latency_seconds
+            .with_label_values(&[fn_name])
+            .start_timer();
+        let mut connection = get_sqlite_pool_connection(&self.connection_pool)?;
+
+        let tx_orders = tx_orders.into_iter().map(|v| v as i64).collect();
+        diesel::delete(
+            transactions::table.filter(transactions::tx_order.eq_any(tx_orders.as_slice())),
+        )
+        .execute(&mut connection)
+        .map_err(|e| IndexerError::SQLiteWriteError(e.to_string()))
+        .context("Failed to delete transactions to SQLiteDB")?;
+
+        Ok(())
+    }
+
+    #[named]
     pub fn persist_events(&self, events: Vec<IndexerEvent>) -> Result<(), IndexerError> {
         if events.is_empty() {
             return Ok(());
@@ -369,6 +395,30 @@ impl SqliteIndexerStore {
             .execute(&mut connection)
             .map_err(|e| IndexerError::SQLiteWriteError(e.to_string()))
             .context("Failed to write events to SQLiteDB")?;
+
+        Ok(())
+    }
+
+    #[named]
+    pub fn delete_events(&self, tx_orders: Vec<u64>) -> Result<(), IndexerError> {
+        if tx_orders.is_empty() {
+            return Ok(());
+        }
+
+        let fn_name = function_name!();
+        let _timer = self
+            .db_metrics
+            .indexer_store_metrics
+            .indexer_persist_or_update_or_delete_latency_seconds
+            .with_label_values(&[fn_name])
+            .start_timer();
+        let mut connection = get_sqlite_pool_connection(&self.connection_pool)?;
+
+        let tx_orders = tx_orders.into_iter().map(|v| v as i64).collect();
+        diesel::delete(events::table.filter(events::tx_order.eq_any(tx_orders.as_slice())))
+            .execute(&mut connection)
+            .map_err(|e| IndexerError::SQLiteWriteError(e.to_string()))
+            .context("Failed to delete events to SQLiteDB")?;
 
         Ok(())
     }

--- a/crates/rooch-indexer/src/store/sqlite_store.rs
+++ b/crates/rooch-indexer/src/store/sqlite_store.rs
@@ -360,7 +360,7 @@ impl SqliteIndexerStore {
             .start_timer();
         let mut connection = get_sqlite_pool_connection(&self.connection_pool)?;
 
-        let tx_orders = tx_orders.into_iter().map(|v| v as i64).collect();
+        let tx_orders: Vec<_> = tx_orders.into_iter().map(|v| v as i64).collect();
         diesel::delete(
             transactions::table.filter(transactions::tx_order.eq_any(tx_orders.as_slice())),
         )
@@ -414,7 +414,7 @@ impl SqliteIndexerStore {
             .start_timer();
         let mut connection = get_sqlite_pool_connection(&self.connection_pool)?;
 
-        let tx_orders = tx_orders.into_iter().map(|v| v as i64).collect();
+        let tx_orders: Vec<_> = tx_orders.into_iter().map(|v| v as i64).collect();
         diesel::delete(events::table.filter(events::tx_order.eq_any(tx_orders.as_slice())))
             .execute(&mut connection)
             .map_err(|e| IndexerError::SQLiteWriteError(e.to_string()))

--- a/crates/rooch-indexer/src/store/traits.rs
+++ b/crates/rooch-indexer/src/store/traits.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::errors::IndexerError;
-use crate::{INDEXER_EVENTS_TABLE_NAME, INDEXER_TRANSACTIONS_TABLE_NAME};
 use rooch_types::indexer::event::IndexerEvent;
 use rooch_types::indexer::state::{IndexerObjectState, IndexerObjectStateChangeSet};
 use rooch_types::indexer::transaction::IndexerTransaction;

--- a/crates/rooch-indexer/src/store/traits.rs
+++ b/crates/rooch-indexer/src/store/traits.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::errors::IndexerError;
+use crate::{INDEXER_EVENTS_TABLE_NAME, INDEXER_TRANSACTIONS_TABLE_NAME};
 use rooch_types::indexer::event::IndexerEvent;
 use rooch_types::indexer::state::{IndexerObjectState, IndexerObjectStateChangeSet};
 use rooch_types::indexer::transaction::IndexerTransaction;
@@ -39,4 +40,8 @@ pub trait IndexerStoreTrait: Send + Sync {
     ) -> Result<(), IndexerError>;
 
     fn persist_events(&self, events: Vec<IndexerEvent>) -> Result<(), IndexerError>;
+
+    fn delete_transactions(&self, tx_orders: Vec<u64>) -> anyhow::Result<(), IndexerError>;
+
+    fn delete_events(&self, tx_orders: Vec<u64>) -> anyhow::Result<(), IndexerError>;
 }

--- a/crates/rooch-indexer/src/tests/test_indexer.rs
+++ b/crates/rooch-indexer/src/tests/test_indexer.rs
@@ -62,7 +62,7 @@ async fn test_transaction_store() -> Result<()> {
     let transactions = vec![indexer_transaction];
     indexer_store.persist_transactions(transactions)?;
 
-    let filter = TransactionFilter::Sender(random_moveos_tx.ctx.sender.into());
+    let filter = TransactionFilter::Sender(random_moveos_tx.ctx.sender);
     let query_transactions =
         indexer_reader.query_transactions_with_filter(filter, None, 1, true)?;
     assert_eq!(query_transactions.len(), 1);
@@ -97,7 +97,7 @@ async fn test_event_store() -> Result<()> {
     let events = vec![indexer_event];
     indexer_store.persist_events(events)?;
 
-    let filter = EventFilter::Sender(random_moveos_tx.ctx.sender.into());
+    let filter = EventFilter::Sender(random_moveos_tx.ctx.sender);
     let query_events = indexer_reader.query_events_with_filter(filter, None, 1, true)?;
     assert_eq!(query_events.len(), 1);
     Ok(())
@@ -250,7 +250,7 @@ async fn test_escape_transaction() -> Result<()> {
     let transactions = vec![indexer_transaction];
     indexer_store.persist_transactions(transactions)?;
 
-    let filter = TransactionFilter::Sender(random_moveos_tx.ctx.sender.into());
+    let filter = TransactionFilter::Sender(random_moveos_tx.ctx.sender);
     let query_transactions =
         indexer_reader.query_transactions_with_filter(filter, None, 1, true)?;
     assert_eq!(query_transactions.len(), 1);

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -746,6 +746,44 @@
           "$ref": "#/components/schemas/primitive_types::H256"
         }
       }
+    },
+    {
+      "name": "rooch_syncStates",
+      "description": "Sync state change sets",
+      "params": [
+        {
+          "name": "filter",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SyncStateFilterView"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "$ref": "#/components/schemas/u64"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "$ref": "#/components/schemas/u64"
+          }
+        },
+        {
+          "name": "query_option",
+          "schema": {
+            "$ref": "#/components/schemas/QueryOptions"
+          }
+        }
+      ],
+      "result": {
+        "name": "StateChangeSetPageView",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/PageView_for_StateChangeSetWithTxOrderView_and_u64"
+        }
+      }
     }
   ],
   "components": {
@@ -2479,6 +2517,35 @@
           }
         }
       },
+      "PageView_for_StateChangeSetWithTxOrderView_and_u64": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
+        "type": "object",
+        "required": [
+          "data",
+          "has_next_page"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StateChangeSetWithTxOrderView"
+            }
+          },
+          "has_next_page": {
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/u64"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
       "PageView_for_StateKVView_and_String": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
@@ -2712,6 +2779,21 @@
           }
         }
       },
+      "StateChangeSetWithTxOrderView": {
+        "type": "object",
+        "required": [
+          "state_change_set",
+          "tx_order"
+        ],
+        "properties": {
+          "state_change_set": {
+            "$ref": "#/components/schemas/StateChangeSetView"
+          },
+          "tx_order": {
+            "$ref": "#/components/schemas/u64"
+          }
+        }
+      },
       "StateKVView": {
         "type": "object",
         "required": [
@@ -2741,6 +2823,30 @@
             "type": "boolean"
           }
         }
+      },
+      "SyncStateFilterView": {
+        "oneOf": [
+          {
+            "description": "Sync by object id.",
+            "type": "object",
+            "required": [
+              "object_i_d"
+            ],
+            "properties": {
+              "object_i_d": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Sync all.",
+            "type": "string",
+            "enum": [
+              "all"
+            ]
+          }
+        ]
       },
       "TransactionExecutionInfoView": {
         "type": "object",

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -1762,6 +1762,12 @@
               "type"
             ],
             "properties": {
+              "bitcoin_block_hash": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "block_hash": {
                 "$ref": "#/components/schemas/alloc::vec::Vec<u8>"
               },

--- a/crates/rooch-relayer/src/actor/bitcoin_client.rs
+++ b/crates/rooch-relayer/src/actor/bitcoin_client.rs
@@ -110,7 +110,6 @@ impl Handler<GetBlockHeaderInfoMessage> for BitcoinClientActor {
         _ctx: &mut ActorContext,
     ) -> Result<json::GetBlockHeaderResult> {
         let GetBlockHeaderInfoMessage { hash } = msg;
-        println!("Debug GetBlockHeaderInfoMessage msg {:?}", hash);
         Ok(self
             .retry(|| self.rpc_client.get_block_header_info(&hash))
             .await?)

--- a/crates/rooch-relayer/src/actor/bitcoin_client.rs
+++ b/crates/rooch-relayer/src/actor/bitcoin_client.rs
@@ -110,6 +110,7 @@ impl Handler<GetBlockHeaderInfoMessage> for BitcoinClientActor {
         _ctx: &mut ActorContext,
     ) -> Result<json::GetBlockHeaderResult> {
         let GetBlockHeaderInfoMessage { hash } = msg;
+        println!("Debug GetBlockHeaderInfoMessage msg {:?}", hash);
         Ok(self
             .retry(|| self.rpc_client.get_block_header_info(&hash))
             .await?)

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -11,8 +11,9 @@ use crate::jsonrpc_types::{
     DryRunTransactionResponseView, EventOptions, EventPageView, ExecuteTransactionResponseView,
     FieldKeyView, FunctionCallView, H256View, IndexerEventPageView, IndexerObjectStatePageView,
     IndexerStateIDView, ModuleABIView, ObjectIDVecView, ObjectIDView, ObjectStateFilterView,
-    ObjectStateView, QueryOptions, RoochAddressView, StateOptions, StatePageView, StrView,
-    StructTagView, TransactionWithInfoPageView, TxOptions,
+    ObjectStateView, QueryOptions, RoochAddressView, StateChangeSetPageView, StateOptions,
+    StatePageView, StrView, StructTagView, SyncStateFilterView, TransactionWithInfoPageView,
+    TxOptions,
 };
 use crate::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -198,4 +199,15 @@ pub trait RoochAPI {
         repair_type: RepairIndexerTypeView,
         repair_params: RepairIndexerParamsView,
     ) -> RpcResult<()>;
+
+    /// Sync state change sets
+    #[method(name = "syncStates")]
+    async fn sync_states(
+        &self,
+        filter: SyncStateFilterView,
+        // exclusive cursor if `Some`, otherwise start from the beginning
+        cursor: Option<StrView<u64>>,
+        limit: Option<StrView<u64>>,
+        query_option: Option<QueryOptions>,
+    ) -> RpcResult<StateChangeSetPageView>;
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
@@ -9,6 +9,7 @@ use moveos_types::moveos_std::{
     event::{AnnotatedEvent, Event, EventID, TransactionEvent},
     object::ObjectID,
 };
+use rooch_types::address::RoochAddress;
 use rooch_types::indexer::event::{
     AnnotatedIndexerEvent, EventFilter, IndexerEvent, IndexerEventID,
 };
@@ -164,7 +165,7 @@ impl From<IndexerEvent> for IndexerEventView {
             event_type: event.event_type.into(),
             event_data: StrView(event.event_data.unwrap_or_default()),
             tx_hash: event.tx_hash.into(),
-            sender: event.sender.into(),
+            sender: RoochAddress::from(event.sender).into(),
             created_at: event.created_at.into(),
 
             decoded_event_data: None,
@@ -180,7 +181,7 @@ impl From<AnnotatedIndexerEvent> for IndexerEventView {
             event_type: event.event.event_type.into(),
             event_data: StrView(event.event.event_data.unwrap_or_default()),
             tx_hash: event.event.tx_hash.into(),
-            sender: event.event.sender.into(),
+            sender: RoochAddress::from(event.event.sender).into(),
             created_at: event.event.created_at.into(),
             decoded_event_data: Some(event.decoded_event_data.into()),
         }
@@ -224,11 +225,11 @@ impl From<EventFilterView> for EventFilter {
             EventFilterView::EventTypeWithSender { event_type, sender } => {
                 Self::EventTypeWithSender {
                     event_type: event_type.into(),
-                    sender: sender.into(),
+                    sender: sender.0.rooch_address.into(),
                 }
             }
             EventFilterView::EventType(event_type) => Self::EventType(event_type.into()),
-            EventFilterView::Sender(address) => Self::Sender(address.into()),
+            EventFilterView::Sender(address) => Self::Sender(address.0.rooch_address.into()),
             EventFilterView::TxHash(tx_hash) => Self::TxHash(tx_hash.into()),
             EventFilterView::TimeRange {
                 start_time,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::event_view::IndexerEventIDView;
-use super::{HumanReadableDisplay, IndexerStateIDView};
+use super::{HumanReadableDisplay, IndexerStateIDView, StateChangeSetWithTxOrderView};
 use crate::jsonrpc_types::account_view::BalanceInfoView;
 use crate::jsonrpc_types::btc::ord::InscriptionStateView;
 use crate::jsonrpc_types::btc::utxo::UTXOStateView;
@@ -29,6 +29,7 @@ pub type IndexerObjectStatePageView = PageView<IndexerObjectStateView, IndexerSt
 
 pub type UTXOPageView = PageView<UTXOStateView, IndexerStateIDView>;
 pub type InscriptionPageView = PageView<InscriptionStateView, IndexerStateIDView>;
+pub type StateChangeSetPageView = PageView<StateChangeSetWithTxOrderView, StrView<u64>>;
 
 /// `next_cursor` points to the last item in the page;
 /// Reading with `next_cursor` will start from the next item after `next_cursor` if

--- a/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/state_view.rs
@@ -3,7 +3,8 @@
 
 use super::{
     AnnotatedMoveStructView, BytesView, H256View, HumanReadableDisplay, ObjectIDVecView,
-    QueryOptions, RoochAddressView, StrView, StructTagView, TypeTagView, UnitedAddressView,
+    ObjectIDView, QueryOptions, RoochAddressView, StrView, StructTagView, TypeTagView,
+    UnitedAddressView,
 };
 use anyhow::Result;
 use move_core_types::effects::Op;
@@ -15,6 +16,7 @@ use moveos_types::{
     state::{AnnotatedState, ObjectState, StateChangeSet},
 };
 use rooch_types::indexer::state::{IndexerStateID, ObjectStateFilter};
+use rooch_types::state::{StateChangeSetWithTxOrder, SyncStateFilter};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -516,4 +518,37 @@ fn parse_changed_objects(
         deleted_objs.extend(field_deleted_objs);
     }
     (new_objs, modified_objs, deleted_objs)
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncStateFilterView {
+    /// Sync by object id.
+    ObjectID(ObjectIDView),
+    /// Sync all.
+    All,
+}
+
+impl From<SyncStateFilterView> for SyncStateFilter {
+    fn from(state_filter: SyncStateFilterView) -> Self {
+        match state_filter {
+            SyncStateFilterView::ObjectID(object_id) => SyncStateFilter::ObjectID(object_id.into()),
+            SyncStateFilterView::All => SyncStateFilter::All,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct StateChangeSetWithTxOrderView {
+    pub tx_order: StrView<u64>,
+    pub state_change_set: StateChangeSetView,
+}
+
+impl From<StateChangeSetWithTxOrder> for StateChangeSetWithTxOrderView {
+    fn from(state_change_set: StateChangeSetWithTxOrder) -> Self {
+        Self {
+            tx_order: state_change_set.tx_order.into(),
+            state_change_set: state_change_set.state_change_set.into(),
+        }
+    }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
@@ -19,6 +19,7 @@ pub struct L1BlockView {
     pub chain_id: StrView<u64>,
     pub block_height: StrView<u64>,
     pub block_hash: BytesView,
+    pub bitcoin_block_hash: Option<String>,
 }
 
 impl From<L1Block> for L1BlockView {
@@ -26,6 +27,13 @@ impl From<L1Block> for L1BlockView {
         Self {
             chain_id: block.chain_id.id().into(),
             block_height: block.block_height.into(),
+            bitcoin_block_hash: if block.chain_id.is_bitcoin() {
+                bitcoin::BlockHash::from_slice(&block.block_hash)
+                    .map(|hash| hash.to_string())
+                    .ok()
+            } else {
+                None
+            },
             block_hash: block.block_hash.into(),
         }
     }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/transaction_view.rs
@@ -153,7 +153,7 @@ pub enum TransactionFilterView {
 impl From<TransactionFilterView> for TransactionFilter {
     fn from(event_filter: TransactionFilterView) -> Self {
         match event_filter {
-            TransactionFilterView::Sender(address) => Self::Sender(address.into()),
+            TransactionFilterView::Sender(address) => Self::Sender(address.0.rooch_address.into()),
             TransactionFilterView::TxHashes(tx_hashes) => {
                 Self::TxHashes(tx_hashes.into_iter().map(Into::into).collect())
             }

--- a/crates/rooch-store/src/lib.rs
+++ b/crates/rooch-store/src/lib.rs
@@ -3,12 +3,14 @@
 
 use crate::accumulator_store::{AccumulatorStore, TransactionAccumulatorStore};
 use crate::meta_store::{MetaDBStore, MetaStore};
+use crate::state_store::{StateDBStore, StateStore};
 use crate::transaction_store::{TransactionDBStore, TransactionStore};
 use accumulator::AccumulatorTreeStore;
 use anyhow::Result;
 use moveos_config::store_config::RocksdbConfig;
 use moveos_config::DataDirPath;
 use moveos_types::h256::H256;
+use moveos_types::state::StateChangeSetExt;
 use once_cell::sync::Lazy;
 use prometheus::Registry;
 use raw_store::metrics::DBMetrics;
@@ -22,6 +24,7 @@ use std::sync::Arc;
 
 pub mod accumulator_store;
 pub mod meta_store;
+pub mod state_store;
 #[cfg(test)]
 mod tests;
 pub mod transaction_store;
@@ -33,6 +36,8 @@ pub const TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME: ColumnFamilyName =
 pub const META_SEQUENCER_INFO_COLUMN_FAMILY_NAME: ColumnFamilyName = "meta_sequencer_info";
 pub const TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME: ColumnFamilyName = "transaction_acc_node";
 
+pub const STATE_CHANGE_SET_COLUMN_FAMILY_NAME: ColumnFamilyName = "state_change_set";
+
 ///db store use cf_name vec to init
 /// Please note that adding a column family needs to be added in vec simultaneously, remember！！
 static VEC_COLUMN_FAMILY_NAME: Lazy<Vec<ColumnFamilyName>> = Lazy::new(|| {
@@ -41,6 +46,7 @@ static VEC_COLUMN_FAMILY_NAME: Lazy<Vec<ColumnFamilyName>> = Lazy::new(|| {
         TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME,
         META_SEQUENCER_INFO_COLUMN_FAMILY_NAME,
         TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME,
+        STATE_CHANGE_SET_COLUMN_FAMILY_NAME,
     ]
 });
 
@@ -58,6 +64,7 @@ pub struct RoochStore {
     pub transaction_store: TransactionDBStore,
     pub meta_store: MetaDBStore,
     pub transaction_accumulator_store: AccumulatorStore<TransactionAccumulatorStore>,
+    pub state_store: StateDBStore,
 }
 
 impl RoochStore {
@@ -79,8 +86,9 @@ impl RoochStore {
             transaction_store: TransactionDBStore::new(instance.clone()),
             meta_store: MetaDBStore::new(instance.clone()),
             transaction_accumulator_store: AccumulatorStore::new_transaction_accumulator_store(
-                instance,
+                instance.clone(),
             ),
+            state_store: StateDBStore::new(instance),
         };
         Ok(store)
     }
@@ -103,6 +111,10 @@ impl RoochStore {
 
     pub fn get_transaction_accumulator_store(&self) -> Arc<dyn AccumulatorTreeStore> {
         Arc::new(self.transaction_accumulator_store.clone())
+    }
+
+    pub fn get_state_store(&self) -> &StateDBStore {
+        &self.state_store
     }
 }
 
@@ -153,5 +165,35 @@ impl MetaStore for RoochStore {
 
     fn remove_sequencer_info(&self) -> Result<()> {
         self.get_meta_store().remove_sequence_info()
+    }
+}
+
+impl StateStore for RoochStore {
+    // Setting TTL directly in RocksDB may not be a good choice.
+    // RocksDB uses compaction to remove expired keys,
+    // and it may also have performance impact.
+    // TODO Cleaning up data regularly may be an option
+    fn save_state_change_set(
+        &self,
+        tx_order: u64,
+        state_change_set: StateChangeSetExt,
+    ) -> Result<()> {
+        self.get_state_store()
+            .save_state_change_set(tx_order, state_change_set)
+    }
+
+    fn get_state_change_set(&self, tx_order: u64) -> Result<Option<StateChangeSetExt>> {
+        self.get_state_store().get_state_change_set(tx_order)
+    }
+
+    fn multi_get_state_change_set(
+        &self,
+        tx_orders: Vec<u64>,
+    ) -> Result<Vec<Option<StateChangeSetExt>>> {
+        self.get_state_store().multi_get_state_change_set(tx_orders)
+    }
+
+    fn remove_state_change_set(&self, tx_order: u64) -> Result<()> {
+        self.get_state_store().remove_state_change_set(tx_order)
     }
 }

--- a/crates/rooch-store/src/state_store/mod.rs
+++ b/crates/rooch-store/src/state_store/mod.rs
@@ -1,0 +1,66 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::STATE_CHANGE_SET_COLUMN_FAMILY_NAME;
+use anyhow::Result;
+use moveos_types::state::StateChangeSetExt;
+use raw_store::CodecKVStore;
+use raw_store::{derive_store, StoreInstance};
+
+derive_store!(
+    StateChangeSetStore,
+    u64,
+    StateChangeSetExt,
+    STATE_CHANGE_SET_COLUMN_FAMILY_NAME
+);
+
+pub trait StateStore {
+    fn save_state_change_set(
+        &self,
+        tx_order: u64,
+        state_change_set: StateChangeSetExt,
+    ) -> Result<()>;
+    fn get_state_change_set(&self, tx_order: u64) -> Result<Option<StateChangeSetExt>>;
+    fn multi_get_state_change_set(
+        &self,
+        tx_orders: Vec<u64>,
+    ) -> Result<Vec<Option<StateChangeSetExt>>>;
+    fn remove_state_change_set(&self, tx_order: u64) -> Result<()>;
+}
+
+#[derive(Clone)]
+pub struct StateDBStore {
+    state_change_set_store: StateChangeSetStore,
+}
+
+impl StateDBStore {
+    pub fn new(instance: StoreInstance) -> Self {
+        StateDBStore {
+            state_change_set_store: StateChangeSetStore::new(instance.clone()),
+        }
+    }
+
+    pub fn save_state_change_set(
+        &self,
+        tx_order: u64,
+        state_change_set: StateChangeSetExt,
+    ) -> Result<()> {
+        self.state_change_set_store
+            .kv_put(tx_order, state_change_set)
+    }
+
+    pub fn get_state_change_set(&self, tx_order: u64) -> Result<Option<StateChangeSetExt>> {
+        self.state_change_set_store.kv_get(tx_order)
+    }
+
+    pub fn multi_get_state_change_set(
+        &self,
+        tx_orders: Vec<u64>,
+    ) -> Result<Vec<Option<StateChangeSetExt>>> {
+        self.state_change_set_store.multiple_get(tx_orders)
+    }
+
+    pub fn remove_state_change_set(&self, tx_order: u64) -> Result<()> {
+        self.state_change_set_store.remove(tx_order)
+    }
+}

--- a/crates/rooch-types/src/genesis_config.rs
+++ b/crates/rooch-types/src/genesis_config.rs
@@ -67,6 +67,7 @@ pub static G_LOCAL_CONFIG: Lazy<GenesisConfig> = Lazy::new(|| GenesisConfig {
     // The regtest genesis block hash
     bitcoin_block_hash: BlockHash::from_str(
         "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
+        // "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f", // mainnet 0 block hash
     )
     .expect("Should be valid"),
     bitcoin_reorg_block_count: 0,

--- a/crates/rooch-types/src/indexer/event.rs
+++ b/crates/rooch-types/src/indexer/event.rs
@@ -1,10 +1,10 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::address::RoochAddress;
 use crate::indexer::Filter;
 use crate::transaction::LedgerTransaction;
 use anyhow::Result;
+use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::StructTag;
 use move_resource_viewer::AnnotatedMoveStruct;
 use moveos_types::h256::H256;
@@ -28,7 +28,7 @@ pub struct IndexerEvent {
     /// the hash of this transaction.
     pub tx_hash: H256,
     /// the account address of sender who emit the event
-    pub sender: RoochAddress,
+    pub sender: AccountAddress,
 
     /// the event created timestamp on chain
     pub created_at: u64,
@@ -46,7 +46,7 @@ impl IndexerEvent {
             event_type: event.event_type,
             event_data: Some(event.event_data),
             tx_hash: ledger_transaction.tx_hash(),
-            sender: ctx.sender.into(),
+            sender: ctx.sender,
 
             created_at: ledger_transaction.sequence_info.tx_timestamp,
         }
@@ -86,12 +86,12 @@ pub enum EventFilter {
     /// Query by event type with sender
     EventTypeWithSender {
         event_type: StructTag,
-        sender: RoochAddress,
+        sender: AccountAddress,
     },
     /// Query by event type.
     EventType(StructTag),
     /// Query by sender address.
-    Sender(RoochAddress),
+    Sender(AccountAddress),
     /// Return events emitted by the given transaction hash.
     TxHash(H256),
     /// Return events emitted in [start_time, end_time) interval

--- a/crates/rooch-types/src/indexer/state.rs
+++ b/crates/rooch-types/src/indexer/state.rs
@@ -293,7 +293,6 @@ pub fn collect_revert_object_change_ids(
             }
             Op::New(_value) => {}
         }
-    } else {
     }
 
     for (_key, change) in fields {
@@ -365,13 +364,6 @@ impl Filter<IndexerObjectState> for ObjectStateFilter {
     fn matches(&self, item: &IndexerObjectState) -> bool {
         self.try_matches(item).unwrap_or_default()
     }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum StateSyncFilter {
-    /// Query by object id.
-    ObjectId(ObjectID),
 }
 
 #[derive(Clone, Debug)]

--- a/crates/rooch-types/src/indexer/transaction.rs
+++ b/crates/rooch-types/src/indexer/transaction.rs
@@ -1,9 +1,9 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::address::RoochAddress;
 use crate::transaction::{LedgerTransaction, LedgerTxData};
 use anyhow::Result;
+use move_core_types::account_address::AccountAddress;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::transaction::{MoveAction, TransactionExecutionInfo};
@@ -18,7 +18,7 @@ pub struct IndexerTransaction {
 
     pub sequence_number: u64,
     // the account address of sender who send the transaction
-    pub sender: RoochAddress,
+    pub sender: AccountAddress,
     pub action_type: u8,
     pub auth_validator_id: u64,
     // the amount of gas used.
@@ -52,7 +52,7 @@ impl IndexerTransaction {
 
             sequence_number: tx_context.sequence_number,
             // the account address of sender who send the transaction
-            sender: tx_context.sender.into(),
+            sender: tx_context.sender,
             action_type: move_action.action_type(),
             auth_validator_id,
             // the amount of gas used.
@@ -69,7 +69,7 @@ impl IndexerTransaction {
 #[serde(rename_all = "camelCase")]
 pub enum TransactionFilter {
     /// Query by sender address.
-    Sender(RoochAddress),
+    Sender(AccountAddress),
     /// Query by the transaction hash list.
     TxHashes(Vec<H256>),
     /// Return transactions in [start_time, end_time) interval

--- a/crates/rooch-types/src/lib.rs
+++ b/crates/rooch-types/src/lib.rs
@@ -23,6 +23,7 @@ pub mod rooch_network;
 pub mod rooch_signature;
 pub mod sequencer;
 pub mod service_status;
+pub mod state;
 pub mod test_utils;
 pub mod to_bech32;
 pub mod transaction;

--- a/crates/rooch-types/src/state.rs
+++ b/crates/rooch-types/src/state.rs
@@ -1,0 +1,39 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use moveos_types::moveos_std::object::ObjectID;
+use moveos_types::state::StateChangeSet;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SyncStateFilter {
+    /// Sync by object id.
+    ObjectID(ObjectID),
+    /// Sync all.
+    All,
+}
+
+// impl SyncStateFilter {
+//     fn try_matches(&self, item: &StateChangeSet) -> Result<bool> {
+//         Ok(match self {
+//             SyncStateFilter::ObjectId(object_id) => object_id == &item.object_id,
+//         })
+//     }
+// }
+
+/// Global State change set ext.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct StateChangeSetWithTxOrder {
+    pub tx_order: u64,
+    pub state_change_set: StateChangeSet,
+}
+
+impl StateChangeSetWithTxOrder {
+    pub fn new(tx_order: u64, state_change_set: StateChangeSet) -> Self {
+        Self {
+            tx_order,
+            state_change_set,
+        }
+    }
+}

--- a/crates/rooch/src/commands/db/commands/mod.rs
+++ b/crates/rooch/src/commands/db/commands/mod.rs
@@ -1,5 +1,28 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use metrics::RegistryService;
+use moveos_types::moveos_std::object::ObjectMeta;
+use rooch_config::RoochOpt;
+use rooch_db::RoochDB;
+use rooch_genesis::RoochGenesis;
+use rooch_types::rooch_network::RoochChainID;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
 pub mod revert_tx;
 pub mod rollback;
+
+fn init(
+    base_data_dir: Option<PathBuf>,
+    chain_id: Option<RoochChainID>,
+) -> (ObjectMeta, RoochDB, SystemTime) {
+    let start_time = SystemTime::now();
+
+    let opt = RoochOpt::new_with_default(base_data_dir, chain_id, None).unwrap();
+    let registry_service = RegistryService::default();
+    let rooch_db = RoochDB::init(opt.store_config(), &registry_service.default_registry()).unwrap();
+    let _genesis = RoochGenesis::load_or_init(opt.network(), &rooch_db).unwrap();
+    let root = rooch_db.latest_root().unwrap().unwrap();
+    (root, rooch_db, start_time)
+}

--- a/crates/rooch/src/commands/db/commands/mod.rs
+++ b/crates/rooch/src/commands/db/commands/mod.rs
@@ -5,7 +5,6 @@ use metrics::RegistryService;
 use moveos_types::moveos_std::object::ObjectMeta;
 use rooch_config::RoochOpt;
 use rooch_db::RoochDB;
-use rooch_genesis::RoochGenesis;
 use rooch_types::rooch_network::RoochChainID;
 use std::path::PathBuf;
 use std::time::SystemTime;
@@ -22,7 +21,6 @@ fn init(
     let opt = RoochOpt::new_with_default(base_data_dir, chain_id, None).unwrap();
     let registry_service = RegistryService::default();
     let rooch_db = RoochDB::init(opt.store_config(), &registry_service.default_registry()).unwrap();
-    let _genesis = RoochGenesis::load_or_init(opt.network(), &rooch_db).unwrap();
     let root = rooch_db.latest_root().unwrap().unwrap();
     (root, rooch_db, start_time)
 }

--- a/crates/rooch/src/commands/db/commands/rollback.rs
+++ b/crates/rooch/src/commands/db/commands/rollback.rs
@@ -163,7 +163,6 @@ impl RollbackCommand {
                 .rooch_store
                 .get_state_change_set(previous_tx_order)?;
             if previous_state_change_set_ext_opt.is_some() && state_change_set_ext_opt.is_some() {
-                // let previoud_state_root = previous_state_change_set_ext_opt.unwrap().state_change_set.state_root;
                 let previous_state_change_set_ext = previous_state_change_set_ext_opt.unwrap();
                 let state_change_set_ext = state_change_set_ext_opt.unwrap();
 
@@ -171,7 +170,7 @@ impl RollbackCommand {
                 for (_feild_key, object_change) in
                     state_change_set_ext.state_change_set.changes.clone()
                 {
-                    let _ = collect_revert_object_change_ids(object_change, &mut object_ids)?;
+                    collect_revert_object_change_ids(object_change, &mut object_ids)?;
                 }
 
                 let root = ObjectMeta::root_metadata(
@@ -185,8 +184,6 @@ impl RollbackCommand {
                     .flatten()
                     .map(|v| (v.metadata.id.clone(), v.metadata))
                     .collect::<HashMap<_, _>>();
-                // let
-                // rooch_db.indexer_store.
 
                 // 1. revert indexer transaction
                 rooch_db
@@ -205,16 +202,8 @@ impl RollbackCommand {
                 let mut state_index_generator = IndexerObjectStatesIndexGenerator::default();
                 let mut indexer_object_state_change_set = IndexerObjectStateChangeSet::default();
 
-                // // set genesis tx_order and state_index_generator for new indexer revert
-                // let tx_order: u64 = 0;
-                // let last_state_index = self
-                //     .query_last_state_index_by_tx_order(tx_order, state_type.clone())
-                //     .await?;
-                // let mut state_index_generator = last_state_index.map_or(0, |x| x + 1);
-
-                // let object_mapping = HashMap::<ObjectID, ObjectMeta>::new();
                 for (_feild_key, object_change) in state_change_set_ext.state_change_set.changes {
-                    let _ = handle_revert_object_change(
+                    handle_revert_object_change(
                         &mut state_index_generator,
                         tx_order,
                         &mut indexer_object_state_change_set,

--- a/moveos/moveos-types/src/state.rs
+++ b/moveos/moveos-types/src/state.rs
@@ -971,6 +971,18 @@ impl StateChangeSet {
         }
     }
 
+    pub fn new_with_changes(
+        state_root: H256,
+        global_size: u64,
+        changes: BTreeMap<FieldKey, ObjectChange>,
+    ) -> Self {
+        Self {
+            state_root,
+            global_size,
+            changes,
+        }
+    }
+
     pub fn root_metadata(&self) -> ObjectMeta {
         ObjectMeta::root_metadata(self.state_root, self.global_size)
     }

--- a/moveos/moveos-types/src/state.rs
+++ b/moveos/moveos-types/src/state.rs
@@ -1021,6 +1021,24 @@ impl Default for StateChangeSet {
     }
 }
 
+/// Global State change set ext.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct StateChangeSetExt {
+    /// The state change set
+    pub state_change_set: StateChangeSet,
+    /// Sequence number of this transaction corresponding to sender's account.
+    pub sequence_number: u64,
+}
+
+impl StateChangeSetExt {
+    pub fn new(state_change_set: StateChangeSet, sequence_number: u64) -> Self {
+        Self {
+            state_change_set,
+            sequence_number,
+        }
+    }
+}
+
 mod op_serde {
     use super::*;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};


### PR DESCRIPTION
## Summary

1. Support state sync and provide RPC to sync state
2. Revert indexer based on state change set when rollback tx
3. Replace tx and event indexer field sender from RoochAddress to AccountAddress, for reduce sender store size in SQLite by using short_str_lossless
4. Refactor revert tx and rollback tx tool to reuse code

TODO
RocksDB uses compaction to remove expired keys, setting TTL directly in RocksDB may not be a good choice.
and it may also have a performance impact.
Cleaning up state change set data regularly may be an option

- Closes #2596 