### PR TITLE
refactor(rooch-da): simplify find_last_executed logic

### DIFF
--- a/crates/rooch/src/commands/da/commands/mod.rs
+++ b/crates/rooch/src/commands/da/commands/mod.rs
@@ -424,7 +424,7 @@ mod tests {
         #[test]
         fn test_various_transition_points() {
             // Test cases with different transition points
-            let test_cases = vec![
+            let test_cases = [
                 (vec![true], 0),
                 (vec![true, false], 0),
                 (vec![true, true, false], 1),

--- a/crates/rooch/src/commands/da/commands/mod.rs
+++ b/crates/rooch/src/commands/da/commands/mod.rs
@@ -188,6 +188,9 @@ impl std::str::FromStr for TxOrderHashBlock {
     }
 }
 
+/// TxOrderHashBlockGetter is used to get TxOrderHashBlock from a file
+/// all tx_order_hash_blocks(start from tx_order 1) are stored in a file,
+/// each line is a TxOrderHashBlock
 pub struct TxOrderHashBlockGetter {
     tx_order_hash_blocks: Vec<TxOrderHashBlock>,
     transaction_store: TransactionDBStore,
@@ -272,5 +275,177 @@ impl TxOrderHashBlockGetter {
     ) -> anyhow::Result<Option<TransactionExecutionInfo>> {
         let execution_info = self.transaction_store.get_tx_execution_info(tx_hash)?;
         Ok(execution_info)
+    }
+}
+
+// find the last true element in the array:
+// the array is sorted by the predicate, and the predicate is true for the first n elements and false for the rest.
+fn find_last_true<T>(arr: &[T], predicate: impl Fn(&T) -> bool) -> Option<&T> {
+    if arr.is_empty() {
+        return None;
+    }
+    if !predicate(&arr[0]) {
+        return None;
+    }
+    if predicate(&arr[arr.len() - 1]) {
+        return Some(&arr[arr.len() - 1]);
+    }
+
+    // binary search
+    let mut left = 0;
+    let mut right = arr.len() - 1;
+
+    while left + 1 < right {
+        let mid = left + (right - left) / 2;
+        if predicate(&arr[mid]) {
+            left = mid; // mid is true, the final answer is mid or on the right
+        } else {
+            right = mid; // mid is false, the final answer is on the left
+        }
+    }
+
+    // left is the last true position
+    Some(&arr[left])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct TestItem {
+        id: usize,
+        value: bool,
+    }
+
+    impl TestItem {
+        fn new(id: usize, value: bool) -> Self {
+            Self { id, value }
+        }
+    }
+
+    #[test]
+    fn test_find_last_true_empty_array() {
+        let items: Vec<TestItem> = vec![];
+        let result = find_last_true(&items, |item| item.value);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_find_last_true_single_element_true() {
+        let items = vec![TestItem::new(0, true)];
+        let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+        assert_eq!(result, Some(0));
+    }
+
+    #[test]
+    fn test_find_last_true_single_element_false() {
+        let items = vec![TestItem::new(0, false)];
+        let result = find_last_true(&items, |item| item.value);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_last_true_all_true() {
+        let items = vec![
+            TestItem::new(0, true),
+            TestItem::new(1, true),
+            TestItem::new(2, true),
+        ];
+        let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+        assert_eq!(result, Some(2));
+    }
+
+    #[test]
+    fn test_find_last_true_all_false() {
+        let items = vec![
+            TestItem::new(0, false),
+            TestItem::new(1, false),
+            TestItem::new(2, false),
+        ];
+        let result = find_last_true(&items, |item| item.value);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_last_true_odd_length_middle_transition() {
+        let items = vec![
+            TestItem::new(0, true),
+            TestItem::new(1, true),
+            TestItem::new(2, true),
+            TestItem::new(3, false),
+            TestItem::new(4, false),
+        ];
+        let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+        assert_eq!(result, Some(2));
+    }
+
+    #[test]
+    fn test_find_last_true_even_length_middle_transition() {
+        let items = vec![
+            TestItem::new(0, true),
+            TestItem::new(1, true),
+            TestItem::new(2, false),
+            TestItem::new(3, false),
+        ];
+        let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+        assert_eq!(result, Some(1));
+    }
+
+    #[test]
+    fn test_find_last_true_only_first_true() {
+        let items = vec![
+            TestItem::new(0, true),
+            TestItem::new(1, false),
+            TestItem::new(2, false),
+            TestItem::new(3, false),
+        ];
+        let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+        assert_eq!(result, Some(0));
+    }
+
+    #[test]
+    fn test_find_last_true_only_last_true() {
+        let items = vec![
+            TestItem::new(0, false),
+            TestItem::new(1, false),
+            TestItem::new(2, false),
+            TestItem::new(3, true),
+        ];
+        let result = find_last_true(&items, |item| item.value);
+        assert_eq!(result, None); // 因为违反了有序性假设
+    }
+
+    #[test]
+    fn test_find_last_true_large_array() {
+        let mut items = Vec::new();
+        for i in 0..1000 {
+            items.push(TestItem::new(i, i <= 500));
+        }
+        let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+        assert_eq!(result, Some(500));
+    }
+
+    #[test]
+    fn test_find_last_true_various_transition_points() {
+        // Test cases with different transition points
+        let test_find_last_true_cases = vec![
+            (vec![true], 0),
+            (vec![true, false], 0),
+            (vec![true, true, false], 1),
+            (vec![true, true, true, false], 2),
+            (vec![true, true, true, true, false], 3),
+        ];
+
+        for (i, (values, expected)) in test_find_last_true_cases.iter().enumerate() {
+            let items: Vec<TestItem> = values
+                .iter()
+                .enumerate()
+                .map(|(id, &v)| TestItem::new(id, v))
+                .collect();
+
+            let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+            assert_eq!(result, Some(*expected), "Failed at test case {}", i);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Refactored `find_last_executed` to use a generic utility function `find_last_true`, reducing code complexity. Updated tests to cover edge cases and maintain coverage for the new implementation.