### PR TITLE
[framework] Gas fee distribute

### DIFF
--- a/frameworks/moveos-stdlib/doc/gas_schedule.md
+++ b/frameworks/moveos-stdlib/doc/gas_schedule.md
@@ -11,6 +11,7 @@
 -  [Struct `GasScheduleConfig`](#0x2_gas_schedule_GasScheduleConfig)
 -  [Constants](#@Constants_0)
 -  [Function `initial_max_gas_amount`](#0x2_gas_schedule_initial_max_gas_amount)
+-  [Function `max_gas_amount`](#0x2_gas_schedule_max_gas_amount)
 -  [Function `genesis_init`](#0x2_gas_schedule_genesis_init)
 -  [Function `new_gas_schedule_config`](#0x2_gas_schedule_new_gas_schedule_config)
 -  [Function `new_gas_entry`](#0x2_gas_schedule_new_gas_entry)
@@ -93,9 +94,22 @@
 
 <a name="0x2_gas_schedule_InitialMaxGasAmount"></a>
 
+The initial max gas amount from genesis.
 
 
 <pre><code><b>const</b> <a href="gas_schedule.md#0x2_gas_schedule_InitialMaxGasAmount">InitialMaxGasAmount</a>: u64 = 1000000000;
+</code></pre>
+
+
+
+<a name="0x2_gas_schedule_MaxGasAmount"></a>
+
+The max gas amount of the transaction.
+This const can be changed via framework upgrade.
+We use const other than the GasScheduleConfig for the performance.
+
+
+<pre><code><b>const</b> <a href="gas_schedule.md#0x2_gas_schedule_MaxGasAmount">MaxGasAmount</a>: u64 = 1000000000;
 </code></pre>
 
 
@@ -107,6 +121,17 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="gas_schedule.md#0x2_gas_schedule_initial_max_gas_amount">initial_max_gas_amount</a>(): u64
+</code></pre>
+
+
+
+<a name="0x2_gas_schedule_max_gas_amount"></a>
+
+## Function `max_gas_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="gas_schedule.md#0x2_gas_schedule_max_gas_amount">max_gas_amount</a>(): u64
 </code></pre>
 
 
@@ -170,6 +195,7 @@
 
 ## Function `gas_schedule_max_gas_amount`
 
+This function will deprecated in the future, please use <code><a href="gas_schedule.md#0x2_gas_schedule_max_gas_amount">max_gas_amount</a>()</code> instead.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="gas_schedule.md#0x2_gas_schedule_gas_schedule_max_gas_amount">gas_schedule_max_gas_amount</a>(schedule: &<a href="gas_schedule.md#0x2_gas_schedule_GasSchedule">gas_schedule::GasSchedule</a>): u64

--- a/frameworks/moveos-stdlib/sources/gas_schedule.move
+++ b/frameworks/moveos-stdlib/sources/gas_schedule.move
@@ -10,9 +10,17 @@ module moveos_std::gas_schedule {
     
     const ErrorInvalidGasScheduleEntries: u64 = 1;
 
+    /// The initial max gas amount from genesis.
     const InitialMaxGasAmount: u64 = 1_000_000_000u64;
     public fun initial_max_gas_amount(): u64 {
         InitialMaxGasAmount
+    }
+    /// The max gas amount of the transaction.
+    /// This const can be changed via framework upgrade.
+    /// We use const other than the GasScheduleConfig for the performance.
+    const MaxGasAmount: u64 = 1_000_000_000u64;
+    public fun max_gas_amount(): u64 {
+        MaxGasAmount
     }
 
     struct GasScheduleUpdated has store, copy, drop {
@@ -85,6 +93,7 @@ module moveos_std::gas_schedule {
         object::borrow(obj)
     }
 
+    ///This function will deprecated in the future, please use `max_gas_amount()` instead.
     public fun gas_schedule_max_gas_amount(schedule: &GasSchedule): u64 {
         schedule.max_gas_amount
     }

--- a/frameworks/rooch-framework/doc/transaction_fee.md
+++ b/frameworks/rooch-framework/doc/transaction_fee.md
@@ -3,17 +3,33 @@
 
 # Module `0x3::transaction_fee`
 
+The transaction fee module is used to manage the transaction fee pool.
+Distribution of Transaction Gas Fees:
+
+1. RoochNetwork 40%
+* Before Mainnet launch: Used to repay the debt from Gas airdrops
+* After Mainnet launch: Used to buy back Mainnet tokens
+2. Sequencer 30%
+3. Application Developers 30%
+* Goes to the developer of the entry function contract called by the transaction
+* If the entry contract is a system Framework contract, this portion goes to the Rooch network
 
 
 -  [Resource `TransactionFeePool`](#0x3_transaction_fee_TransactionFeePool)
+-  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x3_transaction_fee_genesis_init)
 -  [Function `get_gas_factor`](#0x3_transaction_fee_get_gas_factor)
 -  [Function `calculate_gas`](#0x3_transaction_fee_calculate_gas)
 -  [Function `withdraw_fee`](#0x3_transaction_fee_withdraw_fee)
 -  [Function `deposit_fee`](#0x3_transaction_fee_deposit_fee)
+-  [Function `distribute_fee`](#0x3_transaction_fee_distribute_fee)
+-  [Function `withdraw_gas_revenue`](#0x3_transaction_fee_withdraw_gas_revenue)
+-  [Function `gas_revenue_balance`](#0x3_transaction_fee_gas_revenue_balance)
 
 
-<pre><code><b>use</b> <a href="">0x2::object</a>;
+<pre><code><b>use</b> <a href="">0x2::core_addresses</a>;
+<b>use</b> <a href="">0x2::object</a>;
+<b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
 <b>use</b> <a href="coin_store.md#0x3_coin_store">0x3::coin_store</a>;
 <b>use</b> <a href="gas_coin.md#0x3_gas_coin">0x3::gas_coin</a>;
@@ -28,6 +44,29 @@
 
 
 <pre><code><b>struct</b> <a href="transaction_fee.md#0x3_transaction_fee_TransactionFeePool">TransactionFeePool</a> <b>has</b> key
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x3_transaction_fee_ErrorInvalidGasUsed"></a>
+
+
+
+<pre><code><b>const</b> <a href="transaction_fee.md#0x3_transaction_fee_ErrorInvalidGasUsed">ErrorInvalidGasUsed</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x3_transaction_fee_SystemFeeAddress"></a>
+
+
+
+<pre><code><b>const</b> <a href="transaction_fee.md#0x3_transaction_fee_SystemFeeAddress">SystemFeeAddress</a>: <b>address</b> = 0x3;
 </code></pre>
 
 
@@ -84,4 +123,40 @@ Returns the gas factor of gas.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="transaction_fee.md#0x3_transaction_fee_deposit_fee">deposit_fee</a>(<a href="gas_coin.md#0x3_gas_coin">gas_coin</a>: <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;<a href="gas_coin.md#0x3_gas_coin_RGas">gas_coin::RGas</a>&gt;)
+</code></pre>
+
+
+
+<a name="0x3_transaction_fee_distribute_fee"></a>
+
+## Function `distribute_fee`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="transaction_fee.md#0x3_transaction_fee_distribute_fee">distribute_fee</a>(total_paid_gas: <a href="">u256</a>, gas_used: <a href="">u256</a>, contract_address: <b>address</b>, sequencer_address: <b>address</b>): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;<a href="gas_coin.md#0x3_gas_coin_RGas">gas_coin::RGas</a>&gt;
+</code></pre>
+
+
+
+<a name="0x3_transaction_fee_withdraw_gas_revenue"></a>
+
+## Function `withdraw_gas_revenue`
+
+Withdraw the all gas revenue for the sender
+The contract address can use <code>moveos_std::signer::module_signer</code> to get the signer
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_fee.md#0x3_transaction_fee_withdraw_gas_revenue">withdraw_gas_revenue</a>(sender: &<a href="">signer</a>, amount: <a href="">u256</a>): <a href="coin.md#0x3_coin_Coin">coin::Coin</a>&lt;<a href="gas_coin.md#0x3_gas_coin_RGas">gas_coin::RGas</a>&gt;
+</code></pre>
+
+
+
+<a name="0x3_transaction_fee_gas_revenue_balance"></a>
+
+## Function `gas_revenue_balance`
+
+Get the gas revenue balance for the given address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_fee.md#0x3_transaction_fee_gas_revenue_balance">gas_revenue_balance</a>(addr: <b>address</b>): <a href="">u256</a>
 </code></pre>

--- a/frameworks/rooch-framework/doc/transaction_fee.md
+++ b/frameworks/rooch-framework/doc/transaction_fee.md
@@ -55,6 +55,7 @@ Distribution of Transaction Gas Fees:
 
 <a name="0x3_transaction_fee_ErrorInvalidGasUsed"></a>
 
+Error code for invalid gas used in transaction
 
 
 <pre><code><b>const</b> <a href="transaction_fee.md#0x3_transaction_fee_ErrorInvalidGasUsed">ErrorInvalidGasUsed</a>: u64 = 1;
@@ -142,7 +143,7 @@ Returns the gas factor of gas.
 
 ## Function `withdraw_gas_revenue`
 
-Withdraw the all gas revenue for the sender
+Withdraw all the gas revenue for the sender
 The contract address can use <code>moveos_std::signer::module_signer</code> to get the signer
 
 

--- a/frameworks/rooch-framework/doc/transaction_validator.md
+++ b/frameworks/rooch-framework/doc/transaction_validator.md
@@ -16,6 +16,7 @@
 <b>use</b> <a href="">0x2::signer</a>;
 <b>use</b> <a href="">0x2::timestamp</a>;
 <b>use</b> <a href="">0x2::tx_context</a>;
+<b>use</b> <a href="">0x2::tx_meta</a>;
 <b>use</b> <a href="">0x2::tx_result</a>;
 <b>use</b> <a href="account.md#0x3_account">0x3::account</a>;
 <b>use</b> <a href="account_authentication.md#0x3_account_authentication">0x3::account_authentication</a>;
@@ -29,6 +30,7 @@
 <b>use</b> <a href="chain_id.md#0x3_chain_id">0x3::chain_id</a>;
 <b>use</b> <a href="coin.md#0x3_coin">0x3::coin</a>;
 <b>use</b> <a href="gas_coin.md#0x3_gas_coin">0x3::gas_coin</a>;
+<b>use</b> <a href="onchain_config.md#0x3_onchain_config">0x3::onchain_config</a>;
 <b>use</b> <a href="session_key.md#0x3_session_key">0x3::session_key</a>;
 <b>use</b> <a href="session_validator.md#0x3_session_validator">0x3::session_validator</a>;
 <b>use</b> <a href="transaction.md#0x3_transaction">0x3::transaction</a>;

--- a/frameworks/rooch-framework/sources/gas_coin.move
+++ b/frameworks/rooch-framework/sources/gas_coin.move
@@ -14,6 +14,7 @@ module rooch_framework::gas_coin {
 
     friend rooch_framework::genesis;
     friend rooch_framework::transaction_validator;
+    friend rooch_framework::transaction_fee;
 
     /// RGas is the symbol of Rooch Gas Coin
     //If not, we can remove `store` ability from RGas.

--- a/frameworks/rooch-framework/sources/transaction_fee.move
+++ b/frameworks/rooch-framework/sources/transaction_fee.move
@@ -26,7 +26,8 @@ module rooch_framework::transaction_fee {
     friend rooch_framework::transaction_validator;
 
     const SystemFeeAddress: address = @rooch_framework;
-
+    
+    ///Error code for invalid gas used in transaction
     const ErrorInvalidGasUsed: u64 = 1;
 
     struct TransactionFeePool has key {
@@ -103,7 +104,7 @@ module rooch_framework::transaction_fee {
         total_paid_gas_coin
     }
 
-    /// Withdraw the all gas revenue for the sender
+    /// Withdraw all the gas revenue for the sender
     /// The contract address can use `moveos_std::signer::module_signer` to get the signer
     public fun withdraw_gas_revenue(sender: &signer, amount: u256): Coin<RGas> {
         let addr = signer::address_of(sender);

--- a/frameworks/rooch-framework/sources/transaction_fee.move
+++ b/frameworks/rooch-framework/sources/transaction_fee.move
@@ -1,15 +1,33 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+/// The transaction fee module is used to manage the transaction fee pool.
+/// Distribution of Transaction Gas Fees:
+/// 
+/// 1. RoochNetwork 40%
+///     * Before Mainnet launch: Used to repay the debt from Gas airdrops
+///     * After Mainnet launch: Used to buy back Mainnet tokens
+/// 2. Sequencer 30%
+/// 3. Application Developers 30%
+///     * Goes to the developer of the entry function contract called by the transaction
+///     * If the entry contract is a system Framework contract, this portion goes to the Rooch network
+
 module rooch_framework::transaction_fee {
 
     use moveos_std::object::{Self, Object};
+    use moveos_std::core_addresses;
+    use moveos_std::signer;
+
     use rooch_framework::coin_store::{Self, CoinStore};
-    use rooch_framework::coin::Coin;
+    use rooch_framework::coin::{Self,Coin};
     use rooch_framework::gas_coin::{RGas};
 
     friend rooch_framework::genesis;
     friend rooch_framework::transaction_validator;
+
+    const SystemFeeAddress: address = @rooch_framework;
+
+    const ErrorInvalidGasUsed: u64 = 1;
 
     struct TransactionFeePool has key {
         fee: Object<CoinStore<RGas>>,
@@ -21,6 +39,18 @@ module rooch_framework::transaction_fee {
             fee: fee_store,
         });
         object::transfer_extend(obj, @rooch_framework);
+    }
+
+    // Borrow the gas revenue store or init a new one if it does not exist for the given address.
+    // The address can be a contract address or sequencer address.
+    fun borrow_mut_or_init_gas_revenue_store(addr: address): &mut Object<CoinStore<RGas>>{
+        let fee_pool_id = object::named_object_id<TransactionFeePool>();
+        let fee_pool_object = object::borrow_mut_object_extend<TransactionFeePool>(fee_pool_id);
+        if(!object::contains_field(fee_pool_object, addr)){
+            let gas_revenue_store_obj = coin_store::create_coin_store<RGas>();
+            object::add_field(fee_pool_object, addr, gas_revenue_store_obj);
+        };
+        object::borrow_mut_field(fee_pool_object, addr)
     }
 
     /// Returns the gas factor of gas.
@@ -46,5 +76,83 @@ module rooch_framework::transaction_fee {
         let pool_object = object::borrow_mut_object_extend<TransactionFeePool>(object_id);
         let pool = object::borrow_mut(pool_object);
         coin_store::deposit<RGas>(&mut pool.fee, gas_coin);
+    }
+
+    public(friend) fun distribute_fee(total_paid_gas: u256, gas_used: u256, contract_address: address, sequencer_address: address) : Coin<RGas> {
+        assert!(total_paid_gas >= gas_used, ErrorInvalidGasUsed);
+        let total_paid_gas_coin = withdraw_fee(total_paid_gas);
+        let used_gas_coin = coin::extract(&mut total_paid_gas_coin, gas_used);
+        
+        let sequencer_fee = gas_used * 30 / 100;
+        let developer_fee = gas_used * 30 / 100;
+        
+        let sequencer_fee_coin = coin::extract(&mut used_gas_coin, sequencer_fee);
+        let sequencer_fee_coin_store = borrow_mut_or_init_gas_revenue_store(sequencer_address);
+        coin_store::deposit(sequencer_fee_coin_store, sequencer_fee_coin);
+
+        let is_framework_address = core_addresses::is_system_reserved_address(contract_address);
+        if(!is_framework_address){
+            let developer_fee_coin = coin::extract(&mut used_gas_coin, developer_fee);
+            let developer_fee_coin_store = borrow_mut_or_init_gas_revenue_store(contract_address);
+            coin_store::deposit(developer_fee_coin_store, developer_fee_coin);
+        };
+
+        let system_fee_coin_store = borrow_mut_or_init_gas_revenue_store(SystemFeeAddress);
+        coin_store::deposit(system_fee_coin_store, used_gas_coin);
+        //Return the remaining gas coin to the sender
+        total_paid_gas_coin
+    }
+
+    /// Withdraw the all gas revenue for the sender
+    /// The contract address can use `moveos_std::signer::module_signer` to get the signer
+    public fun withdraw_gas_revenue(sender: &signer, amount: u256): Coin<RGas> {
+        let addr = signer::address_of(sender);
+        let gas_revenue_store = borrow_mut_or_init_gas_revenue_store(addr);
+        coin_store::withdraw(gas_revenue_store, amount)
+    }
+
+    /// Get the gas revenue balance for the given address
+    public fun gas_revenue_balance(addr: address): u256 {
+        let fee_pool_id = object::named_object_id<TransactionFeePool>();
+        let fee_pool_object = object::borrow_object<TransactionFeePool>(fee_pool_id);
+        if(object::contains_field(fee_pool_object, addr)){
+            let gas_revenue_store = object::borrow_field<TransactionFeePool, address, Object<CoinStore<RGas>>>(fee_pool_object, addr);
+            coin_store::balance(gas_revenue_store)
+        }else{
+            0u256
+        }
+    }
+
+    #[test]
+    fun test_distribute_fee(){
+        let system_signer = moveos_std::account::create_signer_for_testing(SystemFeeAddress);   
+        rooch_framework::gas_coin::genesis_init(&system_signer);
+        genesis_init(&system_signer);
+
+        let gas_coin = rooch_framework::gas_coin::mint_for_test(120);
+        deposit_fee(gas_coin);
+        let total_paid_gas = 120;
+        let gas_used = 100;
+        let contract_address = @0x42;
+        let sequencer_address = @0x43;
+        let remaining_gas_coin = distribute_fee(total_paid_gas, gas_used, contract_address, sequencer_address);
+        assert!(coin::value(&remaining_gas_coin) == 20, 1);
+        
+        let contract_signer = moveos_std::account::create_signer_for_testing(contract_address);
+        let gas_revenue = withdraw_gas_revenue(&contract_signer, 30);
+        assert!(coin::value(&gas_revenue) == 30, 2);
+        
+        let sequencer_signer = moveos_std::account::create_signer_for_testing(sequencer_address);
+        let sequencer_gas_revenue = withdraw_gas_revenue(&sequencer_signer, 30);
+        assert!(coin::value(&sequencer_gas_revenue) == 30, 3);
+
+        
+        let system_gas_revenue = withdraw_gas_revenue(&system_signer, 40);
+        assert!(coin::value(&system_gas_revenue) == 40, 4);
+        
+        coin::destroy_for_testing(remaining_gas_coin);
+        coin::destroy_for_testing(gas_revenue);
+        coin::destroy_for_testing(sequencer_gas_revenue);
+        coin::destroy_for_testing(system_gas_revenue);
     }
 }

--- a/frameworks/rooch-framework/sources/transaction_validator.move
+++ b/frameworks/rooch-framework/sources/transaction_validator.move
@@ -9,6 +9,7 @@ module rooch_framework::transaction_validator {
     use moveos_std::tx_result;
     use moveos_std::account;
     use moveos_std::gas_schedule;
+    use moveos_std::tx_meta;
     use rooch_framework::account as account_entry;
     use rooch_framework::account_authentication;
     use rooch_framework::auth_validator::{Self, TxValidateResult};
@@ -23,6 +24,8 @@ module rooch_framework::transaction_validator {
     use rooch_framework::address_mapping;
     use rooch_framework::account_coin_store;
     use rooch_framework::builtin_validators;
+    use rooch_framework::onchain_config;
+    use rooch_framework::coin;
 
     const MAX_U64: u128 = 18446744073709551615;
 
@@ -169,10 +172,21 @@ module rooch_framework::transaction_validator {
         let max_gas_amount = tx_context::max_gas_amount();
         let paid_gas = transaction_fee::calculate_gas(max_gas_amount);
 
-        if (gas_used_after_scale < paid_gas) {
-            let refund_gas = paid_gas - gas_used_after_scale;
-            let refund_gas_coin = transaction_fee::withdraw_fee(refund_gas);
-            account_coin_store::deposit(gas_payment_account, refund_gas_coin);
+        let tx_meta = tx_context::tx_meta();
+        let function_call_opt = tx_meta::function_meta(&tx_meta);
+        let contract_address = if (option::is_some(&function_call_opt)) {
+            let function_call = option::borrow(&function_call_opt);
+            *tx_meta::function_meta_module_address(function_call)
+        } else {
+            //If it is not a function call, we use the framework address as the contract address
+            @rooch_framework
         };
+        let sequencer_address = onchain_config::sequencer();
+        let remaining_gas_coin = transaction_fee::distribute_fee(paid_gas, gas_used_after_scale, contract_address, sequencer_address);
+        if (coin::value(&remaining_gas_coin) > 0) {
+            account_coin_store::deposit(gas_payment_account, remaining_gas_coin);
+        }else{
+            coin::destroy_zero(remaining_gas_coin);
+        }
     }
 }

--- a/frameworks/rooch-framework/sources/transaction_validator.move
+++ b/frameworks/rooch-framework/sources/transaction_validator.move
@@ -71,8 +71,7 @@ module rooch_framework::transaction_validator {
         let max_gas_amount = tx_context::max_gas_amount();
         let gas = transaction_fee::calculate_gas(max_gas_amount);
 
-        let gas_schedule = gas_schedule::gas_schedule();
-        let max_gas_amount_config = gas_schedule::gas_schedule_max_gas_amount(gas_schedule);
+        let max_gas_amount_config = gas_schedule::max_gas_amount();
         assert!(
             max_gas_amount <= max_gas_amount_config,
             auth_validator::error_validate_max_gas_amount_exceeded(),


### PR DESCRIPTION
## Summary

1. Distribute the gas fee to the sequencer and contract address.
2. Use gas_schedule::max_gas_amount const in transaction_validator. @steelgeek091 

The benchmark result is regressed because we need to split the gas fee. I can not find a better solution to optimize it.

<img width="990" alt="Screenshot 2024-11-26 at 16 47 02" src="https://github.com/user-attachments/assets/b44c3a58-c8c1-4316-9c55-80ddd2880e46">

