### PR TITLE
feat(rooch-da): Enhance get_submitting_blocks with count limit

### DIFF
--- a/crates/rooch-store/src/da_store/mod.rs
+++ b/crates/rooch-store/src/da_store/mod.rs
@@ -27,6 +27,7 @@ derive_store!(
 );
 
 pub trait DAMetaStore {
+    /// Get submitting blocks from start_block(inclusive) with expected count until the end of submitting blocks
     fn get_submitting_blocks(
         &self,
         start_block: u128,
@@ -201,9 +202,9 @@ impl DAMetaStore for DAMetaDBStore {
         let exp_count = exp_count.unwrap_or(SUBMITTING_BLOCKS_PAGE_SIZE);
         // try to get exp_count unsubmitted blocks
         let mut blocks = Vec::with_capacity(exp_count);
-        let mut blocks_count = 0;
+        let mut done_count = 0;
         let mut block_number = start_block;
-        while blocks_count < exp_count {
+        while done_count < exp_count {
             let state = self.block_submit_state_store.kv_get(block_number)?;
             if let Some(state) = state {
                 if !state.done {
@@ -212,7 +213,7 @@ impl DAMetaStore for DAMetaDBStore {
                         tx_order_start: state.block_range.tx_order_start,
                         tx_order_end: state.block_range.tx_order_end,
                     });
-                    blocks_count += 1;
+                    done_count += 1;
                 }
             } else {
                 break;

--- a/crates/rooch-store/src/tests/test_da_store.rs
+++ b/crates/rooch-store/src/tests/test_da_store.rs
@@ -28,7 +28,22 @@ async fn test_append_submitting_blocks() {
     assert_eq!(submitting_blocks[1].tx_order_start, 7);
     assert_eq!(submitting_blocks[1].tx_order_end, 7);
 
+    let submitting_blocks = da_meta_store.get_submitting_blocks(0, Some(2)).unwrap();
+    assert_eq!(submitting_blocks.len(), 2);
+    assert_eq!(submitting_blocks[0].block_number, 0);
+    assert_eq!(submitting_blocks[0].tx_order_start, 1);
+    assert_eq!(submitting_blocks[0].tx_order_end, 6);
+    assert_eq!(submitting_blocks[1].block_number, 1);
+    assert_eq!(submitting_blocks[1].tx_order_start, 7);
+    assert_eq!(submitting_blocks[1].tx_order_end, 7);
+
     let submitting_blocks = da_meta_store.get_submitting_blocks(1, None).unwrap();
+    assert_eq!(submitting_blocks.len(), 1);
+    assert_eq!(submitting_blocks[0].block_number, 1);
+    assert_eq!(submitting_blocks[0].tx_order_start, 7);
+    assert_eq!(submitting_blocks[0].tx_order_end, 7);
+
+    let submitting_blocks = da_meta_store.get_submitting_blocks(1, Some(1)).unwrap();
     assert_eq!(submitting_blocks.len(), 1);
     assert_eq!(submitting_blocks[0].block_number, 1);
     assert_eq!(submitting_blocks[0].tx_order_start, 7);


### PR DESCRIPTION
## Summary

Updated the get_submitting_blocks function to accept an optional count parameter for fetching a specific number of blocks. Added corresponding tests to validate the new functionality.

