### PR TITLE
[CLI] Use tabled as cli default output style #

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7679,6 +7679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7419ad52a7de9b60d33e11085a0fe3df1fbd5926aa3f93d3dd53afbc9e86725"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9366,6 +9377,7 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "serenity",
  "smt",
+ "tabled",
  "tempfile",
  "termcolor",
  "tiny-keccak",
@@ -11684,6 +11696,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c9303ee60b9bedf722012ea29ae3711ba13a67c9b9ae28993838b63057cb1b"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0fb8bfdc709786c154e24a66777493fb63ae97e3036d914c8666774c477069"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12680,9 +12715,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,6 +334,7 @@ celestia-rpc = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = 
 celestia-types = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "129272e8d926b4c7badf27a26dea915323dd6489" }
 opendal = { version = "0.47.3", features = ["services-fs", "services-gcs"] }
 toml = "0.8.19"
+tabled = "0.16.0"
 csv = "1.2.1"
 revm-precompile = "7.0.0"
 revm-primitives = "4.0.0"

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -44,6 +44,7 @@ tempfile = { workspace = true }
 jemallocator = { version = "0.5.4", features = ["unprefixed_malloc_on_supported_platforms", "profiling"] }
 rustc-hash = { workspace = true }
 rand = { workspace = true }
+tabled = { workspace = true }
 xorf = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 vergen-pretty = { workspace = true }

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -18,7 +18,10 @@ use rooch_types::error::RoochResult;
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::collections::HashMap;
-use tabled::{builder::Builder, settings::{Style, Width}};
+use tabled::{
+    builder::Builder,
+    settings::{Style, Width},
+};
 
 /// Show account balance, only the accounts managed by the current node are supported
 #[derive(Debug, Parser)]
@@ -93,18 +96,27 @@ impl CommandAction<Option<BalancesView>> for BalanceCommand {
         balances.push(BalanceInfoViewUnion::Bitcoin(btc_balance));
 
         let other_balances = match coin_type {
-            Some(coin_type) => vec![client
-                .rooch
-                .get_balance(address_addr.into(), coin_type.into())
-                .await?],
-            None => client
-                .rooch
-                .get_balances(address_addr.into(), None, Some(MAX_RESULT_LIMIT))
-                .await?
-                .data,
+            Some(coin_type) => vec![
+                client
+                    .rooch
+                    .get_balance(address_addr.into(), coin_type.into())
+                    .await?,
+            ],
+            None => {
+                client
+                    .rooch
+                    .get_balances(address_addr.into(), None, Some(MAX_RESULT_LIMIT))
+                    .await?
+                    .data
+            }
         };
 
-        balances.extend(other_balances.iter().cloned().map(BalanceInfoViewUnion::Other));
+        balances.extend(
+            other_balances
+                .iter()
+                .cloned()
+                .map(BalanceInfoViewUnion::Other),
+        );
 
         if self.json {
             let mut balances_view: BalancesView = HashMap::new();
@@ -122,7 +134,8 @@ impl CommandAction<Option<BalancesView>> for BalanceCommand {
                         } else {
                             other_balance.coin_info.symbol.to_string()
                         };
-                        balances_view.insert(key, BalanceInfoViewUnion::Other(other_balance.clone()));
+                        balances_view
+                            .insert(key, BalanceInfoViewUnion::Other(other_balance.clone()));
                     }
                 }
             }
@@ -214,9 +227,7 @@ fn print_balance_info_table(balances: Vec<(String, String, u8, String)>) {
     }
 
     let mut table = builder.build();
-    table
-        .with(Style::rounded())
-        .with(Width::increase(20));
+    table.with(Style::rounded()).with(Width::increase(20));
 
     println!("{}", table);
 }

--- a/crates/rooch/src/commands/account/commands/balance.rs
+++ b/crates/rooch/src/commands/account/commands/balance.rs
@@ -1,9 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright (c) The Starcoin Core Contributors
-// SPDX-License-Identifier: Apache-2.0
-
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
@@ -21,6 +18,7 @@ use rooch_types::error::RoochResult;
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::collections::HashMap;
+use tabled::{builder::Builder, settings::{Style, Width}};
 
 /// Show account balance, only the accounts managed by the current node are supported
 #[derive(Debug, Parser)]
