### PR TITLE
Print full tx hash for trouble shoot

### DIFF
--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -289,7 +289,7 @@ impl ExecutorActor {
                         Ok(verified_tx) => Ok(verified_tx),
                         Err(e) => {
                             tracing::warn!(
-                                "transaction verify vm error, tx_hash: {}, error:{:?}",
+                                "transaction verify vm error, tx_hash: {:?}, error:{:?}",
                                 tx_hash,
                                 e
                             );
@@ -301,7 +301,7 @@ impl ExecutorActor {
                     let resolver = RootObjectResolver::new(self.root.clone(), &self.moveos_store);
                     let status_view = explain_vm_status(&resolver, e.clone())?;
                     tracing::warn!(
-                        "transaction validate vm error, tx_hash: {}, error:{:?}",
+                        "transaction validate vm error, tx_hash: {:?}, error:{:?}",
                         tx_hash,
                         status_view,
                     );
@@ -311,7 +311,7 @@ impl ExecutorActor {
             },
             Err(e) => {
                 tracing::warn!(
-                    "transaction validate error, tx_hash: {}, error:{:?}",
+                    "transaction validate error, tx_hash: {:?}, error:{:?}",
                     tx_hash,
                     e
                 );

--- a/crates/rooch-oracle/src/data_process.rs
+++ b/crates/rooch-oracle/src/data_process.rs
@@ -208,7 +208,7 @@ pub async fn execute_submit_data_tx(
         Ok(tx) => match tx.execution_info.status {
             KeptVMStatusView::Executed => {
                 info!(
-                    "Submit data value: {}, timestamp:{}, tx_hash: {}, gas_used:{}",
+                    "Submit data value: {}, timestamp:{}, tx_hash: {:?}, gas_used:{}",
                     data.value,
                     data.timestamp,
                     tx.execution_info.tx_hash,

--- a/crates/rooch-proposer/src/scc/mod.rs
+++ b/crates/rooch-proposer/src/scc/mod.rs
@@ -116,7 +116,7 @@ impl StateCommitmentChain {
         let tx_execution_info_opt = self.moveos_store.get_tx_execution_info(tx_hash)?;
         if tx_execution_info_opt.is_none() {
             return Err(anyhow::anyhow!(
-                "TransactionExecutionInfo not found for tx_hash: {}",
+                "TransactionExecutionInfo not found for tx_hash: {:?}",
                 tx_hash
             ));
         };

--- a/crates/rooch-relayer/src/actor/bitcoin_relayer.rs
+++ b/crates/rooch-relayer/src/actor/bitcoin_relayer.rs
@@ -164,7 +164,7 @@ impl BitcoinRelayer {
                 .await?;
 
             info!(
-                "BitcoinRelayer buffer block, height: {}, hash: {}",
+                "BitcoinRelayer buffer block, height: {}, hash: {:?}",
                 next_block_height, header_info.hash
             );
             self.buffer.push(BlockResult { header_info, block });
@@ -187,7 +187,7 @@ impl BitcoinRelayer {
             let time = block_result.block.header.time;
             let tx_size = block_result.block.txdata.len();
             info!(
-                "BitcoinRelayer process block, height: {}, hash: {}, tx_size: {}, time: {}",
+                "BitcoinRelayer process block, height: {}, hash: {:?}, tx_size: {}, time: {}",
                 block_height, block_hash, tx_size, time
             );
             debug!("GetBlockHeaderResult: {:?}", block_result);

--- a/crates/rooch-relayer/src/actor/ethereum_relayer.rs
+++ b/crates/rooch-relayer/src/actor/ethereum_relayer.rs
@@ -46,7 +46,7 @@ impl EthereumRelayer {
                 }
                 let block_header = BlockHeader::try_from(&block)?;
                 info!(
-                    "EthereumRelayer process block, hash: {}, number: {}, timestamp: {}",
+                    "EthereumRelayer process block, hash: {:?}, number: {}, timestamp: {}",
                     block_hash, block_header.number, block_header.timestamp
                 );
                 let l1_block = L1BlockWithBody {

--- a/crates/rooch-relayer/src/actor/relayer.rs
+++ b/crates/rooch-relayer/src/actor/relayer.rs
@@ -109,14 +109,14 @@ impl RelayerActor {
         match result.execution_info.status {
             KeptVMStatus::Executed => {
                 info!(
-                    "Relayer execute relay block(hash: {}, height: {}) success",
+                    "Relayer execute relay block(hash: {:?}, height: {}) success",
                     block_hash, block_height
                 );
             }
             _ => {
                 //TODO should we stop the service if the relayer failed
                 error!(
-                    "Relayer execute relay block(hash: {}, height: {}) failed, status: {:?}",
+                    "Relayer execute relay block(hash: {:?}, height: {}) failed, status: {:?}",
                     block_hash, block_height, result.execution_info.status
                 );
             }

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -104,7 +104,7 @@ impl RoochAPIServer for RoochServer {
         debug!("send_raw_transaction payload: {:?}", payload);
         let mut tx = bcs::from_bytes::<RoochTransaction>(&payload.0)?;
         info!(
-            "send_raw_transaction tx sender:{:?}, hash:{}",
+            "send_raw_transaction tx sender:{:?}, hash:{:?}",
             tx.sender(),
             tx.tx_hash()
         );

--- a/crates/rooch-sequencer/src/actor/sequencer.rs
+++ b/crates/rooch-sequencer/src/actor/sequencer.rs
@@ -156,7 +156,7 @@ impl SequencerActor {
             tx_accumulator_unsaved_nodes,
         )?;
         info!(
-            "sequencer sequenced tx_hash: {} tx_order: {:?}",
+            "sequencer sequenced tx_hash: {:?} tx_order: {:?}",
             tx_hash, tx_order
         );
         self.last_sequencer_info = sequencer_info;

--- a/crates/rooch/src/commands/transaction/commands/sign.rs
+++ b/crates/rooch/src/commands/transaction/commands/sign.rs
@@ -183,7 +183,7 @@ impl SignCommand {
     fn print_tx_details(input: &SignInput) {
         let tx_data = |tx_data: &RoochTransactionData| -> String {
             format!(
-                " Sender: {}\n Sequence number: {}\n Chain id: {}\n Max gas amount: {}\n Action: {}\n Transaction hash: {}\n",
+                " Sender: {}\n Sequence number: {}\n Chain id: {}\n Max gas amount: {}\n Action: {}\n Transaction hash: {:?}\n",
                 tx_data.sender,
                 tx_data.sequence_number,
                 tx_data.chain_id,

--- a/moveos/moveos-store/src/lib.rs
+++ b/moveos/moveos-store/src/lib.rs
@@ -184,7 +184,7 @@ impl MoveOSStore {
 
         if tracing::enabled!(tracing::Level::DEBUG) {
             tracing::debug!(
-                "handle_tx_output: tx_hash: {}, state_root: {}, size: {}, gas_used: {}, status: {:?}",
+                "handle_tx_output: tx_hash: {:?}, state_root: {}, size: {}, gas_used: {}, status: {:?}",
                 tx_hash,
                 new_state_root,
                 size,

--- a/moveos/moveos/src/moveos.rs
+++ b/moveos/moveos/src/moveos.rs
@@ -260,7 +260,7 @@ impl MoveOS {
         let tx_hash = ctx.tx_hash();
         if tracing::enabled!(tracing::Level::DEBUG) {
             tracing::debug!(
-                "execute tx(sender:{}, hash:{}, action:{})",
+                "execute tx(sender:{}, hash:{:?}, action:{})",
                 ctx.sender(),
                 tx_hash,
                 action
@@ -308,7 +308,7 @@ impl MoveOS {
                 let status = VMStatus::Executed;
                 if tracing::enabled!(tracing::Level::DEBUG) {
                     tracing::debug!(
-                        "execute_action ok tx(hash:{}) vm_status:{:?}",
+                        "execute_action ok tx(hash:{:?}) vm_status:{:?}",
                         tx_hash,
                         status
                     );
@@ -318,7 +318,7 @@ impl MoveOS {
             Err(vm_err) => {
                 if tracing::enabled!(tracing::Level::WARN) {
                     tracing::warn!(
-                        "execute_action error tx(hash:{}) vm_err:{:?} need respawn session.",
+                        "execute_action error tx(hash:{:?}) vm_err:{:?} need respawn session.",
                         tx_hash,
                         vm_err
                     );


### PR DESCRIPTION
## Summary

The tx hash printed in the current log is truncated, which is not convenient for troubleshooting. All logs output the complete tx hash.

- Closes #issue