### PR TITLE
feat(rooch-config): add OpenDAScheme conversion and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9568,6 +9568,7 @@ dependencies = [
  "moveos-config",
  "moveos-types",
  "once_cell",
+ "opendal",
  "rooch-types",
  "serde 1.0.210",
  "serde_json",

--- a/crates/rooch-config/Cargo.toml
+++ b/crates/rooch-config/Cargo.toml
@@ -24,6 +24,7 @@ clap = { workspace = true }
 dirs-next = { workspace = true }
 celestia-types = { workspace = true }
 hex = { workspace = true }
+opendal = { workspace = true }
 
 rooch-types = { workspace = true }
 moveos-config = { workspace = true }

--- a/crates/rooch-config/src/da_config.rs
+++ b/crates/rooch-config/src/da_config.rs
@@ -97,6 +97,17 @@ impl FromStr for OpenDAScheme {
     }
 }
 
+// OpenDAScheme to OpenDALScheme
+impl From<OpenDAScheme> for opendal::Scheme {
+    fn from(scheme: OpenDAScheme) -> Self {
+        match scheme {
+            OpenDAScheme::Fs => opendal::Scheme::Fs,
+            OpenDAScheme::Gcs => opendal::Scheme::Gcs,
+            OpenDAScheme::S3 => opendal::Scheme::S3,
+        }
+    }
+}
+
 #[derive(Clone, Default, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]


### PR DESCRIPTION
## Summary

Implement From<OpenDAScheme> for opendal::Scheme conversion. Add tests for retrieve_map_config_value and check_backend_config.

For fixing server starting issue with empty bucket config:

```
[2m2024-10-21T21:00:18.277729Z[0m [31mERROR[0m [2mrooch_rpc_server[0m[2m:[0m ConfigInvalid (permanent) at Builder::build, context: { service: gcs } => The bucket is misconfigured
```