@@ -30,7 +28,6 @@ pub struct BalanceCommand {
     address: ParsedAddress,
 
     /// Struct name as `<ADDRESS>::<MODULE_ID>::<STRUCT_NAME><TypeParam>`
-    /// Example: `0x3::gas_coin::RGas`, `0x123::Coin::Box<0x123::coin_box::FCoin>`
     #[clap(long, value_parser=ParsedStructType::parse)]
     coin_type: Option<ParsedStructType>,
 
@@ -96,75 +93,63 @@ impl CommandAction<Option<BalancesView>> for BalanceCommand {
         balances.push(BalanceInfoViewUnion::Bitcoin(btc_balance));
 
         let other_balances = match coin_type {
-            Some(coin_type) => {
-                vec![
-                    client
-                        .rooch
-                        .get_balance(address_addr.into(), coin_type.into())
-                        .await?,
-                ]
-            }
-            None => {
-                client
-                    .rooch
-                    .get_balances(address_addr.into(), None, Some(MAX_RESULT_LIMIT))
-                    .await?
-                    .data
-            }
+            Some(coin_type) => vec![client
+                .rooch
+                .get_balance(address_addr.into(), coin_type.into())
+                .await?],
+            None => client
+                .rooch
+                .get_balances(address_addr.into(), None, Some(MAX_RESULT_LIMIT))
+                .await?
+                .data,
         };
 
-        balances.extend(other_balances.into_iter().map(BalanceInfoViewUnion::Other));
+        balances.extend(other_balances.iter().cloned().map(BalanceInfoViewUnion::Other));
 
         if self.json {
             let mut balances_view: BalancesView = HashMap::new();
-            for balance_info in balances {
+            for balance_info in &balances {
                 match balance_info {
                     BalanceInfoViewUnion::Bitcoin(bitcoin_balance) => {
                         balances_view.insert(
                             bitcoin_balance.coin_info.symbol.to_string(),
-                            bitcoin_balance.into(),
+                            BalanceInfoViewUnion::Bitcoin(bitcoin_balance.clone()),
                         );
                     }
                     BalanceInfoViewUnion::Other(other_balance) => {
-                        if balances_view.contains_key(&other_balance.coin_info.symbol) {
-                            balances_view.insert(
-                                other_balance.coin_info.coin_type.to_string(),
-                                other_balance.into(),
-                            );
+                        let key = if balances_view.contains_key(&other_balance.coin_info.symbol) {
+                            other_balance.coin_info.coin_type.to_string()
                         } else {
-                            balances_view.insert(
-                                other_balance.coin_info.symbol.to_string(),
-                                other_balance.into(),
-                            );
-                        }
+                            other_balance.coin_info.symbol.to_string()
+                        };
+                        balances_view.insert(key, BalanceInfoViewUnion::Other(other_balance.clone()));
                     }
                 }
             }
             Ok(Some(balances_view))
         } else {
-            print_balance_table_header();
-
-            for balance_info in balances {
+            let mut formatted_balances = vec![];
+            for balance_info in &balances {
                 match balance_info {
-                    BalanceInfoViewUnion::Bitcoin(balance_info) => {
-                        print_balance_info(
+                    BalanceInfoViewUnion::Bitcoin(bitcoin_balance) => {
+                        formatted_balances.push((
                             "Bitcoin".to_string(),
-                            balance_info.coin_info.symbol,
-                            balance_info.coin_info.decimals,
-                            balance_info.balance.to_string(),
-                        );
+                            bitcoin_balance.coin_info.symbol.clone(),
+                            bitcoin_balance.coin_info.decimals,
+                            bitcoin_balance.balance.to_string(),
+                        ));
                     }
-                    BalanceInfoViewUnion::Other(balance_info) => {
-                        print_balance_info(
-                            balance_info.coin_info.coin_type.to_string(),
-                            balance_info.coin_info.symbol,
-                            balance_info.coin_info.decimals,
-                            balance_info.balance.to_string(),
-                        );
+                    BalanceInfoViewUnion::Other(other_balance) => {
+                        formatted_balances.push((
+                            other_balance.coin_info.coin_type.to_string(),
+                            other_balance.coin_info.symbol.clone(),
+                            other_balance.coin_info.decimals,
+                            other_balance.balance.to_string(),
+                        ));
                     }
                 }
             }
-
+            print_balance_info_table(formatted_balances);
             Ok(None)
         }
     }
@@ -220,25 +205,18 @@ async fn get_total_utxo_value(
     Ok(total_value)
 }
 
-const TABLE_WIDTH: usize = 102;
-const SYMBOL_WIDTH: usize = 16;
-const DECIMALS_WIDTH: usize = 8;
-const BALANCE_WIDTH: usize = 32;
+fn print_balance_info_table(balances: Vec<(String, String, u8, String)>) {
+    let mut builder = Builder::default();
+    builder.push_record(["Coin Type", "Symbol", "Decimals", "Balance"]);
 
-fn print_balance_table_header() {
-    println!(
-        "{0: ^TABLE_WIDTH$} | {1: ^SYMBOL_WIDTH$} | {2: ^DECIMALS_WIDTH$} | {3: ^BALANCE_WIDTH$}",
-        "Coin Type", "Symbol", "Decimals", "Balance"
-    );
-    println!(
-        "{}",
-        "-".repeat(TABLE_WIDTH + SYMBOL_WIDTH + DECIMALS_WIDTH + BALANCE_WIDTH + 5)
-    );
-}
+    for (coin_type, symbol, decimals, balance) in balances {
+        builder.push_record([&coin_type, &symbol, &decimals.to_string(), &balance]);
+    }
 
-fn print_balance_info(coin_type: String, symbol: String, decimals: u8, balance: String) {
-    println!(
-        "{0: ^TABLE_WIDTH$} | {1: ^SYMBOL_WIDTH$} | {2: ^DECIMALS_WIDTH$} |  {3: ^BALANCE_WIDTH$} ",
-        coin_type, symbol, decimals, balance
-    );
+    let mut table = builder.build();
+    table
+        .with(Style::rounded())
+        .with(Width::increase(20));
+
+    println!("{}", table);
 }

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -13,7 +13,10 @@ use rooch_types::{
 use rpassword::prompt_password;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tabled::{builder::Builder, settings::{Style, Modify, Width, object::Columns}};
+use tabled::{
+    builder::Builder,
+    settings::{object::Columns, Modify, Style, Width},
+};
 
 /// List all keys by its Rooch address, Base64 encoded public key
 #[derive(Debug, Parser)]
@@ -83,7 +86,7 @@ impl CommandAction<Option<AccountsView>> for ListCommand {
             .get_active_env()
             .map(|env| env.guess_network())
             .unwrap_or(RoochNetwork::from(BuiltinChainID::Local));
-        
+
         let account_views: Vec<AccountView> = accounts
             .into_iter()
             .map(|account: LocalAccount| {
@@ -111,13 +114,15 @@ impl CommandAction<Option<AccountsView>> for ListCommand {
             }
             Ok(Some(accounts_view))
         } else {
-            
             let mut builder = Builder::default();
             builder.push_record(["Field", "Value", "Active"]);
 
             for account in account_views {
                 let fields = [
-                    "Address", "Hex Address", "Bitcoin Address", "Nostr Public Key",
+                    "Address",
+                    "Hex Address",
+                    "Bitcoin Address",
+                    "Nostr Public Key",
                 ];
                 let values = [
                     &account.local_account.address,
@@ -137,20 +142,19 @@ impl CommandAction<Option<AccountsView>> for ListCommand {
                         builder.push_record([*field, &**value, ""]);
                     }
                 }
-                
+
                 builder.push_record([
-                    "─────────────────────────────────", 
-                    "─────────────────────────────────────────────────────────────────────────", 
-                    "──────────"
+                    "─────────────────────────────────",
+                    "─────────────────────────────────────────────────────────────────────────",
+                    "──────────",
                 ]);
             }
 
             let mut table = builder.build();
-            table.with(Style::rounded())
-                
+            table
+                .with(Style::rounded())
                 .with(Modify::new(Columns::single(0)).with(Width::truncate(16)));
 
-            
             println!("{}", table);
 
             Ok(None)

--- a/crates/rooch/src/commands/account/commands/list.rs
+++ b/crates/rooch/src/commands/account/commands/list.rs
@@ -13,7 +13,7 @@ use rooch_types::{
 use rpassword::prompt_password;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fmt::Debug;
+use tabled::{builder::Builder, settings::{Style, Modify, Width, object::Columns}};
 
 /// List all keys by its Rooch address, Base64 encoded public key
 #[derive(Debug, Parser)]
@@ -83,6 +83,7 @@ impl CommandAction<Option<AccountsView>> for ListCommand {
             .get_active_env()
             .map(|env| env.guess_network())
             .unwrap_or(RoochNetwork::from(BuiltinChainID::Local));
+        
         let account_views: Vec<AccountView> = accounts
             .into_iter()
             .map(|account: LocalAccount| {
@@ -110,26 +111,48 @@ impl CommandAction<Option<AccountsView>> for ListCommand {
             }
             Ok(Some(accounts_view))
         } else {
-            let mut output = String::new();
-
-            // TODO: remove non-json print as it goes too long?
-            output.push_str(&format!(
-                "{:^66} | {:^66} | {:^48} | {:^47} | {:^10}\n",
-                "Address", "Hex Address", "Bitcoin Address", "Nostr Public Key", "Active"
-            ));
-            output.push_str(&format!("{}\n", ["-"; 270].join("")));
+            
+            let mut builder = Builder::default();
+            builder.push_record(["Field", "Value", "Active"]);
 
             for account in account_views {
-                output.push_str(&format!(
-                    "{:^66} | {:^66} | {:^48} | {:^47} | {:^10}\n",
-                    account.local_account.address,
-                    account.local_account.hex_address,
-                    account.local_account.bitcoin_address,
-                    account.local_account.nostr_public_key,
-                    account.active
-                ));
+                let fields = [
+                    "Address", "Hex Address", "Bitcoin Address", "Nostr Public Key",
+                ];
+                let values = [
+                    &account.local_account.address,
+                    &account.local_account.hex_address,
+                    &account.local_account.bitcoin_address,
+                    &account.local_account.nostr_public_key,
+                ];
+
+                let active = if account.active { "True" } else { "False" };
+
+                let mut first_row = true;
+                for (field, value) in fields.iter().zip(values.iter()) {
+                    if first_row {
+                        builder.push_record([*field, &**value, active]);
+                        first_row = false;
+                    } else {
+                        builder.push_record([*field, &**value, ""]);
+                    }
+                }
+                
+                builder.push_record([
+                    "─────────────────────────────────", 
+                    "─────────────────────────────────────────────────────────────────────────", 
+                    "──────────"
+                ]);
             }
-            println!("{}", output);
+
+            let mut table = builder.build();
+            table.with(Style::rounded())
+                
+                .with(Modify::new(Columns::single(0)).with(Width::truncate(16)));
+
+            
+            println!("{}", table);
+
             Ok(None)
         }
     }

--- a/crates/rooch/src/commands/env/commands/list.rs
+++ b/crates/rooch/src/commands/env/commands/list.rs
@@ -1,8 +1,6 @@
-// Copyright (c) RoochNetwork
-// SPDX-License-Identifier: Apache-2.0
-
 use clap::Parser;
 use rooch_types::error::RoochResult;
+use tabled::{builder::Builder, settings::Style};
 
 use crate::cli_types::WalletContextOptions;
 
@@ -15,25 +13,25 @@ pub struct ListCommand {
 impl ListCommand {
     pub async fn execute(self) -> RoochResult<()> {
         let context = self.context_options.build()?;
+        let mut builder = Builder::default();
 
-        println!(
-            "{:^24} | {:^48} | {:^48} | {:^12}",
-            "Env Alias", "RPC URL", "Websocket URL", "Active Env"
-        );
-        println!("{}", ["-"; 153].join(""));
+        builder.push_record(["Env Alias", "RPC URL", "Websocket URL", "Active Env"]);
 
         for env in context.client_config.envs.iter() {
-            let mut active = "";
-            if context.client_config.active_env == Some(env.alias.clone()) {
-                active = "True"
-            }
+            let active = if context.client_config.active_env == Some(env.alias.clone()) {
+                "True"
+            } else {
+                ""
+            };
+            let ws = env.ws.clone().unwrap_or_else(|| "Null".to_owned());
 
-            let ws = env.ws.clone().unwrap_or("Null".to_owned());
-            println!(
-                "{:^24} | {:^48} | {:^48} | {:^12}",
-                env.alias, env.rpc, ws, active
-            )
+            builder.push_record([&env.alias, &env.rpc, &ws, active]);
         }
+
+        let mut table = builder.build();
+        table.with(Style::rounded());
+
+        println!("{}", table);
 
         Ok(())
     }

--- a/crates/rooch/src/commands/env/commands/list.rs
+++ b/crates/rooch/src/commands/env/commands/list.rs
@@ -1,3 +1,6 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
 use clap::Parser;
 use rooch_types::error::RoochResult;
 use tabled::{builder::Builder, settings::Style};

--- a/crates/rooch/src/commands/session_key/commands/list.rs
+++ b/crates/rooch/src/commands/session_key/commands/list.rs
@@ -1,4 +1,5 @@
-// src/commands/session_key/commands/list.rs
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;

--- a/crates/rooch/src/commands/session_key/commands/list.rs
+++ b/crates/rooch/src/commands/session_key/commands/list.rs
@@ -1,5 +1,4 @@
-// Copyright (c) RoochNetwork
-// SPDX-License-Identifier: Apache-2.0
+// src/commands/session_key/commands/list.rs
 
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
@@ -21,6 +20,10 @@ pub struct ListCommand {
 
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
+
+    /// Display output as a table instead of JSON
+    #[clap(long)]
+    pub table: bool,
 }
 
 #[async_trait]

--- a/crates/rooch/src/commands/session_key/mod.rs
+++ b/crates/rooch/src/commands/session_key/mod.rs
@@ -1,6 +1,5 @@
-// Copyright (c) RoochNetwork
-// SPDX-License-Identifier: Apache-2.0
-
+use serde_json::Value;
+use tabled::{builder::Builder, settings::Style};
 use crate::cli_types::CommandAction;
 use async_trait::async_trait;
 use clap::Parser;
@@ -10,7 +9,6 @@ use rooch_types::error::RoochResult;
 
 pub mod commands;
 
-/// Session key Commands
 #[derive(Parser)]
 pub struct SessionKey {
     #[clap(subcommand)]
@@ -24,7 +22,18 @@ impl CommandAction<String> for SessionKey {
             SessionKeyCommand::Create(create) => create.execute().await.map(|resp| {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
             }),
-            SessionKeyCommand::List(list) => list.execute_serialized().await,
+            SessionKeyCommand::List(list) => {
+                let display_as_table = list.table; 
+                let json_output = list.execute_serialized().await?;
+                let json_value: Value = serde_json::from_str(&json_output).expect("Failed to parse JSON");
+                
+                if display_as_table {
+                    display_json_as_table(&json_value);
+                    Ok(String::new()) 
+                } else {
+                    Ok(json_output)
+                }
+            }
         }
     }
 }
@@ -34,4 +43,68 @@ impl CommandAction<String> for SessionKey {
 pub enum SessionKeyCommand {
     Create(Box<CreateCommand>),
     List(ListCommand),
+}
+
+fn display_json_as_table(data: &Value) {
+    if let Some(array) = data.as_array() {
+        for item in array {
+            let mut main_table = Builder::default();
+            main_table.push_record(["Field", "Value"]);
+
+            if let Some(name) = item.get("name").and_then(|v| v.as_str()) {
+                main_table.push_record(["Name", name]);
+            }
+            if let Some(abilities) = item.get("value").and_then(|v| v.get("abilities")) {
+                main_table.push_record(["Abilities", &abilities.to_string()]);
+            }
+            if let Some(type_str) = item.get("value").and_then(|v| v.get("type")).and_then(|v| v.as_str()) {
+                main_table.push_record(["Type", type_str]);
+            }
+
+            let mut details_table = Builder::default();
+            details_table.push_record(["Detail", "Value"]);
+            if let Some(details) = item.get("value").and_then(|v| v.get("value")) {
+                if let Some(app_name) = details.get("app_name").and_then(|v| v.as_str()) {
+                    details_table.push_record(["App Name", app_name]);
+                }
+                if let Some(app_url) = details.get("app_url").and_then(|v| v.as_str()) {
+                    details_table.push_record(["App URL", app_url]);
+                }
+                if let Some(auth_key) = details.get("authentication_key").and_then(|v| v.as_str()) {
+                    details_table.push_record(["Authentication Key", auth_key]);
+                }
+                if let Some(create_time) = details.get("create_time") {
+                    details_table.push_record(["Create Time", &create_time.to_string()]);
+                }
+                if let Some(last_active) = details.get("last_active_time") {
+                    details_table.push_record(["Last Active Time", &last_active.to_string()]);
+                }
+                if let Some(max_interval) = details.get("max_inactive_interval") {
+                    details_table.push_record(["Max Inactive Interval", &max_interval.to_string()]);
+                }
+            }
+
+            main_table.push_record(["Details", &format!("{}", details_table.build().with(Style::rounded()))]);
+
+            if let Some(scopes) = item.get("value").and_then(|v| v.get("value")).and_then(|v| v.get("scopes")).and_then(|v| v.as_array()) {
+                let mut scopes_table = Builder::default();
+                scopes_table.push_record(["Abilities", "Type", "Function Name", "Module Address", "Module Name"]);
+                
+                for scope in scopes {
+                    scopes_table.push_record([
+                        &scope.get("abilities").map_or(String::new(), |v| v.to_string()),
+                        scope.get("type").and_then(|v| v.as_str()).unwrap_or(""),
+                        scope.get("value").and_then(|v| v.get("function_name")).and_then(|v| v.as_str()).unwrap_or(""),
+                        scope.get("value").and_then(|v| v.get("module_address")).and_then(|v| v.as_str()).unwrap_or(""),
+                        scope.get("value").and_then(|v| v.get("module_name")).and_then(|v| v.as_str()).unwrap_or(""),
+                    ]);
+                }
+
+                main_table.push_record(["Scopes", &format!("{}", scopes_table.build().with(Style::rounded()))]);
+            }
+
+        
+            println!("{}", main_table.build().with(Style::rounded()));
+        }
+    }
 }

--- a/crates/rooch/src/commands/session_key/mod.rs
+++ b/crates/rooch/src/commands/session_key/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
 use serde_json::Value;
 use tabled::{builder::Builder, settings::Style};
 use crate::cli_types::CommandAction;

--- a/crates/rooch/src/commands/session_key/mod.rs
+++ b/crates/rooch/src/commands/session_key/mod.rs
@@ -1,14 +1,14 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use serde_json::Value;
-use tabled::{builder::Builder, settings::Style};
 use crate::cli_types::CommandAction;
 use async_trait::async_trait;
 use clap::Parser;
 use commands::create::CreateCommand;
 use commands::list::ListCommand;
 use rooch_types::error::RoochResult;
+use serde_json::Value;
+use tabled::{builder::Builder, settings::Style};
 
 pub mod commands;
 
@@ -26,13 +26,14 @@ impl CommandAction<String> for SessionKey {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
             }),
             SessionKeyCommand::List(list) => {
-                let display_as_table = list.table; 
+                let display_as_table = list.table;
                 let json_output = list.execute_serialized().await?;
-                let json_value: Value = serde_json::from_str(&json_output).expect("Failed to parse JSON");
-                
+                let json_value: Value =
+                    serde_json::from_str(&json_output).expect("Failed to parse JSON");
+
                 if display_as_table {
                     display_json_as_table(&json_value);
-                    Ok(String::new()) 
+                    Ok(String::new())
                 } else {
                     Ok(json_output)
                 }
@@ -60,7 +61,11 @@ fn display_json_as_table(data: &Value) {
             if let Some(abilities) = item.get("value").and_then(|v| v.get("abilities")) {
                 main_table.push_record(["Abilities", &abilities.to_string()]);
             }
-            if let Some(type_str) = item.get("value").and_then(|v| v.get("type")).and_then(|v| v.as_str()) {
+            if let Some(type_str) = item
+                .get("value")
+                .and_then(|v| v.get("type"))
+                .and_then(|v| v.as_str())
+            {
                 main_table.push_record(["Type", type_str]);
             }
 
@@ -87,26 +92,56 @@ fn display_json_as_table(data: &Value) {
                 }
             }
 
-            main_table.push_record(["Details", &format!("{}", details_table.build().with(Style::rounded()))]);
+            main_table.push_record([
+                "Details",
+                &format!("{}", details_table.build().with(Style::rounded())),
+            ]);
 
-            if let Some(scopes) = item.get("value").and_then(|v| v.get("value")).and_then(|v| v.get("scopes")).and_then(|v| v.as_array()) {
+            if let Some(scopes) = item
+                .get("value")
+                .and_then(|v| v.get("value"))
+                .and_then(|v| v.get("scopes"))
+                .and_then(|v| v.as_array())
+            {
                 let mut scopes_table = Builder::default();
-                scopes_table.push_record(["Abilities", "Type", "Function Name", "Module Address", "Module Name"]);
-                
+                scopes_table.push_record([
+                    "Abilities",
+                    "Type",
+                    "Function Name",
+                    "Module Address",
+                    "Module Name",
+                ]);
+
                 for scope in scopes {
                     scopes_table.push_record([
-                        &scope.get("abilities").map_or(String::new(), |v| v.to_string()),
+                        &scope
+                            .get("abilities")
+                            .map_or(String::new(), |v| v.to_string()),
                         scope.get("type").and_then(|v| v.as_str()).unwrap_or(""),
-                        scope.get("value").and_then(|v| v.get("function_name")).and_then(|v| v.as_str()).unwrap_or(""),
-                        scope.get("value").and_then(|v| v.get("module_address")).and_then(|v| v.as_str()).unwrap_or(""),
-                        scope.get("value").and_then(|v| v.get("module_name")).and_then(|v| v.as_str()).unwrap_or(""),
+                        scope
+                            .get("value")
+                            .and_then(|v| v.get("function_name"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        scope
+                            .get("value")
+                            .and_then(|v| v.get("module_address"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        scope
+                            .get("value")
+                            .and_then(|v| v.get("module_name"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
                     ]);
                 }
 
-                main_table.push_record(["Scopes", &format!("{}", scopes_table.build().with(Style::rounded()))]);
+                main_table.push_record([
+                    "Scopes",
+                    &format!("{}", scopes_table.build().with(Style::rounded())),
+                ]);
             }
 
-        
             println!("{}", main_table.build().with(Style::rounded()));
         }
     }


### PR DESCRIPTION
## Summary

This update improves the `rooch` CLI output formatting using the `tabled` library. It aims to optimize the display of data tables to enhance readability, especially for commands that return long text fields. Additional table views across the CLI can be similarly optimized if provided.

### Examples of Optimized CLI Commands

1. **`rooch account list`**: The output for account lists is adjusted so that multiple wallet addresses are consolidated into a readable table format, preventing line wrapping due to overly long addresses.

   ![Account List Output](https://github.com/user-attachments/assets/086a0f55-74b4-4698-b93c-848bf0035f69)

2. **`rooch account balance`**: Account balances are displayed with clearer column formatting, ensuring balance values align effectively.

   ![Account Balance Output](https://github.com/user-attachments/assets/753b399d-998a-439f-b688-52813248857e)

3. **`rooch env list`**: The environment list displays each configuration in a structured table format, improving readability.

   ![Env List Output](https://github.com/user-attachments/assets/0b918d57-9378-4157-a98e-9cadab213c64)

4. **`session-key list`**: Adds a new feature that converts JSON output into a table format when using the `--table` flag.

   - **Table Format**:
     ```bash
     rooch session-key list --table
     ```
     ![Session-Key Table Output](https://github.com/user-attachments/assets/92550dd6-0b69-40f9-a86b-424ed0c577ef)

   - **JSON Format**:
     ```bash
     rooch session-key list
     ```
     ![Session-Key JSON Output](https://github.com/user-attachments/assets/a41501a6-bc70-454b-8d71-38e04a807ade)

References #2864
