### PR TITLE
[cli] Display the transaction info when sign tx

### DIFF
--- a/crates/rooch/src/utils.rs
+++ b/crates/rooch/src/utils.rs
@@ -64,3 +64,20 @@ pub fn read_line() -> Result<String, anyhow::Error> {
     io::stdin().read_line(&mut s)?;
     Ok(s.trim_end().to_string())
 }
+
+pub fn prompt_yes_no(question: &str) -> bool {
+    loop {
+        println!("{} [yes/no] > ", question);
+
+        let Ok(input) = read_line() else {
+            println!("Please answer yes or no.");
+            continue;
+        };
+
+        match input.trim_start().to_lowercase().as_str() {
+            "yes" | "y" => return true,
+            "no" | "n" => return false,
+            _ => println!("Please answer yes or no."),
+        }
+    }
+}

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -75,7 +75,7 @@ Feature: Rooch CLI integration tests
       Then cmd: "transaction get-transactions-by-hash --hashes {{$.transaction[-1].data[0].execution_info.tx_hash}}"
       Then cmd: "transaction build --function rooch_framework::empty::empty --json"
       Then assert: "'{{$.transaction[-1]}}' not_contains error"
-      Then cmd: "transaction sign {{$.transaction[-1].path}} --json"
+      Then cmd: "transaction sign {{$.transaction[-1].path}} --json -y"
       Then assert: "'{{$.transaction[-1]}}' not_contains error"
       Then cmd: "transaction submit {{$.transaction[-1].path}}"
       Then assert: "{{$.transaction[-1].execution_info.status.type}} == executed"

--- a/crates/testsuite/features/multisign.feature
+++ b/crates/testsuite/features/multisign.feature
@@ -60,9 +60,9 @@ Feature: Rooch CLI multisign integration tests
       # l2 transaction
       Then cmd: "tx build --sender {{$.account[-3].multisign_address}}  --function rooch_framework::empty::empty --json"
       Then assert: "'{{$.tx[-1]}}' not_contains error"
-      Then cmd: "tx sign {{$.tx[-1].path}} -s {{$.account[-3].participants[0].participant_address}}  --json"
+      Then cmd: "tx sign {{$.tx[-1].path}} -s {{$.account[-3].participants[0].participant_address}}  --json -y"
       Then assert: "'{{$.tx[-1]}}' not_contains error"
-      Then cmd: "tx sign {{$.tx[-1].path}} -s {{$.account[-3].participants[1].participant_address}}  --json"
+      Then cmd: "tx sign {{$.tx[-1].path}} -s {{$.account[-3].participants[1].participant_address}}  --json -y"
       Then assert: "'{{$.tx[-1]}}' not_contains error"
       Then cmd: "tx submit {{$.tx[-1].path}} --json"
       Then assert: "{{$.tx[-1].execution_info.status.type}} == executed"

--- a/moveos/moveos-types/src/transaction.rs
+++ b/moveos/moveos-types/src/transaction.rs
@@ -219,7 +219,7 @@ impl Display for MoveAction {
                 }
                 write!(
                     f,
-                    "MoveAction::FunctionCall( function_id: 0x{:?},  type_args: {:?}, args: {:?})",
+                    "MoveAction::FunctionCall( function_id: {},  type_args: {:?}, args: {:?})",
                     function.function_id, function.ty_args, arg_list
                 )
             }


### PR DESCRIPTION
- Closes #2588 

The readability of the args of the function is not good.

```
rooch tx sign /tmp/6716d5ff7ff8fe42.rtd
Transaction data:
 Sender: rooch1xm3k80jyqh9hf5m8vjm4xjcna99xx0vrjyylzts3zmuks379kzusp270zj
 Sequence number: 0
 Chain id: 4
 Max gas amount: 100000000
 Action: MoveAction::FunctionCall( function_id: 0x0000000000000000000000000000000000000000000000000000000000000003::gas_coin::faucet_entry,  type_args: [], args: ["0x00e40b5402000000000000000000000000000000000000000000000000000000"])
 Transaction hash: 0x6716…5efb

Do you want to sign this transaction? [yes/no] > 
y
Signed transaction is written to "/tmp/6716d5ff7ff8fe42.srt"
You can submit the transaction with `rooch tx submit /tmp/6716d5ff7ff8fe42.srt`

```



```
Partially signed transaction data:
 Sender: rooch14gjawvfc9spxrnrdcuwhv2vlt39dt7fs6w78d4d0j8zmyrjqk32saxxg8t
 Sequence number: 0
 Chain id: 4
 Max gas amount: 100000000
 Action: MoveAction::FunctionCall( function_id: 0x0000000000000000000000000000000000000000000000000000000000000003::empty::empty,  type_args: [], args: [])
 Transaction hash: 0xcc78…648a
 Collected signatures: 1/2

Do you want to sign this transaction? [yes/no] > 
y
Signed transaction is written to "/tmp/cc7808a8f3f8fa1f.srt"
You can submit the transaction with `rooch tx submit /tmp/cc7808a8f3f8fa1f.srt`

```