### PR TITLE
fix(Cargo.lock): bump bitcoin-client version to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",


### PR DESCRIPTION
## Summary

fix:

```
 Notice: Git status is dirty
  xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
  Notice:   File: Cargo.lock
  ::endgroup
```

in https://github.com/rooch-network/rooch/actions/runs/12041865458/job/33574520713