### PR TITLE
[bitcoin_move] process Babylon protocol when processing Bitcoin transactions

### DIFF
--- a/frameworks/bitcoin-move/doc/README.md
+++ b/frameworks/bitcoin-move/doc/README.md
@@ -13,6 +13,7 @@ This is the reference documentation of the Bitcoin Move Framework.
 
 
 -  [`0x4::bbn`](bbn.md#0x4_bbn)
+-  [`0x4::bbn_updater`](bbn_updater.md#0x4_bbn_updater)
 -  [`0x4::bitcoin`](bitcoin.md#0x4_bitcoin)
 -  [`0x4::bitcoin_hash`](bitcoin_hash.md#0x4_bitcoin_hash)
 -  [`0x4::bitcoin_multisign_validator`](bitcoin_multisign_validator.md#0x4_bitcoin_multisign_validator)

--- a/frameworks/bitcoin-move/doc/bbn.md
+++ b/frameworks/bitcoin-move/doc/bbn.md
@@ -14,6 +14,8 @@
 -  [Struct `BBNScriptPaths`](#0x4_bbn_BBNScriptPaths)
 -  [Struct `BBNStakingEvent`](#0x4_bbn_BBNStakingEvent)
 -  [Struct `BBNStakingFailedEvent`](#0x4_bbn_BBNStakingFailedEvent)
+-  [Struct `BBNStakingUnbondingEvent`](#0x4_bbn_BBNStakingUnbondingEvent)
+-  [Struct `TempStateDropEvent`](#0x4_bbn_TempStateDropEvent)
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x4_bbn_genesis_init)
 -  [Function `init_for_upgrade`](#0x4_bbn_init_for_upgrade)
@@ -22,6 +24,8 @@
 -  [Function `is_possible_bbn_transaction`](#0x4_bbn_is_possible_bbn_transaction)
 -  [Function `process_bbn_tx_entry`](#0x4_bbn_process_bbn_tx_entry)
 -  [Function `process_bbn_transaction`](#0x4_bbn_process_bbn_transaction)
+-  [Function `on_utxo_spend`](#0x4_bbn_on_utxo_spend)
+-  [Function `remove_bbn_seal`](#0x4_bbn_remove_bbn_seal)
 -  [Function `add_temp_state`](#0x4_bbn_add_temp_state)
 -  [Function `contains_temp_state`](#0x4_bbn_contains_temp_state)
 -  [Function `borrow_temp_state`](#0x4_bbn_borrow_temp_state)
@@ -45,6 +49,7 @@
 <b>use</b> <a href="">0x1::vector</a>;
 <b>use</b> <a href="">0x2::bcs</a>;
 <b>use</b> <a href="">0x2::event</a>;
+<b>use</b> <a href="">0x2::event_queue</a>;
 <b>use</b> <a href="">0x2::object</a>;
 <b>use</b> <a href="">0x2::result</a>;
 <b>use</b> <a href="">0x2::sort</a>;
@@ -155,6 +160,31 @@
 
 
 <pre><code><b>struct</b> <a href="bbn.md#0x4_bbn_BBNStakingFailedEvent">BBNStakingFailedEvent</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<a name="0x4_bbn_BBNStakingUnbondingEvent"></a>
+
+## Struct `BBNStakingUnbondingEvent`
+
+
+
+<pre><code><b>struct</b> <a href="bbn.md#0x4_bbn_BBNStakingUnbondingEvent">BBNStakingUnbondingEvent</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<a name="0x4_bbn_TempStateDropEvent"></a>
+
+## Struct `TempStateDropEvent`
+
+Event emitted when the temporary state of a BBNStakeSeal is dropped
+The temporary state is dropped when the UTXO is spent
+The event is onchain event, and the event_queue name is type_name of the temporary state
+
+
+<pre><code><b>struct</b> <a href="bbn.md#0x4_bbn_TempStateDropEvent">TempStateDropEvent</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -442,6 +472,28 @@ Use <code><a href="bbn_updater.md#0x4_bbn_updater_process_bbn_tx_entry">bbn_upda
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bbn.md#0x4_bbn_process_bbn_transaction">process_bbn_transaction</a>(block_height: u64, tx: &<a href="types.md#0x4_types_Transaction">types::Transaction</a>)
+</code></pre>
+
+
+
+<a name="0x4_bbn_on_utxo_spend"></a>
+
+## Function `on_utxo_spend`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bbn.md#0x4_bbn_on_utxo_spend">on_utxo_spend</a>(<a href="utxo.md#0x4_utxo">utxo</a>: &<b>mut</b> <a href="utxo.md#0x4_utxo_UTXO">utxo::UTXO</a>)
+</code></pre>
+
+
+
+<a name="0x4_bbn_remove_bbn_seal"></a>
+
+## Function `remove_bbn_seal`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bbn.md#0x4_bbn_remove_bbn_seal">remove_bbn_seal</a>(seal_obj_id: <a href="_ObjectID">object::ObjectID</a>)
 </code></pre>
 
 

--- a/frameworks/bitcoin-move/doc/bbn.md
+++ b/frameworks/bitcoin-move/doc/bbn.md
@@ -17,8 +17,11 @@
 -  [Constants](#@Constants_0)
 -  [Function `genesis_init`](#0x4_bbn_genesis_init)
 -  [Function `init_for_upgrade`](#0x4_bbn_init_for_upgrade)
+-  [Function `init_bbn_global_param_v2`](#0x4_bbn_init_bbn_global_param_v2)
 -  [Function `is_possible_bbn_tx`](#0x4_bbn_is_possible_bbn_tx)
+-  [Function `is_possible_bbn_transaction`](#0x4_bbn_is_possible_bbn_transaction)
 -  [Function `process_bbn_tx_entry`](#0x4_bbn_process_bbn_tx_entry)
+-  [Function `process_bbn_transaction`](#0x4_bbn_process_bbn_transaction)
 -  [Function `add_temp_state`](#0x4_bbn_add_temp_state)
 -  [Function `contains_temp_state`](#0x4_bbn_contains_temp_state)
 -  [Function `borrow_temp_state`](#0x4_bbn_borrow_temp_state)
@@ -34,6 +37,7 @@
 -  [Function `staking_time`](#0x4_bbn_staking_time)
 -  [Function `staking_value`](#0x4_bbn_staking_value)
 -  [Function `is_expired`](#0x4_bbn_is_expired)
+-  [Function `is_expired_at`](#0x4_bbn_is_expired_at)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -46,7 +50,6 @@
 <b>use</b> <a href="">0x2::sort</a>;
 <b>use</b> <a href="">0x2::type_info</a>;
 <b>use</b> <a href="">0x3::bitcoin_address</a>;
-<b>use</b> <a href="bitcoin.md#0x4_bitcoin">0x4::bitcoin</a>;
 <b>use</b> <a href="opcode.md#0x4_opcode">0x4::opcode</a>;
 <b>use</b> <a href="script_buf.md#0x4_script_buf">0x4::script_buf</a>;
 <b>use</b> <a href="taproot_builder.md#0x4_taproot_builder">0x4::taproot_builder</a>;
@@ -175,6 +178,51 @@
 
 
 <pre><code><b>const</b> <a href="bbn.md#0x4_bbn_TEMPORARY_AREA">TEMPORARY_AREA</a>: <a href="">vector</a>&lt;u8&gt; = [116, 101, 109, 112, 111, 114, 97, 114, 121, 95, 97, 114, 101, 97];
+</code></pre>
+
+
+
+<a name="0x4_bbn_BBN_V1_ACTIVATION_HEIGHT"></a>
+
+
+
+<pre><code><b>const</b> <a href="bbn.md#0x4_bbn_BBN_V1_ACTIVATION_HEIGHT">BBN_V1_ACTIVATION_HEIGHT</a>: u64 = 864790;
+</code></pre>
+
+
+
+<a name="0x4_bbn_BBN_V1_CAP_HEIGHT"></a>
+
+
+
+<pre><code><b>const</b> <a href="bbn.md#0x4_bbn_BBN_V1_CAP_HEIGHT">BBN_V1_CAP_HEIGHT</a>: u64 = 864799;
+</code></pre>
+
+
+
+<a name="0x4_bbn_BBN_V2_ACTIVATION_HEIGHT"></a>
+
+
+
+<pre><code><b>const</b> <a href="bbn.md#0x4_bbn_BBN_V2_ACTIVATION_HEIGHT">BBN_V2_ACTIVATION_HEIGHT</a>: u64 = 874088;
+</code></pre>
+
+
+
+<a name="0x4_bbn_BBN_V2_CAP_HEIGHT"></a>
+
+
+
+<pre><code><b>const</b> <a href="bbn.md#0x4_bbn_BBN_V2_CAP_HEIGHT">BBN_V2_CAP_HEIGHT</a>: u64 = 875087;
+</code></pre>
+
+
+
+<a name="0x4_bbn_DeprecatedFunction"></a>
+
+
+
+<pre><code><b>const</b> <a href="bbn.md#0x4_bbn_DeprecatedFunction">DeprecatedFunction</a>: u64 = 16;
 </code></pre>
 
 
@@ -336,15 +384,40 @@
 
 
 
+<a name="0x4_bbn_init_bbn_global_param_v2"></a>
+
+## Function `init_bbn_global_param_v2`
+
+BBN global param version 2 initialization
+
+
+<pre><code>entry <b>fun</b> <a href="bbn.md#0x4_bbn_init_bbn_global_param_v2">init_bbn_global_param_v2</a>()
+</code></pre>
+
+
+
 <a name="0x4_bbn_is_possible_bbn_tx"></a>
 
 ## Function `is_possible_bbn_tx`
+
+Deprecated function
+Use <code><a href="bbn_updater.md#0x4_bbn_updater_is_possible_bbn_tx">bbn_updater::is_possible_bbn_tx</a></code> instead
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bbn.md#0x4_bbn_is_possible_bbn_tx">is_possible_bbn_tx</a>(_txid: <b>address</b>): bool
+</code></pre>
+
+
+
+<a name="0x4_bbn_is_possible_bbn_transaction"></a>
+
+## Function `is_possible_bbn_transaction`
 
 Check if the transaction is a possible Babylon transaction
 If the transaction contains an OP_RETURN output with the correct tag, it is considered a possible Babylon transaction
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bbn.md#0x4_bbn_is_possible_bbn_tx">is_possible_bbn_tx</a>(txid: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="bbn.md#0x4_bbn_is_possible_bbn_transaction">is_possible_bbn_transaction</a>(block_height: u64, tx: &<a href="types.md#0x4_types_Transaction">types::Transaction</a>): bool
 </code></pre>
 
 
@@ -353,9 +426,22 @@ If the transaction contains an OP_RETURN output with the correct tag, it is cons
 
 ## Function `process_bbn_tx_entry`
 
+Deprecated function
+Use <code><a href="bbn_updater.md#0x4_bbn_updater_process_bbn_tx_entry">bbn_updater::process_bbn_tx_entry</a></code> instead
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="bbn.md#0x4_bbn_process_bbn_tx_entry">process_bbn_tx_entry</a>(txid: <b>address</b>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="bbn.md#0x4_bbn_process_bbn_tx_entry">process_bbn_tx_entry</a>(_txid: <b>address</b>)
+</code></pre>
+
+
+
+<a name="0x4_bbn_process_bbn_transaction"></a>
+
+## Function `process_bbn_transaction`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bbn.md#0x4_bbn_process_bbn_transaction">process_bbn_transaction</a>(block_height: u64, tx: &<a href="types.md#0x4_types_Transaction">types::Transaction</a>)
 </code></pre>
 
 
@@ -521,7 +607,20 @@ If the transaction contains an OP_RETURN output with the correct tag, it is cons
 
 ## Function `is_expired`
 
+Deprecated function
+Use <code><a href="bbn_updater.md#0x4_bbn_updater_is_expired">bbn_updater::is_expired</a></code> instead
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bbn.md#0x4_bbn_is_expired">is_expired</a>(stake: &<a href="bbn.md#0x4_bbn_BBNStakeSeal">bbn::BBNStakeSeal</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="bbn.md#0x4_bbn_is_expired">is_expired</a>(_stake: &<a href="bbn.md#0x4_bbn_BBNStakeSeal">bbn::BBNStakeSeal</a>): bool
+</code></pre>
+
+
+
+<a name="0x4_bbn_is_expired_at"></a>
+
+## Function `is_expired_at`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bbn.md#0x4_bbn_is_expired_at">is_expired_at</a>(stake: &<a href="bbn.md#0x4_bbn_BBNStakeSeal">bbn::BBNStakeSeal</a>, current_block_height: u64): bool
 </code></pre>

--- a/frameworks/bitcoin-move/doc/bbn_updater.md
+++ b/frameworks/bitcoin-move/doc/bbn_updater.md
@@ -1,0 +1,67 @@
+
+<a name="0x4_bbn_updater"></a>
+
+# Module `0x4::bbn_updater`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `is_possible_bbn_tx`](#0x4_bbn_updater_is_possible_bbn_tx)
+-  [Function `process_bbn_tx_entry`](#0x4_bbn_updater_process_bbn_tx_entry)
+-  [Function `is_expired`](#0x4_bbn_updater_is_expired)
+
+
+<pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="bbn.md#0x4_bbn">0x4::bbn</a>;
+<b>use</b> <a href="bitcoin.md#0x4_bitcoin">0x4::bitcoin</a>;
+<b>use</b> <a href="types.md#0x4_types">0x4::types</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x4_bbn_updater_ErrorTransactionNotFound"></a>
+
+
+
+<pre><code><b>const</b> <a href="bbn_updater.md#0x4_bbn_updater_ErrorTransactionNotFound">ErrorTransactionNotFound</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x4_bbn_updater_is_possible_bbn_tx"></a>
+
+## Function `is_possible_bbn_tx`
+
+Check if the transaction is a possible Babylon transaction
+If the transaction contains an OP_RETURN output with the correct tag, it is considered a possible Babylon transaction
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bbn_updater.md#0x4_bbn_updater_is_possible_bbn_tx">is_possible_bbn_tx</a>(txid: <b>address</b>): bool
+</code></pre>
+
+
+
+<a name="0x4_bbn_updater_process_bbn_tx_entry"></a>
+
+## Function `process_bbn_tx_entry`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="bbn_updater.md#0x4_bbn_updater_process_bbn_tx_entry">process_bbn_tx_entry</a>(txid: <b>address</b>)
+</code></pre>
+
+
+
+<a name="0x4_bbn_updater_is_expired"></a>
+
+## Function `is_expired`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bbn_updater.md#0x4_bbn_updater_is_expired">is_expired</a>(stake: &<a href="bbn.md#0x4_bbn_BBNStakeSeal">bbn::BBNStakeSeal</a>): bool
+</code></pre>

--- a/frameworks/bitcoin-move/doc/bbn_updater.md
+++ b/frameworks/bitcoin-move/doc/bbn_updater.md
@@ -9,12 +9,15 @@
 -  [Function `is_possible_bbn_tx`](#0x4_bbn_updater_is_possible_bbn_tx)
 -  [Function `process_bbn_tx_entry`](#0x4_bbn_updater_process_bbn_tx_entry)
 -  [Function `is_expired`](#0x4_bbn_updater_is_expired)
+-  [Function `clear_unbonded_stakes`](#0x4_bbn_updater_clear_unbonded_stakes)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x2::object</a>;
 <b>use</b> <a href="bbn.md#0x4_bbn">0x4::bbn</a>;
 <b>use</b> <a href="bitcoin.md#0x4_bitcoin">0x4::bitcoin</a>;
 <b>use</b> <a href="types.md#0x4_types">0x4::types</a>;
+<b>use</b> <a href="utxo.md#0x4_utxo">0x4::utxo</a>;
 </code></pre>
 
 
@@ -64,4 +67,15 @@ If the transaction contains an OP_RETURN output with the correct tag, it is cons
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bbn_updater.md#0x4_bbn_updater_is_expired">is_expired</a>(stake: &<a href="bbn.md#0x4_bbn_BBNStakeSeal">bbn::BBNStakeSeal</a>): bool
+</code></pre>
+
+
+
+<a name="0x4_bbn_updater_clear_unbonded_stakes"></a>
+
+## Function `clear_unbonded_stakes`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="bbn_updater.md#0x4_bbn_updater_clear_unbonded_stakes">clear_unbonded_stakes</a>(seal_obj_id: <a href="_ObjectID">object::ObjectID</a>)
 </code></pre>

--- a/frameworks/bitcoin-move/doc/bitcoin.md
+++ b/frameworks/bitcoin-move/doc/bitcoin.md
@@ -35,6 +35,7 @@
 <b>use</b> <a href="">0x3::address_mapping</a>;
 <b>use</b> <a href="">0x3::bitcoin_address</a>;
 <b>use</b> <a href="">0x3::chain_id</a>;
+<b>use</b> <a href="bbn.md#0x4_bbn">0x4::bbn</a>;
 <b>use</b> <a href="inscription_updater.md#0x4_inscription_updater">0x4::inscription_updater</a>;
 <b>use</b> <a href="network.md#0x4_network">0x4::network</a>;
 <b>use</b> <a href="pending_block.md#0x4_pending_block">0x4::pending_block</a>;

--- a/frameworks/bitcoin-move/sources/bbn.move
+++ b/frameworks/bitcoin-move/sources/bbn.move
@@ -527,11 +527,12 @@ module bitcoin_move::bbn {
         };
         let version = option::destroy_some(version_opt);
         let param = get_bbn_param(version);
-        assert!(block_height >= param.activation_height && block_height <= param.cap_height, ErrorOutBlockRange);
         let tx_output = types::tx_output(tx);
 
         let op_return_output_opt = try_get_bbn_op_return_ouput(tx_output);
-        assert!(is_some(&op_return_output_opt), ErrorNotBabylonTx);
+        if(is_none(&op_return_output_opt)) {
+            return
+        };
         let op_return_output = option::destroy_some(op_return_output_opt);
         let txid = types::tx_id(tx);
         let process_result = process_parsed_bbn_tx(param, txid, block_height, tx, op_return_output);

--- a/frameworks/bitcoin-move/sources/bbn_updater.move
+++ b/frameworks/bitcoin-move/sources/bbn_updater.move
@@ -1,0 +1,55 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+module bitcoin_move::bbn_updater {
+
+    use std::option::{Self, is_none, is_some};
+
+    use bitcoin_move::types;
+    use bitcoin_move::bbn::{Self, BBNStakeSeal};
+    use bitcoin_move::bitcoin;
+
+    const ErrorTransactionNotFound: u64 = 1;
+
+    /// Check if the transaction is a possible Babylon transaction
+    /// If the transaction contains an OP_RETURN output with the correct tag, it is considered a possible Babylon transaction
+    public fun is_possible_bbn_tx(txid: address): bool {
+        let block_height_opt = bitcoin::get_tx_height(txid);
+        if (is_none(&block_height_opt)) {
+            return false
+        };
+        let block_height = option::destroy_some(block_height_opt); 
+        let tx_opt = bitcoin::get_tx(txid);
+        if (is_none(&tx_opt)) {
+            return false
+        };
+        let tx = option::destroy_some(tx_opt);
+        bbn::is_possible_bbn_transaction(block_height, &tx)
+    }
+
+    public entry fun process_bbn_tx_entry(txid: address){
+        process_bbn_tx(txid)
+    }
+
+    fun process_bbn_tx(txid: address) {
+        let block_height_opt = bitcoin::get_tx_height(txid);
+        assert!(is_some(&block_height_opt), ErrorTransactionNotFound);
+        let block_height = option::destroy_some(block_height_opt);
+
+        let tx_opt = bitcoin::get_tx(txid);
+        assert!(is_some(&tx_opt), ErrorTransactionNotFound);
+        
+        let tx = option::destroy_some(tx_opt);
+        bbn::process_bbn_transaction(block_height, &tx)
+    }
+
+    public fun is_expired(stake: &BBNStakeSeal): bool {
+        let latest_block_opt = bitcoin::get_latest_block();
+        if (is_none(&latest_block_opt)) {
+            return false
+        };
+        let latest_block = option::destroy_some(latest_block_opt);
+        let (current_block_height, _hash) = types::unpack_block_height_hash(latest_block);
+        bbn::is_expired_at(stake, current_block_height)
+    }
+}

--- a/frameworks/bitcoin-move/sources/bbn_updater.move
+++ b/frameworks/bitcoin-move/sources/bbn_updater.move
@@ -5,9 +5,12 @@ module bitcoin_move::bbn_updater {
 
     use std::option::{Self, is_none, is_some};
 
+    use moveos_std::object::{Self, ObjectID};
+
     use bitcoin_move::types;
     use bitcoin_move::bbn::{Self, BBNStakeSeal};
     use bitcoin_move::bitcoin;
+    use bitcoin_move::utxo;
 
     const ErrorTransactionNotFound: u64 = 1;
 
@@ -51,5 +54,14 @@ module bitcoin_move::bbn_updater {
         let latest_block = option::destroy_some(latest_block_opt);
         let (current_block_height, _hash) = types::unpack_block_height_hash(latest_block);
         bbn::is_expired_at(stake, current_block_height)
+    }
+
+    public entry fun clear_unbonded_stakes(seal_obj_id: ObjectID){
+        let seal_obj = object::borrow_object<BBNStakeSeal>(seal_obj_id);
+        let seal = object::borrow(seal_obj);
+        let outpoint = bbn::outpoint(seal);
+        if(!utxo::exists_utxo(outpoint))(
+            bbn::remove_bbn_seal(seal_obj_id)
+        )
     }
 }

--- a/frameworks/bitcoin-move/sources/bitcoin.move
+++ b/frameworks/bitcoin-move/sources/bitcoin.move
@@ -192,6 +192,7 @@ module bitcoin_move::bitcoin{
         let _ = output_seals;
 
         vector::for_each(input_utxos, |utxo| {
+            bbn::on_utxo_spend(&mut utxo);
             utxo::drop(utxo);
         });
         repeat_txid

--- a/frameworks/bitcoin-move/sources/bitcoin.move
+++ b/frameworks/bitcoin-move/sources/bitcoin.move
@@ -23,6 +23,7 @@ module bitcoin_move::bitcoin{
     use bitcoin_move::utxo::{Self, UTXOSeal};
     use bitcoin_move::pending_block::{Self, PendingBlock};
     use bitcoin_move::script_buf;
+    use bitcoin_move::bbn;
 
     friend bitcoin_move::genesis;
 
@@ -120,7 +121,10 @@ module bitcoin_move::bitcoin{
             table::add(&mut btc_block_store.txs, txid, *tx);
             table::add(&mut btc_block_store.tx_to_height, txid, block_height);
             table_vec::push_back(&mut btc_block_store.tx_ids, txid);
-        }
+        };
+        if (bbn::is_possible_bbn_transaction(block_height, tx)) {
+            bbn::process_bbn_transaction(block_height, tx);
+        };
     }
 
     fun process_utxo(block_height: u64, pending_block: &mut Object<PendingBlock>, tx: &Transaction, is_coinbase: bool) : bool{


### PR DESCRIPTION
## Summary

1. An implementation to process Babylon protocol when processing Bitcoin transactions.
2. Init the Babylon cap3 global parameter.
3. Unbunding Babylon stake when UTXO spent