### PR TITLE
fix(da): rm open-da(gcs) for mainnet deploy workflow

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -72,6 +72,4 @@ jobs:
             "cd /root/rooch && git fetch origin && git checkout -B $BRANCH origin/$BRANCH || git checkout $BRANCH && bash scripts/deploy_rooch_mainnet.sh \
             '${{ env.REF }}' \
             '${{ secrets.BTC_MAIN_RPC_URL }}' \
-            '${{ secrets.BTC_MAIN_RPC_PWD }}' \
-            '${{ secrets.OPENDA_GCP_MAINNET_BUCKET }}' \
-            '${{ secrets.OPENDA_GCP_MAINNET_CREDENTIAL }}'"
+            '${{ secrets.BTC_MAIN_RPC_PWD }}'"

--- a/scripts/deploy_rooch_mainnet.sh
+++ b/scripts/deploy_rooch_mainnet.sh
@@ -5,8 +5,6 @@
 REF="$1"
 BTC_MAIN_RPC_URL="$2"
 BTC_MAIN_RPC_PWD="$3"
-OPENDA_GCP_MAINNET_BUCKET="$4"
-OPENDA_GCP_MAINNET_CREDENTIAL="$5"
 
 sleep 30
 docker image prune -a -f
@@ -17,5 +15,4 @@ docker run -d --name rooch-mainnet --restart unless-stopped -v /data:/root -p 67
     server start -n main \
     --btc-rpc-url "$BTC_MAIN_RPC_URL" \
     --btc-rpc-username rooch-main \
-    --btc-rpc-password "$BTC_MAIN_RPC_PWD" \
-    --da "{\"internal-da-server\": {\"servers\": [{\"open-da\": {\"scheme\": \"gcs\", \"config\": {\"bucket\": \"$OPENDA_GCP_MAINNET_BUCKET\", \"credential\": \"$OPENDA_GCP_MAINNET_CREDENTIAL\"}}}]}}"
+    --btc-rpc-password "$BTC_MAIN_RPC_PWD"


### PR DESCRIPTION
## Summary

1. rm open-da(gcs) for mainnet deploy workflow
2. switch to save last block instead of a map: Replaced BTreeMap with an Option to store only the last block in StateCommitmentChain. Updated methods for adding and retrieving the last block accordingly, streamlining state management.
