### PR TITLE
refactor(rooch-da): add nop_backend flag for fallback handling

### DIFF
--- a/crates/rooch-config/src/da_config.rs
+++ b/crates/rooch-config/src/da_config.rs
@@ -260,7 +260,9 @@ pub struct DABackendOpenDAConfig {
     /// specifies the configuration of the storage service. 'gcs' with corresponding GCS server configuration, 's3' with corresponding S3 server configuration, etc.
     pub config: HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    /// <namespace>/<segment_id> is the path to store the segment. If not set, the <derive_genesis_namespace>/<segment_id> is the full path
+    /// <namespace>/<segment_id> is the path to store the segment.
+    /// If not set, the <derive_genesis_namespace>/<segment_id> is the full path
+    /// If root is set in config, the <root>/<namespace>/<segment_id> is the full path
     pub namespace: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// max segment size.
@@ -268,10 +270,10 @@ pub struct DABackendOpenDAConfig {
     pub max_segment_size: Option<u64>,
 }
 
-/// Derive a namespace from genesis config for DA backend (could be used for open-da backend)
+/// Derive a namespace from genesis config for DA backend (as default namespace open-da backend)
+/// first 7 chars of sha256 of genesis in hex is used as namespace
 pub fn derive_genesis_namespace(genesis: &[u8]) -> String {
     let raw = encode(sha2_256_of(genesis).0);
-    // get first 7 bytes is enough to avoid collision for genesis config
     raw.chars().take(7).collect()
 }
 

--- a/crates/rooch-da/README.md
+++ b/crates/rooch-da/README.md
@@ -17,7 +17,7 @@ verification:
 ### Target
 
 1. **Equivalent to Bitcoin Consensus**: Pack DA into Bitcoin block.
-2. **Self-Verifying**: Anyone could verify DA by checksum and sign.
+2. **Self-Verifying**: Anyone could verify DA by checksum and its signature.
 3. **Open**: DA could be anywhere, anyone could access it without permission.
 
 ## Key Concepts
@@ -33,11 +33,11 @@ verification:
 In Verifier's perspective (verifier verifies tx), the data flow is as follows:
 
 1. user submits tx to sequencer
-2. sequencer batch maker buffer transactions to batch for lower average latency & gas cost
-3. sequencer batch maker put to DA server
+2. sequencer buffers transactions to a batch for lower average latency & gas cost
+3. sequencer puts batch to DA server
 4. verifier get batch from DA server by:
     1. pull DA stream from DA server (after booking)
-    2. get batch from DA server by batch hash
+    2. get batch from DA server by batch hash/block number
     3. get segments from DA backend (after being submitted to DA backend)
 
 ## Roles
@@ -50,8 +50,9 @@ Tx batch maker. Each sequencer maintains its own DA server.
 
 Has responsibilities:
 
-1. public DA Backend info for anyone could access DA data easily.
-2. provides Put/Get interface for DA by DA Server.
+1. public DA Backend info.
+2. provides Put/Get interface for DA.
+3. Response to DA challenges.
 
 Each DA server could connect to multiple DA backends.
 
@@ -68,7 +69,7 @@ submit data to DA backend asynchronously.
 Put includes these actions:
 
 1. Sequencer puts data to DA server
-2. Sequencer packs data meta to Bitcoin
+2. Sequencer packs data meta to Proposer
 3. DA server put data to DA backends
 
 ### Get

--- a/crates/rooch-types/src/da/batch.rs
+++ b/crates/rooch-types/src/da/batch.rs
@@ -117,4 +117,9 @@ impl DABatch {
             tx_list_bytes,
         }
     }
+
+    pub fn get_hash(&self) -> H256 {
+        let meta_bytes = bcs::to_bytes(&self.meta).expect("encode batch_meta should success");
+        sha2_256_of(&meta_bytes)
+    }
 }


### PR DESCRIPTION
## Summary

1. Introduce a `nop_backend` flag to manage fallback behavior in absence of backend configuration. This allows the system to use a No-Operation backend and skip block state updates accordingly.
2. Improve DA configuration with additional path logic for segments.
3. Add `get_hash` function for batch meta in rooch-types.
4. Update README for clarity on DA process and roles.
