### PR TITLE
chore(openda): adjust several default configs for backends

### DIFF
--- a/crates/rooch-da/src/backend/openda/avail.rs
+++ b/crates/rooch-da/src/backend/openda/avail.rs
@@ -14,7 +14,7 @@ use tokio::time::{sleep, Duration};
 
 // small blob size for transaction to get included in a block quickly
 pub(crate) const DEFAULT_AVAIL_MAX_SEGMENT_SIZE: u64 = 256 * 1024;
-const BACK_OFF_MIN_DELAY: Duration = Duration::from_millis(2000);
+const BACK_OFF_MIN_DELAY: Duration = Duration::from_millis(3000);
 const SUBMIT_API_PATH: &str = "v2/submit";
 
 pub(crate) struct AvailClient {
@@ -88,7 +88,7 @@ impl Operator for AvailClient {
                     if retries < max_retries {
                         retries += 1;
                         sleep(retry_delay).await;
-                        retry_delay *= 2; // Exponential backoff
+                        retry_delay *= 3; // Exponential backoff
                         tracing::warn!(
                             "Failed to submit segment: {:?} to Avail, retrying after {}ms, attempt: {}",
                             segment_id,

--- a/crates/rooch-da/src/backend/openda/operator.rs
+++ b/crates/rooch-da/src/backend/openda/operator.rs
@@ -10,7 +10,7 @@ use rooch_config::retrieve_map_config_value;
 use rooch_types::da::segment::SegmentID;
 use std::collections::HashMap;
 
-const DEFAULT_MAX_SEGMENT_SIZE: u64 = 4 * 1024 * 1024;
+const DEFAULT_MAX_SEGMENT_SIZE: u64 = 8 * 1024 * 1024;
 pub(crate) const DEFAULT_MAX_RETRY_TIMES: usize = 4;
 
 #[async_trait]


### PR DESCRIPTION
## Summary

1. increase default max segment size to 8MB
2. increase initial backoff delay from 2000ms to 3000ms.
3. modify exponential backoff multiplier from 2 to 3 to better handle transaction resubmissions.
4. Increased the initial backoff delay from 2000ms to 3000ms and changed the exponential backoff multiplier from 2 to 3 to improve retry mechanism for avail-da