### PR TITLE
feat(rooch-da): add transaction order verification in unpack

### DIFF
--- a/crates/rooch/src/commands/da/README.md
+++ b/crates/rooch/src/commands/da/README.md
@@ -7,5 +7,5 @@ Toolkits for RoochDA.
 1. Unpack tx list to human-readable format:
 
 ```shell
-rooch da unpack --segment-dir {segment-dir} -batch-dir {batch-dir}
+rooch da unpack --segment-dir {segment-dir} --batch-dir {batch-dir}
 ```


### PR DESCRIPTION
## Summary

Add a `--verify-order` flag to the unpack command to ensure transactions across all batches have strictly incremental order. Introduced a new method to validate transaction sequences during the unpacking process, enhancing data consistency checks.