### PR TITLE
fix(rooch-da): correct cursor update in background submitter

### DIFF
--- a/crates/rooch-da/src/actor/server.rs
+++ b/crates/rooch-da/src/actor/server.rs
@@ -316,7 +316,7 @@ impl DAServerActor {
                 );
             }
         }
-        if max_block_number_submitted > 0 {
+        if submit_count > 0 {
             self.rooch_store
                 .set_background_submit_block_cursor(max_block_number_submitted)?;
             tracing::info!(

--- a/crates/rooch-store/src/da_store/mod.rs
+++ b/crates/rooch-store/src/da_store/mod.rs
@@ -52,6 +52,7 @@ pub trait DAMetaStore {
         tx_order_end: u64,
     ) -> anyhow::Result<u128>;
     // get submitting blocks(block is not submitted) from start_block(inclusive) with expected count until the end of submitting blocks
+    // Result<Vec<BlockRange>>: Vec<BlockRange> is sorted by block_number
     fn get_submitting_blocks(
         &self,
         start_block: u128,


### PR DESCRIPTION
## Summary

Ensure cursor is correctly updated to the last submitted block. This prevents reprocessing already submitted blocks and improves logging for better traceability.

