### PR TITLE
fix(rooch-rpc-server): adjust default rate limit configuration

### DIFF
--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -451,7 +451,7 @@ pub async fn run_start_server(opt: RoochOpt, server_opt: ServerOpt) -> Result<Se
         traffic_per_second = opt.traffic_per_second.unwrap_or(0.1f64);
     } else {
         traffic_burst_size = opt.traffic_burst_size.unwrap_or(5000);
-        traffic_per_second = opt.traffic_per_second.unwrap_or(0.0001f64);
+        traffic_per_second = opt.traffic_per_second.unwrap_or(0.001f64);
     };
 
     // init limit


### PR DESCRIPTION
fix server start panic issue:

```
RUST_BACKTRACE=1 rooch server start
...
2024-11-22T21:19:12.659554Z  INFO rooch_rpc_server: acl=Const("*")
thread 'main' panicked at /Users/popcnt/rx/popcnt1/rooch/crates/rooch-rpc-server/src/lib.rs:471:14:
called `Option::unwrap()` on a `None` value
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic
   3: core::option::unwrap_failed
   4: rooch_rpc_server::run_start_server::{{closure}}
   5: <rooch::commands::server::commands::start::StartCommand as rooch::cli_types::CommandAction<()>>::execute::{{closure}}
   6: rooch::cli_types::CommandAction::execute_serialized::{{closure}}
   7: <rooch::commands::server::Server as rooch::cli_types::CommandAction<alloc::string::String>>::execute::{{closure}}
   8: rooch::main::{{closure}}
   9: tokio::runtime::park::CachedParkThread::block_on
  10: rooch::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2024-11-22T21:19:12.704996Z ERROR rooch_rpc_server: Panic occurred:
 panicked at /Users/popcnt/rx/popcnt1/rooch/crates/rooch-rpc-server/src/lib.rs:471:14:
called `Option::unwrap()` on a `None` value
 exit the process
 ```
