### PR TITLE
feat(da-config): add initial block offset configuration

### DIFF
--- a/crates/rooch-config/src/da_config.rs
+++ b/crates/rooch-config/src/da_config.rs
@@ -126,6 +126,10 @@ impl From<OpenDAScheme> for opendal::Scheme {
 pub struct DAConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub da_backend: Option<DABackendConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// The offset of the first block to be submitted.
+    /// If not set, the default value is 0.
+    pub da_init_offset: Option<u128>,
     #[serde(skip)]
     base: Option<Arc<BaseConfig>>,
 }
@@ -300,7 +304,7 @@ mod tests {
         let da_config_str = r#"{"da-backend": {"submit-strategy": "all",
         "backends": [{"open-da": {"scheme": "gcs", "config": {"bucket": "test-bucket", "credential": "test-credential"}}},
         {"open-da": {"scheme": "celestia", "config": {"endpoint": "test-conn", "auth_token": "test-auth"}, "namespace": "000000000000000000000000000000000000000102030405060708090a"}},
-        {"open-da": {"scheme": "fs", "config": {}}}]}}"#;
+        {"open-da": {"scheme": "fs", "config": {}}}]}, "da-init-offset": 340282366920938463463374607431768211455}"#;
 
         let exp_gcs_config = DABackendOpenDAConfig {
             scheme: OpenDAScheme::Gcs,
@@ -345,6 +349,7 @@ mod tests {
                 ],
                 background_submit_interval: None,
             }),
+            da_init_offset: Some(340282366920938463463374607431768211455),
             base: None,
         };
         match DAConfig::from_str(da_config_str) {
@@ -367,6 +372,7 @@ mod tests {
                 backends: vec![DABackendConfigType::OpenDa(exp_fs_config.clone())],
                 background_submit_interval: None,
             }),
+            da_init_offset: None,
             base: None,
         };
         match DAConfig::from_str(da_config_str) {


### PR DESCRIPTION
## Summary

Added a new configuration option 'da_init_offset' in `DAConfig` to set the initial block offset for submission. Modified `start_job` function to accommodate this new offset and adjust the block submission cursor accordingly.