### PR TITLE
feat(da): track max chunk ID and find begin chunk for speed up re-exec init process

### DIFF
--- a/crates/rooch/src/commands/da/commands/unpack.rs
+++ b/crates/rooch/src/commands/da/commands/unpack.rs
@@ -118,7 +118,7 @@ impl UnpackInner {
     }
 
     fn collect_chunks(&mut self) -> anyhow::Result<()> {
-        let chunks = collect_chunks(self.segment_dir.clone())?;
+        let (chunks, _max_chunk_id) = collect_chunks(self.segment_dir.clone())?;
         self.chunks = chunks;
         Ok(())
     }


### PR DESCRIPTION
## Summary


Add functionality to track the maximum chunk ID and determine the starting chunk for transaction processing. This optimizes chunk handling with binary search and improves transaction execution flow.