### PR TITLE
ci(deploy-scripts): adjust rocksdb cache size configurations

### DIFF
--- a/scripts/deploy_rooch_mainnet.sh
+++ b/scripts/deploy_rooch_mainnet.sh
@@ -22,5 +22,5 @@ docker run -d --name rooch-mainnet --restart unless-stopped -v /data:/root -p 67
     --da "{\"da-backend\": {\"backends\": [{\"open-da\": {\"scheme\": \"gcs\", \"config\": {\"bucket\": \"$OPENDA_GCP_MAINNET_BUCKET\", \"credential\": \"$OPENDA_GCP_MAINNET_CREDENTIAL\"}}}]}}" \
     --traffic-burst-size 200 \
     --traffic-per-second 0.1 \
-    --rocksdb-row-cache-size 17179869184 \
-    --rocksdb-block-cache-size 17179869184
+    --rocksdb-row-cache-size 2147483648 \
+    --rocksdb-block-cache-size 34359738368

--- a/scripts/deploy_rooch_testnet.sh
+++ b/scripts/deploy_rooch_testnet.sh
@@ -24,5 +24,5 @@ docker run -d --name rooch-testnet --restart unless-stopped -v /data:/root -p 67
     --da "{\"da-backend\":{\"backends\":[{\"open-da\":{\"scheme\":\"gcs\",\"config\":{\"bucket\":\"$OPENDA_GCP_TESTNET_BUCKET\",\"credential\":\"$OPENDA_GCP_TESTNET_CREDENTIAL\"}}},{\"open-da\":{\"scheme\":\"avail\",\"config\":{\"turbo_endpoint\":\"$TURBO_DA_TURING_ENDPOINT\",\"turbo_api_key\":\"$TURBO_DA_TURING_API_KEY\"}}}]}}" \
     --traffic-burst-size 200 \
     --traffic-per-second 0.1 \
-    --rocksdb-row-cache-size 4294967296 \
-    --rocksdb-block-cache-size 8589934592
+    --rocksdb-row-cache-size 1073741824 \
+    --rocksdb-block-cache-size 12884901888


### PR DESCRIPTION
## Summary

Update `rocksdb-row-cache-size` and `rocksdb-block-cache-size` parameters in mainnet and testnet deploy scripts to optimize resource allocation:

1. row-cache hit rate is low, reduce size
2. increase block-cache size gain better performance in real data test