### PR TITLE
feat(rooch-da): add transaction stats tracking to unpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5174,7 +5174,11 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
+ "base64 0.21.7",
  "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom 7.1.3",
  "num-traits 0.2.19",
 ]
 
@@ -10093,6 +10097,7 @@ dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=56f6223b84ada922b6cb2c672c69db2ea3dc6a13)",
  "framework-release",
  "framework-types",
+ "hdrhistogram",
  "hex",
  "itertools 0.13.0",
  "jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,7 @@ eyre = "0.6.8"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "56f6223b84ada922b6cb2c672c69db2ea3dc6a13" }
 futures = "0.3.31"
 futures-util = "0.3.31"
+hdrhistogram = "7.5.4"
 hex = "0.4.3"
 itertools = "0.13.0"
 jsonrpsee = { version = "0.23.2", features = ["full"] }

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -34,6 +34,7 @@ async-trait = { workspace = true }
 codespan-reporting = { workspace = true }
 termcolor = { workspace = true }
 itertools = { workspace = true }
+hdrhistogram = { workspace = true }
 hex = { workspace = true }
 regex = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/rooch/src/commands/da/commands/exec.rs
+++ b/crates/rooch/src/commands/da/commands/exec.rs
@@ -465,6 +465,14 @@ impl ExecInner {
                 );
                 Err(error)
             } else {
+                // return error if is state root not equal to RoochNetwork
+                if error
+                    .to_string()
+                    .contains("Execution state root is not equal to RoochNetwork")
+                {
+                    return Err(error);
+                }
+
                 tracing::warn!(
                     "L2 Tx execution failed with a non-VM panic error. Ignoring and returning Ok; tx_order: {}, error: {:?}",
                     tx_order,


### PR DESCRIPTION
## Summary

1. Added support for tracking and displaying L2 transaction size statistics in the unpack command, including histograms and top-N transaction sizes. Also introduced a `--stats-only` flag to unpack for stats-only processing.

2. fix(rooch-da): handle state root mismatch error in execution
    
    Add explicit error handling for cases where the execution state root does not match RoochNetwork. This ensures more accurate error reporting and avoids unintended behavior during L2 transaction execution.