### PR TITLE
Verify state change set data

### DIFF
--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -213,6 +213,15 @@ impl Message for GetStateChangeSetsMessage {
     type Result = Result<Vec<Option<StateChangeSetExt>>>;
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CheckStateChangeSetsMessage {
+    pub tx_orders: Vec<u64>,
+}
+
+impl Message for CheckStateChangeSetsMessage {
+    type Result = Result<Vec<u64>>;
+}
+
 #[derive(Debug)]
 pub struct ConvertL2TransactionData {
     pub tx_data: RoochTransactionData,

--- a/crates/rooch-executor/src/actor/reader_executor.rs
+++ b/crates/rooch-executor/src/actor/reader_executor.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::messages::{
-    AnnotatedStatesMessage, ExecuteViewFunctionMessage, GetAnnotatedEventsByEventHandleMessage,
-    GetAnnotatedEventsByEventIDsMessage, GetEventsByEventHandleMessage, GetStateChangeSetsMessage,
-    RefreshStateMessage, StatesMessage,
+    AnnotatedStatesMessage, CheckStateChangeSetsMessage, ExecuteViewFunctionMessage,
+    GetAnnotatedEventsByEventHandleMessage, GetAnnotatedEventsByEventIDsMessage,
+    GetEventsByEventHandleMessage, GetStateChangeSetsMessage, RefreshStateMessage, StatesMessage,
 };
 use crate::actor::messages::{
     GetEventsByEventIDsMessage, GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage,
@@ -355,5 +355,19 @@ impl Handler<GetStateChangeSetsMessage> for ReaderExecutorActor {
         self.rooch_store
             .state_store
             .multi_get_state_change_set(tx_orders)
+    }
+}
+
+#[async_trait]
+impl Handler<CheckStateChangeSetsMessage> for ReaderExecutorActor {
+    async fn handle(
+        &mut self,
+        msg: CheckStateChangeSetsMessage,
+        _ctx: &mut ActorContext,
+    ) -> Result<Vec<u64>> {
+        let CheckStateChangeSetsMessage { tx_orders } = msg;
+        self.rooch_store
+            .state_store
+            .check_state_change_set(tx_orders)
     }
 }

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::actor::messages::{
-    ConvertL2TransactionData, DryRunTransactionResult, GetAnnotatedEventsByEventIDsMessage,
-    GetEventsByEventHandleMessage, GetEventsByEventIDsMessage, GetStateChangeSetsMessage,
-    GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage, ListStatesMessage,
-    RefreshStateMessage, SaveStateChangeSetMessage, ValidateL1BlockMessage, ValidateL1TxMessage,
+    CheckStateChangeSetsMessage, ConvertL2TransactionData, DryRunTransactionResult,
+    GetAnnotatedEventsByEventIDsMessage, GetEventsByEventHandleMessage, GetEventsByEventIDsMessage,
+    GetStateChangeSetsMessage, GetTxExecutionInfosByHashMessage, ListAnnotatedStatesMessage,
+    ListStatesMessage, RefreshStateMessage, SaveStateChangeSetMessage, ValidateL1BlockMessage,
+    ValidateL1TxMessage,
 };
 use crate::actor::reader_executor::ReaderExecutorActor;
 use crate::actor::{
@@ -276,6 +277,12 @@ impl ExecutorProxy {
     ) -> Result<Vec<Option<StateChangeSetExt>>> {
         self.reader_actor
             .send(GetStateChangeSetsMessage { tx_orders })
+            .await?
+    }
+
+    pub async fn check_state_change_sets(&self, tx_orders: Vec<u64>) -> Result<Vec<u64>> {
+        self.reader_actor
+            .send(CheckStateChangeSetsMessage { tx_orders })
             .await?
     }
 

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -126,6 +126,42 @@
       }
     },
     {
+      "name": "rooch_checkChangeSets",
+      "description": "Check change sets from sync states",
+      "params": [
+        {
+          "name": "cursor",
+          "schema": {
+            "$ref": "#/components/schemas/u64"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "$ref": "#/components/schemas/u64"
+          }
+        },
+        {
+          "name": "query_option",
+          "schema": {
+            "$ref": "#/components/schemas/QueryOptions"
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec<u64>",
+        "required": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        }
+      }
+    },
+    {
       "name": "rooch_dryRunRawTransaction",
       "params": [
         {

--- a/crates/rooch-rpc-api/src/api/mod.rs
+++ b/crates/rooch-rpc-api/src/api/mod.rs
@@ -11,6 +11,7 @@ pub const DEFAULT_RESULT_LIMIT_USIZE: usize = DEFAULT_RESULT_LIMIT as usize;
 
 pub const MAX_RESULT_LIMIT: u64 = 200;
 pub const MAX_RESULT_LIMIT_USIZE: usize = MAX_RESULT_LIMIT as usize;
+pub const MAX_INTERNAL_LIMIT_USIZE: usize = 2000;
 
 // pub fn validate_limit(limit: Option<u64>, max: usize) -> Result<usize, anyhow::Error> {
 //     match limit {

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -214,4 +214,13 @@ pub trait RoochAPI {
     /// Get the chain and service status
     #[method(name = "status")]
     async fn status(&self) -> RpcResult<Status>;
+
+    /// Check change sets from sync states
+    #[method(name = "checkChangeSets")]
+    async fn check_change_set(
+        &self,
+        cursor: Option<StrView<u64>>,
+        limit: Option<StrView<u64>>,
+        query_option: Option<QueryOptions>,
+    ) -> RpcResult<Vec<u64>>;
 }

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -524,7 +524,7 @@ impl RoochAPIServer for RoochServer {
 
             (end..start).rev().collect::<Vec<_>>()
         } else {
-            let start = cursor.unwrap_or(0);
+            let start = cursor.map(|s| s + 1).unwrap_or(0);
             let start_plus = start
                 .checked_add(limit_of + 1)
                 .ok_or(RpcError::UnexpectedError(
@@ -818,15 +818,15 @@ impl RoochAPIServer for RoochServer {
         let last_sequencer_order = self.rpc_service.get_sequencer_order().await?;
         let tx_orders = if descending_order {
             let start = cursor_of.unwrap_or(last_sequencer_order + 1);
-            let end = if start >= limit_of {
-                start - limit_of
+            let end = if start >= (limit_of + 1) {
+                start - (limit_of + 1)
             } else {
                 0
             };
 
             (end..start).rev().collect::<Vec<_>>()
         } else {
-            let start = cursor_of.unwrap_or(0);
+            let start = cursor_of.map(|s| s + 1).unwrap_or(0);
             let end_check = start
                 .checked_add(limit_of + 1)
                 .ok_or(RpcError::UnexpectedError(

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -799,6 +799,12 @@ impl RpcService {
         Ok(result)
     }
 
+    pub async fn check_state_change_sets(&self, tx_orders: Vec<u64>) -> Result<Vec<u64>> {
+        let result = self.executor.check_state_change_sets(tx_orders).await?;
+
+        Ok(result)
+    }
+
     pub async fn status(&self) -> Result<Status> {
         let service_status = self.pipeline_processor.get_service_status().await?;
         let sequencer_info = self.sequencer.get_sequencer_info().await?;

--- a/crates/rooch-store/src/lib.rs
+++ b/crates/rooch-store/src/lib.rs
@@ -342,6 +342,10 @@ impl StateStore for RoochStore {
     fn remove_state_change_set(&self, tx_order: u64) -> Result<()> {
         self.get_state_store().remove_state_change_set(tx_order)
     }
+
+    fn check_state_change_set(&self, tx_orders: Vec<u64>) -> Result<Vec<u64>> {
+        self.get_state_store().check_state_change_set(tx_orders)
+    }
 }
 
 impl DAMetaStore for RoochStore {

--- a/crates/rooch/src/commands/db/commands/changeset.rs
+++ b/crates/rooch/src/commands/db/commands/changeset.rs
@@ -1,0 +1,106 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_types::WalletContextOptions;
+use clap::Parser;
+use rooch_rpc_api::jsonrpc_types::{StateChangeSetPageView, StateChangeSetWithTxOrderView};
+use rooch_rpc_client::Client;
+use rooch_types::error::RoochResult;
+
+#[derive(Debug, Parser)]
+pub struct ChangesetCommand {
+    #[clap(long = "tx-order", help = "Start with the tx order")]
+    pub tx_order: Option<u64>,
+
+    #[clap(
+        long = "max-limit",
+        help = "Max limit for data verify",
+        default_value = "10000"
+    )]
+    pub max_limit: Option<u64>,
+
+    #[clap(flatten)]
+    pub(crate) context_options: WalletContextOptions,
+}
+
+impl ChangesetCommand {
+    pub async fn execute(self) -> RoochResult<()> {
+        let client = self.context_options.build()?.get_client().await?;
+
+        let mut counter = 0u64;
+        let per_limit = 200u64;
+        let max_limit = self.max_limit.unwrap_or(10000);
+        let tx_order = self.tx_order.unwrap_or(0);
+        loop {
+            if counter > max_limit {
+                break;
+            }
+
+            let cursor = if tx_order >= counter {
+                tx_order - counter + 1
+            } else {
+                0
+            };
+            let limit = if cursor >= per_limit {
+                per_limit
+            } else {
+                cursor
+            };
+            let expect_tx_orders = ((cursor - limit)..cursor).collect::<Vec<_>>();
+            let (data, _next_cursor, _has_next) = list_state_change_set(cursor, &client).await?;
+            let result_tx_orders = data.iter().map(|v| v.tx_order.0).collect::<Vec<_>>();
+
+            expect_tx_orders.iter().for_each(|v| {
+                if !result_tx_orders.contains(v) {
+                    println!("tx order {} in syncstate is inconsistent with statedb", v);
+                }
+            });
+
+            if !expect_tx_orders.is_empty() {
+                println!(
+                    "verify tx order from {} to {} in syncstate and statedb done",
+                    expect_tx_orders[0],
+                    expect_tx_orders[expect_tx_orders.len() - 1]
+                );
+            }
+
+            if limit < per_limit {
+                break;
+            }
+            counter += per_limit;
+        }
+
+        Ok(())
+    }
+}
+
+pub async fn list_state_change_set(
+    tx_order: u64,
+    client: &Client,
+) -> anyhow::Result<(Vec<StateChangeSetWithTxOrderView>, Option<u64>, bool)> {
+    let method = "rooch_syncStates";
+    let filter = "all";
+    let limit = 200u64;
+    let params_str = format!(
+        r#"["{}", "{}", "{}", {{"descending": true}}]"#,
+        filter, tx_order, limit
+    );
+    let params_ret = serde_json::from_str(&params_str);
+    let params = match params_ret {
+        Ok(value) => value,
+        Err(_) => {
+            vec![serde_json::value::Value::String(params_str)]
+        }
+    };
+
+    // Then cmd: "rpc request --method rooch_listStates --params '["/resource/0x3", null, null, {"decode":true}]' --json"
+    let resp = client.request(method, params).await?;
+    let state_change_set_view: StateChangeSetPageView = serde_json::from_value(resp)?;
+
+    let next_cursor = state_change_set_view.next_cursor.map(|v| v.0);
+    Ok((
+        state_change_set_view.data,
+        next_cursor,
+        state_change_set_view.has_next_page,
+    ))
+}

--- a/crates/rooch/src/commands/db/commands/mod.rs
+++ b/crates/rooch/src/commands/db/commands/mod.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 pub mod best_rollback;
+pub mod changeset;
 pub mod cp_cf;
 pub mod drop;
 pub mod get_changeset_by_order;

--- a/crates/rooch/src/commands/db/mod.rs
+++ b/crates/rooch/src/commands/db/mod.rs
@@ -3,6 +3,7 @@
 
 use crate::cli_types::CommandAction;
 use crate::commands::db::commands::best_rollback::BestRollbackCommand;
+use crate::commands::db::commands::changeset::ChangesetCommand;
 use crate::commands::db::commands::cp_cf::CpCfCommand;
 use crate::commands::db::commands::drop::DropCommand;
 use crate::commands::db::commands::get_changeset_by_order::GetChangesetByOrderCommand;
@@ -62,6 +63,9 @@ impl CommandAction<String> for DB {
             DBCommand::CpCf(cp_cf) => cp_cf.execute().map(|resp| {
                 serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
             }),
+            DBCommand::Changeset(changeset) => changeset.execute().await.map(|resp| {
+                serde_json::to_string_pretty(&resp).expect("Failed to serialize response")
+            }),
         }
     }
 }
@@ -79,4 +83,5 @@ pub enum DBCommand {
     BestRollback(BestRollbackCommand),
     ListEmpty(ListEmptyCommand),
     CpCf(CpCfCommand),
+    Changeset(ChangesetCommand),
 }


### PR DESCRIPTION
## Summary

1. Support changeset cmd to verify data
2. Fixup has next page flag when asc order for tx and change set rpc
3. Verifying data based on rooch_syncStates RPC is too slow, so provide a new change set RPC for verify data

- Closes #3341