### PR TITLE
[cli] Display bitcoin tx detail

### DIFF
--- a/crates/testsuite/features/multisign.feature
+++ b/crates/testsuite/features/multisign.feature
@@ -40,9 +40,9 @@ Feature: Rooch CLI multisign integration tests
       # l1 transaction
       Then cmd: "bitcoin build-tx --sender {{$.account[-1].multisign_bitcoin_address}} -o {{$.account[-2].account0.bitcoin_address}}:100000000"
       Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
-      Then cmd: "bitcoin sign-tx -s {{$.account[-1].participants[0].participant_address}}   {{$.bitcoin[-1].path}}"
+      Then cmd: "bitcoin sign-tx -s {{$.account[-1].participants[0].participant_address}}   {{$.bitcoin[-1].path}} -y"
       Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
-      Then cmd: "bitcoin sign-tx -s {{$.account[-1].participants[2].participant_address}}   {{$.bitcoin[-1].path}}"
+      Then cmd: "bitcoin sign-tx -s {{$.account[-1].participants[2].participant_address}}   {{$.bitcoin[-1].path}} -y"
       Then assert: "'{{$.bitcoin[-1]}}' not_contains error"
       Then cmd: "bitcoin broadcast-tx {{$.bitcoin[-1].path}}"
       Then assert: "'{{$.bitcoin[-1]}}' not_contains error"


### PR DESCRIPTION
Print utxo address if network provided; else print script.

```
rooch bitcoin sign-tx -s rooch13jgu06vyaucyfa4ylac7270ayzs7ll303g7yejzsqpvrekm7dpkqa9rlyr /tmp/f41721630dae28d1.psbt -n regtest
Transaction details before signing:
  Version: 2
  Lock time: 0
  Network: regtest
  Inputs:
    Input 0:
      Previous output: 2d4acda35bc3c1a6610d452d08c7e233358fe1ac097c34540a4e7ff78b499dff:0
      Sequence: 4294967293
      Address: bcrt1pefq58pva5v34jj5hp7pw89nrc8k7w6lfg5776uyh5wjgtyt74rrs8hg6xv
  Outputs:
    Output 0:
      Value: 0.00010000 BTC
      Address: bcrt1p9tjl8a76mx9glle4krl35fvlns5ncggpxfsneajdme27gdgxpf2qrakmd0
    Output 1:
      Value: 6.24989060 BTC
      Address: bcrt1pefq58pva5v34jj5hp7pw89nrc8k7w6lfg5776uyh5wjgtyt74rrs8hg6xv

Do you want to sign this transaction? [yes/no] > 

```



```
rooch bitcoin sign-tx -s rooch13jgu06vyaucyfa4ylac7270ayzs7ll303g7yejzsqpvrekm7dpkqa9rlyr /tmp/f41721630dae28d1.psbt
Transaction details before signing:
  Version: 2
  Lock time: 0
  Inputs:
    Input 0:
      Previous output: 2d4acda35bc3c1a6610d452d08c7e233358fe1ac097c34540a4e7ff78b499dff:0
      Sequence: 4294967293
      Script pubkey: OP_PUSHNUM_1 OP_PUSHBYTES_32 ca4143859da323594a970f82e39663c1ede76be9453ded7097a3a485917ea8c7
  Outputs:
    Output 0:
      Value: 0.00010000 BTC
      Script pubkey: OP_PUSHNUM_1 OP_PUSHBYTES_32 2ae5f3f7dad98a8fff35b0ff1a259f9c293c210132613cf64dde55e435060a54
    Output 1:
      Value: 6.24989060 BTC
      Script pubkey: OP_PUSHNUM_1 OP_PUSHBYTES_32 ca4143859da323594a970f82e39663c1ede76be9453ded7097a3a485917ea8c7

Do you want to sign this transaction? [yes/no] >
```