### PR TITLE
feat(rooch-da): add verify command for segment order validation

### DIFF
--- a/crates/rooch/src/commands/da/commands/exec.rs
+++ b/crates/rooch/src/commands/da/commands/exec.rs
@@ -526,7 +526,7 @@ impl ExecInner {
                 }
                 result = self
                 .ledger_tx_getter
-                .load_ledger_tx_list(next_block_number, false) => {
+                .load_ledger_tx_list(next_block_number, false, true) => {
                 let tx_list = result?;
             if tx_list.is_none() {
                 if self.mode == ExecMode::Sync {

--- a/crates/rooch/src/commands/da/commands/mod.rs
+++ b/crates/rooch/src/commands/da/commands/mod.rs
@@ -41,6 +41,7 @@ pub mod index;
 pub mod namespace;
 pub mod pack;
 pub mod unpack;
+pub mod verify;
 
 pub(crate) struct SequencedTxStore {
     tx_accumulator: MerkleAccumulator,
@@ -425,6 +426,7 @@ impl LedgerTxGetter {
         &self,
         chunk_id: u128,
         must_has: bool,
+        verify_order: bool,
     ) -> anyhow::Result<Option<Vec<LedgerTransaction>>> {
         let tx_list_opt = self
             .chunks
@@ -445,7 +447,7 @@ impl LedgerTxGetter {
                         self.segment_dir.clone(),
                         chunk_id,
                         segment_numbers.clone(),
-                        true,
+                        verify_order,
                     )?;
                     Ok(Some(tx_list))
                 },
@@ -927,7 +929,7 @@ impl TxPositionIndexer {
 
         while block_number <= stop_at {
             let tx_list = ledger_tx_loader
-                .load_ledger_tx_list(block_number, true)
+                .load_ledger_tx_list(block_number, true, true)
                 .await?;
             let tx_list = tx_list.unwrap();
             {

--- a/crates/rooch/src/commands/da/commands/verify.rs
+++ b/crates/rooch/src/commands/da/commands/verify.rs
@@ -1,0 +1,53 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::da::commands::LedgerTxGetter;
+use clap::Parser;
+use rooch_types::error::RoochResult;
+use std::path::PathBuf;
+
+/// Verify segments from segments directory.
+/// Output: {expected_tx_order},{actual_tx_order},{tx_hash},{block_number}
+#[derive(Debug, Parser)]
+pub struct VerifyCommand {
+    #[clap(long = "segment-dir")]
+    pub segment_dir: PathBuf,
+    #[clap(long = "start-from", help = "Start from the specified block number")]
+    pub start_from: Option<u128>,
+}
+
+impl VerifyCommand {
+    pub async fn execute(self) -> RoochResult<()> {
+        let segment_dir = self.segment_dir;
+        let ledger_tx_loader = LedgerTxGetter::new(segment_dir)?;
+        let stop_at = ledger_tx_loader.get_max_chunk_id();
+        let mut block_number = self.start_from.unwrap_or(0);
+
+        let mut expected_tx_order = 0;
+
+        while block_number <= stop_at {
+            let tx_list = ledger_tx_loader
+                .load_ledger_tx_list(block_number, true, false)
+                .await?;
+            let tx_list = tx_list.unwrap();
+
+            if expected_tx_order == 0 {
+                expected_tx_order = tx_list.first().unwrap().sequence_info.tx_order;
+            }
+
+            for mut ledger_tx in tx_list {
+                let tx_order = ledger_tx.sequence_info.tx_order;
+                let tx_hash = ledger_tx.tx_hash();
+                if tx_order != expected_tx_order {
+                    println!(
+                        "{},{},{:?},{}",
+                        expected_tx_order, tx_order, tx_hash, block_number
+                    );
+                }
+                expected_tx_order += 1;
+            }
+            block_number += 1;
+        }
+        Ok(())
+    }
+}

--- a/crates/rooch/src/commands/da/mod.rs
+++ b/crates/rooch/src/commands/da/mod.rs
@@ -9,6 +9,7 @@ use crate::commands::da::commands::index::IndexCommand;
 use crate::commands::da::commands::namespace::NamespaceCommand;
 use crate::commands::da::commands::pack::PackCommand;
 use crate::commands::da::commands::unpack::UnpackCommand;
+use crate::commands::da::commands::verify::VerifyCommand;
 use async_trait::async_trait;
 use clap::Parser;
 use rooch_types::error::RoochResult;
@@ -32,6 +33,10 @@ impl CommandAction<String> for DA {
                 index.execute().await?;
                 Ok("".to_owned())
             }
+            DACommand::Verify(verify) => {
+                verify.execute().await?;
+                Ok("".to_owned())
+            }
         }
     }
 }
@@ -44,4 +49,5 @@ pub enum DACommand {
     Namespace(NamespaceCommand),
     Exec(Box<ExecCommand>),
     Index(IndexCommand),
+    Verify(VerifyCommand),
 }


### PR DESCRIPTION
## Summary

Introduce the `verify` command to validate transaction order in segments. This includes a new execution flow that checks expected vs. actual transaction orders and logs discrepancies.

output ( block: `[0,374435]`)

```
expected_tx_order,actual_tx_order,tx_hash,block_number
84658122,84658124,0x4854d82441239cda0805b963b404a007ecbc6366ce3fd4c37572cdb692624430,373386
84659999,84660000,0x44955c646f81defdcd4db2d038fc52f50949e943b59dc02757587f05e14ef007,373386
84706263,84706267,0xbb3bf39a48f85413e43f09de8a16b90237379f33abd77a8e6ea3c19ca96f2bc0,373392
84706265,84706267,0xbb3bf39a48f85413e43f09de8a16b90237379f33abd77a8e6ea3c19ca96f2bc0,373392
84706266,84706267,0xbb3bf39a48f85413e43f09de8a16b90237379f33abd77a8e6ea3c19ca96f2bc0,373392
```