### PR TITLE
[cli] Provide a util address command to resolve and convert address format

### DIFF
--- a/crates/rooch/src/commands/util/commands/address.rs
+++ b/crates/rooch/src/commands/util/commands/address.rs
@@ -1,0 +1,46 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::{CommandAction, WalletContextOptions};
+use async_trait::async_trait;
+use clap::Parser;
+use rooch_types::{address::ParsedAddress, error::RoochResult};
+use serde::{Deserialize, Serialize};
+
+/// Tool for convert address format
+#[derive(Debug, Parser)]
+pub struct AddressCommand {
+    /// Address to convert, any format which rooch supports
+    addr: ParsedAddress,
+
+    #[clap(flatten)]
+    pub context_options: WalletContextOptions,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddressOutput {
+    pub rooch_address: String,
+    pub hex_address: String,
+    pub bitcoin_main_address: String,
+    pub bitcoin_test_address: String,
+    pub bitcoin_regtest_address: String,
+    pub bitcoin_segtest_address: String,
+}
+
+#[async_trait]
+impl CommandAction<AddressOutput> for AddressCommand {
+    async fn execute(self) -> RoochResult<AddressOutput> {
+        let context = self.context_options.build()?;
+        let rooch_addr = context.resolve_rooch_address(self.addr.clone())?;
+        let bitcoin_addr = context.resolve_bitcoin_address(self.addr).await?;
+
+        Ok(AddressOutput {
+            rooch_address: rooch_addr.to_string(),
+            hex_address: rooch_addr.to_hex_literal(),
+            bitcoin_main_address: bitcoin_addr.format(bitcoin::Network::Bitcoin)?.to_string(),
+            bitcoin_test_address: bitcoin_addr.format(bitcoin::Network::Testnet)?.to_string(),
+            bitcoin_regtest_address: bitcoin_addr.format(bitcoin::Network::Regtest)?.to_string(),
+            bitcoin_segtest_address: bitcoin_addr.format(bitcoin::Network::Signet)?.to_string(),
+        })
+    }
+}

--- a/crates/rooch/src/commands/util/commands/mod.rs
+++ b/crates/rooch/src/commands/util/commands/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod address;
 pub mod hex;

--- a/crates/rooch/src/commands/util/mod.rs
+++ b/crates/rooch/src/commands/util/mod.rs
@@ -4,7 +4,7 @@
 use crate::CommandAction;
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
-use commands::hex::HexCommand;
+use commands::{address::AddressCommand, hex::HexCommand};
 use rooch_types::error::RoochResult;
 
 pub mod commands;
@@ -19,6 +19,7 @@ pub struct Util {
 #[clap(name = "util")]
 pub enum UtilCommand {
     Hex(HexCommand),
+    Address(AddressCommand),
 }
 
 #[async_trait]
@@ -26,6 +27,7 @@ impl CommandAction<String> for Util {
     async fn execute(self) -> RoochResult<String> {
         match self.cmd {
             UtilCommand::Hex(c) => c.execute().await,
+            UtilCommand::Address(c) => c.execute_serialized().await,
         }
     }
 }


### PR DESCRIPTION
## Summary

```bash
rooch util address bc1prcajaj9n7e29u4dfp33x3hcf52yqeegspdpcd79pqu4fpr6llx4sugkfjt
```
```json
{
  "rooch_address": "rooch1wqwzr0cu3n26lrzznqufpkx22hn6sgqhrw88gnqn7tvenzlhdnps9x2j4l",
  "hex_address": "0x701c21bf1c8cd5af8c42983890d8ca55e7a820171b8e744c13f2d9998bf76cc3",
  "bitcoin_main_address": "bc1prcajaj9n7e29u4dfp33x3hcf52yqeegspdpcd79pqu4fpr6llx4sugkfjt",
  "bitcoin_test_address": "tb1prcajaj9n7e29u4dfp33x3hcf52yqeegspdpcd79pqu4fpr6llx4stqqxgy",
  "bitcoin_regtest_address": "bcrt1prcajaj9n7e29u4dfp33x3hcf52yqeegspdpcd79pqu4fpr6llx4sxe2qa7",
  "bitcoin_segtest_address": "tb1prcajaj9n7e29u4dfp33x3hcf52yqeegspdpcd79pqu4fpr6llx4stqqxgy"
}
```