### PR TITLE
[rooch-portal] Fix:amount input field behavior when clearing value

### DIFF
--- a/infra/rooch-portal-v2/src/sections/trade/liquidity/components/add-liquidity-modal.tsx
+++ b/infra/rooch-portal-v2/src/sections/trade/liquidity/components/add-liquidity-modal.tsx
@@ -262,6 +262,10 @@ export default function AddLiquidityModal({
                   autoComplete="off"
                   onChange={(e) => {
                     const value = e.target.value.replaceAll(',', '');
+                    if (value === '') {
+                      setXAmount('');
+                      return;
+                    }
                     if (/^\d*\.?\d*$/.test(value) === false) {
                       return;
                     }

--- a/infra/rooch-portal-v2/src/sections/trade/liquidity/components/add-liquidity-modal.tsx
+++ b/infra/rooch-portal-v2/src/sections/trade/liquidity/components/add-liquidity-modal.tsx
@@ -344,7 +344,7 @@ export default function AddLiquidityModal({
                             size="small"
                             variant="outlined"
                             onClick={() => {
-                              router.push('./swap');
+                              router.push('./swap-v2');
                             }}
                           >
                             Go to Swap


### PR DESCRIPTION
## Summary

Fixed a usability issue in the Add Liquidity modal where the amount input field would display "-" and become unusable after clearing all input values.

<img width="804" alt="33441741026144_ pic" src="https://github.com/user-attachments/assets/85c4ab6b-ca56-4fb7-bfef-9cc62b61779c" />


## Changes
- Added special handling for empty input values in the amount TextField
- Ensures the input field remains empty (instead of showing "-") when user clears all content
- Maintains the ability to input new numbers after clearing