### PR TITLE
feat(db): add force option to drop command

### DIFF
--- a/crates/rooch/src/commands/db/commands/drop.rs
+++ b/crates/rooch/src/commands/db/commands/drop.rs
@@ -17,10 +17,16 @@ pub struct DropCommand {
 
     #[clap(
         long = "re-create",
-        help = "re-create column family after drop, default is false"
+        help = "re-create column family after drop to clear column family, default is false"
     )]
     /// re-create column family after drop, default is false
     pub re_create: Option<bool>,
+
+    #[clap(
+        long = "force",
+        help = "force to execute the command: drop column family is a dangerous operation, make sure you know what you are doing. default is false"
+    )]
+    pub force: Option<bool>,
 
     #[clap(long = "data-dir", short = 'd')]
     /// Path to data dir, this dir is base dir, the final data_dir is base_dir/chain_network_name
@@ -34,14 +40,21 @@ pub struct DropCommand {
 
 impl DropCommand {
     pub async fn execute(self) -> RoochResult<()> {
+        if !self.force.unwrap_or(false) {
+            println!("This operation is dangerous, make sure you know what you are doing. If you are sure, please add --force to execute this command.");
+            return Ok(());
+        }
         let mut rocks = open_rocks(self.base_data_dir.clone(), self.chain_id)?;
         let re_create = self.re_create.unwrap_or(false);
         let cf_name = self.cf_name.clone();
+        let mut op = "drop";
         if re_create {
+            op = "clear";
             rocks.clear_cfs(vec![&cf_name])?;
         } else {
             rocks.drop_cf(&cf_name)?;
         }
+        println!("{} column family {} success", op, cf_name);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Introduce '--force' flag to ensure deliberate execution of drop command. Update help description for 're-create' to clarify its purpose.