### PR TITLE
feat(db): add command to dump transaction state roots

### DIFF
--- a/crates/rooch-common/src/utils/mod.rs
+++ b/crates/rooch-common/src/utils/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod humanize;
+pub mod vec;

--- a/crates/rooch-common/src/utils/vec.rs
+++ b/crates/rooch-common/src/utils/vec.rs
@@ -1,0 +1,192 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+// find the last true element in the array:
+// the array is sorted by the predicate, and the predicate is true for the first n elements and false for the rest.
+pub fn find_last_true<T>(arr: &[T], predicate: impl Fn(&T) -> bool) -> Option<&T> {
+    if arr.is_empty() {
+        return None;
+    }
+    if !predicate(&arr[0]) {
+        return None;
+    }
+    if predicate(&arr[arr.len() - 1]) {
+        return Some(&arr[arr.len() - 1]);
+    }
+
+    // binary search
+    let mut left = 0;
+    let mut right = arr.len() - 1;
+
+    while left + 1 < right {
+        let mid = left + (right - left) / 2;
+        if predicate(&arr[mid]) {
+            left = mid; // mid is true, the final answer is mid or on the right
+        } else {
+            right = mid; // mid is false, the final answer is on the left
+        }
+    }
+
+    // left is the last true position
+    Some(&arr[left])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod find_last_true {
+        use super::*;
+
+        #[derive(Debug, PartialEq)]
+        struct TestItem {
+            id: usize,
+            value: bool,
+        }
+
+        impl TestItem {
+            fn new(id: usize, value: bool) -> Self {
+                Self { id, value }
+            }
+        }
+
+        #[test]
+        fn test_empty_array() {
+            let items: Vec<TestItem> = vec![];
+            let result = find_last_true(&items, |item| item.value);
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn test_single_element_true() {
+            let items = vec![TestItem::new(0, true)];
+            let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+            assert_eq!(result, Some(0));
+        }
+
+        #[test]
+        fn test_single_element_false() {
+            let items = vec![TestItem::new(0, false)];
+            let result = find_last_true(&items, |item| item.value);
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn test_all_true() {
+            let items = vec![
+                TestItem::new(1, true),
+                TestItem::new(2, true),
+                TestItem::new(3, true),
+            ];
+            let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+            assert_eq!(result, Some(3));
+        }
+
+        #[test]
+        fn test_all_false() {
+            let items = vec![
+                TestItem::new(1, false),
+                TestItem::new(2, false),
+                TestItem::new(3, false),
+            ];
+            let result = find_last_true(&items, |item| item.value);
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn test_odd_length_middle_transition() {
+            let items = vec![
+                TestItem::new(1, true),
+                TestItem::new(2, true),
+                TestItem::new(3, true),
+                TestItem::new(4, false),
+                TestItem::new(5, false),
+            ];
+            let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+            assert_eq!(result, Some(3));
+        }
+
+        #[test]
+        fn test_even_length_middle_transition() {
+            let items = vec![
+                TestItem::new(1, true),
+                TestItem::new(2, true),
+                TestItem::new(3, false),
+                TestItem::new(4, false),
+            ];
+            let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+            assert_eq!(result, Some(2));
+        }
+
+        #[test]
+        fn test_only_first_true() {
+            let items = vec![
+                TestItem::new(1, true),
+                TestItem::new(2, false),
+                TestItem::new(3, false),
+                TestItem::new(4, false),
+            ];
+            let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+            assert_eq!(result, Some(1));
+        }
+
+        #[test]
+        fn test_only_last_true() {
+            let items = vec![
+                TestItem::new(1, false),
+                TestItem::new(2, false),
+                TestItem::new(3, false),
+                TestItem::new(4, true),
+            ];
+            let result = find_last_true(&items, |item| item.value);
+            assert_eq!(result, None); // no sorted array, so no result
+        }
+
+        #[test]
+        fn test_large_array() {
+            let mut items = Vec::new();
+            for i in 1..1000 {
+                items.push(TestItem::new(i, i <= 500));
+            }
+            let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+            assert_eq!(result, Some(500));
+
+            let mut items = Vec::new();
+            for i in 1..1001 {
+                items.push(TestItem::new(i, i <= 500));
+            }
+            let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+            assert_eq!(result, Some(500));
+
+            let mut items = Vec::new();
+            for i in 1..1001 {
+                items.push(TestItem::new(i, i <= 501));
+            }
+            let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+            assert_eq!(result, Some(501));
+        }
+
+        #[test]
+        fn test_various_transition_points() {
+            // Test cases with different transition points
+            let test_cases = [
+                (vec![true], 0),
+                (vec![true, false], 0),
+                (vec![true, true, false], 1),
+                (vec![true, true, true, false], 2),
+                (vec![true, true, true, true, false], 3),
+            ];
+
+            for (i, (values, expected)) in test_cases.iter().enumerate() {
+                let items: Vec<TestItem> = values
+                    .iter()
+                    .enumerate()
+                    .map(|(id, &v)| TestItem::new(id, v))
+                    .collect();
+
+                let result = find_last_true(&items, |item| item.value).map(|item| item.id);
+                assert_eq!(result, Some(*expected), "Failed at test case {}", i);
+            }
+        }
+    }
+}

--- a/crates/rooch/src/commands/da/commands/index_tx.rs
+++ b/crates/rooch/src/commands/da/commands/index_tx.rs
@@ -1,23 +1,23 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::commands::da::commands::{LedgerTxGetter, TxOrderHashBlock};
+use crate::commands::da::commands::{LedgerTxGetter, TxDAIndex};
 use rooch_types::error::{RoochError, RoochResult};
 use std::fs::File;
 use std::io::BufWriter;
 use std::io::Write;
 use std::path::PathBuf;
 
-/// Dump tx_order:tx_hash:block_number to a file from segments
+/// Index tx_order:tx_hash:block_number to a file from segments
 #[derive(Debug, clap::Parser)]
-pub struct DumpTxOrderHashCommand {
+pub struct IndexTxCommand {
     #[clap(long = "segment-dir")]
     pub segment_dir: PathBuf,
     #[clap(long = "output")]
     pub output: PathBuf,
 }
 
-impl DumpTxOrderHashCommand {
+impl IndexTxCommand {
     pub fn execute(self) -> RoochResult<()> {
         let ledger_tx_loader = LedgerTxGetter::new(self.segment_dir)?;
         let mut block_number = ledger_tx_loader.get_min_chunk_id();
@@ -46,7 +46,7 @@ impl DumpTxOrderHashCommand {
                 writeln!(
                     writer,
                     "{}",
-                    TxOrderHashBlock::new(tx_order, tx_hash, block_number)
+                    TxDAIndex::new(tx_order, tx_hash, block_number)
                 )?;
                 expected_tx_order += 1;
             }

--- a/crates/rooch/src/commands/da/mod.rs
+++ b/crates/rooch/src/commands/da/mod.rs
@@ -4,8 +4,8 @@
 pub mod commands;
 
 use crate::cli_types::CommandAction;
-use crate::commands::da::commands::dump_tx_order_hash::DumpTxOrderHashCommand;
 use crate::commands::da::commands::exec::ExecCommand;
+use crate::commands::da::commands::index_tx::IndexTxCommand;
 use crate::commands::da::commands::namespace::NamespaceCommand;
 use crate::commands::da::commands::unpack::UnpackCommand;
 use async_trait::async_trait;
@@ -26,9 +26,7 @@ impl CommandAction<String> for DA {
             DACommand::Unpack(unpack) => unpack.execute().map(|_| "".to_owned()),
             DACommand::Namespace(namespace) => namespace.execute().map(|_| "".to_owned()),
             DACommand::Exec(exec) => exec.execute().await.map(|_| "".to_owned()),
-            DACommand::DumpTxOrderHash(dump_tx_order_hash) => {
-                dump_tx_order_hash.execute().map(|_| "".to_owned())
-            }
+            DACommand::IndexTx(index_tx) => index_tx.execute().map(|_| "".to_owned()),
         }
     }
 }
@@ -39,5 +37,5 @@ pub enum DACommand {
     Unpack(UnpackCommand),
     Namespace(NamespaceCommand),
     Exec(ExecCommand),
-    DumpTxOrderHash(DumpTxOrderHashCommand),
+    IndexTx(IndexTxCommand),
 }

--- a/crates/rooch/src/commands/db/commands/dump_tx_root.rs
+++ b/crates/rooch/src/commands/db/commands/dump_tx_root.rs
@@ -1,0 +1,69 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::da::commands::TxDAIndexer;
+use crate::commands::db::commands::init;
+use clap::Parser;
+use rooch_config::R_OPT_NET_HELP;
+use rooch_types::error::RoochResult;
+use rooch_types::rooch_network::RoochChainID;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+
+/// Get changeset by order
+#[derive(Debug, Parser)]
+pub struct DumpTxRootCommand {
+    #[clap(long, help = "start tx order")]
+    pub start: u64,
+    #[clap(long, help = "total tx count, [start, start+limit)")]
+    pub limit: u64,
+    #[clap(
+        long = "order-hash-path",
+        help = "Path to tx_order:tx_hash:block_number file"
+    )]
+    pub order_hash_path: PathBuf,
+    #[clap(long, help = "tx_order:state_root output file path")]
+    pub output: PathBuf,
+
+    #[clap(long = "data-dir", short = 'd')]
+    /// Path to data dir, this dir is base dir, the final data_dir is base_dir/chain_network_name
+    pub base_data_dir: Option<PathBuf>,
+
+    /// If local chainid, start the service with a temporary data store.
+    /// All data will be deleted when the service is stopped.
+    #[clap(long, short = 'n', help = R_OPT_NET_HELP)]
+    pub chain_id: Option<RoochChainID>,
+}
+
+impl DumpTxRootCommand {
+    pub async fn execute(self) -> RoochResult<()> {
+        let (_root, rooch_db, _start_time) = init(self.base_data_dir, self.chain_id);
+        let moveos_store = rooch_db.moveos_store.clone();
+        let tx_da_indexer = TxDAIndexer::load_from_file(
+            self.order_hash_path.clone(),
+            moveos_store.transaction_store,
+        )?;
+
+        let file = File::create(self.output.clone())?;
+        let mut writer = BufWriter::with_capacity(8 * 1024 * 1024, file.try_clone().unwrap());
+
+        for tx_order in self.start..self.start + self.limit {
+            let execution_info = tx_da_indexer.get_execution_info_by_order(tx_order)?;
+            if execution_info.is_none() {
+                tracing::warn!("tx_order {} execution_info not found", tx_order);
+                continue;
+            }
+            writeln!(
+                writer,
+                "{}:{:?}",
+                tx_order,
+                execution_info.unwrap().state_root
+            )?;
+        }
+        writer.flush()?;
+        file.sync_data()?;
+
+        Ok(())
+    }
+}

--- a/crates/rooch/src/commands/db/commands/mod.rs
+++ b/crates/rooch/src/commands/db/commands/mod.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 pub mod drop;
+pub mod dump_tx_root;
 pub mod get_changeset_by_order;
 pub mod repair;
 pub mod revert;

--- a/crates/rooch/src/commands/db/mod.rs
+++ b/crates/rooch/src/commands/db/mod.rs
@@ -3,6 +3,7 @@
 
 use crate::cli_types::CommandAction;
 use crate::commands::db::commands::drop::DropCommand;
+use crate::commands::db::commands::dump_tx_root::DumpTxRootCommand;
 use crate::commands::db::commands::get_changeset_by_order::GetChangesetByOrderCommand;
 use crate::commands::db::commands::repair::RepairCommand;
 use crate::commands::db::commands::revert::RevertCommand;
@@ -41,6 +42,9 @@ impl CommandAction<String> for DB {
                     serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
                 })
             }
+            DBCommand::DumpTxRoot(dump_tx_root) => dump_tx_root.execute().await.map(|resp| {
+                serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
+            }),
         }
     }
 }
@@ -53,4 +57,5 @@ pub enum DBCommand {
     Drop(DropCommand),
     Repair(RepairCommand),
     GetChangesetByOrder(GetChangesetByOrderCommand),
+    DumpTxRoot(DumpTxRootCommand),
 }


### PR DESCRIPTION
## Summary

Introduce `DumpTxRootCommand` to export transaction orders and state roots to an output file. This enhances database debugging and transaction analysis capabilities.