### PR TITLE
feat(build): add optdev profile for optimized debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,3 +405,8 @@ codegen-units = 1 # Help to achieve a better result with lto
 [profile.bench]
 inherits = "release"
 #debug = true
+
+[profile.optdev]
+inherits = "release"
+lto = "off"
+codegen-units = 16


### PR DESCRIPTION
## Summary

Added a new `optdev` profile in Cargo.toml inheriting from `release`. This profile disables LTO and sets codegen-units to 16 for faster, optimized debug builds. 