### PR TITLE
fix(sdk): duplicate instance

### DIFF
--- a/sdk/typescript/rooch-sdk-kit/src/utils/walletUtils.ts
+++ b/sdk/typescript/rooch-sdk-kit/src/utils/walletUtils.ts
@@ -7,10 +7,10 @@ import { Wallet, UniSatWallet, OkxWallet, OnekeyWallet } from '../wellet/index.j
 const unisatWallet = new UniSatWallet()
 const okxWallet = new OkxWallet()
 const onekeyWallet = new OnekeyWallet()
-const allWallets = [unisatWallet, okxWallet, onekeyWallet]
+const supportedWallets = [unisatWallet, okxWallet, onekeyWallet]
 
 export async function checkWallets(filter?: SupportChain) {
-  const wallets: Wallet[] = allWallets.filter(
+  const wallets: Wallet[] = supportedWallets.filter(
     (wallet) => wallet.getChain() === filter || !filter,
   )
 

--- a/sdk/typescript/rooch-sdk-kit/src/utils/walletUtils.ts
+++ b/sdk/typescript/rooch-sdk-kit/src/utils/walletUtils.ts
@@ -4,8 +4,13 @@
 import { SupportChain } from '../feature/index.js'
 import { Wallet, UniSatWallet, OkxWallet, OnekeyWallet } from '../wellet/index.js'
 
+const unisatWallet = new UniSatWallet()
+const okxWallet = new OkxWallet()
+const onekeyWallet = new OnekeyWallet()
+const allWallets = [unisatWallet, okxWallet, onekeyWallet]
+
 export async function checkWallets(filter?: SupportChain) {
-  const wallets: Wallet[] = [new UniSatWallet(), new OkxWallet(), new OnekeyWallet()].filter(
+  const wallets: Wallet[] = allWallets.filter(
     (wallet) => wallet.getChain() === filter || !filter,
   )
 


### PR DESCRIPTION
## Summary

### Root Cause

The function `checkWallets` is called multiple times, which creates different wallet instances for the same wallet class. Because of this, even though `registered` is a Set, it still ends up adding multiple duplicate wallets.

https://github.com/rooch-network/rooch/blob/b98ce6fefb1433d861f9d292a900b681f62c3352/sdk/typescript/rooch-sdk-kit/src/wellet/wallets.ts#L6-L8

### How to Fix

At the SDK level, each wallet class should have only one instance.

- Closes #2779