### PR TITLE
feat(rpc): add DA server status to rooch_status RPC

### DIFF
--- a/crates/rooch-da/src/actor/messages.rs
+++ b/crates/rooch-da/src/actor/messages.rs
@@ -3,7 +3,7 @@
 
 use coerce::actor::message::Message;
 use rooch_types::da::batch::SignedDABatchMeta;
-use rooch_types::da::state::ServerStatus;
+use rooch_types::da::state::DAServerStatus;
 use rooch_types::transaction::LedgerTransaction;
 use serde::{Deserialize, Serialize};
 
@@ -32,5 +32,5 @@ impl PutDABatchMessage {
 pub struct GetServerStatusMessage {}
 
 impl Message for GetServerStatusMessage {
-    type Result = anyhow::Result<ServerStatus>;
+    type Result = anyhow::Result<DAServerStatus>;
 }

--- a/crates/rooch-da/src/actor/server.rs
+++ b/crates/rooch-da/src/actor/server.rs
@@ -17,7 +17,7 @@ use rooch_store::transaction_store::TransactionStore;
 use rooch_store::RoochStore;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::da::batch::{BlockRange, DABatch, SignedDABatchMeta};
-use rooch_types::da::state::ServerStatus;
+use rooch_types::da::state::DAServerStatus;
 use rooch_types::transaction::LedgerTransaction;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -166,7 +166,7 @@ impl DAServerActor {
         Ok(server)
     }
 
-    pub fn get_status(&self) -> anyhow::Result<ServerStatus> {
+    pub fn get_status(&self) -> anyhow::Result<DAServerStatus> {
         let last_tx_order = if let Some(last_block_number) = self.last_block_number {
             let last_block_state = self.rooch_store.get_block_state(last_block_number)?;
             Some(last_block_state.block_range.tx_order_end)
@@ -195,7 +195,7 @@ impl DAServerActor {
             None
         };
 
-        Ok(ServerStatus {
+        Ok(DAServerStatus {
             last_block_number: self.last_block_number,
             last_tx_order,
             last_block_update_time,
@@ -242,7 +242,7 @@ impl Handler<GetServerStatusMessage> for DAServerActor {
         &mut self,
         _msg: GetServerStatusMessage,
         _ctx: &mut ActorContext,
-    ) -> anyhow::Result<ServerStatus> {
+    ) -> anyhow::Result<DAServerStatus> {
         self.get_status()
     }
 }

--- a/crates/rooch-da/src/proxy/mod.rs
+++ b/crates/rooch-da/src/proxy/mod.rs
@@ -4,8 +4,8 @@
 use crate::actor::messages::{GetServerStatusMessage, PutDABatchMessage};
 use crate::actor::server::DAServerActor;
 use coerce::actor::ActorRef;
-use rooch_types::da;
 use rooch_types::da::batch::SignedDABatchMeta;
+use rooch_types::da::state::DAServerStatus;
 
 #[derive(Clone)]
 pub struct DAServerProxy {
@@ -17,7 +17,7 @@ impl DAServerProxy {
         Self { actor }
     }
 
-    pub async fn get_status(&self) -> anyhow::Result<da::state::ServerStatus> {
+    pub async fn get_status(&self) -> anyhow::Result<DAServerStatus> {
         self.actor.send(GetServerStatusMessage {}).await?
     }
 

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -1018,6 +1018,76 @@
           }
         }
       },
+      "DAServerStatus": {
+        "description": "DA server basic status",
+        "type": "object",
+        "required": [
+          "avail_backends"
+        ],
+        "properties": {
+          "avail_backends": {
+            "description": "The available backends names",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "last_avail_block_number": {
+            "description": "The last available block number, may little behind the last block number. [0, last_avail_block_number] blocks were confirmed by DA backend. If meet error in background submitter job, it may be far behind the last block number.",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint128",
+            "minimum": 0.0
+          },
+          "last_avail_block_update_time": {
+            "description": "The last available block number updated time(Unix timestamp) If both of last_avail_block_number and last_avail_tx_order are not updated for a long time, it may indicate that the background submitter job is not working: 1. DA backends collapse 2. RoochStore is not consistent (cannot get tx from DB by tx order)",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "last_avail_tx_order": {
+            "description": "The last available tx order",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "last_block_number": {
+            "description": "The last block number",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint128",
+            "minimum": 0.0
+          },
+          "last_block_update_time": {
+            "description": "The last block number updated time(Unix timestamp in seconds) Should be closed to request time if there were new blocks. None if no blocks were received after server start.",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "last_tx_order": {
+            "description": "The last tx order in the last block",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      },
       "DisplayFieldsView": {
         "type": "object",
         "required": [
@@ -3001,6 +3071,7 @@
         "type": "object",
         "required": [
           "bitcoin_status",
+          "da_server_status",
           "rooch_status",
           "service_status"
         ],
@@ -3010,6 +3081,14 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/BitcoinStatus"
+              }
+            ]
+          },
+          "da_server_status": {
+            "description": "The status of the DA service",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DAServerStatus"
               }
             ]
           },

--- a/crates/rooch-rpc-api/src/jsonrpc_types/status.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/status.rs
@@ -6,6 +6,7 @@ use accumulator::accumulator_info::AccumulatorInfo;
 use bitcoin::BlockHash;
 use moveos_types::h256::H256;
 use moveos_types::{startup_info::StartupInfo, state::ObjectState};
+use rooch_types::da::state::DAServerStatus;
 use rooch_types::into_address::FromAddress;
 use rooch_types::{
     bitcoin::types::BlockHeightHash, sequencer::SequencerInfo, service_status::ServiceStatus,
@@ -110,4 +111,6 @@ pub struct Status {
     pub rooch_status: RoochStatus,
     /// The status of the Bitcoin chain
     pub bitcoin_status: BitcoinStatus,
+    /// The status of the DA service
+    pub da_server_status: DAServerStatus,
 }

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -317,7 +317,7 @@ pub async fn run_start_server(opt: RoochOpt, server_opt: ServerOpt) -> Result<Se
     let proposer_keypair = server_opt.proposer_keypair.unwrap();
     let proposer_account: RoochAddress = proposer_keypair.public().rooch_address()?;
     info!("RPC Server proposer address: {:?}", proposer_account);
-    let proposer = ProposerActor::new(proposer_keypair, da_proxy, &prometheus_registry)
+    let proposer = ProposerActor::new(proposer_keypair, da_proxy.clone(), &prometheus_registry)
         .into_actor(Some("Proposer"), &actor_system)
         .await?;
     let proposer_proxy = ProposerProxy::new(proposer.clone().into());
@@ -409,6 +409,7 @@ pub async fn run_start_server(opt: RoochOpt, server_opt: ServerOpt) -> Result<Se
         indexer_proxy,
         processor_proxy,
         bitcoin_client_proxy,
+        da_proxy,
     );
     let aggregate_service = AggregateService::new(rpc_service.clone());
 

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -16,6 +16,7 @@ use moveos_types::moveos_std::object::{ObjectID, MAX_OBJECT_IDS_PER_QUERY};
 use moveos_types::state::{AnnotatedState, FieldKey, ObjectState, StateChangeSet};
 use moveos_types::state_resolver::{AnnotatedStateKV, StateKV};
 use moveos_types::transaction::{FunctionCall, TransactionExecutionInfo};
+use rooch_da::proxy::DAServerProxy;
 use rooch_executor::actor::messages::DryRunTransactionResult;
 use rooch_executor::proxy::ExecutorProxy;
 use rooch_indexer::proxy::IndexerProxy;
@@ -56,6 +57,7 @@ pub struct RpcService {
     pub(crate) indexer: IndexerProxy,
     pub(crate) pipeline_processor: PipelineProcessorProxy,
     pub(crate) bitcoin_client: Option<BitcoinClientProxy>,
+    pub(crate) da_server: DAServerProxy,
 }
 
 impl RpcService {
@@ -67,6 +69,7 @@ impl RpcService {
         indexer: IndexerProxy,
         pipeline_processor: PipelineProcessorProxy,
         bitcoin_client: Option<BitcoinClientProxy>,
+        da_server: DAServerProxy,
     ) -> Self {
         Self {
             chain_id,
@@ -76,6 +79,7 @@ impl RpcService {
             indexer,
             pipeline_processor,
             bitcoin_client,
+            da_server,
         }
     }
 }
@@ -809,10 +813,13 @@ impl RpcService {
             pending_block: pending_block.map(Into::into),
         };
 
+        let da_server_status = self.da_server.get_status().await?;
+
         Ok(Status {
             service_status,
             rooch_status,
             bitcoin_status,
+            da_server_status,
         })
     }
 }

--- a/crates/rooch-store/src/da_store/mod.rs
+++ b/crates/rooch-store/src/da_store/mod.rs
@@ -43,11 +43,10 @@ pub trait DAMetaStore {
     // after repair with condition2, we may need to repair with condition1 for the last block(it will be done automatically)
     fn try_repair_da_meta(&self, last_order: u64) -> anyhow::Result<()>;
 
-    // append new submitting block with tx_order_start and tx_order_end
+    // append new submitting block with tx_order_start and tx_order_end, return the block_number
     // warning: not thread safe
     fn append_submitting_block(
         &self,
-        last_block_number: Option<u128>,
         tx_order_start: u64,
         tx_order_end: u64,
     ) -> anyhow::Result<u128>;
@@ -305,11 +304,12 @@ impl DAMetaStore for DAMetaDBStore {
 
     fn append_submitting_block(
         &self,
-        last_block_number: Option<u128>,
         tx_order_start: u64,
         tx_order_end: u64,
     ) -> anyhow::Result<u128> {
         let inner_store = self.block_submit_state_store.store.store();
+
+        let last_block_number = self.get_last_block_number()?;
 
         let block_number = match last_block_number {
             Some(last_block_number) => last_block_number + 1,

--- a/crates/rooch-store/src/lib.rs
+++ b/crates/rooch-store/src/lib.rs
@@ -260,17 +260,9 @@ impl DAMetaStore for RoochStore {
         self.get_da_meta_store().try_repair_da_meta(last_order)
     }
 
-    fn append_submitting_block(
-        &self,
-        last_block_number: Option<u128>,
-        tx_order_start: u64,
-        tx_order_end: u64,
-    ) -> Result<u128> {
-        self.get_da_meta_store().append_submitting_block(
-            last_block_number,
-            tx_order_start,
-            tx_order_end,
-        )
+    fn append_submitting_block(&self, tx_order_start: u64, tx_order_end: u64) -> Result<u128> {
+        self.get_da_meta_store()
+            .append_submitting_block(tx_order_start, tx_order_end)
     }
 
     fn get_submitting_blocks(

--- a/crates/rooch-store/src/tests/test_da_store.rs
+++ b/crates/rooch-store/src/tests/test_da_store.rs
@@ -10,13 +10,12 @@ async fn get_submitting_blocks() {
     let (rooch_store, _) = RoochStore::mock_rooch_store().unwrap();
     let da_meta_store = rooch_store.get_da_meta_store();
 
-    da_meta_store.append_submitting_block(None, 1, 6).unwrap();
+    da_meta_store.append_submitting_block(1, 6).unwrap();
 
-    let last_block_number = 0;
     let tx_order_start = 7;
     let tx_order_end = 7;
     da_meta_store
-        .append_submitting_block(Some(last_block_number), tx_order_start, tx_order_end)
+        .append_submitting_block(tx_order_start, tx_order_end)
         .unwrap();
 
     let submitting_blocks = da_meta_store.get_submitting_blocks(0, None).unwrap();
@@ -55,13 +54,9 @@ async fn rollback_to_last_tx_order() {
     let (rooch_store, _) = RoochStore::mock_rooch_store().unwrap();
     let da_meta_store = rooch_store.get_da_meta_store();
 
-    da_meta_store.append_submitting_block(None, 1, 6).unwrap();
-    da_meta_store
-        .append_submitting_block(Some(0), 7, 7)
-        .unwrap();
-    da_meta_store
-        .append_submitting_block(Some(1), 8, 1024)
-        .unwrap();
+    da_meta_store.append_submitting_block(1, 6).unwrap();
+    da_meta_store.append_submitting_block(7, 7).unwrap();
+    da_meta_store.append_submitting_block(8, 1024).unwrap();
 
     fn check_remove_blocks(
         case: u64,
@@ -133,10 +128,12 @@ async fn catch_up_last_tx_order() {
     );
 
     let tx_order_end = 3 * MAX_TXS_PER_BLOCK_IN_FIX as u64 + 1;
-    let last_block_number = rooch_store.append_submitting_block(None, 1, 3).unwrap();
+    let last_block_number = rooch_store.append_submitting_block(1, 3).unwrap();
+    assert_eq!(last_block_number, 0);
     let last_block_number = rooch_store
-        .append_submitting_block(Some(last_block_number), 4, tx_order_end)
+        .append_submitting_block(4, tx_order_end)
         .unwrap();
+    assert_eq!(last_block_number, 1);
 
     for i in 1..2 * MAX_TXS_PER_BLOCK_IN_FIX + 2 {
         run_catch_up_last_tx_order_case(

--- a/crates/rooch-types/src/da/state.rs
+++ b/crates/rooch-types/src/da/state.rs
@@ -1,8 +1,12 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 /// DA server basic status
-pub struct ServerStatus {
+pub struct DAServerStatus {
     /// The last block number
     pub last_block_number: Option<u128>,
     /// The last tx order in the last block


### PR DESCRIPTION
## Summary

1. feat(rpc): add DA server status to rooch_status RPC
2. feat(rooch-store): refactor append_submitting_block logic

    Remove redundancy by eliminating last_block_number parameter from append_submitting_block. Adjust related tests and background submission interval to reflect changes and ensure database consistency checks