### PR TITLE
[rooch-portal] fix: change go to swap link

### DIFF
--- a/infra/rooch-portal-v2/src/sections/trade/liquidity/components/add-liquidity-modal.tsx
+++ b/infra/rooch-portal-v2/src/sections/trade/liquidity/components/add-liquidity-modal.tsx
@@ -344,7 +344,7 @@ export default function AddLiquidityModal({
                             size="small"
                             variant="outlined"
                             onClick={() => {
-                              router.push('./swap');
+                              router.push('./swap-v2');
                             }}
                           >
                             Go to Swap


### PR DESCRIPTION
## Summary

The jump link for go to swap on the site is an error and when clicked on it goes to a 404 page.

<img width="1066" alt="33411741024628_ pic" src="https://github.com/user-attachments/assets/7f6e5514-866f-4e59-9198-35fa7e35cd28" />


<img width="1101" alt="33421741024642_ pic" src="https://github.com/user-attachments/assets/c070d415-d792-438c-ad9d-51d44c3fa5c2" />

Change: /swap -> /swap-v2

<img width="768" alt="33431741024725_ pic" src="https://github.com/user-attachments/assets/99a3a013-8e18-474d-9c71-b6e8d117003c" />
