### PR TITLE
[CLI] Add cursor argument for rooch object command

### DIFF
--- a/crates/rooch-types/src/indexer/state.rs
+++ b/crates/rooch-types/src/indexer/state.rs
@@ -15,6 +15,8 @@ use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::num::ParseIntError;
+use std::str::FromStr;
 
 pub static UTXO_TYPE_TAG: Lazy<TypeTag> = Lazy::new(UTXO::type_tag);
 
@@ -305,6 +307,30 @@ impl std::fmt::Display for IndexerStateID {
             "IndexerStateID[tx order: {:?}, state index: {}]",
             self.tx_order, self.state_index,
         )
+    }
+}
+
+impl FromStr for IndexerStateID {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(',').collect();
+        if parts.len() == 2 {
+            let tx_order = parts[0]
+                .parse::<u64>()
+                .map_err(|e: ParseIntError| format!("tx_order parse error: {}", e))?;
+            let state_index = parts[1]
+                .parse::<u64>()
+                .map_err(|e: ParseIntError| format!("state_index parse error: {}", e))?;
+            Ok(IndexerStateID {
+                tx_order,
+                state_index,
+            })
+        } else {
+            Err(
+                "Invalid format. Expected format: 'tx_order,state_index' (e.g., '12345,67890')"
+                    .to_string(),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
rooch object --help
```
rooch object --help                               
Usage: rooch object [OPTIONS]

Options:
  -i, --object-ids <OBJECT_IDS>...  Object ids. Separate multiple IDs with a space
  -t, --object-type <OBJECT_TYPE>   Struct name as `ADDRESS::MODULE_NAME::STRUCT_NAME<TypeParam1?, TypeParam2?>`
  -o, --owner <OWNER>               The address of the object's owner
      --cursor <CURSOR>             Provide the cursor in the format 'tx_order,state_index' (e.g., '12345,67890')
      --limit <LIMIT>               Max number of items returned per page
  -d, --descending-order            descending order
      --show-display                Render and return display fields
      --filter-out                  Is filter not object_type
      --password <PASSWORD>         The key store password
      --config-dir <CONFIG_DIR>     rooch config path
  -h, --help                        Print help
```
For example:

`rooch object --cursor 8991470,4`

- Closes #3018