### PR TITLE
[framework] Limit session key max_inactive_interval to 30 days

### DIFF
--- a/frameworks/rooch-framework/doc/session_key.md
+++ b/frameworks/rooch-framework/doc/session_key.md
@@ -79,6 +79,16 @@ The session's scope
 ## Constants
 
 
+<a name="0x3_session_key_ErrorInvalidMaxInactiveInterval"></a>
+
+The max inactive interval is invalid
+
+
+<pre><code><b>const</b> <a href="session_key.md#0x3_session_key_ErrorInvalidMaxInactiveInterval">ErrorInvalidMaxInactiveInterval</a>: u64 = 5;
+</code></pre>
+
+
+
 <a name="0x3_session_key_ErrorSessionKeyAlreadyExists"></a>
 
 The session key already exists
@@ -115,6 +125,15 @@ The lengths of the parts of the session's scope do not match.
 
 
 <pre><code><b>const</b> <a href="session_key.md#0x3_session_key_ErrorSessionScopePartLengthNotMatch">ErrorSessionScopePartLengthNotMatch</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x3_session_key_MAX_INACTIVE_INTERVAL"></a>
+
+
+
+<pre><code><b>const</b> <a href="session_key.md#0x3_session_key_MAX_INACTIVE_INTERVAL">MAX_INACTIVE_INTERVAL</a>: u64 = 2592000;
 </code></pre>
 
 

--- a/frameworks/rooch-framework/sources/session_key.move
+++ b/frameworks/rooch-framework/sources/session_key.move
@@ -16,6 +16,8 @@ module rooch_framework::session_key {
     friend rooch_framework::transaction_validator;
     friend rooch_framework::session_validator;
 
+    const MAX_INACTIVE_INTERVAL: u64 = 3600 * 24 * 30; // 30 days
+
     /// Create session key in this context is not allowed
     const ErrorSessionKeyCreatePermissionDenied: u64 = 1;
     /// The session key already exists
@@ -24,6 +26,8 @@ module rooch_framework::session_key {
     const ErrorSessionKeyIsInvalid: u64 = 3;
     /// The lengths of the parts of the session's scope do not match.
     const ErrorSessionScopePartLengthNotMatch: u64 = 4;
+    /// The max inactive interval is invalid
+    const ErrorInvalidMaxInactiveInterval: u64 = 5;
 
     /// The session's scope
     struct SessionScope has store,copy,drop {
@@ -115,6 +119,8 @@ module rooch_framework::session_key {
 
         //Can not create new session key by the other session key
         assert!(!auth_validator::is_validate_via_session_key(), ErrorSessionKeyCreatePermissionDenied);
+        assert!(max_inactive_interval <= MAX_INACTIVE_INTERVAL, ErrorInvalidMaxInactiveInterval);
+
         let sender_addr = signer::address_of(sender);
         assert!(!exists_session_key(sender_addr, authentication_key), ErrorSessionKeyAlreadyExists);
         let now_seconds = timestamp::now_seconds();


### PR DESCRIPTION
## Summary

Limit session key max_inactive_interval to 30 days
