### PR TITLE
[rooch-sdk] Update rooch-sdk readme some nits and change NetworkType name

### DIFF
--- a/sdk/typescript/rooch-sdk-kit/src/hooks/client/useCurrentNetwork.ts
+++ b/sdk/typescript/rooch-sdk-kit/src/hooks/client/useCurrentNetwork.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useRoochContext } from './index.js'
-import { NetWorkType } from '@roochnetwork/rooch-sdk'
+import { NetworkType } from '@roochnetwork/rooch-sdk'
 
-export function useCurrentNetwork(): NetWorkType {
+export function useCurrentNetwork(): NetworkType {
   return useRoochContext().network
 }

--- a/sdk/typescript/rooch-sdk-kit/src/provider/clientProvider.tsx
+++ b/sdk/typescript/rooch-sdk-kit/src/provider/clientProvider.tsx
@@ -9,7 +9,7 @@ import {
   getRoochNodeUrl,
   RoochClient,
   RoochClientOptions,
-  NetWorkType,
+  NetworkType,
 } from '@roochnetwork/rooch-sdk'
 
 import { NetworkConfig } from '../hooks/index.js'
@@ -21,7 +21,7 @@ export type NetworkConfigs<T extends NetworkConfig | RoochClient = NetworkConfig
 export interface ClientProviderContext {
   client: RoochClient
   networks: NetworkConfigs
-  network: NetWorkType
+  network: NetworkType
   config: NetworkConfig | null
   selectNetwork: (network: string) => void
 }
@@ -60,7 +60,7 @@ export function RoochClientProvider<T extends NetworkConfigs>(props: RoochClient
   const ctx = useMemo((): ClientProviderContext => {
     return {
       client,
-      network: currentNetwork as NetWorkType,
+      network: currentNetwork as NetworkType,
       networks,
       config:
         networks[currentNetwork] instanceof RoochClient

--- a/sdk/typescript/rooch-sdk/README.md
+++ b/sdk/typescript/rooch-sdk/README.md
@@ -103,7 +103,7 @@ const client = new RoochClient({
   url: getRoochNodeUrl('devnet'),
 })
 
-const result = provider.executeViewFunction(
+const result = await client.executeViewFunction(
   '0x49ee3cf17a017b331ab2b8a4d40ecc9706f328562f9db63cba625a9c106cdf35::counter::view',
 )
 ```

--- a/sdk/typescript/rooch-sdk/src/client/index.ts
+++ b/sdk/typescript/rooch-sdk/src/client/index.ts
@@ -14,6 +14,6 @@ export {
 } from './httpTransport.js'
 
 export { getRoochNodeUrl } from './networks.js'
-export type { NetWorkType } from './networks.js'
+export type { NetworkType } from './networks.js'
 
 export * from './error.js'

--- a/sdk/typescript/rooch-sdk/src/client/networks.ts
+++ b/sdk/typescript/rooch-sdk/src/client/networks.ts
@@ -1,9 +1,9 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-export type NetWorkType = 'mainnet' | 'testnet' | 'devnet' | 'localnet'
+export type NetworkType = 'mainnet' | 'testnet' | 'devnet' | 'localnet'
 
-export function getRoochNodeUrl(network: NetWorkType) {
+export function getRoochNodeUrl(network: NetworkType) {
   switch (network) {
     case 'mainnet':
       return 'https://main-seed.rooch.network'


### PR DESCRIPTION
## Summary

- Update `provider` to `client` in rooch-sdk readme
- Change `NetWorkType` to `NetworkType`