### PR TITLE
fix(logging): remove deprecated `log` crate in favor of `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,6 @@ dependencies = [
  "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcs-ext",
  "itertools 0.13.0",
- "log",
  "lru",
  "mirai-annotations",
  "moveos-types",
@@ -30,6 +29,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde 1.0.215",
+ "tracing",
 ]
 
 [[package]]
@@ -6918,7 +6918,6 @@ dependencies = [
  "codespan",
  "codespan-reporting",
  "itertools 0.13.0",
- "log",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
@@ -6945,6 +6944,7 @@ dependencies = [
  "serde 1.0.215",
  "tempfile",
  "thiserror",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -6956,11 +6956,11 @@ dependencies = [
  "bcs",
  "itertools 0.13.0",
  "libc",
- "log",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
  "serde 1.0.215",
+ "tracing",
 ]
 
 [[package]]
@@ -6988,8 +6988,8 @@ dependencies = [
  "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "coerce",
  "crossbeam-channel",
- "log",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -7016,7 +7016,6 @@ dependencies = [
  "bcs",
  "better_any",
  "hex",
- "log",
  "move-binary-format",
  "move-core-types",
  "move-vm-runtime",
@@ -7039,7 +7038,6 @@ dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=56f6223b84ada922b6cb2c672c69db2ea3dc6a13)",
  "fastcrypto-zkp",
  "itertools 0.13.0",
- "log",
  "move-binary-format",
  "move-core-types",
  "move-stdlib",
@@ -7057,6 +7055,7 @@ dependencies = [
  "rlp",
  "serde_json",
  "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -7068,7 +7067,6 @@ dependencies = [
  "bcs",
  "chrono",
  "function_name",
- "log",
  "metrics",
  "move-core-types",
  "moveos-config",
@@ -7079,6 +7077,7 @@ dependencies = [
  "raw-store",
  "smt",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7116,7 +7115,6 @@ dependencies = [
  "bcs",
  "codespan-reporting",
  "itertools 0.13.0",
- "log",
  "move-binary-format",
  "move-command-line-common",
  "move-compiler",
@@ -7131,6 +7129,7 @@ dependencies = [
  "serde 1.0.215",
  "termcolor",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -9561,9 +9560,9 @@ dependencies = [
  "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "coerce",
- "log",
  "moveos-eventbus",
  "rooch-types",
+ "tracing",
 ]
 
 [[package]]
@@ -9574,7 +9573,6 @@ dependencies = [
  "async-trait",
  "coerce",
  "function_name",
- "log",
  "metrics",
  "move-core-types",
  "move-resource-viewer",
@@ -9719,7 +9717,6 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "function_name",
- "log",
  "metrics",
  "move-core-types",
  "moveos-config",
@@ -9795,7 +9792,6 @@ dependencies = [
  "ciborium",
  "cosmwasm-std",
  "cosmwasm-vm",
- "log",
  "move-binary-format",
  "move-core-types",
  "move-vm-runtime",
@@ -9810,6 +9806,7 @@ dependencies = [
  "rooch-types",
  "serde_json",
  "smallvec",
+ "tracing",
  "wasmer",
 ]
 
@@ -9913,7 +9910,6 @@ dependencies = [
  "coerce",
  "function_name",
  "hex",
- "log",
  "metrics",
  "moveos",
  "moveos-types",
@@ -10008,7 +10004,6 @@ dependencies = [
  "bitcoincore-rpc",
  "futures",
  "jsonrpsee 0.23.2",
- "log",
  "move-core-types",
  "moveos-types",
  "rooch-config",
@@ -10035,7 +10030,6 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.3.1",
  "jsonrpsee 0.23.2",
- "log",
  "metrics",
  "move-core-types",
  "move-resource-viewer",
@@ -11353,7 +11347,6 @@ dependencies = [
  "bytes",
  "function_name",
  "hex",
- "log",
  "metrics",
  "more-asserts 0.3.1",
  "num-derive",
@@ -11367,6 +11360,7 @@ dependencies = [
  "rand 0.8.5",
  "serde 1.0.215",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9433,7 +9433,6 @@ dependencies = [
  "ethers",
  "jemallocator",
  "lazy_static 1.5.0",
- "log",
  "metrics",
  "move-binary-format",
  "move-bytecode-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9350,7 +9350,6 @@ dependencies = [
  "itertools 0.13.0",
  "jemallocator",
  "lazy_static 1.5.0",
- "log",
  "metrics",
  "mimalloc",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,6 @@ jsonrpsee = { version = "0.23.2", features = ["full"] }
 jpst = "0.1.1"
 lazy_static = "1.5.0"
 linked-hash-map = "0.5.6"
-log = "0.4.22"
 more-asserts = "0.3.0"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
@@ -263,7 +262,7 @@ bcs-ext = { path = "moveos/moveos-commons/bcs_ext" }
 http = "1.0.0"
 tower = { version = "0.5.1", features = ["full", "log", "util", "timeout", "load-shed", "limit"] }
 tower-http = { version = "0.5.2", features = ["cors", "full", "trace", "set-header", "propagate-header"] }
-tower_governor = { version = "0.4.3", features = ["tracing"]}
+tower_governor = { version = "0.4.3", features = ["tracing"] }
 pin-project = "1.1.7"
 mirai-annotations = "1.12.0"
 lru = "0.11.0"
@@ -343,7 +342,7 @@ scopeguard = "1.1"
 uuid = { version = "1.11.0", features = ["v4", "fast-rng"] }
 protobuf = { version = "2.28", features = ["with-bytes"] }
 redb = { version = "2.1.1" }
-rocksdb = { git = "https://github.com/rooch-network/rust-rocksdb.git", rev = "41d102327ba3cf9a2335d1192e8312c92bc3d6f9", features = ["lz4","mt_static"] }
+rocksdb = { git = "https://github.com/rooch-network/rust-rocksdb.git", rev = "41d102327ba3cf9a2335d1192e8312c92bc3d6f9", features = ["lz4", "mt_static"] }
 lz4 = { version = "1.28.0" }
 ripemd = { version = "0.1.3" }
 fastcrypto-zkp = { version = "0.1.3" }

--- a/crates/rooch-benchmarks/Cargo.toml
+++ b/crates/rooch-benchmarks/Cargo.toml
@@ -23,7 +23,6 @@ ethers = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 rand = { workspace = true }
-log = { workspace = true }
 lazy_static = { workspace = true }
 criterion = { workspace = true }
 pprof = { workspace = true, features = ["flamegraph", "criterion", "cpp", "frame-pointer", "protobuf-codec"] }
@@ -35,6 +34,7 @@ toml = { workspace = true }
 jemallocator = { version = "0.5.4", features = ["unprefixed_malloc_on_supported_platforms", "profiling"] }
 prometheus = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 move-core-types = { workspace = true }
 move-resource-viewer = { workspace = true }

--- a/crates/rooch-benchmarks/src/config.rs
+++ b/crates/rooch-benchmarks/src/config.rs
@@ -135,11 +135,11 @@ impl BenchTxConfig {
             Ok(config_data) => match toml::from_str::<BenchTxConfig>(&config_data) {
                 Ok(parsed_config) => config.merge(parsed_config),
                 Err(e) => {
-                    log::error!("Failed to parse config file: {}", e);
+                    tracing::error!("Failed to parse config file: {}", e);
                 }
             },
             Err(e) => {
-                log::error!("Failed to read config file: {}", e);
+                tracing::error!("Failed to read config file: {}", e);
             }
         };
         // Override config with env variables

--- a/crates/rooch-event/Cargo.toml
+++ b/crates/rooch-event/Cargo.toml
@@ -11,9 +11,10 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-coerce = { workspace = true }
 async-trait = { workspace = true }
+coerce = { workspace = true }
+tracing = { workspace = true }
+
 moveos-eventbus = { workspace = true }
-log = { workspace = true }
 
 rooch-types = { workspace = true }

--- a/crates/rooch-event/src/actor.rs
+++ b/crates/rooch-event/src/actor.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use coerce::actor::context::ActorContext;
 use coerce::actor::message::{Handler, Message};
 use coerce::actor::Actor;
-use log;
 use moveos_eventbus::bus::{EventBus, EventNotifier};
 use rooch_types::service_status::ServiceStatus;
 
@@ -37,7 +36,7 @@ impl Handler<GasUpgradeMessage> for EventActor {
         message: GasUpgradeMessage,
         _ctx: &mut ActorContext,
     ) -> anyhow::Result<()> {
-        log::debug!("EventActor receive message {:?}", message);
+        tracing::debug!("EventActor receive message {:?}", message);
         self.event_bus
             .notify::<GasUpgradeEvent>(GasUpgradeEvent {})?;
         Ok(())
@@ -60,7 +59,7 @@ impl Handler<UpdateServiceStatusMessage> for EventActor {
         message: UpdateServiceStatusMessage,
         _ctx: &mut ActorContext,
     ) -> anyhow::Result<()> {
-        log::debug!("EventActor receive message {:?}", message);
+        tracing::debug!("EventActor receive message {:?}", message);
         self.event_bus
             .notify::<ServiceStatusEvent>(ServiceStatusEvent {
                 status: message.status,

--- a/crates/rooch-executor/Cargo.toml
+++ b/crates/rooch-executor/Cargo.toml
@@ -18,7 +18,6 @@ coerce = { workspace = true }
 serde = { workspace = true }
 tokio = { features = ["full"], workspace = true }
 tracing = { workspace = true }
-log = { workspace = true }
 prometheus = { workspace = true }
 function_name = { workspace = true }
 

--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -46,7 +46,6 @@ use rooch_types::transaction::{
 };
 use std::str::FromStr;
 use std::sync::Arc;
-use tracing::{debug, warn};
 
 pub struct ExecutorActor {
     root: ObjectMeta,
@@ -268,7 +267,7 @@ impl ExecutorActor {
             .start_timer();
         let sender = tx.sender();
         let tx_hash = tx.tx_hash();
-        debug!("executor validate_l2_tx: {:?}, sender: {}", tx_hash, sender);
+        tracing::debug!("executor validate_l2_tx: {:?}, sender: {}", tx_hash, sender);
 
         let authenticator = tx.authenticator_info();
         let mut moveos_tx: MoveOSTransaction = tx.into_moveos_transaction(self.root.clone());
@@ -287,7 +286,7 @@ impl ExecutorActor {
                     match verify_result {
                         Ok(verified_tx) => Ok(verified_tx),
                         Err(e) => {
-                            log::warn!(
+                            tracing::warn!(
                                 "transaction verify vm error, tx_hash: {}, error:{:?}",
                                 tx_hash,
                                 e
@@ -299,16 +298,17 @@ impl ExecutorActor {
                 Err(e) => {
                     let resolver = RootObjectResolver::new(self.root.clone(), &self.moveos_store);
                     let status_view = explain_vm_status(&resolver, e.clone())?;
-                    warn!(
+                    tracing::warn!(
                         "transaction validate vm error, tx_hash: {}, error:{:?}",
-                        tx_hash, status_view,
+                        tx_hash,
+                        status_view,
                     );
                     //TODO how to return the vm status to rpc client.
                     Err(e.into())
                 }
             },
             Err(e) => {
-                log::warn!(
+                tracing::warn!(
                     "transaction validate error, tx_hash: {}, error:{:?}",
                     tx_hash,
                     e
@@ -516,7 +516,7 @@ impl MoveFunctionCaller for ExecutorActor {
 impl Handler<EventData> for ExecutorActor {
     async fn handle(&mut self, message: EventData, _ctx: &mut ActorContext) -> Result<()> {
         if let Ok(_gas_upgrade_msg) = message.data.downcast::<GasUpgradeEvent>() {
-            log::debug!("ExecutorActor: Reload the MoveOS instance...");
+            tracing::debug!("ExecutorActor: Reload the MoveOS instance...");
 
             let resolver = RootObjectResolver::new(self.root.clone(), &self.moveos_store);
             let gas_parameters = FrameworksGasParameters::load_from_chain(&resolver)?;

--- a/crates/rooch-executor/src/actor/reader_executor.rs
+++ b/crates/rooch-executor/src/actor/reader_executor.rs
@@ -317,7 +317,7 @@ impl Handler<RefreshStateMessage> for ReaderExecutorActor {
 impl Handler<EventData> for ReaderExecutorActor {
     async fn handle(&mut self, message: EventData, _ctx: &mut ActorContext) -> Result<()> {
         if let Ok(_gas_upgrade_msg) = message.data.downcast::<GasUpgradeEvent>() {
-            log::debug!("ReadExecutorActor: Reload the MoveOS instance...");
+            tracing::debug!("ReadExecutorActor: Reload the MoveOS instance...");
 
             let resolver = RootObjectResolver::new(self.root.clone(), &self.moveos_store);
             let gas_parameters = FrameworksGasParameters::load_from_chain(&resolver)?;

--- a/crates/rooch-indexer/Cargo.toml
+++ b/crates/rooch-indexer/Cargo.toml
@@ -26,7 +26,6 @@ diesel = { workspace = true }
 diesel_migrations = { workspace = true }
 coerce = { workspace = true }
 rand = { workspace = true }
-log = { workspace = true }
 tap = { workspace = true }
 prometheus = { workspace = true }
 function_name = { workspace = true }

--- a/crates/rooch-indexer/src/lib.rs
+++ b/crates/rooch-indexer/src/lib.rs
@@ -354,7 +354,7 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
             .write()
             .map_err(|e| diesel::r2d2::Error::ConnectionError(BadConnection(e.to_string())))?;
         *locker_cnt += 1;
-        log::trace!(
+        tracing::trace!(
             "Sqlite CustomizeConnection on_acquire connection [rw:{}]",
             *locker_cnt
         );
@@ -387,7 +387,7 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
     }
 
     fn on_release(&self, _conn: SqliteConnection) {
-        log::trace!("Sqlite CustomizeConnection on_release connection");
+        tracing::trace!("Sqlite CustomizeConnection on_release connection");
     }
 }
 

--- a/crates/rooch-indexer/src/store/sqlite_store.rs
+++ b/crates/rooch-indexer/src/store/sqlite_store.rs
@@ -10,7 +10,6 @@ use rooch_types::indexer::event::IndexerEvent;
 use rooch_types::indexer::state::IndexerObjectState;
 use rooch_types::indexer::transaction::IndexerTransaction;
 use std::sync::Arc;
-use tracing::log;
 
 use crate::models::events::StoredEvent;
 use crate::models::inscriptions::StoredInscription;
@@ -108,7 +107,7 @@ impl SqliteIndexerStore {
         diesel::sql_query(query.clone())
             .execute(&mut connection)
             .map_err(|e| {
-                log::error!("Upsert object states Executing Query error: {}", query);
+                tracing::error!("Upsert object states Executing Query error: {}", query);
                 IndexerError::SQLiteWriteError(e.to_string())
             })
             .context("Failed to write or update object states to SQLiteDB")?;
@@ -168,7 +167,7 @@ impl SqliteIndexerStore {
         diesel::sql_query(query.clone())
             .execute(&mut connection)
             .map_err(|e| {
-                log::error!("Upsert object state utxos Executing Query error: {}", query);
+                tracing::error!("Upsert object state utxos Executing Query error: {}", query);
                 IndexerError::SQLiteWriteError(e.to_string())
             })
             .context("Failed to write or update object state utxos to SQLiteDB")?;
@@ -231,7 +230,7 @@ impl SqliteIndexerStore {
         diesel::sql_query(query.clone())
             .execute(&mut connection)
             .map_err(|e| {
-                log::error!(
+                tracing::error!(
                     "Upsert object state inscriptions Executing Query error: {}",
                     query
                 );

--- a/crates/rooch-pipeline-processor/Cargo.toml
+++ b/crates/rooch-pipeline-processor/Cargo.toml
@@ -18,7 +18,6 @@ bcs = { workspace = true }
 coerce = { workspace = true }
 function_name = { workspace = true }
 hex = { workspace = true }
-log = { workspace = true }
 tracing = { workspace = true }
 prometheus = { workspace = true }
 

--- a/crates/rooch-pipeline-processor/src/actor/processor.rs
+++ b/crates/rooch-pipeline-processor/src/actor/processor.rs
@@ -151,7 +151,7 @@ impl PipelineProcessorActor {
             Ok(v) => v,
             Err(err) => {
                 if is_vm_panic_error(&err) {
-                    log::error!(
+                    tracing::error!(
                         "Execute L1 Block failed while VM panic occurred then \
                         set service to Maintenance mode and pause the relayer. error: {:?}, block {}, tx order {}",
                         err, block_height, tx_order
@@ -195,7 +195,7 @@ impl PipelineProcessorActor {
             Ok(v) => v,
             Err(err) => {
                 if is_vm_panic_error(&err) {
-                    log::error!(
+                    tracing::error!(
                         "Execute L1 Tx failed while VM panic occurred then \
                         set service to Maintenance mode and pause the relayer. error: {:?}, tx order {}",
                         err, tx_order
@@ -249,7 +249,7 @@ impl PipelineProcessorActor {
             Err(err) => {
                 if is_vm_panic_error(&err) {
                     let l2_tx_bcs_bytes = bcs::to_bytes(&tx)?;
-                    log::error!(
+                    tracing::error!(
                         "Execute L2 Tx failed while VM panic occurred and revert tx. error: {:?} tx info {}",
                         err, hex::encode(l2_tx_bcs_bytes)
                     );
@@ -327,7 +327,7 @@ impl PipelineProcessorActor {
                 .await;
             match result {
                 Ok(_) => {}
-                Err(error) => log::error!("Update indexer error: {}", error),
+                Err(error) => tracing::error!("Update indexer error: {}", error),
             };
         };
 

--- a/crates/rooch-relayer/src/actor/relayer.rs
+++ b/crates/rooch-relayer/src/actor/relayer.rs
@@ -23,7 +23,7 @@ use rooch_types::multichain_id::RoochMultiChainID;
 use rooch_types::service_status::ServiceStatus;
 use rooch_types::transaction::{L1BlockWithBody, L1Transaction};
 use std::ops::Deref;
-use tracing::{debug, error, info, log, warn};
+use tracing::{debug, error, info, warn};
 
 pub struct RelayerActor {
     relayers: Vec<RelayerProxy>,
@@ -265,7 +265,7 @@ impl Handler<EventData> for RelayerActor {
     async fn handle(&mut self, message: EventData, _ctx: &mut ActorContext) -> Result<()> {
         if let Ok(service_status_event) = message.data.downcast::<ServiceStatusEvent>() {
             if service_status_event.deref().status == ServiceStatus::Maintenance {
-                log::warn!("RelayerActor: MoveVM panic occurs, set the status to paused...");
+                tracing::warn!("RelayerActor: MoveVM panic occurs, set the status to paused...");
                 self.paused = true;
             }
         }

--- a/crates/rooch-rpc-client/Cargo.toml
+++ b/crates/rooch-rpc-client/Cargo.toml
@@ -21,7 +21,6 @@ futures = { workspace = true }
 serde = { workspace = true }
 jsonrpsee = { workspace = true }
 serde_json = { workspace = true }
-log = { workspace = true }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rooch-rpc-client/src/wallet_context.rs
+++ b/crates/rooch-rpc-client/src/wallet_context.rs
@@ -213,7 +213,7 @@ impl WalletContext {
                 .await
                 .map_err(RoochError::from)?,
         );
-        log::debug!("use sequence_number: {}", sequence_number);
+        tracing::debug!("use sequence_number: {}", sequence_number);
         //TODO max gas amount from cli option or dry run estimate
         let tx_data = RoochTransactionData::new(
             sender,

--- a/crates/rooch-rpc-server/Cargo.toml
+++ b/crates/rooch-rpc-server/Cargo.toml
@@ -24,7 +24,6 @@ tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 axum = { workspace = true }
-log = { workspace = true }
 prometheus = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 tokio = { workspace = true }

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -148,7 +148,7 @@ pub async fn start_server(opt: RoochOpt, server_opt: ServerOpt) -> Result<Server
         Ok(server_handle) => Ok(server_handle),
         Err(e) => match e.downcast::<GenesisError>() {
             Ok(e) => {
-                log::error!(
+                tracing::error!(
                     "{:?}, please clean your data dir. `rooch server clean -n {}` ",
                     e,
                     chain_name
@@ -157,7 +157,7 @@ pub async fn start_server(opt: RoochOpt, server_opt: ServerOpt) -> Result<Server
             }
             Err(e) => match e.downcast::<RawStoreError>() {
                 Ok(e) => {
-                    log::error!(
+                    tracing::error!(
                         "{:?}, please clean your data dir. `rooch server clean -n {}` ",
                         e,
                         chain_name
@@ -165,7 +165,7 @@ pub async fn start_server(opt: RoochOpt, server_opt: ServerOpt) -> Result<Server
                     std::process::exit(R_EXIT_CODE_NEED_HELP);
                 }
                 Err(e) => {
-                    log::error!("{:?}, server start fail. ", e);
+                    tracing::error!("{:?}, server start fail. ", e);
                     std::process::exit(R_EXIT_CODE_NEED_HELP);
                 }
             },

--- a/crates/rooch-sequencer/src/actor/sequencer.rs
+++ b/crates/rooch-sequencer/src/actor/sequencer.rs
@@ -26,7 +26,7 @@ use rooch_types::crypto::{RoochKeyPair, Signature};
 use rooch_types::sequencer::SequencerInfo;
 use rooch_types::service_status::ServiceStatus;
 use rooch_types::transaction::{LedgerTransaction, LedgerTxData};
-use tracing::{info, log};
+use tracing::info;
 
 pub struct SequencerActor {
     last_sequencer_info: SequencerInfo,
@@ -241,7 +241,7 @@ impl Handler<EventData> for SequencerActor {
     async fn handle(&mut self, msg: EventData, _ctx: &mut ActorContext) -> Result<()> {
         if let Ok(service_status_event) = msg.data.downcast::<ServiceStatusEvent>() {
             let service_status = service_status_event.deref().status;
-            log::warn!("SequencerActor set self status to {:?}", service_status);
+            tracing::warn!("SequencerActor set self status to {:?}", service_status);
             self.service_status = service_status;
         }
 

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -37,7 +37,6 @@ regex = { workspace = true }
 parking_lot = { workspace = true }
 rpassword = { workspace = true }
 fastcrypto = { workspace = true }
-log = { workspace = true }
 csv = { workspace = true }
 tempfile = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/rooch/src/commands/bitseed/operation.rs
+++ b/crates/rooch/src/commands/bitseed/operation.rs
@@ -7,12 +7,12 @@ use super::{
 };
 use anyhow::{anyhow, bail, Result};
 use ciborium::Value;
-use log::debug;
 use rooch_types::bitcoin::ord::{Inscription, InscriptionRecord};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use serde_json::Value as JSONValue;
 use std::io::Cursor;
+use tracing::debug;
 
 pub trait AsSFT {
     fn as_sft(&self) -> SFT;

--- a/crates/rooch/src/commands/indexer/commands/bench.rs
+++ b/crates/rooch/src/commands/indexer/commands/bench.rs
@@ -52,7 +52,7 @@ impl BenchCommand {
         let start_time = Instant::now();
         let (indexer_store, indexer_reader) =
             init_indexer(self.base_data_dir.clone(), self.chain_id.clone()).unwrap();
-        log::info!("indexer bench started");
+        tracing::info!("indexer bench started");
         (indexer_store, indexer_reader, start_time)
     }
 
@@ -88,7 +88,7 @@ impl BenchCommand {
         )?;
         let tx_order = query_object_states[0].1.tx_order;
         let mut state_index = query_object_states[0].1.state_index;
-        log::info!(
+        tracing::info!(
             "bench start for tx_order: {}, state_index: {}. init query cost: {:?}",
             tx_order,
             state_index,

--- a/crates/rooch/src/commands/indexer/commands/rebuild.rs
+++ b/crates/rooch/src/commands/indexer/commands/rebuild.rs
@@ -73,7 +73,7 @@ impl RebuildCommand {
         let start_time = Instant::now();
         let (indexer_store, indexer_reader) =
             init_indexer(self.base_data_dir.clone(), self.chain_id.clone()).unwrap();
-        log::info!("indexer rebuild started");
+        tracing::info!("indexer rebuild started");
         (indexer_store, indexer_reader, start_time)
     }
 }

--- a/crates/rooch/src/commands/statedb/commands/export.rs
+++ b/crates/rooch/src/commands/statedb/commands/export.rs
@@ -267,7 +267,7 @@ impl ExportCommand {
         }
 
         writer.flush()?;
-        log::info!("Done in {:?}.", start_time.elapsed(),);
+        tracing::info!("Done in {:?}.", start_time.elapsed(),);
         Ok(())
     }
 

--- a/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_ord.rs
@@ -185,7 +185,7 @@ pub(crate) fn apply_inscription_updates(
             apply_nodes_cost,
         );
 
-        log::debug!(
+        tracing::debug!(
             "last inscription_store_state_root: {:?}, new inscription_store_state_root: {:?}",
             last_inscription_store_state_root,
             inscription_store_state_root,

--- a/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_utxo.rs
@@ -234,7 +234,7 @@ pub(crate) fn apply_address_updates(
             gen_nodes_cost, apply_nodes_cost
         );
 
-        log::debug!(
+        tracing::debug!(
             "last_rooch_to_bitcoin_address_mapping_state_root: {:?}, new rooch_to_bitcoin_address_mapping_state_root: {:?}",
             last_rooch_to_bitcoin_address_mapping_state_root,rooch_to_bitcoin_address_mapping_state_root
         );
@@ -291,7 +291,7 @@ pub(crate) fn apply_utxo_updates(
             apply_nodes_cost
         );
 
-        log::debug!(
+        tracing::debug!(
             "last_utxo_store_state_root: {:?}, new utxo_store_state_root: {:?}",
             last_utxo_store_state_root,
             utxo_store_state_root,

--- a/crates/rooch/src/commands/statedb/commands/genesis_verify.rs
+++ b/crates/rooch/src/commands/statedb/commands/genesis_verify.rs
@@ -201,7 +201,7 @@ impl UTXOFilter {
         outpoint_inscriptions_map: Option<Arc<OutpointInscriptionsMap>>,
     ) -> UTXOFilter {
         let start_time = Instant::now();
-        log::info!("start building utxo & address filter");
+        tracing::info!("start building utxo & address filter");
 
         let mut reader = BufReader::with_capacity(8 * 1024 * 1024, File::open(input).unwrap());
         let mut is_title_line = true;

--- a/crates/rooch/src/commands/statedb/commands/mod.rs
+++ b/crates/rooch/src/commands/statedb/commands/mod.rs
@@ -69,9 +69,9 @@ fn init_job(
         .latest_root()
         .unwrap()
         .expect("statedb is empty, genesis must be initialed.");
-    log::info!("original root object: {:?}", root);
+    tracing::info!("original root object: {:?}", root);
 
-    log::info!("job progress started");
+    tracing::info!("job progress started");
 
     (root, rooch_db.moveos_store, start_time)
 }
@@ -337,7 +337,7 @@ impl OutpointInscriptionsMap {
         let start_time = Instant::now();
         let map_existed = path.exists();
         if map_existed {
-            log::info!("load outpoint_inscriptions_map...");
+            tracing::info!("load outpoint_inscriptions_map...");
             let outpoint_inscriptions_map = OutpointInscriptionsMap::load(path.clone());
             let (outpoint_count, inscription_count) = outpoint_inscriptions_map.stats();
             println!(
@@ -348,7 +348,7 @@ impl OutpointInscriptionsMap {
             );
             outpoint_inscriptions_map
         } else {
-            log::info!("indexing and dumping outpoint_inscriptions_map...");
+            tracing::info!("indexing and dumping outpoint_inscriptions_map...");
             let (outpoint_inscriptions_map, mapped_outpoint, mapped_inscription, unbound_count) =
                 OutpointInscriptionsMap::index_and_dump(
                     inscriptions_path.clone().expect("if outpoint_inscriptions_map not existed, inscriptions_path must be provided"),

--- a/crates/rooch/src/commands/statedb/commands/re_genesis.rs
+++ b/crates/rooch/src/commands/statedb/commands/re_genesis.rs
@@ -111,7 +111,7 @@ impl ReGenesisCommand {
         }
         writer.flush().unwrap();
 
-        log::info!("Export {} success", outputed.join(", "));
+        tracing::info!("Export {} success", outputed.join(", "));
     }
 
     fn remove(&self) {
@@ -133,7 +133,7 @@ impl ReGenesisCommand {
             .join(chain_network_name)
             .join("roochdb/indexer");
         std::fs::remove_dir_all(indexer_dir).unwrap();
-        log::info!("Remove genesis info, startup info and sequencer info success");
+        tracing::info!("Remove genesis info, startup info and sequencer info success");
     }
 
     fn restore(&self) {
@@ -161,6 +161,6 @@ impl ReGenesisCommand {
             .save_sequencer_info(sequencer_info)
             .unwrap();
 
-        log::info!("Restore genesis info, startup info and sequencer info success");
+        tracing::info!("Restore genesis info, startup info and sequencer info success");
     }
 }

--- a/frameworks/moveos-stdlib/Cargo.toml
+++ b/frameworks/moveos-stdlib/Cargo.toml
@@ -17,7 +17,6 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 better_any = { workspace = true }
 fastcrypto = { workspace = true }
-log = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }
 itertools = { workspace = true }
@@ -31,6 +30,7 @@ revm-precompile = { workspace = true }
 revm-primitives = { workspace = true }
 ripemd = { workspace = true }
 fastcrypto-zkp = { workspace = true }
+tracing = { workspace = true }
 
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }

--- a/frameworks/moveos-stdlib/src/natives/helpers.rs
+++ b/frameworks/moveos-stdlib/src/natives/helpers.rs
@@ -38,7 +38,7 @@ where
             if cfg!(debug_assertions) {
                 match &result {
                     Err(err) => {
-                        log::debug!("Error in native function: {:?}", err);
+                        tracing::debug!("Error in native function: {:?}", err);
                     }
                     Ok(res) => match res {
                         NativeResult::Success {
@@ -46,14 +46,14 @@ where
                             ret_vals: _,
                         } => {}
                         NativeResult::Abort { cost, abort_code } => {
-                            log::debug!(
+                            tracing::debug!(
                                 "Abort in native function: cost: {:?}, abort_code: {:?}",
                                 cost,
                                 abort_code
                             );
                         }
                         NativeResult::OutOfGas { partial_cost } => {
-                            log::debug!(
+                            tracing::debug!(
                                 "OutOfGas in native function: partial_cost: {:?}",
                                 partial_cost
                             );
@@ -68,7 +68,7 @@ where
                 match vm_status.keep_or_discard() {
                     Ok(_) => result,
                     Err(_) => {
-                        log::error!("{}", error_message);
+                        tracing::error!("{}", error_message);
                         Err(PartialVMError::new(StatusCode::ABORTED)
                             .with_sub_status(E_NATIVE_FUNCTION_PANIC)
                             .with_message(error_message))

--- a/frameworks/moveos-stdlib/src/natives/moveos_stdlib/cbor.rs
+++ b/frameworks/moveos-stdlib/src/natives/moveos_stdlib/cbor.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use ciborium::de::from_reader;
 use ciborium::ser::into_writer;
 use ciborium::value::Value as CborValue;
-use log::debug;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::gas_algebra::{InternalGas, InternalGasPerByte, NumBytes};
@@ -23,6 +22,7 @@ use move_vm_types::{
     pop_arg,
     values::{values_impl::Reference, Struct, Value as MoveValue, Vector},
 };
+use tracing::debug;
 
 use move_core_types::u256::{self, U256_NUM_BYTES};
 use moveos_types::addresses::MOVE_STD_ADDRESS;

--- a/frameworks/moveos-stdlib/src/natives/moveos_stdlib/event.rs
+++ b/frameworks/moveos-stdlib/src/natives/moveos_stdlib/event.rs
@@ -76,8 +76,8 @@ pub fn native_emit(
             ty
         ))
     })?;
-    if log::log_enabled!(log::Level::Trace) {
-        log::trace!("Emitting event {}, {:?}", struct_tag, msg);
+    if tracing::enabled!(tracing::Level::TRACE) {
+        tracing::trace!("Emitting event {}, {:?}", struct_tag, msg);
     }
     let event_data = msg
         .simple_serialize(&layout)

--- a/frameworks/moveos-stdlib/src/natives/moveos_stdlib/json.rs
+++ b/frameworks/moveos-stdlib/src/natives/moveos_stdlib/json.rs
@@ -5,12 +5,12 @@ use std::collections::VecDeque;
 use std::str::FromStr;
 
 use anyhow::Result;
-use log::debug;
 use primitive_types::U128 as PrimitiveU128;
 use primitive_types::U256 as PrimitiveU256;
 use serde_json;
 use serde_json::Value as JsonValue;
 use smallvec::smallvec;
+use tracing::debug;
 
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::account_address::AccountAddress;

--- a/frameworks/moveos-stdlib/src/natives/moveos_stdlib/move_module.rs
+++ b/frameworks/moveos-stdlib/src/natives/moveos_stdlib/move_module.rs
@@ -172,7 +172,7 @@ fn native_sort_and_verify_modules_inner(
     match verify_result {
         Ok(_) => {}
         Err(e) => {
-            log::info!("modules verification error: {:?}", e);
+            tracing::info!("modules verification error: {:?}", e);
             let error_code = e.sub_status().unwrap_or(E_MODULE_VERIFICATION_ERROR);
             return Ok(NativeResult::err(cost, error_code));
         }
@@ -191,7 +191,7 @@ fn native_sort_and_verify_modules_inner(
     match verify_result {
         Ok(_) => {}
         Err(e) => {
-            log::info!("modules verification error: {:?}", e);
+            tracing::info!("modules verification error: {:?}", e);
             return Ok(NativeResult::err(cost, E_MODULE_VERIFICATION_ERROR));
         }
     }
@@ -212,7 +212,7 @@ fn native_sort_and_verify_modules_inner(
             }
             Err(e) => {
                 //TODO provide a flag to control whether to print debug log.
-                log::info!("module {} verification error: {:?}", module.self_id(), e);
+                tracing::info!("module {} verification error: {:?}", module.self_id(), e);
                 return Ok(NativeResult::err(cost, E_MODULE_VERIFICATION_ERROR));
             }
         }

--- a/frameworks/moveos-stdlib/src/natives/moveos_stdlib/object/mod.rs
+++ b/frameworks/moveos-stdlib/src/natives/moveos_stdlib/object/mod.rs
@@ -52,8 +52,8 @@ impl CommonGasParameters {
 pub(crate) fn pop_object_id(args: &mut VecDeque<Value>) -> PartialVMResult<ObjectID> {
     let handle = args.pop_back().unwrap();
     ObjectID::from_runtime_value(handle).map_err(|e| {
-        if log::log_enabled!(log::Level::Debug) {
-            log::warn!("[ObjectRuntime] get_object_id: {:?}", e);
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            tracing::warn!("[ObjectRuntime] get_object_id: {:?}", e);
         }
         PartialVMError::new(StatusCode::TYPE_RESOLUTION_FAILURE).with_message(e.to_string())
     })
@@ -67,7 +67,7 @@ pub(crate) fn read_object_id(value: &Value) -> PartialVMResult<ObjectID> {
 }
 
 pub(crate) fn partial_extension_error(msg: impl ToString) -> PartialVMError {
-    log::debug!("PartialVMError: {}", msg.to_string());
+    tracing::debug!("PartialVMError: {}", msg.to_string());
     PartialVMError::new(StatusCode::VM_EXTENSION_ERROR).with_message(msg.to_string())
 }
 
@@ -82,8 +82,8 @@ pub(crate) fn error_to_abort_code(err: PartialVMError) -> u64 {
         StatusCode::ABORTED => err.sub_status().unwrap_or(ERROR_OBJECT_RUNTIME_ERROR),
         _ => ERROR_OBJECT_RUNTIME_ERROR,
     };
-    if log::log_enabled!(log::Level::Debug) {
-        log::warn!(
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        tracing::warn!(
             "[ObjectRuntime] error err: {:?}, abort: {}",
             err,
             abort_code

--- a/frameworks/moveos-stdlib/src/natives/moveos_stdlib/rlp.rs
+++ b/frameworks/moveos-stdlib/src/natives/moveos_stdlib/rlp.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::natives::helpers;
-use log::info;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::gas_algebra::{InternalGas, InternalGasPerByte, NumBytes};
@@ -21,6 +20,7 @@ use primitive_types::U256 as PrimitiveU256;
 use rlp::{self, Rlp, RlpStream};
 use smallvec::smallvec;
 use std::{collections::VecDeque, sync::Arc};
+use tracing::info;
 
 use crate::natives::helpers::make_module_natives;
 

--- a/frameworks/rooch-nursery/Cargo.toml
+++ b/frameworks/rooch-nursery/Cargo.toml
@@ -15,13 +15,13 @@ rust-version = { workspace = true }
 
 [dependencies]
 smallvec = { workspace = true }
-log = { workspace = true }
 serde_json = { workspace = true }
 ciborium = { workspace = true }
 wasmer = { workspace = true }
 cosmwasm-vm = { workspace = true }
 cosmwasm-std = { workspace = true }
 once_cell = { workspace = true }
+tracing = { workspace = true }
 
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }

--- a/frameworks/rooch-nursery/src/natives/cosmwasm_vm.rs
+++ b/frameworks/rooch-nursery/src/natives/cosmwasm_vm.rs
@@ -1,10 +1,10 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use log::error;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::vec;
+use tracing::error;
 
 use cosmwasm_std::Checksum;
 use cosmwasm_vm::{

--- a/frameworks/rooch-nursery/src/natives/helper.rs
+++ b/frameworks/rooch-nursery/src/natives/helper.rs
@@ -46,8 +46,8 @@ impl CommonGasParametersOption {
 pub(crate) fn pop_object_id(args: &mut VecDeque<Value>) -> PartialVMResult<ObjectID> {
     let handle = args.pop_back().unwrap();
     ObjectID::from_runtime_value(handle).map_err(|e| {
-        if log::log_enabled!(log::Level::Debug) {
-            log::warn!("[ObjectRuntime] get_object_id: {:?}", e);
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            tracing::warn!("[ObjectRuntime] get_object_id: {:?}", e);
         }
         PartialVMError::new(StatusCode::TYPE_RESOLUTION_FAILURE).with_message(e.to_string())
     })

--- a/frameworks/rooch-nursery/src/natives/wasm.rs
+++ b/frameworks/rooch-nursery/src/natives/wasm.rs
@@ -1,7 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use log::{debug, warn};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::gas_algebra::{InternalGas, InternalGasPerByte, NumBytes};
 use move_core_types::vm_status::StatusCode;
@@ -16,6 +15,7 @@ use std::collections::VecDeque;
 use std::ffi::CString;
 use std::ops::Deref;
 use std::vec;
+use tracing::{debug, warn};
 
 use moveos_wasm::wasm::{
     create_wasm_instance, get_instance_pool, insert_wasm_instance, put_data_on_stack,
@@ -164,7 +164,7 @@ fn native_create_cbor_values(
     }
 
     let mint_args_array = JSONValue::Array(mint_args_json);
-    log::debug!(
+    tracing::debug!(
         "native_create_cbor_values -> mint_args_array {:?}",
         mint_args_array
     );
@@ -180,7 +180,7 @@ fn native_create_cbor_values(
         Ok(v) => v,
         Err(_) => return build_err(gas_params.base, E_CBOR_UNMARSHAL_FAILED),
     };
-    log::debug!(
+    tracing::debug!(
         "native_create_cbor_values -> mint_args_array {:?}",
         cbor_value
     );
@@ -516,7 +516,7 @@ fn execute_wasm_function_inner(
                                 "execute_wasm_function_inner->calling_function_error:{}",
                                 err.message()
                             );
-                            if log::log_enabled!(log::Level::Debug) {
+                            if tracing::enabled!(tracing::Level::DEBUG) {
                                 debug!("trace:{:?}", err.trace());
                             }
                             Ok(NativeResult::err(

--- a/moveos/metrics/Cargo.toml
+++ b/moveos/metrics/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = { workspace = true }
 [dependencies]
 axum = { workspace = true }
 axum-server = { workspace = true }
-tracing = { workspace = true }
 scopeguard = { workspace = true }
 prometheus = { workspace = true }
 once_cell = { workspace = true }
@@ -28,3 +27,4 @@ futures = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 protobuf = { workspace = true }
+tracing = { workspace = true }

--- a/moveos/moveos-commons/accumulator/Cargo.toml
+++ b/moveos/moveos-commons/accumulator/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 itertools = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 lru = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }

--- a/moveos/moveos-commons/accumulator/src/tree.rs
+++ b/moveos/moveos-commons/accumulator/src/tree.rs
@@ -384,7 +384,7 @@ impl AccumulatorTree {
         let cache = &mut self.index_cache;
         for node in nodes {
             if let Some(old) = cache.put(node.index(), node.hash()) {
-                log::trace!("cache exist node hash: {}-{:?}-{:?}", id, node.index(), old);
+                tracing::trace!("cache exist node hash: {}-{:?}-{:?}", id, node.index(), old);
             }
         }
     }

--- a/moveos/moveos-commons/moveos-common/Cargo.toml
+++ b/moveos/moveos-commons/moveos-common/Cargo.toml
@@ -17,9 +17,9 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 bcs = { workspace = true }
-log = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
+tracing = { workspace = true }
 
 move-core-types = { workspace = true }
 move-binary-format = { workspace = true }

--- a/moveos/moveos-commons/moveos-common/src/utils.rs
+++ b/moveos/moveos-commons/moveos-common/src/utils.rs
@@ -75,7 +75,7 @@ pub fn check_open_fds_limit(max_files: u64) -> Result<(), Error> {
             fd_limit.rlim_max = max_files;
         }
         err = libc::setrlimit(libc::RLIMIT_NOFILE, &fd_limit);
-        log::info!("set max open fds {}", max_files);
+        tracing::info!("set max open fds {}", max_files);
         if err == 0 {
             return Ok(());
         }

--- a/moveos/moveos-eventbus/Cargo.toml
+++ b/moveos/moveos-eventbus/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-log = { workspace = true }
 crossbeam-channel = { workspace = true }
 coerce = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/moveos/moveos-eventbus/src/bus.rs
+++ b/moveos/moveos-eventbus/src/bus.rs
@@ -94,7 +94,7 @@ impl EventBus {
             if let Some(event_senders) = senders.get(&event_type_id) {
                 for (subscriber, sender) in event_senders {
                     if sender.send(Box::new(event_data.clone())).is_err() {
-                        log::error!(
+                        tracing::error!(
                             "Failed to send event '{:?}' to subscriber '{}'",
                             event_type_id,
                             subscriber
@@ -114,7 +114,7 @@ impl EventBus {
         };
         if let Some(event_callbacks) = callbacks.get(&event_type_id) {
             for (subscriber, callback) in event_callbacks {
-                log::debug!(
+                tracing::debug!(
                     "Executing callback for subscriber: '{}' on event: '{:?}'",
                     subscriber,
                     event_type_id
@@ -122,7 +122,7 @@ impl EventBus {
                 callback(Box::new(event_data.clone()));
             }
         } else {
-            log::debug!("No subscribers found for event: '{:?}'", event_type_id);
+            tracing::debug!("No subscribers found for event: '{:?}'", event_type_id);
         }
 
         let actors = match self.actors.read() {
@@ -135,7 +135,7 @@ impl EventBus {
         };
         if let Some(actors_map) = actors.get(&event_type_id) {
             for (subscriber, actor) in actors_map {
-                log::debug!(
+                tracing::debug!(
                     "Executing actor for subscriber: '{}' on event: '{:?}'",
                     subscriber,
                     event_type_id
@@ -171,21 +171,21 @@ impl EventBus {
                     if let Ok(event_data) = boxed_event.downcast::<T>() {
                         return Ok(Some(*event_data));
                     } else {
-                        log::error!(
+                        tracing::error!(
                             "Failed to downcast event data for subscriber: '{}'",
                             subscriber
                         );
                     }
                 }
             } else {
-                log::debug!(
+                tracing::debug!(
                     "Subscriber: '{}' is not registered for event: '{:?}'",
                     subscriber,
                     event_type_id
                 );
             }
         } else {
-            log::debug!("No event '{:?}' found in the system", event_type_id);
+            tracing::debug!("No event '{:?}' found in the system", event_type_id);
         }
         Ok(None)
     }
@@ -224,7 +224,7 @@ impl EventBus {
             event_receivers.insert(subscriber.to_string(), receiver);
         }
 
-        log::debug!(
+        tracing::debug!(
             "Registered subscriber: '{}' for event: '{:?}'",
             subscriber,
             event_type_id
@@ -253,7 +253,7 @@ impl EventBus {
         let event_callbacks = callbacks.entry(event_type_id).or_default();
         event_callbacks.insert(subscriber.to_string(), Box::new(callback));
 
-        log::debug!(
+        tracing::debug!(
             "Subscriber '{}' registered callback for event '{:?}'",
             subscriber,
             event_type_id
@@ -294,13 +294,13 @@ impl EventBus {
         };
 
         for (event_type_id, subscribers) in senders.iter() {
-            log::debug!(
+            tracing::debug!(
                 "Event: '{:?}', Subscribers: {}",
                 event_type_id,
                 subscribers.len()
             );
             for subscriber in subscribers.keys() {
-                log::debug!("  - Subscriber: '{}'", subscriber);
+                tracing::debug!("  - Subscriber: '{}'", subscriber);
             }
         }
         Ok(())
@@ -321,7 +321,7 @@ impl EventBus {
 
             if let Some(event_senders) = senders.get_mut(&event_type_id) {
                 event_senders.remove(subscriber);
-                log::debug!(
+                tracing::debug!(
                     "Removed sender for subscriber: '{}' from event: '{:?}'",
                     subscriber,
                     event_type_id
@@ -341,7 +341,7 @@ impl EventBus {
 
             if let Some(event_receivers) = receivers.get_mut(&event_type_id) {
                 event_receivers.remove(subscriber);
-                log::debug!(
+                tracing::debug!(
                     "Removed receiver for subscriber: '{}' from event: '{:?}'",
                     subscriber,
                     event_type_id
@@ -361,7 +361,7 @@ impl EventBus {
 
             if let Some(event_callbacks) = callbacks.get_mut(&event_type_id) {
                 event_callbacks.remove(subscriber);
-                log::debug!(
+                tracing::debug!(
                     "Removed callback for subscriber: '{}' from event: '{:?}'",
                     subscriber,
                     event_type_id
@@ -404,7 +404,7 @@ impl EventBus {
         senders.clear();
         receivers.clear();
         callbacks.clear();
-        log::debug!("Cleared all events and subscribers.");
+        tracing::debug!("Cleared all events and subscribers.");
 
         Ok(())
     }

--- a/moveos/moveos-object-runtime/Cargo.toml
+++ b/moveos/moveos-object-runtime/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = { workspace = true }
 
 [dependencies]
 better_any = { workspace = true }
-log = { workspace = true }
 tracing = { workspace = true }
 hex = { workspace = true }
 parking_lot = { workspace = true }

--- a/moveos/moveos-object-runtime/src/runtime.rs
+++ b/moveos/moveos-object-runtime/src/runtime.rs
@@ -127,7 +127,7 @@ impl<'r> ObjectRuntime<'r> {
         root: ObjectMeta,
         resolver: &'r dyn StatelessResolver,
     ) -> Self {
-        if log::log_enabled!(log::Level::Trace) {
+        if tracing::enabled!(tracing::Level::TRACE) {
             tracing::trace!(
                 "Init ObjectRuntime with tx_hash: {:?}, state_root: {}",
                 tx_context.tx_hash(),
@@ -515,7 +515,7 @@ impl<'r> ObjectRuntime<'r> {
 }
 
 pub(crate) fn partial_extension_error(msg: impl ToString) -> PartialVMError {
-    log::debug!("PartialVMError: {}", msg.to_string());
+    tracing::debug!("PartialVMError: {}", msg.to_string());
     PartialVMError::new(StatusCode::VM_EXTENSION_ERROR).with_message(msg.to_string())
 }
 

--- a/moveos/moveos-object-runtime/src/runtime_object.rs
+++ b/moveos/moveos-object-runtime/src/runtime_object.rs
@@ -346,7 +346,7 @@ impl RuntimeObject {
                     //We need to change the Object owner to system
                     if !matches!(&value_change, Some(Op::Delete)) {
                         rt_meta.to_system_owner()?;
-                        if log::log_enabled!(log::Level::Trace) {
+                        if tracing::enabled!(tracing::Level::TRACE) {
                             tracing::trace!(
                                 object_id = tracing::field::display(&object_id),
                                 op = "embeded",
@@ -536,7 +536,7 @@ impl RuntimeObject {
         tv.move_to(value, value_type.clone(), value_layout)?;
         let object_pointer = tv.take_object(Some(&value_type))?;
         self.rt_meta.increase_size()?;
-        if log::log_enabled!(log::Level::Trace) {
+        if tracing::enabled!(tracing::Level::TRACE) {
             tracing::trace!(
                 object_id = tracing::field::display(&self.rt_meta.id()),
                 op = "add_field",
@@ -559,7 +559,7 @@ impl RuntimeObject {
         let (tv, field_load_gas) = self.load_field(layout_loader, resolver, field_key)?;
         let value = tv.move_from(Some(&expect_value_type))?;
         self.rt_meta.decrease_size()?;
-        if log::log_enabled!(log::Level::Trace) {
+        if tracing::enabled!(tracing::Level::TRACE) {
             tracing::trace!(
                 object_id = tracing::field::display(self.rt_meta.id()),
                 op = "remove_field",

--- a/moveos/moveos-object-runtime/src/runtime_object_meta.rs
+++ b/moveos/moveos-object-runtime/src/runtime_object_meta.rs
@@ -192,7 +192,7 @@ impl RuntimeObjectMeta {
         match meta.size.checked_add(1) {
             Some(size) => {
                 meta.size = size;
-                if log::log_enabled!(log::Level::Trace) {
+                if tracing::enabled!(tracing::Level::TRACE) {
                     tracing::trace!(
                         object_id = tracing::field::display(&meta.id),
                         op = "increase_size",
@@ -216,7 +216,7 @@ impl RuntimeObjectMeta {
         match meta.size.checked_sub(1) {
             Some(size) => {
                 meta.size = size;
-                if log::log_enabled!(log::Level::Trace) {
+                if tracing::enabled!(tracing::Level::TRACE) {
                     tracing::trace!(
                         object_id = tracing::field::display(&meta.id),
                         op = "decrease_size",

--- a/moveos/moveos-store/Cargo.toml
+++ b/moveos/moveos-store/Cargo.toml
@@ -20,10 +20,10 @@ smt = { workspace = true }
 once_cell = { workspace = true }
 chrono = { workspace = true }
 rand = { workspace = true }
-log = { workspace = true }
 prometheus = { workspace = true }
 tokio = { workspace = true }
 function_name = { workspace = true }
+tracing = { workspace = true }
 
 move-core-types = { workspace = true }
 

--- a/moveos/moveos-store/src/lib.rs
+++ b/moveos/moveos-store/src/lib.rs
@@ -180,8 +180,8 @@ impl MoveOSStore {
         // config_store updates
         let new_startup_info = StartupInfo::new(new_state_root, size);
 
-        if log::log_enabled!(log::Level::Debug) {
-            log::debug!(
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            tracing::debug!(
                 "handle_tx_output: tx_hash: {}, state_root: {}, size: {}, gas_used: {}, status: {:?}",
                 tx_hash,
                 new_state_root,

--- a/moveos/moveos-store/src/state_store/statedb.rs
+++ b/moveos/moveos-store/src/state_store/statedb.rs
@@ -54,8 +54,8 @@ impl StateDBStore {
             .with_label_values(&[fn_name])
             .start_timer();
         let change_set = self.smt.puts(pre_state_root, update_set)?;
-        if log::log_enabled!(log::Level::Trace) {
-            log::trace!(
+        if tracing::enabled!(tracing::Level::TRACE) {
+            tracing::trace!(
                 "update_fields pre_state_root: {}, new_state_root: {}",
                 pre_state_root,
                 change_set.state_root,
@@ -173,8 +173,8 @@ impl StateDBStore {
         let mut tree_change_set = self.update_fields(pre_state_root, update_set)?;
         let new_state_root = tree_change_set.state_root;
         nodes.append(&mut tree_change_set.nodes);
-        if log::log_enabled!(log::Level::Debug) {
-            log::debug!(
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            tracing::debug!(
                 "apply_change_set new_state_root: {:?}, smt nodes: {}, new_global_size: {}",
                 new_state_root,
                 nodes.len(),
@@ -226,12 +226,12 @@ impl StatelessResolver for StateDBStore {
             return Ok(None);
         }
         let result = self.smt.get(state_root, *key)?;
-        if log::log_enabled!(log::Level::Trace) {
+        if tracing::enabled!(tracing::Level::TRACE) {
             let result_info = match &result {
                 Some(state) => format!("Some({})", state.metadata.object_type),
                 None => "None".to_string(),
             };
-            log::trace!(
+            tracing::trace!(
                 "get_field_at state_root: {} key: {}, result: {:?}",
                 state_root,
                 key,

--- a/moveos/moveos-verifier/Cargo.toml
+++ b/moveos/moveos-verifier/Cargo.toml
@@ -19,8 +19,8 @@ codespan-reporting = { workspace = true }
 termcolor = { workspace = true }
 bcs = { workspace = true }
 thiserror = { workspace = true }
-log = { workspace = true }
 itertools = { workspace = true }
+tracing = { workspace = true }
 
 move-core-types = { workspace = true }
 move-model = { workspace = true }

--- a/moveos/moveos-verifier/src/build.rs
+++ b/moveos/moveos-verifier/src/build.rs
@@ -348,20 +348,20 @@ pub fn inject_runtime_metadata<P: AsRef<Path>>(
             CompiledUnit::Module(named_module) => {
                 if let Some(module_metadata) = metadata.get(&named_module.module.self_id()) {
                     if !module_metadata.is_empty() {
-                        log::trace!(
+                        tracing::trace!(
                             "\n\nstart dump data structs map {:?}",
                             named_module.module.self_id().to_string()
                         );
                         for (k, v) in module_metadata.data_struct_map.iter() {
-                            log::trace!("{:?} -> {:?}", k, v);
+                            tracing::trace!("{:?} -> {:?}", k, v);
                         }
-                        log::trace!(
+                        tracing::trace!(
                             "start dump data structs map func {:?}\n\n",
                             named_module.module.self_id().to_string()
                         );
-                        log::trace!("\n");
+                        tracing::trace!("\n");
                         for (k, v) in module_metadata.data_struct_func_map.iter() {
-                            log::trace!("{:?} -> {:?}", k, v);
+                            tracing::trace!("{:?} -> {:?}", k, v);
                         }
 
                         let serialized_metadata =

--- a/moveos/moveos-verifier/src/metadata.rs
+++ b/moveos/moveos-verifier/src/metadata.rs
@@ -981,14 +981,14 @@ impl<'a> ExtendedChecker<'a> {
         }
 
         if !available_data_structs.is_empty() {
-            log::trace!(
+            tracing::trace!(
                 "\n\ncheck_data_struct() module {:?} data structs start...",
                 module_env.get_full_name_str()
             );
             for (k, v) in available_data_structs.iter() {
-                log::trace!("{:?} -> {:?}", k, v);
+                tracing::trace!("{:?} -> {:?}", k, v);
             }
-            log::trace!(
+            tracing::trace!(
                 "\n\ncheck_data_struct() module {:?} data structs end...",
                 module_env.get_full_name_str()
             );
@@ -1316,14 +1316,14 @@ fn check_data_struct_func(extended_checker: &mut ExtendedChecker, module_env: &M
         .collect();
 
     if !data_struct_func_map.is_empty() {
-        log::trace!(
+        tracing::trace!(
             "\n\ncheck_data_struct_func() module {:?} data structs func start...",
             module_env.get_full_name_str()
         );
         for (k, v) in data_struct_func_map.iter() {
-            log::trace!("{:?} -> {:?}", k, v);
+            tracing::trace!("{:?} -> {:?}", k, v);
         }
-        log::trace!(
+        tracing::trace!(
             "\n\ncheck_data_struct_func() module {:?} data structs func end...",
             module_env.get_full_name_str()
         );
@@ -1371,7 +1371,7 @@ fn check_data_struct_func(extended_checker: &mut ExtendedChecker, module_env: &M
 
                 if let Some(data_struct_func_indicies) = data_struct_func_types {
                     let caller_fun_name = fun.get_full_name_str();
-                    log::trace!(
+                    tracing::trace!(
                         "function {:?}::{:?} call data_struct func {:?} with types {:?}",
                         module_env.self_address(),
                         caller_fun_name,

--- a/moveos/moveos/Cargo.toml
+++ b/moveos/moveos/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = { workspace = true }
 [dependencies]
 serde = { workspace = true }
 anyhow = { workspace = true }
-log = { workspace = true }
 once_cell = { workspace = true }
 clap = { workspace = true }
 rayon = { workspace = true }
@@ -26,6 +25,7 @@ codespan = { workspace = true }
 itertools = { workspace = true }
 regex = { workspace = true }
 parking_lot = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 move-binary-format = { workspace = true }

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -159,14 +159,14 @@ impl MoveOS {
         let mut session = self.vm.new_genesis_session(&resolver, ctx, genesis_objects);
 
         let verified_action = session.verify_move_action(action).map_err(|e| {
-            log::error!("verify_genesis_tx error:{:?}", e);
+            tracing::error!("verify_genesis_tx error:{:?}", e);
             e
         })?;
 
         // execute main tx
         let execute_result = session.execute_move_action(verified_action);
         if let Some(vm_error) = execute_result.clone().err() {
-            log::error!("execute_genesis_tx vm_error:{:?}", vm_error,);
+            tracing::error!("execute_genesis_tx vm_error:{:?}", vm_error,);
         }
         let status = match vm_status_of_result(execute_result.clone()).keep_or_discard() {
             Ok(status) => status,
@@ -191,8 +191,8 @@ impl MoveOS {
             }
         }
 
-        if log::log_enabled!(log::Level::Trace) {
-            log::trace!("load_cost_table from db");
+        if tracing::enabled!(tracing::Level::TRACE) {
+            tracing::trace!("load_cost_table from db");
         }
         let resolver = RootObjectResolver::new(root.clone(), &self.db);
         let gas_entries = get_gas_schedule_entries(&resolver).map_err(|e| {
@@ -206,7 +206,7 @@ impl MoveOS {
                 w.replace(cost_table.clone());
             }
             None => {
-                log::warn!("load_cost_table try_write failed");
+                tracing::warn!("load_cost_table try_write failed");
             }
         }
         Ok(cost_table)
@@ -258,8 +258,8 @@ impl MoveOS {
     ) -> Result<(RawTransactionOutput, Option<VMErrorInfo>)> {
         let VerifiedMoveOSTransaction { root, ctx, action } = tx;
         let tx_hash = ctx.tx_hash();
-        if log::log_enabled!(log::Level::Debug) {
-            log::debug!(
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            tracing::debug!(
                 "execute tx(sender:{}, hash:{}, action:{})",
                 ctx.sender(),
                 tx_hash,
@@ -295,7 +295,7 @@ impl MoveOS {
             match session.execute_function_call(self.system_pre_execute_functions.clone(), false) {
                 Ok(_) => {}
                 Err(error) => {
-                    log::warn!("System pre execution failed: {:?}", error);
+                    tracing::warn!("System pre execution failed: {:?}", error);
                     return Err(Error::from(VMPanicError::SystemCallPanicError(
                         format_err!("Execute System Pre call Panic {:?}", error),
                     )));
@@ -306,8 +306,8 @@ impl MoveOS {
         match self.execute_action(&mut session, action.clone()) {
             Ok(_) => {
                 let status = VMStatus::Executed;
-                if log::log_enabled!(log::Level::Debug) {
-                    log::debug!(
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    tracing::debug!(
                         "execute_action ok tx(hash:{}) vm_status:{:?}",
                         tx_hash,
                         status
@@ -316,8 +316,8 @@ impl MoveOS {
                 self.execution_cleanup(is_system_call, session, status, None)
             }
             Err(vm_err) => {
-                if log::log_enabled!(log::Level::Warn) {
-                    log::warn!(
+                if tracing::enabled!(tracing::Level::WARN) {
+                    tracing::warn!(
                         "execute_action error tx(hash:{}) vm_err:{:?} need respawn session.",
                         tx_hash,
                         vm_err
@@ -422,8 +422,8 @@ impl MoveOS {
                 }
             }
             Err(e) => {
-                if log::log_enabled!(log::Level::Debug) {
-                    log::warn!("execute_readonly_function error:{:?}", e);
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    tracing::warn!("execute_readonly_function error:{:?}", e);
                 }
                 FunctionResult::err(e)
             }
@@ -452,7 +452,7 @@ impl MoveOS {
             Ok(kept_status) => {
                 if is_system_call && kept_status != KeptVMStatus::Executed {
                     // system call should always success
-                    log::warn!("System call failed: {:?}", kept_status);
+                    tracing::warn!("System call failed: {:?}", kept_status);
                     return Err(Error::from(VMPanicError::SystemCallPanicError(
                         format_err!("Execute system call with Panic {:?}", vm_error_info),
                     )));
@@ -462,7 +462,7 @@ impl MoveOS {
             }
             Err(discard_status) => {
                 //This should not happen, if it happens, it means that the VM or verifer has a bug
-                log::warn!("Discard status: {:?}", discard_status);
+                tracing::warn!("Discard status: {:?}", discard_status);
                 return Err(Error::from(VMPanicError::VerifierPanicError(format_err!(
                     "Execute Action with Panic {:?}",
                     vm_error_info
@@ -498,7 +498,7 @@ impl MoveOS {
         let mut gas_upgrade = false;
         let gas_schedule_updated = session.tx_context().get::<GasScheduleUpdated>()?;
         if let Some(_updated) = gas_schedule_updated {
-            log::info!("Gas schedule updated");
+            tracing::info!("Gas schedule updated");
             gas_upgrade = true;
             self.cost_table.write().take();
         }

--- a/moveos/moveos/src/vm/data_cache.rs
+++ b/moveos/moveos/src/vm/data_cache.rs
@@ -109,8 +109,8 @@ impl<'r, 'l, S: MoveOSResolver> TransactionCache for MoveosDataCache<'r, 'l, S> 
             .get_loaded_module(module_id)
             .and_then(|module| match module {
                 Some(move_module) => {
-                    if log::log_enabled!(log::Level::Trace) {
-                        log::trace!("Loaded module {:?} from ObjectRuntime", module_id);
+                    if tracing::enabled!(tracing::Level::TRACE) {
+                        tracing::trace!("Loaded module {:?} from ObjectRuntime", module_id);
                     }
                     Ok(Some(move_module.byte_codes))
                 }
@@ -133,8 +133,8 @@ impl<'r, 'l, S: MoveOSResolver> TransactionCache for MoveosDataCache<'r, 'l, S> 
                     .finish(Location::Undefined))
             }
             Err(err) => {
-                if log::log_enabled!(log::Level::Debug) {
-                    log::warn!("Error loading module {:?}: {:?}", module_id, err);
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    tracing::warn!("Error loading module {:?}: {:?}", module_id, err);
                 }
                 Err(err.finish(Location::Undefined))
             }

--- a/moveos/moveos/src/vm/moveos_vm.rs
+++ b/moveos/moveos/src/vm/moveos_vm.rs
@@ -550,8 +550,8 @@ where
         for module_id in init_function_modules {
             let function_id = FunctionId::new(module_id.clone(), INIT_FN_NAME_IDENTIFIER.clone());
             let call = FunctionCall::new(function_id, vec![], vec![]);
-            if log::log_enabled!(log::Level::Trace) {
-                log::trace!(
+            if tracing::enabled!(tracing::Level::TRACE) {
+                tracing::trace!(
                     "Execute init function for module: {:?}",
                     module_id.to_string()
                 );

--- a/moveos/smt/Cargo.toml
+++ b/moveos/smt/Cargo.toml
@@ -23,7 +23,6 @@ byteorder = { workspace = true }
 bitcoin_hashes = { workspace = true }
 function_name = { workspace = true }
 hex = { workspace = true }
-log = { workspace = true }
 metrics = { workspace = true }
 more-asserts = { workspace = true }
 num-derive = { workspace = true }
@@ -35,6 +34,7 @@ parking_lot = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 proptest = { optional = true, workspace = true }
 proptest-derive = { optional = true, workspace = true }

--- a/moveos/smt/src/jellyfish_merkle/mod.rs
+++ b/moveos/smt/src/jellyfish_merkle/mod.rs
@@ -92,13 +92,13 @@ use crate::{Key, SMTObject, Value};
 use anyhow::{bail, ensure, format_err, Result};
 use backtrace::Backtrace;
 use hash::{Hash, SMTHash, SMTNodeHash};
-use log::debug;
 use nibble_path::{skip_common_prefix, NibbleIterator, NibblePath};
 use node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey};
 use primitive_types::H256;
 use proof::{SparseMerkleProof, SparseMerkleRangeProof};
 use std::collections::{BTreeMap, BTreeSet};
 use std::marker::PhantomData;
+use tracing::debug;
 use tree_cache::TreeCache;
 
 /// The hardcoded maximum height of a [`JellyfishMerkleTree`] in nibbles.


### PR DESCRIPTION
## Summary

    Replaced the deprecated `log` crate with `tracing` for logging operations across multiple modules, ensuring consistency and utilizing modern logging capabilities.
    
- Closes #2810