### PR TITLE
fix(rooch-pipeline-processor): reverse txs in processor startup execution

### DIFF
--- a/crates/rooch-pipeline-processor/src/actor/processor.rs
+++ b/crates/rooch-pipeline-processor/src/actor/processor.rs
@@ -100,7 +100,8 @@ impl PipelineProcessorActor {
             txs
         );
 
-        for tx_hash in txs.into_iter() {
+        for tx_hash in txs.into_iter().rev() {
+            // reverse the txs to keep the order
             let ledger_tx = self
                 .sequencer
                 .get_transaction_by_hash(tx_hash)


### PR DESCRIPTION
## Summary

Reverse the transactions to maintain their order during startup processing. This ensures the correct sequence is preserved, preventing potential issues.