### PR TITLE
[deps] Lock the bitcoin version to 0.32.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ bcs = "0.1.3"
 bytes = "1.10.0"
 bech32 = "0.11.0"
 better_any = "0.1.1"
-bitcoin = { version = "0.32.3", features = ["rand-std", "bitcoinconsensus"] }
+bitcoin = { version = "=0.32.3", features = ["rand-std", "bitcoinconsensus"] }
 bitcoin_hashes = { version = "0.14.0", features = ["serde"] }
 bitcoincore-rpc = "0.19.0"
 bitcoincore-rpc-json = "0.19.0"


### PR DESCRIPTION
## Summary

If the bitcoin auto upgrades to 0.32.5, it will raise error.

```
error[E0276]: impl has stricter requirements than trait
   --> /home/jolestar/opensource/src/github.com/rooch-network/rooch/crates/rooch-types/src/framework/auth_payload.rs:107:28
    |
107 |     fn consensus_decode<D: BufRead + ?Sized>(
    |                            ^^^^^^^ impl has extra requirement `D: bitcoin::bitcoin_io::BufRead`
```

TODO manually upgraded the bitcoin dependency. #2853