### PR TITLE
fix(openda): allow max retry limit for retries

### DIFF
--- a/crates/rooch-da/src/backend/openda/avail.rs
+++ b/crates/rooch-da/src/backend/openda/avail.rs
@@ -85,7 +85,7 @@ impl Operator for AvailClient {
                     ))
                 }
                 _ => {
-                    if retries < max_retries {
+                    if retries <= max_retries {
                         retries += 1;
                         sleep(retry_delay).await;
                         retry_delay *= 3; // Exponential backoff

--- a/crates/rooch-da/src/backend/openda/celestia.rs
+++ b/crates/rooch-da/src/backend/openda/celestia.rs
@@ -72,7 +72,7 @@ impl Operator for CelestiaClient {
                     return Ok(());
                 }
                 Err(e) => {
-                    if retries < max_retries {
+                    if retries <= max_retries {
                         retries += 1;
                         sleep(retry_delay).await;
                         retry_delay *= 3;


### PR DESCRIPTION
## Summary

This commit adjusts the retry logic in `celestia.rs` and `avail.rs` by changing the condition to allow retries up to the max retry limit, ensuring one additional retry attempt by using '<=' instead of '<'.