### PR TITLE
fix: fix website docs spelling mistake

### DIFF
--- a/docs/website/pages/build/getting-started/connect-to-rooch/run-local-testnet.zh-CN.mdx
+++ b/docs/website/pages/build/getting-started/connect-to-rooch/run-local-testnet.zh-CN.mdx
@@ -29,7 +29,7 @@ StoreConfig init store dir "/tmp/.tmpHkNH5Q/dev/roochdb/rooch_store" "/tmp/.tmpH
 
 ## 解决数据兼容问题
 
-如果有遇到服务数据冲突的问题，首先执行清楚命令，再继续启动服务：
+如果有遇到服务数据冲突的问题，首先执行清除命令，再继续启动服务：
 
 ```shell
 $ rooch server clean


### PR DESCRIPTION
## Summary

fix website docs spelling mistake in the line 

> 如果有遇到服务数据冲突的问题，首先执行**清楚**命令，再继续启动服务：

 to 

>  如果有遇到服务数据冲突的问题，首先执行**清除**命令，再继续启动服务：