### PR TITLE
Optimize vector<u8> deserialization in RuntimeObject

### DIFF
--- a/crates/rooch-benchmarks/README.md
+++ b/crates/rooch-benchmarks/README.md
@@ -80,7 +80,7 @@ for PPROF_OUT output location:
 
 `<tx_type>`:
 
-1. `l2_tx_<transfer/empty>`
+1. `l2_tx_<transfer/empty/transfer_large_object>`
 2. `btc_block`
 3. `btc_tx`
 

--- a/crates/rooch-benchmarks/src/config.rs
+++ b/crates/rooch-benchmarks/src/config.rs
@@ -49,6 +49,7 @@ impl Display for PProfOutput {
 pub enum TxType {
     Empty,
     Transfer,
+    TransferLargeObject,
     BtcBlock,
     BtcTx,
 }
@@ -61,6 +62,7 @@ impl FromStr for TxType {
             "btc_block" => Ok(TxType::BtcBlock),
             "btc_tx" => Ok(TxType::BtcTx),
             "empty" => Ok(TxType::Empty),
+            "transfer_large_object" => Ok(TxType::TransferLargeObject),
             _ => Err(format!("invalid tx type: {}", s)),
         }
     }
@@ -73,6 +75,7 @@ impl Display for TxType {
             TxType::Transfer => "transfer".to_string(),
             TxType::BtcBlock => "btc_block".to_string(),
             TxType::BtcTx => "btc_tx".to_string(),
+            TxType::TransferLargeObject => "transfer_large_object".to_string(),
         };
         write!(f, "{}", str)
     }

--- a/crates/rooch-benchmarks/src/tx.rs
+++ b/crates/rooch-benchmarks/src/tx.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::TxType;
-use crate::tx::TxType::{Empty, Transfer};
+use crate::tx::TxType::{Empty, Transfer, TransferLargeObject};
 use anyhow::Result;
 use bitcoin::consensus::deserialize;
 use bitcoin::hashes::Hash;
@@ -60,6 +60,7 @@ pub fn create_l2_tx(
     let action = match tx_type {
         Empty => test_transaction_builder.call_empty_create(),
         Transfer => test_transaction_builder.call_transfer_create(),
+        TransferLargeObject => test_transaction_builder.call_transfer_large_object_create(),
         _ => panic!("Unsupported tx type"),
     };
 

--- a/crates/rooch-benchmarks/src/tx_exec.rs
+++ b/crates/rooch-benchmarks/src/tx_exec.rs
@@ -94,7 +94,7 @@ pub fn tx_exec_benchmark(c: &mut Criterion) {
                 test_transaction_builder.update_sequence_number(seq_num);
                 seq_num += 1;
                 let publish_action = test_transaction_builder
-                    .new_publish_examples("large_objects", Some("example".to_owned()))
+                    .new_publish_examples("large_objects", Some("rooch_examples".to_owned()))
                     .unwrap();
                 let tx = test_transaction_builder
                     .build_and_sign(publish_action)

--- a/crates/rooch-benchmarks/src/tx_exec.rs
+++ b/crates/rooch-benchmarks/src/tx_exec.rs
@@ -13,7 +13,7 @@ use rooch_types::crypto::RoochKeyPair;
 use rooch_types::transaction::LedgerTxData;
 
 use crate::config::BenchTxConfig;
-use crate::config::TxType::{BtcBlock, BtcTx, Empty, Transfer};
+use crate::config::TxType::{BtcBlock, BtcTx, Empty, Transfer, TransferLargeObject};
 use crate::tx::{create_btc_blk_tx, create_l2_tx, find_block_height, prepare_btc_block};
 
 // pure execution, no validate, sequence
@@ -30,6 +30,7 @@ pub fn tx_exec_benchmark(c: &mut Criterion) {
         BtcTx => ("btc_tx", 5), // The tx_cnt is the block count
         Transfer => ("l2_tx_transfer", 800),
         Empty => ("l2_tx_empty", 1000),
+        TransferLargeObject => ("l2_tx_transfer_large_object", 500),
     };
     let mut blocks = HashMap::new();
     let mut transactions: Vec<_> = Vec::with_capacity(tx_cnt);
@@ -88,16 +89,31 @@ pub fn tx_exec_benchmark(c: &mut Criterion) {
             }
         }
         _ => {
+            let mut seq_num = 0u64;
+            if tx_type.clone() == TransferLargeObject {
+                test_transaction_builder.update_sequence_number(seq_num);
+                seq_num += 1;
+                let publish_action = test_transaction_builder
+                    .new_publish_examples("large_objects", Some("example".to_owned()))
+                    .unwrap();
+                let tx = test_transaction_builder
+                    .build_and_sign(publish_action)
+                    .unwrap();
+                binding_test.execute(tx).unwrap();
+            }
             for n in 0..tx_cnt {
-                let tx =
-                    create_l2_tx(&mut test_transaction_builder, n as u64, tx_type.clone()).unwrap();
+                let tx = create_l2_tx(
+                    &mut test_transaction_builder,
+                    seq_num + n as u64,
+                    tx_type.clone(),
+                )
+                .unwrap();
                 transactions.push(LedgerTxData::L2Tx(tx));
             }
         }
     }
     let sample_size = transactions.len();
     let mut transactions_iter = transactions.into_iter();
