### PR TITLE
Validate the l1 tx before execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11137,6 +11137,7 @@ dependencies = [
  "bs58 0.5.1",
  "chacha20poly1305",
  "clap 4.5.17",
+ "coerce",
  "derive_more 1.0.0",
  "enum_dispatch",
  "ethers",

--- a/crates/rooch-executor/src/actor/executor.rs
+++ b/crates/rooch-executor/src/actor/executor.rs
@@ -241,7 +241,7 @@ impl ExecutorActor {
             RoochMultiChainID::Bitcoin => {
                 // Validate the l1 tx before execution via contract,
                 // If it already execute, skip the tx.
-                let l1_tx_exist = self.validate_l1_tx_exist(tx_hash.clone())?;
+                let l1_tx_exist = self.validate_l1_tx_exist(tx_hash)?;
                 if l1_tx_exist {
                     return Err(anyhow::anyhow!("L1 tx {:?} has been executed", tx_hash));
                 }

--- a/crates/rooch-types/Cargo.toml
+++ b/crates/rooch-types/Cargo.toml
@@ -43,6 +43,7 @@ argon2 = { workspace = true }
 tracing = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 lz4 = { workspace = true }
+coerce = { workspace = true }
 
 move-core-types = { workspace = true }
 move-vm-types = { workspace = true }

--- a/crates/rooch-types/src/bitcoin/mod.rs
+++ b/crates/rooch-types/src/bitcoin/mod.rs
@@ -41,6 +41,7 @@ pub mod utxo;
 
 #[cfg(test)]
 mod tests;
+pub mod transaction_validator;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BitcoinBlockStore {

--- a/crates/rooch-types/src/bitcoin/mod.rs
+++ b/crates/rooch-types/src/bitcoin/mod.rs
@@ -8,6 +8,7 @@ use bitcoin::BlockHash;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
 };
+use moveos_types::h256::H256;
 use moveos_types::{
     module_binding::{ModuleBinding, MoveFunctionCaller},
     move_std::option::MoveOption,
@@ -99,6 +100,7 @@ impl<'a> BitcoinModule<'a> {
     pub const EXECUTE_L1_BLOCK_FUNCTION_NAME: &'static IdentStr = ident_str!("execute_l1_block");
     pub const GET_GENESIS_BLOCK_FUNCTION_NAME: &'static IdentStr = ident_str!("get_genesis_block");
     pub const EXECUTE_L1_TX_FUNCTION_NAME: &'static IdentStr = ident_str!("execute_l1_tx");
+    pub const EXIST_L1_TX_FUNCTION_NAME: &'static IdentStr = ident_str!("exist_l1_tx");
 
     pub fn get_block(&self, block_hash: BlockHash) -> Result<Option<Header>> {
         let call = Self::create_function_call(
@@ -228,6 +230,25 @@ impl<'a> BitcoinModule<'a> {
             vec![],
             vec![MoveValue::Address(block_hash), MoveValue::Address(txid)],
         ))
+    }
+
+    pub fn exist_l1_tx(&self, tx_hash: H256) -> Result<bool> {
+        let call = Self::create_function_call(
+            Self::EXIST_L1_TX_FUNCTION_NAME,
+            vec![],
+            vec![MoveValue::Address(tx_hash.into_address())],
+        );
+        let ctx = TxContext::new_readonly_ctx(AccountAddress::ZERO);
+        let exist = self
+            .caller
+            .call_function(&ctx, call)?
+            .into_result()
+            .map(|mut values| {
+                let value = values.pop().expect("should have one return value");
+                bcs::from_bytes::<bool>(&value.value).expect("should be a valid bool")
+            })
+            .map_err(|e| anyhow::anyhow!("Failed to check l1 tx exist: {:?}", e))?;
+        Ok(exist)
     }
 }
 

--- a/crates/rooch-types/src/bitcoin/transaction_validator.rs
+++ b/crates/rooch-types/src/bitcoin/transaction_validator.rs
@@ -1,0 +1,63 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use framework_types::addresses::BITCOIN_MOVE_ADDRESS;
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, value::MoveValue,
+};
+
+use crate::into_address::IntoAddress;
+use moveos_types::h256::H256;
+use moveos_types::{
+    module_binding::{ModuleBinding, MoveFunctionCaller},
+    moveos_std::tx_context::TxContext,
+};
+
+/// Rust bindings for BitcoinMove transaction_validator module
+pub struct TransactionValidator<'a> {
+    caller: &'a dyn MoveFunctionCaller,
+}
+
+impl<'a> TransactionValidator<'a> {
+    pub const VALIDATE_L1_TX_FUNCTION_NAME: &'static IdentStr = ident_str!("validate_l1_tx");
+
+    pub fn validate_l1_tx(
+        &self,
+        ctx: &TxContext,
+        tx_hash: H256,
+        _payload: Vec<u8>,
+    ) -> Result<bool> {
+        let tx_validator_call = Self::create_function_call(
+            Self::VALIDATE_L1_TX_FUNCTION_NAME,
+            vec![],
+            vec![
+                MoveValue::Address(tx_hash.into_address()),
+                MoveValue::vector_u8(vec![]),
+            ],
+        );
+
+        let result = self
+            .caller
+            .call_function(ctx, tx_validator_call)?
+            .into_result()
+            .map(|mut values| {
+                let value = values.pop().expect("should have one return value");
+                bcs::from_bytes::<bool>(&value.value).expect("should be a valid bool")
+            })
+            .map_err(|e| anyhow::anyhow!("Failed to validate l1 tx: {:?}", e))?;
+        Ok(result)
+    }
+}
+
+impl<'a> ModuleBinding<'a> for TransactionValidator<'a> {
+    const MODULE_NAME: &'static IdentStr = ident_str!("transaction_validator");
+    const MODULE_ADDRESS: AccountAddress = BITCOIN_MOVE_ADDRESS;
+
+    fn new(caller: &'a impl MoveFunctionCaller) -> Self
+    where
+        Self: Sized,
+    {
+        Self { caller }
+    }
+}

--- a/crates/rooch-types/src/error.rs
+++ b/crates/rooch-types/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use coerce::actor::ActorRefErr;
 use move_binary_format::errors::VMError;
 use moveos_types::genesis_info::GenesisInfo;
 use std::io;
@@ -134,8 +135,15 @@ pub enum RoochError {
     #[error("The onchain gas schedule is empty.")]
     OnchainGasScheduleIsEmpty,
 
+    #[error("The l1 tx has been executed.")]
+    L1TxAlreadyExecuted,
+
     #[error("VM error: {0}")]
     VMError(VMError),
+
+    // Add new variant for ActorRefErr
+    #[error("Actor reference error: {0}")]
+    ActorRefError(String),
 }
 
 impl From<anyhow::Error> for RoochError {
@@ -188,6 +196,12 @@ impl From<bitcoin::psbt::Error> for RoochError {
 impl From<hex::FromHexError> for RoochError {
     fn from(e: hex::FromHexError) -> Self {
         RoochError::CommandArgumentError(e.to_string())
+    }
+}
+
+impl From<ActorRefErr> for RoochError {
+    fn from(e: ActorRefErr) -> Self {
+        RoochError::ActorRefError(e.to_string())
     }
 }
 

--- a/frameworks/bitcoin-move/doc/README.md
+++ b/frameworks/bitcoin-move/doc/README.md
@@ -27,6 +27,7 @@ This is the reference documentation of the Bitcoin Move Framework.
 -  [`0x4::script_buf`](script_buf.md#0x4_script_buf)
 -  [`0x4::taproot_builder`](taproot_builder.md#0x4_taproot_builder)
 -  [`0x4::temp_state`](temp_state.md#0x4_temp_state)
+-  [`0x4::transaction_validator`](transaction_validator.md#0x4_transaction_validator)
 -  [`0x4::types`](types.md#0x4_types)
 -  [`0x4::utxo`](utxo.md#0x4_utxo)
 

--- a/frameworks/bitcoin-move/doc/bitcoin.md
+++ b/frameworks/bitcoin-move/doc/bitcoin.md
@@ -20,6 +20,7 @@
 -  [Function `get_latest_block`](#0x4_bitcoin_get_latest_block)
 -  [Function `get_bitcoin_time`](#0x4_bitcoin_get_bitcoin_time)
 -  [Function `contains_header`](#0x4_bitcoin_contains_header)
+-  [Function `exist_l1_tx`](#0x4_bitcoin_exist_l1_tx)
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
@@ -272,4 +273,16 @@ Get the bitcoin time in seconds
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bitcoin.md#0x4_bitcoin_contains_header">contains_header</a>(block_header: &<a href="types.md#0x4_types_Header">types::Header</a>): bool
+</code></pre>
+
+
+
+<a name="0x4_bitcoin_exist_l1_tx"></a>
+
+## Function `exist_l1_tx`
+
+Check is l1 tx exist
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bitcoin.md#0x4_bitcoin_exist_l1_tx">exist_l1_tx</a>(tx_hash: <b>address</b>): bool
 </code></pre>

--- a/frameworks/bitcoin-move/doc/transaction_validator.md
+++ b/frameworks/bitcoin-move/doc/transaction_validator.md
@@ -1,0 +1,39 @@
+
+<a name="0x4_transaction_validator"></a>
+
+# Module `0x4::transaction_validator`
+
+
+
+-  [Struct `TransactionValidatorPlaceholder`](#0x4_transaction_validator_TransactionValidatorPlaceholder)
+-  [Function `validate_l1_tx`](#0x4_transaction_validator_validate_l1_tx)
+
+
+<pre><code><b>use</b> <a href="bitcoin.md#0x4_bitcoin">0x4::bitcoin</a>;
+</code></pre>
+
+
+
+<a name="0x4_transaction_validator_TransactionValidatorPlaceholder"></a>
+
+## Struct `TransactionValidatorPlaceholder`
+
+The l1 tx already execute
+Just using to get module signer
+
+
+<pre><code><b>struct</b> <a href="transaction_validator.md#0x4_transaction_validator_TransactionValidatorPlaceholder">TransactionValidatorPlaceholder</a>
+</code></pre>
+
+
+
+<a name="0x4_transaction_validator_validate_l1_tx"></a>
+
+## Function `validate_l1_tx`
+
+This function is for Rooch to validate the l1 transaction.
+If validate fails, abort this function.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_validator.md#0x4_transaction_validator_validate_l1_tx">validate_l1_tx</a>(tx_hash: <b>address</b>, _payload: <a href="">vector</a>&lt;u8&gt;): bool
+</code></pre>

--- a/frameworks/bitcoin-move/sources/bitcoin.move
+++ b/frameworks/bitcoin-move/sources/bitcoin.move
@@ -401,6 +401,13 @@ module bitcoin_move::bitcoin{
         option::is_some(&block)
     }
 
+    /// Check is l1 tx exist
+    public fun exist_l1_tx(tx_hash: address): bool{
+        let btc_block_store_obj = borrow_block_store();
+        let btc_block_store = object::borrow(btc_block_store_obj);
+        table::contains(&btc_block_store.txs, tx_hash)
+    }
+
     #[test_only]
     public fun execute_l1_block_for_test(block_height: u64, block: Block){
         let block_hash = types::header_to_hash(types::header(&block));

--- a/frameworks/bitcoin-move/sources/transaction_validator.move
+++ b/frameworks/bitcoin-move/sources/transaction_validator.move
@@ -1,0 +1,29 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+module bitcoin_move::transaction_validator {
+    use bitcoin_move::bitcoin;
+
+    /// The l1 tx already execute
+    // const ErrorValidateL1TxAlreadyExist: u64 = 1001;
+
+    /// Just using to get module signer
+    struct TransactionValidatorPlaceholder {}
+
+    /// This function is for Rooch to validate the l1 transaction.
+    /// If validate fails, abort this function.
+    public fun validate_l1_tx(
+        tx_hash: address,
+        _payload: vector<u8>
+    ): bool {
+        // If the l1 tx has been executed, then skip the tx.
+        // And the validate result will be false instead of abort the function
+        if(bitcoin::exist_l1_tx(tx_hash)){
+            return false
+        };
+
+        // If validate fails, abort this function.
+
+        true
+    }
+}


### PR DESCRIPTION
## Summary

1. Validate the l1 tx before execution, if it already execute, skip the tx.
2. rooch move run support sequence-number argument 

- Closes #2763 #3318