### PR TITLE
feat(scripts): add RocksDB cache size configuration

### DIFF
--- a/scripts/deploy_rooch_mainnet.sh
+++ b/scripts/deploy_rooch_mainnet.sh
@@ -21,4 +21,6 @@ docker run -d --name rooch-mainnet --restart unless-stopped -v /data:/root -p 67
     --btc-rpc-password "$BTC_MAIN_RPC_PWD" \
     --da "{\"da-backend\": {\"backends\": [{\"open-da\": {\"scheme\": \"gcs\", \"config\": {\"bucket\": \"$OPENDA_GCP_MAINNET_BUCKET\", \"credential\": \"$OPENDA_GCP_MAINNET_CREDENTIAL\"}}}]}}" \
     --traffic-burst-size 200 \
-    --traffic-per-second 0.1
+    --traffic-per-second 0.1 \
+    --rocksdb-row-cache-size 17179869184 \
+    --rocksdb-block-cache-size 17179869184

--- a/scripts/deploy_rooch_testnet.sh
+++ b/scripts/deploy_rooch_testnet.sh
@@ -19,6 +19,8 @@ docker run -d --name rooch-testnet --restart unless-stopped -v /data:/root -p 67
     --btc-rpc-url "$BTC_TEST_RPC_URL" \
     --btc-rpc-username rooch-test \
     --btc-rpc-password "$BTC_TEST_RPC_PWD" \
+    --da "{\"da-backend\": {\"backends\": [{\"open-da\": {\"scheme\": \"gcs\", \"config\": {\"bucket\": \"$OPENDA_GCP_TESTNET_BUCKET\", \"credential\": \"$OPENDA_GCP_TESTNET_CREDENTIAL\"}}}]}}" \
     --traffic-burst-size 200 \
     --traffic-per-second 0.1 \
-    --da "{\"da-backend\": {\"backends\": [{\"open-da\": {\"scheme\": \"gcs\", \"config\": {\"bucket\": \"$OPENDA_GCP_TESTNET_BUCKET\", \"credential\": \"$OPENDA_GCP_TESTNET_CREDENTIAL\"}}}]}}"
+    --rocksdb-row-cache-size 8589934592 \
+    --rocksdb-block-cache-size 8589934592


### PR DESCRIPTION
## Summary

Added `--rocksdb-row-cache-size` and `--rocksdb-block-cache-size` flags to testnet and mainnet deployment scripts. This improves database performance by configuring cache sizes for RocksDB.

In local testing, an increase in execution speed was observed (after data sizes exceeded 1T)

The extra memory  cost won't much, the total memory usage keeps under 40GB with 16GB cache size for both of row and block cache.

New rocksdb statistics are being collected along with the local execution, and the parameters will be further refined as new evidence becomes available, starting with a relatively coarse cache expansion for this revision.