### PR TITLE
ci(deploy): add Turbo Avail DA backend support

### DIFF
--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -74,4 +74,6 @@ jobs:
             '${{ secrets.BTC_TEST_RPC_URL }}' \
             '${{ secrets.BTC_TEST_RPC_PWD }}' \
             '${{ secrets.OPENDA_GCP_TESTNET_BUCKET }}' \
-            '${{ secrets.OPENDA_GCP_TESTNET_CREDENTIAL }}'"
+            '${{ secrets.OPENDA_GCP_TESTNET_CREDENTIAL }}' \
+            '${{ secrets.TURBO_DA_TURING_ENDPOINT }}' \
+            '${{ secrets.TURBO_DA_TURING_TOKEN }}'"  

--- a/crates/rooch-config/src/da_config.rs
+++ b/crates/rooch-config/src/da_config.rs
@@ -519,5 +519,61 @@ mod tests {
                 panic!("Error parsing DA Config: {}", e)
             }
         }
+
+        let da_config_str = "{\"da-backend\":{\"backends\":[{\"open-da\":{\"scheme\":\"gcs\",\"config\":{\"bucket\":\"$OPENDA_GCP_TESTNET_BUCKET\",\"credential\":\"$OPENDA_GCP_TESTNET_CREDENTIAL\"}}},{\"open-da\":{\"scheme\":\"avail\",\"config\":{\"turbo_endpoint\":\"$TURBO_DA_TURING_ENDPOINT\",\"turbo_auth_token\":\"$TURBO_DA_TURING_TOKEN\"}}}]}}";
+        let exp_da_config = DAConfig {
+            da_backend: Some(DABackendConfig {
+                submit_strategy: None,
+                backends: vec![
+                    DABackendConfigType::OpenDa(DABackendOpenDAConfig {
+                        scheme: OpenDAScheme::Gcs,
+                        config: vec![
+                            (
+                                "bucket".to_string(),
+                                "$OPENDA_GCP_TESTNET_BUCKET".to_string(),
+                            ),
+                            (
+                                "credential".to_string(),
+                                "$OPENDA_GCP_TESTNET_CREDENTIAL".to_string(),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                        namespace: None,
+                        max_segment_size: None,
+                        max_retries: None,
+                    }),
+                    DABackendConfigType::OpenDa(DABackendOpenDAConfig {
+                        scheme: OpenDAScheme::Avail,
+                        config: vec![
+                            (
+                                "turbo_endpoint".to_string(),
+                                "$TURBO_DA_TURING_ENDPOINT".to_string(),
+                            ),
+                            (
+                                "turbo_auth_token".to_string(),
+                                "$TURBO_DA_TURING_TOKEN".to_string(),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                        namespace: None,
+                        max_segment_size: None,
+                        max_retries: None,
+                    }),
+                ],
+            }),
+            da_min_block_to_submit: None,
+            background_submit_interval: None,
+            base: None,
+        };
+        match DAConfig::from_str(da_config_str) {
+            Ok(da_config) => {
+                assert_eq!(da_config, exp_da_config);
+            }
+            Err(e) => {
+                panic!("Error parsing DA Config: {}", e)
+            }
+        }
     }
 }

--- a/scripts/deploy_rooch_testnet.sh
+++ b/scripts/deploy_rooch_testnet.sh
@@ -7,6 +7,8 @@ BTC_TEST_RPC_URL="$2"
 BTC_TEST_RPC_PWD="$3"
 OPENDA_GCP_TESTNET_BUCKET="$4"
 OPENDA_GCP_TESTNET_CREDENTIAL="$5"
+TURBO_DA_TURING_ENDPOINT="$6"
+TURBO_DA_TURING_TOKEN="$7"
 
 sleep 30
 docker image prune -a -f
@@ -19,8 +21,8 @@ docker run -d --name rooch-testnet --restart unless-stopped -v /data:/root -p 67
     --btc-rpc-url "$BTC_TEST_RPC_URL" \
     --btc-rpc-username rooch-test \
     --btc-rpc-password "$BTC_TEST_RPC_PWD" \
-    --da "{\"da-backend\": {\"backends\": [{\"open-da\": {\"scheme\": \"gcs\", \"config\": {\"bucket\": \"$OPENDA_GCP_TESTNET_BUCKET\", \"credential\": \"$OPENDA_GCP_TESTNET_CREDENTIAL\"}}}]}}" \
+    --da "{\"da-backend\":{\"backends\":[{\"open-da\":{\"scheme\":\"gcs\",\"config\":{\"bucket\":\"$OPENDA_GCP_TESTNET_BUCKET\",\"credential\":\"$OPENDA_GCP_TESTNET_CREDENTIAL\"}}},{\"open-da\":{\"scheme\":\"avail\",\"config\":{\"turbo_endpoint\":\"$TURBO_DA_TURING_ENDPOINT\",\"turbo_auth_token\":\"$TURBO_DA_TURING_TOKEN\"}}}]}}" \
     --traffic-burst-size 200 \
     --traffic-per-second 0.1 \
-    --rocksdb-row-cache-size 8589934592 \
+    --rocksdb-row-cache-size 4294967296 \
     --rocksdb-block-cache-size 8589934592


### PR DESCRIPTION
## Summary

Add Turbo Avail as a new data availability backend with support for `turbo_endpoint` and `turbo_auth_token` in configuration. Updated deployment scripts and workflows to include Avail-specific secrets.