### PR TITLE
feat(config): add `enable_statistics` option for RocksDB

### DIFF
--- a/crates/rooch-config/src/store_config.rs
+++ b/crates/rooch-config/src/store_config.rs
@@ -85,6 +85,13 @@ pub struct StoreConfig {
     )]
     pub max_write_buffer_number: Option<u64>,
 
+    #[clap(
+        name = "rocksdb-enable-statistics",
+        long,
+        help = "rocksdb enable statistics"
+    )]
+    pub enable_statistics: bool,
+
     #[serde(skip)]
     #[clap(skip)]
     base: Option<Arc<BaseConfig>>,
@@ -147,6 +154,7 @@ impl StoreConfig {
                 .unwrap_or(default.max_write_buffer_numer),
             block_cache_size: self.block_cache_size.unwrap_or(block_cache_size),
             block_size: self.block_size.unwrap_or(default.block_size),
+            enable_statistics: self.enable_statistics,
         }
     }
 

--- a/moveos/moveos-config/src/store_config.rs
+++ b/moveos/moveos-config/src/store_config.rs
@@ -51,6 +51,12 @@ pub struct RocksdbConfig {
     pub block_cache_size: u64,
     #[clap(name = "rocksdb-block-size", long, help = "rocksdb block size")]
     pub block_size: u64,
+    #[clap(
+        name = "rocksdb-enable-statistics",
+        long,
+        help = "rocksdb enable statistics"
+    )]
+    pub enable_statistics: bool,
 }
 
 impl RocksdbConfig {
@@ -77,6 +83,7 @@ impl Default for RocksdbConfig {
             max_write_buffer_numer: 4,
             block_cache_size: 1u64 << 32,
             block_size: 4 * 1024,
+            enable_statistics: false,
         }
     }
 }

--- a/moveos/raw-store/src/rocks/mod.rs
+++ b/moveos/raw-store/src/rocks/mod.rs
@@ -258,8 +258,10 @@ impl RocksDB {
         db_opts.set_row_cache(&cache);
         db_opts.set_enable_pipelined_write(true);
         db_opts.set_wal_recovery_mode(DBRecoveryMode::PointInTime); // for memtable crash recovery
-        db_opts.enable_statistics();
-        db_opts.set_statistics_level(statistics::StatsLevel::ExceptTimeForMutex);
+        if config.enable_statistics {
+            db_opts.enable_statistics();
+            db_opts.set_statistics_level(statistics::StatsLevel::ExceptTimeForMutex);
+        }
         db_opts
     }
     fn iter_with_direction<K, V>(


### PR DESCRIPTION
## Summary

Enable RocksDB statistics configuration through a new `enable_statistics` option. This adds flexibility to toggle statistics and sets the stats level conditionally.