### PR TITLE
 fix(deps): downgrade anyhow version to 1.0.76

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 name = "accumulator"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs-ext",
  "itertools 0.13.0",
  "log",
@@ -246,9 +246,19 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
+version = "1.0.76"
+source = "git+https://github.com/dtolnay/anyhow?tag=1.0.76#5cad3bf6a2d6198ae29067c9aadf2f0828fdb125"
+
+[[package]]
+name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+
+[[package]]
+name = "anyhow"
+version = "1.0.93"
+source = "git+https://github.com/dtolnay/anyhow?tag=1.0.93#713bda9247df3846c1444a7c1b3b2a3b9a4f5907"
 
 [[package]]
 name = "arbitrary"
@@ -852,7 +862,7 @@ dependencies = [
 name = "bcs-ext"
 version = "1.13.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "serde 1.0.214",
 ]
@@ -1035,7 +1045,7 @@ checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
 name = "bitcoin-move"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "axum",
  "bitcoin 0.32.3",
  "brotli 3.5.0",
@@ -1535,7 +1545,7 @@ name = "celestia-proto"
 version = "0.1.0"
 source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=129272e8d926b4c7badf27a26dea915323dd6489#129272e8d926b4c7badf27a26dea915323dd6489"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost",
  "prost-build",
  "prost-types",
@@ -2463,7 +2473,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cd12917efc3a8b069a4975ef3cb2f2d835d42d04b3814d90838488f9dd9bf69"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 4.5.17",
  "console",
  "cucumber-codegen",