-
     let mut group = c.benchmark_group("bench_tx_exec");
     group.sample_size(sample_size);
     group.sampling_mode(SamplingMode::Flat);

--- a/examples/large_objects/Move.toml
+++ b/examples/large_objects/Move.toml
@@ -8,9 +8,9 @@ MoveosStdlib = { git = "https://github.com/rooch-network/rooch.git", subdir = "f
 RoochFramework = { git = "https://github.com/rooch-network/rooch.git", subdir = "frameworks/rooch-framework", rev = "main" }
 
 [addresses]
-example =  "_"
+rooch_examples =  "_"
 moveos_std =  "0x2"
 rooch_framework =  "0x3"
 
 [dev-addresses]
-example = "0x42"
+rooch_examples = "0x42"

--- a/examples/large_objects/Move.toml
+++ b/examples/large_objects/Move.toml
@@ -1,0 +1,16 @@
+[package]
+name = "large_objects"
+version = "0.0.1"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/rooch-network/rooch.git", subdir = "frameworks/move-stdlib", rev = "main" }
+MoveosStdlib = { git = "https://github.com/rooch-network/rooch.git", subdir = "frameworks/moveos-stdlib", rev = "main" }
+RoochFramework = { git = "https://github.com/rooch-network/rooch.git", subdir = "frameworks/rooch-framework", rev = "main" }
+
+[addresses]
+example =  "_"
+moveos_std =  "0x2"
+rooch_framework =  "0x3"
+
+[dev-addresses]
+example = "0x42"

--- a/examples/large_objects/sources/big_vector.move
+++ b/examples/large_objects/sources/big_vector.move
@@ -1,0 +1,25 @@
+module example::big_vector {
+  use moveos_std::object;
+
+  struct VecU8 has key, store {
+    values: vector<u8>
+  }
+
+  fun init() {
+    let values = std::vector::empty<u8>();
+    let b = 100000;
+    while (b > 0){
+        std::vector::push_back(&mut values, 255);
+        b = b-1
+    };
+    let obj = object::new_named_object( VecU8 { values });
+    object::transfer(obj, @example);
+  }
+
+  entry fun transfer(to: address) {
+    let id = object::named_object_id<VecU8>();
+    let obj = object::take_object_extend<VecU8>(id);
+    object::transfer_extend(obj, to);
+  }
+
+}

--- a/examples/large_objects/sources/big_vector.move
+++ b/examples/large_objects/sources/big_vector.move
@@ -1,4 +1,4 @@
-module large_objects::big_vector {
+module rooch_examples::big_vector {
   use moveos_std::object;
 
   struct VecU8 has key, store {
@@ -13,7 +13,7 @@ module large_objects::big_vector {
         b = b-1
     };
     let obj = object::new_named_object( VecU8 { values });
-    object::transfer(obj, @large_objects);
+    object::transfer(obj, @rooch_examples);
   }
 
   entry fun transfer(to: address) {

--- a/examples/large_objects/sources/big_vector.move
+++ b/examples/large_objects/sources/big_vector.move
@@ -1,4 +1,4 @@
-module example::big_vector {
+module large_objects::big_vector {
   use moveos_std::object;
 
   struct VecU8 has key, store {
@@ -13,7 +13,7 @@ module example::big_vector {
         b = b-1
     };
     let obj = object::new_named_object( VecU8 { values });
-    object::transfer(obj, @example);
+    object::transfer(obj, @large_objects);
   }
 
   entry fun transfer(to: address) {


### PR DESCRIPTION
## Summary

1. Optimize vector\<u8\> deserialization in RuntimeObject
2. Add a benchmark for large object transferring.

related issue: #2678 

## Performance

1. Given the following Move struct with 100000 elements, the deserialization time in `RuntimeObject::load` descreased from 4861.5us to 13.7us.
```
  struct VecU8 has key, store {
    values: vector<u8>
  }
```
2. benchmark for `bench_tx_exec/l2_tx_transfer_large_object`:
![image](https://github.com/user-attachments/assets/223e379f-218d-4827-b7af-f9e48cb1d6c4)

3. benchmark for `bench_tx_exec/l2_tx_transfer`
![image](https://github.com/user-attachments/assets/ae77c25f-c2e7-4d97-831f-0801afd201b5)
