### PR TITLE
fix(openda): improve chunk submission tracking and handle optional latest_done_chunk_id compatibility

### DIFF
--- a/crates/rooch-da/src/actor/server.rs
+++ b/crates/rooch-da/src/actor/server.rs
@@ -132,6 +132,7 @@ impl DAServerActor {
             // (it's block number too for ChunkV0, which is the only version now)
             let future = stat.get_latest_done_chunk_id();
             let result = future.await; // Resolve the future
+            let result = result.unwrap_or_else(|| 0); // for compatibility with old version which doesn't have this Optional field
             avail_backends.push((identifier, result));
         }
 


### PR DESCRIPTION
## Summary

Revamped `AdapterSubmitStat` to track submitted segments using a vector instead of the sum, ensuring accurate submission tracking. Adjusted `get_latest_done_chunk_id` to return `Option<u128>` and implemented a fallback for compatibility with older versions. Updated tests accordingly.