@@ -2719,7 +2729,7 @@ dependencies = [
 name = "data-verify"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "rooch-rpc-api",
  "serde 1.0.214",
  "serde_json",
@@ -4112,7 +4122,7 @@ dependencies = [
 name = "framework-builder"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "codespan-reporting",
  "framework-types",
@@ -4136,7 +4146,7 @@ dependencies = [
 name = "framework-release"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "clap 4.5.17",
  "framework-builder",
@@ -5106,7 +5116,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a0c890c85da4bab7bce4204c707396bbd3c6c8a681716a51c8814cfc2b682df"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -5338,7 +5348,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb61a6bd5d40ffb161d35da618bdc09163de3d697f281fc6c2926bb19bd3caa"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonpath-plus",
  "once_cell",
  "regex",
@@ -5461,7 +5471,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2327ba8df2fdbd5e897e2b5ed25ce7f299d345b9736b6828814c3dbd1fd47b"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-lock",
  "async-trait",
  "beef",
@@ -5483,7 +5493,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "beef",
  "bytes",
@@ -5583,7 +5593,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "654afab2e92e5d88ebd8a39d6074483f3f2bfdf91c5ac57fe285e7127cdd4f51"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -5611,7 +5621,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be0be325642e850ed0bdff426674d2e66b2b7117c9be23a7caef68a2902b7d9"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "beef",
  "serde 1.0.214",
  "serde_json",
@@ -6080,7 +6090,7 @@ dependencies = [
 name = "metrics"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "axum",
  "axum-server",
@@ -6207,7 +6217,7 @@ name = "move-abigen"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "heck 0.3.3",
  "log",
@@ -6224,7 +6234,7 @@ name = "move-binary-format"
 version = "0.0.3"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace",
  "indexmap 1.9.3",
  "move-core-types",
@@ -6244,7 +6254,7 @@ name = "move-bytecode-source-map"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "move-binary-format",
  "move-command-line-common",
@@ -6259,7 +6269,7 @@ name = "move-bytecode-utils"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
  "move-core-types",
  "petgraph 0.5.1",
@@ -6271,7 +6281,7 @@ name = "move-bytecode-verifier"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "fail",
  "move-binary-format",
  "move-borrow-graph",
@@ -6285,7 +6295,7 @@ name = "move-bytecode-viewer"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 4.5.17",
  "crossterm 0.26.1",
  "move-binary-format",
@@ -6302,7 +6312,7 @@ name = "move-cli"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "clap 4.5.17",
  "codespan-reporting",
@@ -6346,7 +6356,7 @@ name = "move-command-line-common"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference",
  "dirs-next",
  "hex",
@@ -6363,7 +6373,7 @@ name = "move-compiler"
 version = "0.0.1"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "clap 4.5.17",
  "codespan-reporting",
@@ -6392,7 +6402,7 @@ name = "move-core-types"
 version = "0.0.4"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "arbitrary",
  "bcs",
  "ethnum",
@@ -6414,7 +6424,7 @@ name = "move-coverage"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "clap 4.5.17",
  "codespan",
@@ -6434,7 +6444,7 @@ name = "move-disassembler"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 4.5.17",
  "colored",
  "move-binary-format",
@@ -6452,7 +6462,7 @@ name = "move-docgen"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan",
  "codespan-reporting",
  "itertools 0.10.5",
@@ -6471,7 +6481,7 @@ name = "move-errmapgen"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "log",
  "move-command-line-common",
@@ -6485,7 +6495,7 @@ name = "move-ir-compiler"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "clap 4.5.17",
  "move-binary-format",
@@ -6504,7 +6514,7 @@ name = "move-ir-to-bytecode"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting",
  "log",
  "move-binary-format",
@@ -6523,7 +6533,7 @@ name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "move-command-line-common",
  "move-core-types",
@@ -6536,7 +6546,7 @@ name = "move-ir-types"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "move-command-line-common",
  "move-core-types",
@@ -6550,7 +6560,7 @@ name = "move-model"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan",
  "codespan-reporting",
  "internment",
@@ -6577,7 +6587,7 @@ name = "move-package"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "clap 4.5.17",
  "colored",
@@ -6613,7 +6623,7 @@ name = "move-prover"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "atty",
  "clap 4.5.17",
@@ -6650,7 +6660,7 @@ name = "move-prover-boogie-backend"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "codespan",
  "codespan-reporting",
@@ -6679,7 +6689,7 @@ name = "move-resource-viewer"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "hex",
  "move-binary-format",
@@ -6720,7 +6730,7 @@ name = "move-stdlib"
 version = "0.1.1"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "log",
  "move-binary-format",
@@ -6752,7 +6762,7 @@ name = "move-table-extension"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "better_any",
  "move-binary-format",
@@ -6769,7 +6779,7 @@ name = "move-transactional-test-runner"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 4.5.17",
  "colored",
  "move-binary-format",
@@ -6800,7 +6810,7 @@ name = "move-unit-test"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "better_any",
  "clap 4.5.17",
  "codespan-reporting",
@@ -6847,7 +6857,7 @@ name = "move-vm-test-utils"
 version = "0.1.0"
 source = "git+https://github.com/rooch-network/move?rev=e8783853c750d952d277efed937049c0c5a7bb24#e8783853c750d952d277efed937049c0c5a7bb24"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
  "move-core-types",
  "move-table-extension",
@@ -6873,7 +6883,7 @@ dependencies = [
 name = "moveos"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 4.5.17",
  "codespan",
  "codespan-reporting",
@@ -6912,7 +6922,7 @@ dependencies = [
 name = "moveos-common"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "itertools 0.13.0",
  "libc",
@@ -6927,7 +6937,7 @@ dependencies = [
 name = "moveos-compiler"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
  "petgraph 0.6.5",
 ]
@@ -6945,7 +6955,7 @@ dependencies = [
 name = "moveos-eventbus"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "coerce",
  "crossbeam-channel",
  "log",
@@ -6956,7 +6966,7 @@ dependencies = [
 name = "moveos-gas-profiling"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars",
  "inferno",
  "move-binary-format",
@@ -6990,7 +7000,7 @@ dependencies = [
 name = "moveos-stdlib"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.22.1",
  "bech32 0.11.0",
  "better_any",
@@ -7024,7 +7034,7 @@ name = "moveos-store"
 version = "0.7.6"
 dependencies = [
  "accumulator",
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "chrono",
  "function_name",
@@ -7045,7 +7055,7 @@ dependencies = [
 name = "moveos-types"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=56f6223b84ada922b6cb2c672c69db2ea3dc6a13)",
  "hex",
@@ -7072,7 +7082,7 @@ dependencies = [
 name = "moveos-verifier"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "codespan-reporting",
  "itertools 0.13.0",
@@ -7097,7 +7107,7 @@ dependencies = [
 name = "moveos-wasm"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
  "rand 0.8.5",
  "tracing",
@@ -7527,7 +7537,7 @@ version = "0.47.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cac4826fe3d5482a49b92955b0f6b06ce45b46ec84484176588209bfbf996870"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "backon",
  "base64 0.22.1",
@@ -8505,7 +8515,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.12.1",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -8825,7 +8835,7 @@ dependencies = [
 name = "raw-store"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrics",
  "moveos-common",
  "moveos-config",
@@ -9003,7 +9013,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70fe66d4cd0b5ed9b1abbfe639bf6baeaaf509f7da2d51b31111ba945be59286"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -9296,7 +9306,7 @@ name = "rooch"
 version = "0.7.6"
 dependencies = [
  "accumulator",
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "bcs",
  "bitcoin 0.32.3",
@@ -9395,7 +9405,9 @@ dependencies = [
 name = "rooch-benchmarks"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.76",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.93 (git+https://github.com/dtolnay/anyhow?tag=1.0.93)",
  "bcs",
  "bitcoin 0.32.3",
  "bitcoincore-rpc",
@@ -9456,7 +9468,7 @@ dependencies = [
 name = "rooch-config"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "celestia-types",
  "clap 4.5.17",
  "dirs",
@@ -9488,7 +9500,7 @@ dependencies = [
 name = "rooch-da"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "celestia-rpc",
  "celestia-types",
@@ -9508,7 +9520,7 @@ name = "rooch-db"
 version = "0.7.6"
 dependencies = [
  "accumulator",
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "moveos-common",
  "moveos-store",
  "moveos-types",
@@ -9525,7 +9537,7 @@ dependencies = [
 name = "rooch-event"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "coerce",
  "log",
@@ -9537,7 +9549,7 @@ dependencies = [
 name = "rooch-executor"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "coerce",
  "function_name",
@@ -9563,7 +9575,7 @@ dependencies = [
 name = "rooch-faucet"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "axum",
  "axum-server",
@@ -9610,7 +9622,7 @@ dependencies = [
 name = "rooch-framework-tests"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "bitcoin 0.32.3",
  "clap 4.5.17",
@@ -9649,7 +9661,7 @@ name = "rooch-genesis"
 version = "0.7.6"
 dependencies = [
  "accumulator",
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "bitcoin-move",
  "clap 4.5.17",
@@ -9679,7 +9691,7 @@ dependencies = [
 name = "rooch-indexer"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "bcs",
  "coerce",
@@ -9707,7 +9719,7 @@ dependencies = [
 name = "rooch-integration-test-runner"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "clap 4.5.17",
  "codespan-reporting",
@@ -9740,7 +9752,7 @@ dependencies = [
 name = "rooch-key"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "argon2",
  "bip32",
  "enum_dispatch",
@@ -9785,7 +9797,7 @@ dependencies = [
 name = "rooch-open-rpc"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 4.5.17",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=56f6223b84ada922b6cb2c672c69db2ea3dc6a13)",
  "rand 0.8.5",
@@ -9823,7 +9835,7 @@ dependencies = [
 name = "rooch-open-rpc-spec-builder"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 4.5.17",
  "rand 0.8.5",
  "rooch-open-rpc",
@@ -9836,7 +9848,7 @@ dependencies = [
 name = "rooch-oracle"
 version = "0.1.0"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "clap 4.5.17",
  "futures",
@@ -9861,7 +9873,7 @@ dependencies = [
 name = "rooch-ord"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordinals",
  "reqwest 0.12.7",
  "rooch-types",
@@ -9875,7 +9887,7 @@ dependencies = [
 name = "rooch-pipeline-processor"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "bcs",
  "coerce",
@@ -9900,7 +9912,7 @@ dependencies = [
 name = "rooch-proposer"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "coerce",
  "log",
@@ -9915,7 +9927,7 @@ dependencies = [
 name = "rooch-relayer"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "bitcoin 0.32.3",
  "bitcoincore-rpc",
@@ -9944,7 +9956,7 @@ name = "rooch-rpc-api"
 version = "0.7.6"
 dependencies = [
  "accumulator",
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "bitcoin 0.32.3",
  "ethers",
@@ -9967,7 +9979,7 @@ dependencies = [
 name = "rooch-rpc-client"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "bitcoin 0.32.3",
  "bitcoincore-rpc",
@@ -9990,7 +10002,7 @@ dependencies = [
 name = "rooch-rpc-server"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "axum",
  "bcs",
  "bitcoincore-rpc",
@@ -10039,7 +10051,7 @@ name = "rooch-sequencer"
 version = "0.7.6"
 dependencies = [
  "accumulator",
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "coerce",
  "function_name",
@@ -10064,7 +10076,7 @@ name = "rooch-store"
 version = "0.7.6"
 dependencies = [
  "accumulator",
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "moveos-common",
  "moveos-config",
  "moveos-types",
@@ -10080,7 +10092,7 @@ dependencies = [
 name = "rooch-test-transaction-builder"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs",
  "move-core-types",
  "move-package",
@@ -10095,7 +10107,7 @@ name = "rooch-types"
 version = "0.7.6"
 dependencies = [
  "accumulator",
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "argon2",
  "bcs",
  "bech32 0.11.0",
@@ -11310,7 +11322,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 name = "smt"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace",
  "bcs",
  "bitcoin_hashes 0.14.0",
@@ -11877,7 +11889,7 @@ dependencies = [
 name = "testsuite"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd",
  "backtrace",
  "clap 4.5.17",
@@ -11988,7 +12000,7 @@ dependencies = [
 name = "timeout-join-handler"
 version = "0.7.6"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -12870,7 +12882,7 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c32e7318e93a9ac53693b6caccfb05ff22e04a44c7cf8a279051f24c09da286f"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata",
  "derive_builder 0.20.1",
  "getset",
@@ -12887,7 +12899,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62c52cd2b2b8b7ec75fc20111b3022ac3ff83e4fc14b9497cfcfd39c54f9c67"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_builder 0.20.1",
  "git2",
  "rustversion",
@@ -12902,7 +12914,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e06bee42361e43b60f363bad49d63798d0f42fb1768091812270eca00c784720"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_builder 0.20.1",
  "getset",
  "rustversion",
@@ -12914,7 +12926,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9579e7d75e528471646aa8c9bf11392154f3f8e0b02d94211bc5d57701d010f0"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "convert_case 0.6.0",
  "derive_builder 0.20.1",
  "rustversion",
@@ -13173,7 +13185,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a0f70c177b1c5062cfe0f5308c3317751796fef9403c22a0cd7b4cacd4ccd8"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytesize",
  "derive_builder 0.12.0",
  "hex",
@@ -13309,7 +13321,7 @@ version = "6.0.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fc686c7b43c9bc630a499f6ae1f0a4c4bd656576a53ae8a147b0cc9bc983ad"
 dependencies = [
- "anyhow",
+ "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.21.7",
  "bytes",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ rooch-nursery = { path = "frameworks/rooch-nursery" }
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
 again = "0.1.2"
-anyhow = "1.0.93"
+anyhow = "1.0.76"
 async-trait = "0"
 backtrace = "0.3"
 bcs = "0.1.3"

--- a/crates/rooch-benchmarks/Cargo.toml
+++ b/crates/rooch-benchmarks/Cargo.toml
@@ -15,6 +15,8 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+anyhow-old = { git = "https://github.com/dtolnay/anyhow", tag = "1.0.76", package = "anyhow" }
+anyhow-new = { git = "https://github.com/dtolnay/anyhow", tag = "1.0.93", package = "anyhow" }
 bcs = { workspace = true }
 clap = { workspace = true }
 ethers = { workspace = true }

--- a/crates/rooch-benchmarks/benches/bench_utils.rs
+++ b/crates/rooch-benchmarks/benches/bench_utils.rs
@@ -55,8 +55,23 @@ pub fn bcs_serialized_size_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+pub fn anyhow_error_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("anyhow_error_bench");
+    group.bench_function("anyhow_v1.0.93", |b| {
+        b.iter(|| {
+            let _ = anyhow_new::anyhow!("anyhow error");
+        })
+    });
+    group.bench_function("anyhow_v1.0.76", |b| {
+        b.iter(|| {
+            let _ = anyhow_old::anyhow!("anyhow error");
+        })
+    });
+    group.finish();
+}
+
 criterion_group! {
-    benchs, bcs_serialized_size_benchmark
+    benchs, bcs_serialized_size_benchmark, anyhow_error_benchmark
 }
 
 criterion_main!(benchs);


### PR DESCRIPTION
## Summary

   new version of anyhow with std backtrace is much slower: https://github.com/dtolnay/anyhow/issues/347

    ```
    cargo bench --bench bench_utils


    anyhow_error_bench/anyhow_v1.0.93
                            time:   [15.040 ns 15.148 ns 15.259 ns]
                            change: [+1.5448% +2.1215% +2.7219%] (p = 0.00 < 0.05)
                            Performance has regressed.
    anyhow_error_bench/anyhow_v1.0.76
                            time:   [6.2104 ns 6.2182 ns 6.2278 ns]
                            change: [-0.4029% -0.1998% +0.0002%] (p = 0.06 > 0.05)
                            No change in performance detected.
    Found 10 outliers among 100 measurements (10.00%)
      2 (2.00%) high mild
      8 (8.00%) high severe
    ...


Downgraded anyhow dependency from version 1.0.93 to 1.0.76. Won't break anything but gain better perf.

