### PR TITLE
[oracle] Fix oracle websocket error handle

### DIFF
--- a/crates/rooch-oracle/src/data_process.rs
+++ b/crates/rooch-oracle/src/data_process.rs
@@ -70,7 +70,7 @@ pub fn subscribe_websocket(
                     }
                     Err(e) => {
                         error!("Failed to read message: {}", e);
-                        return;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fix the oracle websocket error handle, break the read loop and retry.