### PR TITLE
Revert "refactor(rooch-store): rename DA block cursor constant (#2797)"

### DIFF
--- a/crates/rooch-store/src/lib.rs
+++ b/crates/rooch-store/src/lib.rs
@@ -46,7 +46,7 @@ pub const TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME: ColumnFamilyName = "transactio
 pub const STATE_CHANGE_SET_COLUMN_FAMILY_NAME: ColumnFamilyName = "state_change_set";
 
 pub const DA_BLOCK_SUBMIT_STATE_COLUMN_FAMILY_NAME: ColumnFamilyName = "da_block_submit_state";
-pub const DA_BLOCK_CURSOR_COLUMN_FAMILY_NAME: ColumnFamilyName = "da_block_cursor";
+pub const DA_BLOCK_CURSOR_COLUMN_FAMILY_NAME: ColumnFamilyName = "da_last_block_number";
 
 ///db store use cf_name vec to init
 /// Please note that adding a column family needs to be added in vec simultaneously, remember！！


### PR DESCRIPTION
## Summary

This reverts commit b3870af384ba45f99f9f7cd7b07f730c6f7abd08.

this commit cause:
 Error: Invalid argument: Column families not opened: da_last_block_number

and rocksdb cannot be opened correctly

although it's not a good name but enought to tell developer what is it