### PR TITLE
feat(rooch-da): add transaction order verification when making new batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10392,7 +10392,6 @@ dependencies = [
  "rooch-rpc-api",
  "rooch-rpc-client",
  "rooch-rpc-server",
- "rooch-sequencer",
  "rooch-store",
  "rooch-types",
  "rpassword",

--- a/crates/rooch-da/src/actor/server.rs
+++ b/crates/rooch-da/src/actor/server.rs
@@ -302,7 +302,7 @@ impl Submitter {
             tx_order_end,
             &tx_list,
             self.sequencer_key.copy(),
-        );
+        )?;
         let batch_meta = batch.meta.clone();
         let meta_signature = batch.meta_signature.clone();
         let batch_hash = batch.get_hash();

--- a/crates/rooch-types/src/da/batch.rs
+++ b/crates/rooch-types/src/da/batch.rs
@@ -118,7 +118,10 @@ impl DABatch {
         tx_order_end: u64,
         tx_list: &Vec<LedgerTransaction>,
         sequencer_key: RoochKeyPair,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
+        // fast check before signing
+        verify_tx_order(block_number, tx_list, tx_order_start, tx_order_end)?;
+
         let tx_list_bytes = bcs::to_bytes(tx_list).expect("encode tx_list should success");
         let tx_list_hash = sha2_256_of(&tx_list_bytes);
         let batch_meta = DABatchMeta::new(block_number, tx_order_start, tx_order_end, tx_list_hash);
@@ -128,11 +131,11 @@ impl DABatch {
             .as_ref()
             .to_vec();
 
-        Self {
+        Ok(Self {
             meta: batch_meta,
             meta_signature,
             tx_list_bytes,
-        }
+        })
     }
 
     pub fn get_hash(&self) -> H256 {
@@ -140,50 +143,77 @@ impl DABatch {
         sha2_256_of(&meta_bytes)
     }
 
+    /// Verify the batch, helpful when unpacking a batch from DA or other sources.
+    /// If verify_order is true, it will verify the tx order and its signature
     pub fn verify(&self, verify_order: bool) -> anyhow::Result<()> {
-        // verify tx_list_hash
+        // verify meta
         let tx_list_bytes = &self.tx_list_bytes;
         let tx_list_hash = sha2_256_of(tx_list_bytes);
         if tx_list_hash != self.meta.tx_list_hash {
             return Err(anyhow::anyhow!("tx_list_hash mismatch"));
         }
-
         let batch_hash = self.get_hash();
         let meta_signature = Signature::from_bytes(&self.meta_signature)?;
         meta_signature.verify(batch_hash.as_bytes())?;
-
+        // verify order and signature
         if verify_order {
-            self.verify_tx_order()?;
+            self.verify_order_and_signature()?;
         }
 
         Ok(())
     }
 
-    pub fn verify_tx_order(&self) -> anyhow::Result<()> {
-        let tx_list: Vec<LedgerTransaction> = self.get_tx_list();
-        let mut last_order = self.meta.block_range.tx_order_start;
+    fn verify_order_and_signature(&self) -> anyhow::Result<()> {
+        let tx_list = self.get_tx_list();
+        verify_tx_order(
+            self.meta.block_range.block_number,
+            &tx_list,
+            self.meta.block_range.tx_order_start,
+            self.meta.block_range.tx_order_end,
+        )?;
         for mut tx in tx_list {
             let tx_order = tx.sequence_info.tx_order;
-            if tx_order != last_order {
-                return Err(anyhow::anyhow!(
-                    "Transaction order is not strictly incremental for block {}: last_tx_order: {}, tx_order: {}",
-                            self.meta.block_range.block_number, last_order, tx_order
-                ));
-            }
-
             let tx_hash = tx.data.tx_hash();
             let mut witness_data = tx_hash.as_ref().to_vec();
             witness_data.extend(tx_order.to_le_bytes().iter());
             let witness_hash = h256::sha3_256_of(&witness_data);
             let tx_order_signature = Signature::from_bytes(&tx.sequence_info.tx_order_signature)?;
             tx_order_signature.verify(witness_hash.as_bytes())?;
-
-            last_order += 1;
         }
+
         Ok(())
     }
 
     pub fn get_tx_list(&self) -> Vec<LedgerTransaction> {
         bcs::from_bytes(&self.tx_list_bytes).expect("decode tx_list should success")
     }
+}
+
+// fast order verification
+fn verify_tx_order(
+    block_number: u128,
+    tx_list: &Vec<LedgerTransaction>,
+    tx_order_start: u64,
+    tx_order_end: u64,
+) -> anyhow::Result<()> {
+    let mut exp_tx_order = tx_order_start;
+    for tx in tx_list {
+        let tx_order = tx.sequence_info.tx_order;
+        if tx_order != exp_tx_order {
+            return Err(anyhow::anyhow!(
+                "Transaction order is not strictly incremental for block {}: exp_tx_order: {}, tx_order: {}",
+                block_number, exp_tx_order, tx_order
+            ));
+        }
+        exp_tx_order += 1;
+    }
+    exp_tx_order -= 1;
+    if exp_tx_order != tx_order_end {
+        return Err(anyhow::anyhow!(
+            "Transaction order is not strictly incremental for block {}: exp_tx_order: {}, tx_order_end: {}",
+            block_number, exp_tx_order, tx_order_end
+        ));
+    }
+
+    Ok(())
 }

--- a/crates/rooch-types/src/da/batch.rs
+++ b/crates/rooch-types/src/da/batch.rs
@@ -119,7 +119,7 @@ impl DABatch {
         tx_list: &Vec<LedgerTransaction>,
         sequencer_key: RoochKeyPair,
     ) -> anyhow::Result<Self> {
-        // fast check before signing
+        // Verify transaction ordering constraints before signing
         verify_tx_order(block_number, tx_list, tx_order_start, tx_order_end)?;
 
         let tx_list_bytes = bcs::to_bytes(tx_list).expect("encode tx_list should success");
@@ -164,7 +164,7 @@ impl DABatch {
     }
 
     fn verify_order_and_signature(&self) -> anyhow::Result<()> {
-        let tx_list = self.get_tx_list();
+        let tx_list = self.get_tx_list()?;
         verify_tx_order(
             self.meta.block_range.block_number,
             &tx_list,
@@ -184,8 +184,9 @@ impl DABatch {
         Ok(())
     }
 
-    pub fn get_tx_list(&self) -> Vec<LedgerTransaction> {
-        bcs::from_bytes(&self.tx_list_bytes).expect("decode tx_list should success")
+    pub fn get_tx_list(&self) -> anyhow::Result<Vec<LedgerTransaction>> {
+        let tx_list: Vec<LedgerTransaction> = bcs::from_bytes(&self.tx_list_bytes)?;
+        Ok(tx_list)
     }
 }
 

--- a/crates/rooch-types/src/test_utils.rs
+++ b/crates/rooch-types/src/test_utils.rs
@@ -11,6 +11,7 @@ use move_core_types::account_address::AccountAddress;
 use moveos_types::moveos_std::object::ObjectID;
 use rand::{thread_rng, Rng};
 
+use crate::crypto::RoochKeyPair;
 use crate::indexer::state::IndexerObjectState;
 pub use moveos_types::test_utils::*;
 
@@ -26,6 +27,19 @@ pub fn random_ledger_transaction() -> LedgerTransaction {
     let accumulator_info = random_accumulator_info();
     let random_sequence_info =
         TransactionSequenceInfo::new(rand::random(), tx_order_signature, accumulator_info, 0);
+    LedgerTransaction::new_l2_tx(rooch_transaction, random_sequence_info)
+}
+
+pub fn random_ledger_transaction_with_order(
+    tx_order: u64,
+    keypair: &RoochKeyPair,
+) -> LedgerTransaction {
+    let mut rooch_transaction = random_rooch_transaction();
+    let tx_hash = rooch_transaction.tx_hash();
+    let tx_order_signature = LedgerTransaction::sign_tx_order(tx_order, tx_hash, keypair);
+    let accumulator_info = random_accumulator_info();
+    let random_sequence_info =
+        TransactionSequenceInfo::new(tx_order, tx_order_signature, accumulator_info, 0);
     LedgerTransaction::new_l2_tx(rooch_transaction, random_sequence_info)
 }
 

--- a/crates/rooch-types/src/transaction/ledger_transaction.rs
+++ b/crates/rooch-types/src/transaction/ledger_transaction.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{RoochTransaction, TransactionSequenceInfo};
+use crate::crypto::{RoochKeyPair, Signature};
 use crate::{
     address::RoochAddress,
     multichain_id::{MultiChainID, RoochMultiChainID},
@@ -10,6 +11,7 @@ use accumulator::accumulator_info::AccumulatorInfo;
 use anyhow::Result;
 use bitcoin::hashes::Hash;
 use core::fmt;
+use moveos_types::h256;
 use moveos_types::h256::H256;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -221,5 +223,15 @@ impl LedgerTransaction {
         );
 
         LedgerTransaction::new(tx_data, tx_sequence_info)
+    }
+
+    /// Sign the tx order with the sequencer key.
+    pub fn sign_tx_order(tx_order: u64, tx_hash: H256, sequencer_key: &RoochKeyPair) -> Vec<u8> {
+        let mut witness_data = tx_hash.as_ref().to_vec();
+        witness_data.extend(tx_order.to_le_bytes().iter());
+        let witness_hash = h256::sha3_256_of(&witness_data);
+        Signature::sign(&witness_hash.0, sequencer_key)
+            .as_ref()
+            .to_vec()
     }
 }

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -106,7 +106,6 @@ rooch-common = { workspace = true }
 rooch-store = { workspace = true }
 rooch-faucet = { workspace = true }
 rooch-oracle = { workspace = true }
-rooch-sequencer = { workspace = true }
 
 framework-release = { workspace = true }
 

--- a/crates/rooch/src/commands/da/commands/mod.rs
+++ b/crates/rooch/src/commands/da/commands/mod.rs
@@ -235,7 +235,7 @@ pub(crate) fn get_tx_list_from_chunk(
     let chunk = chunk_from_segments(segments)?;
     let batch = chunk.get_batches().into_iter().next().unwrap();
     batch.verify(verify_order)?;
-    Ok(batch.get_tx_list())
+    batch.get_tx_list()
 }
 
 pub(crate) fn build_rooch_db(

--- a/crates/rooch/src/commands/da/commands/pack.rs
+++ b/crates/rooch/src/commands/da/commands/pack.rs
@@ -50,7 +50,8 @@ impl PackCommand {
             tx_order_end,
             &tx_list,
             sequencer_keypair,
-        );
+        )?;
+        // ensure the batch is valid
         batch.verify(true)?;
 
         let segments = ChunkV0::from(batch).to_segments(DEFAULT_MAX_SEGMENT_SIZE);

--- a/crates/rooch/src/commands/db/commands/best_rollback.rs
+++ b/crates/rooch/src/commands/db/commands/best_rollback.rs
@@ -204,7 +204,7 @@ async fn get_tx_list_from_chunk(
     let chunk = chunk_from_segments(segments)?;
     let batch = chunk.get_batches().into_iter().next().unwrap();
     batch.verify(true)?;
-    Ok(batch.get_tx_list())
+    batch.get_tx_list()
 }
 
 async fn get_segment(

--- a/crates/rooch/src/commands/transaction/commands/sign_order.rs
+++ b/crates/rooch/src/commands/transaction/commands/sign_order.rs
@@ -4,8 +4,8 @@
 use crate::cli_types::WalletContextOptions;
 use crate::utils::get_sequencer_keypair;
 use moveos_types::h256::H256;
-use rooch_sequencer::actor::sequencer::sign_tx_order;
 use rooch_types::error::RoochResult;
+use rooch_types::transaction::LedgerTransaction;
 
 /// Get transactions by hashes
 #[derive(Debug, clap::Parser)]
@@ -25,7 +25,8 @@ impl SignOrderCommand {
     pub fn execute(self) -> RoochResult<String> {
         let sequencer_keypair =
             get_sequencer_keypair(self.context_options, self.sequencer_account)?;
-        let tx_order_sign = sign_tx_order(self.tx_order, self.tx_hash, &sequencer_keypair);
+        let tx_order_sign =
+            LedgerTransaction::sign_tx_order(self.tx_order, self.tx_hash, &sequencer_keypair);
         let tx_order_sign_str = serde_json::to_string(&tx_order_sign)?;
         Ok(tx_order_sign_str)
     }


### PR DESCRIPTION
## Summary

1. feat(rooch-da): add transaction order verification
    
    Introduce `verify_tx_order` method for fast transaction order validation. Updated methods to include proper error handling with `anyhow::Result` and integrated validation checks when creating and verifying batches.

2. fix(rooch-da): handle errors in `get_tx_list` and improve checks
    
    Refactored `get_tx_list` to return `Result`, ensuring robust error handling. Added transaction ordering verification before signing to enhance consistency and reliability during batch processing.

3. feat(rooch-sequencer): move sign_tx_order to LedgerTransaction
    
    Relocated `sign_tx_order` function from `rooch-sequencer` to `LedgerTransaction` for better modularity and reuse. Updated relevant calls and tests to reflect the change.