### PR TITLE
chore(docs): add rooch db repair readme

### DIFF
--- a/crates/rooch-store/src/da_store/mod.rs
+++ b/crates/rooch-store/src/da_store/mod.rs
@@ -298,7 +298,7 @@ impl DAMetaDBStore {
         }
 
         let mut last_block_tx_order_end = block_0_range.tx_order_end;
-        let mut first_broken: Option<u128> = None;
+        let mut first_illegal: Option<u128> = None;
 
         for i in 1..=last_block_number {
             let block_state = self.get_block_state(i)?;
@@ -308,17 +308,17 @@ impl DAMetaDBStore {
                 tx_order_end: block_state.block_range.tx_order_end,
             };
             if !block_range.is_legal(last_order) {
-                first_broken = Some(i);
+                first_illegal = Some(i);
                 break;
             }
             if block_range.tx_order_start != last_block_tx_order_end + 1 {
-                first_broken = Some(i);
+                first_illegal = Some(i);
                 break;
             } else {
                 last_block_tx_order_end = block_range.tx_order_end;
             }
         }
-        Ok(first_broken)
+        Ok(first_illegal)
     }
 
     // find first illegal block(n), then rollback to n-1

--- a/crates/rooch/src/commands/db/README.md
+++ b/crates/rooch/src/commands/db/README.md
@@ -38,3 +38,18 @@ re-create the column family after dropping for cleaning up the column family.
 ```shell
 rooch db drop --cf-name {column_family} -d {data_dir} -n {network} --force true --re-create true
 ```
+
+### Repair
+
+Repair the database.
+
+```shell
+rooch db repair -d {data_dir} -n {network}
+```
+
+options:
+
+1. `--exec`: execute repair, otherwise only report issues(except DA meta DB, it will be repaired automatically). default
+   is false
+2. `--thorough`: perform a thorough and detailed check, which may take more time. For deep check inconsistency issues.
+   After v0.7.6 release and historical issues fixed, it should be not necessary. default is false


### PR DESCRIPTION
## Summary

Rename the variable `first_broken` to `first_illegal` for better clarity and precision in `da_store/mod.rs`. Additionally, update `README.md` to include documentation for the new database repair options.