### PR TITLE
[rooch-portal] fix: change go to Marketplace link 

### DIFF
--- a/docs/website/pages/_meta.en-US.json
+++ b/docs/website/pages/_meta.en-US.json
@@ -69,7 +69,7 @@
         "title": "Marketplace",
         "type": "page",
         "newWindow": true,
-        "href": "https://portal.rooch.network/trade"
+        "href": "https://portal.rooch.network/trade/market"
       }
     }
   },

--- a/docs/website/pages/_meta.zh-CN.json
+++ b/docs/website/pages/_meta.zh-CN.json
@@ -69,7 +69,7 @@
         "title": "市场",
         "type": "page",
         "newWindow": true,
-        "href": "https://portal.rooch.network/trade"
+        "href": "https://portal.rooch.network/trade/market"
       }
     }
   },


### PR DESCRIPTION
## Summary

The Marketplace link of the online website nav is /trad, tiao'zhuan is 404 after the jump.

<img width="233" alt="image" src="https://github.com/user-attachments/assets/19512e74-200f-477b-b56f-19d5f2861621" />

<img width="796" alt="image" src="https://github.com/user-attachments/assets/a66f27f2-68f4-42f4-94c2-ea0e4faafeea" />

/trad -> /trade/market