### PR TITLE
Add support for vector<vector>

### DIFF
--- a/crates/rooch-types/src/function_arg.rs
+++ b/crates/rooch-types/src/function_arg.rs
@@ -121,10 +121,15 @@ impl FromStr for FunctionArgType {
                         return Err(RoochError::CommandArgumentError(
                             "vector<raw> is not supported".to_owned(),
                         ));
-                    } else if matches!(arg, FunctionArgType::Vector(_)) {
-                        return Err(RoochError::CommandArgumentError(
-                            "nested vector<vector<_>> is not supported".to_owned(),
-                        ));
+                    } else if let FunctionArgType::Vector(inner) = arg {
+                        if *inner == FunctionArgType::Raw {
+                            return Err(RoochError::CommandArgumentError(
+                                "vector<vector<raw>> is not supported".to_owned(),
+                            ));
+                        }
+                        return Ok(FunctionArgType::Vector(Box::new(FunctionArgType::Vector(
+                            inner,
+                        ))));
                     }
 
                     Ok(FunctionArgType::Vector(Box::new(arg)))


### PR DESCRIPTION
## Summary
This PR adds support to pass vector<vector> as transaction arguments. Please let me know if these changes look good and whether I should constrain the concrete type of inner vector to u8.

- Closes #issue
#3294 