### PR TITLE
docs(rooch-db): enhance documentation with new commands

### DIFF
--- a/crates/rooch/src/commands/da/README.md
+++ b/crates/rooch/src/commands/da/README.md
@@ -4,7 +4,7 @@ Toolkits for RoochDA.
 
 ### Usage
 
-1. Unpack tx list:
+1. Unpack tx list to human-readable format:
 
 ```shell
 rooch da unpack --segment-dir {segment-dir} -batch-dir {batch-dir}

--- a/crates/rooch/src/commands/db/README.md
+++ b/crates/rooch/src/commands/db/README.md
@@ -4,8 +4,37 @@ Toolkits for RoochDB.
 
 ### Usage
 
-1. Revert tx by tx_order(> 0):
+#### Revert
+
+Revert the transaction by tx_order.
 
 ```shell
 rooch db revert-tx --tx-order {tx_order} -d {data_dir} -n {network}
+```
+
+tx_order: The order of the transaction to be reverted. Must be last tx_order. If not, it will panic and print the last
+tx_order.
+
+#### Rollback
+
+Rollback to tx_order.
+
+```shell
+rooch db rollback --tx-order {tx_order} -d {data_dir} -n {network}
+```
+
+#### Drop
+
+Drop the database column family.
+
+drop column family is a dangerous operation, make sure you know what you are doing
+
+```shell
+rooch db drop --cf-name {column_family} -d {data_dir} -n {network} --force true
+```
+
+re-create the column family after dropping for cleaning up the column family.
+
+```shell
+rooch db drop --cf-name {column_family} -d {data_dir} -n {network} --force true --re-create true
 ```


### PR DESCRIPTION
## Summary

Add detailed usage instructions for revert, rollback, and drop commands in rooch-db README. Improve clarity on tx_order and column family operations, and specify conditions for dangerous operations.