### PR TITLE
chore(deps): replace rooch-network/rust-rocksdb with upstream rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5880,26 +5880,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jni"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6530,16 +6510,17 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.17.0+9.0.0"
-source = "git+https://github.com/rooch-network/rust-rocksdb.git?rev=41d102327ba3cf9a2335d1192e8312c92bc3d6f9#41d102327ba3cf9a2335d1192e8312c92bc3d6f9"
+version = "0.17.1+9.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
@@ -10072,8 +10053,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
-source = "git+https://github.com/rooch-network/rust-rocksdb.git?rev=41d102327ba3cf9a2335d1192e8312c92bc3d6f9#41d102327ba3cf9a2335d1192e8312c92bc3d6f9"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -10101,7 +10083,6 @@ dependencies = [
  "hdrhistogram",
  "hex",
  "itertools 0.13.0",
- "jemallocator",
  "lazy_static 1.5.0",
  "metrics",
  "mimalloc",
@@ -10164,6 +10145,7 @@ dependencies = [
  "tabled",
  "tempfile",
  "termcolor",
+ "tikv-jemallocator",
  "tiny-keccak",
  "tokio",
  "tracing",
@@ -10189,7 +10171,6 @@ dependencies = [
  "clap 4.5.17",
  "criterion",
  "ethers",
- "jemallocator",
  "lazy_static 1.5.0",
  "metrics",
  "move-binary-format",
@@ -10225,6 +10206,7 @@ dependencies = [
  "rooch-types",
  "serde 1.0.216",
  "smt",
+ "tikv-jemallocator",
  "tokio",
  "toml 0.8.19",
  "tracing",
@@ -12774,6 +12756,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,7 @@ revm-primitives = "4.0.0"
 scopeguard = "1.1"
 uuid = { version = "1.11.0", features = ["v4", "fast-rng"] }
 protobuf = { version = "2.28", features = ["with-bytes"] }
-rocksdb = { git = "https://github.com/rooch-network/rust-rocksdb.git", rev = "41d102327ba3cf9a2335d1192e8312c92bc3d6f9", features = ["lz4", "mt_static"] }
+rocksdb = { version = "0.23.0", features = ["lz4", "mt_static", "jemalloc"] }
 lz4 = { version = "1.28.1" }
 ripemd = { version = "0.1.3" }
 fastcrypto-zkp = { version = "0.1.3" }
@@ -325,6 +325,8 @@ crossbeam-channel = "0.5.14"
 inferno = "0.11.21"
 handlebars = "4.2.2"
 indexmap = "2.7.0"
+tikv-jemallocator = { version = "0.6.0", features = ["unprefixed_malloc_on_supported_platforms", "profiling"] }
+mimalloc = { version = "0.1.39" }
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES

--- a/crates/rooch-benchmarks/Cargo.toml
+++ b/crates/rooch-benchmarks/Cargo.toml
@@ -31,7 +31,7 @@ bitcoincore-rpc = { workspace = true }
 bitcoin = { workspace = true }
 toml = { workspace = true }
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { version = "0.5.4", features = ["unprefixed_malloc_on_supported_platforms", "profiling"] }
+tikv-jemallocator = { workspace = true }
 prometheus = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -110,9 +110,9 @@ framework-release = { workspace = true }
 
 #We should keep the allocator in the last of the dependencies
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { version = "0.5.4", features = ["unprefixed_malloc_on_supported_platforms", "profiling"] }
+tikv-jemallocator = { workspace = true }
 [target.'cfg(target_env = "msvc")'.dependencies]
-mimalloc = { version = "0.1.39" }
+mimalloc = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/rooch/src/main.rs
+++ b/crates/rooch/src/main.rs
@@ -7,7 +7,7 @@ use std::process::exit;
 
 #[cfg(not(target_env = "msvc"))]
 mod allocator {
-    use jemallocator::Jemalloc;
+    use tikv_jemallocator::Jemalloc;
 
     pub type Allocator = Jemalloc;
 


### PR DESCRIPTION
## Summary

1. replace rooch/rust-rocksdb with upstream rocksdb ([fix GETCPU feature](https://github.com/rust-rocksdb/rust-rocksdb/pull/950) has been released in v0.23.0)
2. replace jemalloc with tikv-jemallocator