### PR TITLE
feat(rooch-db): add command to fetch transaction by order

### DIFF
--- a/crates/rooch/src/commands/da/README.md
+++ b/crates/rooch/src/commands/da/README.md
@@ -62,14 +62,17 @@ Features include:
 2. Compare state root with Rooch Network Mainnet/Testnet by tx_order:state_root list file
 3. We could collect performance data in the execution process by tuning tools like `perf` if needed
 
-#### Prepare tx_order:state_root list file
+#### Prepare tx_order:state_root:accumulator_root list file
 
-using [order_state.sh](https://github.com/popcnt1/roh/blob/main/scripts/order_state.sh) to generate tx_order:state_root:
+If not run with `--mode sync`, you should prepare tx_order:state_root:accumulator_root list file by yourself.
+
+using [get_state_interval.sh](https://github.com/popcnt1/roh/blob/main/scripts/get_state_interval.sh) to generate
+tx_order:state_root:
 accumulator_root list file:
 
 ```shell
 rooch env switch -n {network}
-./order_state.sh {start_order} {end_order} {interval}
+./get_state_interval.sh {start_order} {end_order} {interval}
 ```
 
 #### Prepare genesis

--- a/crates/rooch/src/commands/da/commands/exec.rs
+++ b/crates/rooch/src/commands/da/commands/exec.rs
@@ -58,7 +58,7 @@ pub struct ExecCommand {
     #[clap(
         long = "mode",
         default_value = "all",
-        help = "Execution mode: exec, seq, all. Default is all"
+        help = "Execution mode: exec, seq, all, sync. Default is all"
     )]
     pub mode: ExecMode,
     #[clap(long = "segment-dir")]

--- a/crates/rooch/src/commands/da/commands/mod.rs
+++ b/crates/rooch/src/commands/da/commands/mod.rs
@@ -512,7 +512,12 @@ impl TxMetaStore {
             let line = line.unwrap();
             let parts: Vec<&str> = line.split(':').collect();
             let tx_order = parts[0].parse::<u64>()?;
-            let state_root = H256::from_str(parts[1])?;
+            let state_root_raw = parts[1];
+            let state_root = if state_root_raw == "null" {
+                H256::zero()
+            } else {
+                H256::from_str(state_root_raw)?
+            };
             let accumulator_root = H256::from_str(parts[2])?;
             exp_roots.insert(tx_order, (state_root, accumulator_root));
             if tx_order > max_verified_tx_order {

--- a/crates/rooch/src/commands/db/commands/get_tx_by_order.rs
+++ b/crates/rooch/src/commands/db/commands/get_tx_by_order.rs
@@ -1,0 +1,39 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::db::commands::init;
+use clap::Parser;
+use rooch_config::R_OPT_NET_HELP;
+use rooch_types::error::RoochResult;
+use rooch_types::rooch_network::RoochChainID;
+use rooch_types::transaction::LedgerTransaction;
+use std::path::PathBuf;
+
+/// Get LedgerTransaction by tx_order
+#[derive(Debug, Parser)]
+pub struct GetTxByOrderCommand {
+    /// Transaction's order
+    #[clap(long)]
+    pub order: u64,
+
+    #[clap(long = "data-dir", short = 'd')]
+    /// Path to data dir, this dir is base dir, the final data_dir is base_dir/chain_network_name
+    pub base_data_dir: Option<PathBuf>,
+
+    /// If local chainid, start the service with a temporary data store.
+    /// All data will be deleted when the service is stopped.
+    #[clap(long, short = 'n', help = R_OPT_NET_HELP)]
+    pub chain_id: Option<RoochChainID>,
+}
+
+impl GetTxByOrderCommand {
+    pub fn execute(self) -> RoochResult<Option<LedgerTransaction>> {
+        let (_root, rooch_db, _start_time) = init(self.base_data_dir, self.chain_id);
+        let rooch_store = rooch_db.rooch_store.clone();
+
+        let tx_opt = rooch_store
+            .get_transaction_store()
+            .get_tx_by_order(self.order)?;
+        Ok(tx_opt)
+    }
+}

--- a/crates/rooch/src/commands/db/commands/mod.rs
+++ b/crates/rooch/src/commands/db/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod best_rollback;
 pub mod drop;
 pub mod get_changeset_by_order;
 pub mod get_execution_info_by_hash;
+pub mod get_tx_by_order;
 pub mod repair;
 pub mod revert;
 pub mod rollback;

--- a/crates/rooch/src/commands/db/mod.rs
+++ b/crates/rooch/src/commands/db/mod.rs
@@ -6,6 +6,7 @@ use crate::commands::db::commands::best_rollback::BestRollbackCommand;
 use crate::commands::db::commands::drop::DropCommand;
 use crate::commands::db::commands::get_changeset_by_order::GetChangesetByOrderCommand;
 use crate::commands::db::commands::get_execution_info_by_hash::GetExecutionInfoByHashCommand;
+use crate::commands::db::commands::get_tx_by_order::GetTxByOrderCommand;
 use crate::commands::db::commands::repair::RepairCommand;
 use crate::commands::db::commands::revert::RevertCommand;
 use async_trait::async_trait;
@@ -38,6 +39,9 @@ impl CommandAction<String> for DB {
             DBCommand::Repair(repair) => repair.execute().await.map(|resp| {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
             }),
+            DBCommand::GetTxByOrder(get_tx_by_order) => get_tx_by_order.execute().map(|resp| {
+                serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
+            }),
             DBCommand::GetChangesetByOrder(get_changeset_by_order) => {
                 get_changeset_by_order.execute().await.map(|resp| {
                     serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
@@ -62,6 +66,7 @@ pub enum DBCommand {
     Rollback(RollbackCommand),
     Drop(DropCommand),
     Repair(RepairCommand),
+    GetTxByOrder(GetTxByOrderCommand),
     GetChangesetByOrder(GetChangesetByOrderCommand),
     GetExecutionInfoByHash(GetExecutionInfoByHashCommand),
     BestRollback(BestRollbackCommand),

--- a/crates/rooch/src/commands/db/mod.rs
+++ b/crates/rooch/src/commands/db/mod.rs
@@ -39,18 +39,17 @@ impl CommandAction<String> for DB {
             DBCommand::Repair(repair) => repair.execute().await.map(|resp| {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
             }),
-            DBCommand::GetTxByOrder(get_tx_by_order) => get_tx_by_order.execute().map(|resp| {
-                serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
-            }),
-            DBCommand::GetChangesetByOrder(get_changeset_by_order) => {
-                get_changeset_by_order.execute().await.map(|resp| {
-                    serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
-                })
-            }
+            DBCommand::GetTxByOrder(get_tx_by_order) => get_tx_by_order
+                .execute()
+                .map(|resp| serde_json::to_string(&resp).expect("Failed to serialize response")),
+            DBCommand::GetChangesetByOrder(get_changeset_by_order) => get_changeset_by_order
+                .execute()
+                .await
+                .map(|resp| serde_json::to_string(&resp).expect("Failed to serialize response")),
             DBCommand::GetExecutionInfoByHash(get_execution_info_by_hash) => {
-                get_execution_info_by_hash.execute().map(|resp| {
-                    serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
-                })
+                get_execution_info_by_hash
+                    .execute()
+                    .map(|resp| serde_json::to_string(&resp).expect("Failed to serialize response"))
             }
             DBCommand::BestRollback(best_rollback) => best_rollback.execute().await.map(|resp| {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")


### PR DESCRIPTION
## Summary

1. Introduce `GetTxByOrderCommand` to fetch a `LedgerTransaction` based on its order. Integrated the new command into the database commands module and CLI.
2. handle null state roots when parsing expected roots file
3. docs improvements