### PR TITLE
feat(rooch-sequencer): validate tx order continuity

### DIFF
--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -472,6 +472,7 @@ impl RoochGenesis {
             ledger_tx.clone(),
             sequencer_info,
             genesis_accumulator_unsaved_nodes,
+            true,
         )?;
         genesis_tx_accumulator.clear_after_save();
 

--- a/crates/rooch-store/src/lib.rs
+++ b/crates/rooch-store/src/lib.rs
@@ -157,11 +157,18 @@ impl RoochStore {
         tx: LedgerTransaction,
         sequencer_info: SequencerInfo,
         accumulator_nodes: Option<Vec<AccumulatorNode>>,
+        tx_order_checked: bool,
     ) -> Result<()> {
-        let pre_sequencer_info = self.get_sequencer_info()?;
-        if let Some(pre_sequencer_info) = pre_sequencer_info {
+        if !tx_order_checked {
+            let pre_sequencer_info = self
+                .get_sequencer_info()?
+                .ok_or(anyhow::anyhow!("Sequencer info not found"))?;
             if sequencer_info.last_order != pre_sequencer_info.last_order + 1 {
-                return Err(anyhow::anyhow!("Sequencer order is not continuous"));
+                return Err(anyhow::anyhow!(
+                    "Tx order not continuous, expect: {}, actual: {}",
+                    pre_sequencer_info.last_order + 1,
+                    sequencer_info.last_order
+                ));
             }
         }
 

--- a/crates/rooch/src/commands/da/commands/mod.rs
+++ b/crates/rooch/src/commands/da/commands/mod.rs
@@ -133,6 +133,7 @@ impl SequencedTxStore {
             tx.clone(),
             sequencer_info,
             tx_accumulator_unsaved_nodes,
+            false,
         )?;
         self.tx_accumulator.clear_after_save();
         Ok(())


### PR DESCRIPTION
## Summary

Add a tx_order_checked flag and helper function to ensure transaction order continuity. This addresses potential inconsistencies caused by pipeline reverts, enhancing data integrity.