### PR TITLE
feat: check exist before batch handle

### DIFF
--- a/apps/grow_bitcoin/sources/grow_bitcoin.move
+++ b/apps/grow_bitcoin/sources/grow_bitcoin.move
@@ -520,7 +520,7 @@ module grow_bitcoin::grow_bitcoin {
         let total_coin = coin::zero<GROW>();
         while (i < len) {
             let asset_id = *vector::borrow(&assets, i);
-            if (!table::contains(&stake_table.stake, asset_id)) {
+            if (table::contains(&stake_table.stake, asset_id)) {
                 let utxo_obj = object::borrow_mut_object<UTXO>(signer, asset_id);
                 let coin = do_harvest(signer, object::id(utxo_obj));
                 coin::merge(&mut total_coin, coin);
@@ -547,7 +547,7 @@ module grow_bitcoin::grow_bitcoin {
         let total_coin = coin::zero<GROW>();
         while (i < len) {
             let asset_id = *vector::borrow(&assets, i);
-            if (!table::contains(&stake_table.stake, asset_id)) {
+            if (table::contains(&stake_table.stake, asset_id)) {
                 let bbn_obj = object::borrow_mut_object<BBNStakeSeal>(signer, asset_id);
                 let coin = do_harvest(signer, object::id(bbn_obj));
                 coin::merge(&mut total_coin, coin);

--- a/apps/grow_bitcoin/sources/grow_bitcoin.move
+++ b/apps/grow_bitcoin/sources/grow_bitcoin.move
@@ -896,12 +896,18 @@ module grow_bitcoin::grow_bitcoin {
         assert!(amount == 2025450, 1);
         assert!(amount2 == 675150, 2);
 
+        let amount = account_coin_store::balance<GROW>(owner_addr);
+        assert!(amount == 0, 3);
+
+        timestamp::fast_forward_seconds_for_test(seconds);
         batch_harvest(&sender, vector[utxo_id, utxo_id2]);
+        let amount = account_coin_store::balance<GROW>(owner_addr);
+        assert!(amount == 4050900, 4);
 
         batch_unstake(&sender, vector[utxo_id, utxo_id2]);
         let amount = query_gov_token_amount(utxo_id);
-        assert!(amount == 0, 3);
+        assert!(amount == 0, 5);
         let amount2 = query_gov_token_amount(utxo_id2);
-        assert!(amount2 == 0, 4);
+        assert!(amount2 == 0, 6);
     }
 }

--- a/apps/grow_bitcoin/sources/grow_bitcoin.move
+++ b/apps/grow_bitcoin/sources/grow_bitcoin.move
@@ -523,7 +523,6 @@ module grow_bitcoin::grow_bitcoin {
             if (!table::contains(&stake_table.stake, asset_id)) {
                 let utxo_obj = object::borrow_mut_object<UTXO>(signer, asset_id);
                 let coin = do_harvest(signer, object::id(utxo_obj));
-                utxo::remove_temp_state<StakeInfo>(utxo_obj);
                 coin::merge(&mut total_coin, coin);
             };
             i = i + 1;
@@ -551,7 +550,6 @@ module grow_bitcoin::grow_bitcoin {
             if (!table::contains(&stake_table.stake, asset_id)) {
                 let bbn_obj = object::borrow_mut_object<BBNStakeSeal>(signer, asset_id);
                 let coin = do_harvest(signer, object::id(bbn_obj));
-                bbn::remove_temp_state<StakeInfo>(bbn_obj);
                 coin::merge(&mut total_coin, coin);
             };
             i = i + 1;


### PR DESCRIPTION
## Summary

Before executing the batch operation, it is necessary to determine whether there are records or not. If there are no records, skip it.