### PR TITLE
[moveos_std] Add AccountCap for contract account

### DIFF
--- a/frameworks/moveos-stdlib/doc/account.md
+++ b/frameworks/moveos-stdlib/doc/account.md
@@ -6,14 +6,17 @@
 
 
 -  [Resource `Account`](#0x2_account_Account)
+-  [Resource `AccountCap`](#0x2_account_AccountCap)
 -  [Constants](#@Constants_0)
 -  [Function `create_account_by_system`](#0x2_account_create_account_by_system)
 -  [Function `create_account`](#0x2_account_create_account)
+-  [Function `create_account_with_cap`](#0x2_account_create_account_with_cap)
 -  [Function `sequence_number`](#0x2_account_sequence_number)
 -  [Function `increment_sequence_number_for_system`](#0x2_account_increment_sequence_number_for_system)
 -  [Function `exists_at`](#0x2_account_exists_at)
 -  [Function `create_signer_for_system`](#0x2_account_create_signer_for_system)
 -  [Function `create_signer_with_account`](#0x2_account_create_signer_with_account)
+-  [Function `create_signer_with_account_cap`](#0x2_account_create_signer_with_account_cap)
 -  [Function `account_object_id`](#0x2_account_account_object_id)
 -  [Function `account_borrow_resource`](#0x2_account_account_borrow_resource)
 -  [Function `account_borrow_mut_resource`](#0x2_account_account_borrow_mut_resource)
@@ -21,6 +24,7 @@
 -  [Function `account_move_resource_from`](#0x2_account_account_move_resource_from)
 -  [Function `account_exists_resource`](#0x2_account_account_exists_resource)
 -  [Function `destroy_account`](#0x2_account_destroy_account)
+-  [Function `destroy_account_cap`](#0x2_account_destroy_account_cap)
 -  [Function `borrow_account`](#0x2_account_borrow_account)
 -  [Function `borrow_mut_account`](#0x2_account_borrow_mut_account)
 -  [Function `borrow_resource`](#0x2_account_borrow_resource)
@@ -44,11 +48,23 @@
 
 ## Resource `Account`
 
-Account is part of the StorageAbstraction
-It is also used to store the account's resources
+Account is a struct that holds the sequence number for an address
 
 
 <pre><code><b>struct</b> <a href="account.md#0x2_account_Account">Account</a> <b>has</b> key
+</code></pre>
+
+
+
+<a name="0x2_account_AccountCap"></a>
+
+## Resource `AccountCap`
+
+AccountCap is a capability for Account
+The contract that has AccountCap can access the Account object
+
+
+<pre><code><b>struct</b> <a href="account.md#0x2_account_AccountCap">AccountCap</a> <b>has</b> store, key
 </code></pre>
 
 
@@ -83,6 +99,16 @@ Cannot create account because address is reserved
 
 
 <pre><code><b>const</b> <a href="account.md#0x2_account_ErrorAddressReserved">ErrorAddressReserved</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x2_account_ErrorDeprecateFunction"></a>
+
+Deprecate function
+
+
+<pre><code><b>const</b> <a href="account.md#0x2_account_ErrorDeprecateFunction">ErrorDeprecateFunction</a>: u64 = 7;
 </code></pre>
 
 
@@ -143,10 +169,22 @@ Create a new account for the given address, only callable by the system account
 
 ## Function `create_account`
 
-Create an Account Object with a generated address
+This function is deprecated, please use <code>create_account_with_cap</code> instead
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_create_account">create_account</a>(): <a href="object.md#0x2_object_Object">object::Object</a>&lt;<a href="account.md#0x2_account_Account">account::Account</a>&gt;
+</code></pre>
+
+
+
+<a name="0x2_account_create_account_with_cap"></a>
+
+## Function `create_account_with_cap`
+
+Create a new account and return the AccountCap
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_create_account_with_cap">create_account_with_cap</a>(): <a href="account.md#0x2_account_AccountCap">account::AccountCap</a>
 </code></pre>
 
 
@@ -200,10 +238,21 @@ Return the current sequence number at <code>addr</code>
 
 ## Function `create_signer_with_account`
 
-Create a signer with mutable Object<Account>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_create_signer_with_account">create_signer_with_account</a>(<a href="account.md#0x2_account">account</a>: &<b>mut</b> <a href="object.md#0x2_object_Object">object::Object</a>&lt;<a href="account.md#0x2_account_Account">account::Account</a>&gt;): <a href="">signer</a>
+</code></pre>
+
+
+
+<a name="0x2_account_create_signer_with_account_cap"></a>
+
+## Function `create_signer_with_account_cap`
+
+Create a signer with the given account capability
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_create_signer_with_account_cap">create_signer_with_account_cap</a>(cap: &<b>mut</b> <a href="account.md#0x2_account_AccountCap">account::AccountCap</a>): <a href="">signer</a>
 </code></pre>
 
 
@@ -281,10 +330,22 @@ Create a signer with mutable Object<Account>
 
 ## Function `destroy_account`
 
-Destroy the account object
+Deprecated, we do not allow to destroy account object directly
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_destroy_account">destroy_account</a>(account_obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;<a href="account.md#0x2_account_Account">account::Account</a>&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_destroy_account">destroy_account</a>(_account_obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;<a href="account.md#0x2_account_Account">account::Account</a>&gt;)
+</code></pre>
+
+
+
+<a name="0x2_account_destroy_account_cap"></a>
+
+## Function `destroy_account_cap`
+
+Destroy the account capability
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_destroy_account_cap">destroy_account_cap</a>(account_cap: <a href="account.md#0x2_account_AccountCap">account::AccountCap</a>)
 </code></pre>
 
 

--- a/frameworks/moveos-stdlib/doc/account.md
+++ b/frameworks/moveos-stdlib/doc/account.md
@@ -10,7 +10,7 @@
 -  [Constants](#@Constants_0)
 -  [Function `create_account_by_system`](#0x2_account_create_account_by_system)
 -  [Function `create_account`](#0x2_account_create_account)
--  [Function `create_account_with_cap`](#0x2_account_create_account_with_cap)
+-  [Function `create_account_and_return_cap`](#0x2_account_create_account_and_return_cap)
 -  [Function `sequence_number`](#0x2_account_sequence_number)
 -  [Function `increment_sequence_number_for_system`](#0x2_account_increment_sequence_number_for_system)
 -  [Function `exists_at`](#0x2_account_exists_at)
@@ -105,7 +105,7 @@ Cannot create account because address is reserved
 
 <a name="0x2_account_ErrorDeprecateFunction"></a>
 
-Deprecate function
+The function is deprecated
 
 
 <pre><code><b>const</b> <a href="account.md#0x2_account_ErrorDeprecateFunction">ErrorDeprecateFunction</a>: u64 = 7;
@@ -169,7 +169,7 @@ Create a new account for the given address, only callable by the system account
 
 ## Function `create_account`
 
-This function is deprecated, please use <code>create_account_with_cap</code> instead
+This function is deprecated, please use <code>create_account_and_return_cap</code> instead
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_create_account">create_account</a>(): <a href="object.md#0x2_object_Object">object::Object</a>&lt;<a href="account.md#0x2_account_Account">account::Account</a>&gt;
@@ -177,14 +177,14 @@ This function is deprecated, please use <code>create_account_with_cap</code> ins
 
 
 
-<a name="0x2_account_create_account_with_cap"></a>
+<a name="0x2_account_create_account_and_return_cap"></a>
 
-## Function `create_account_with_cap`
+## Function `create_account_and_return_cap`
 
 Create a new account and return the AccountCap
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_create_account_with_cap">create_account_with_cap</a>(): <a href="account.md#0x2_account_AccountCap">account::AccountCap</a>
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_create_account_and_return_cap">create_account_and_return_cap</a>(): <a href="account.md#0x2_account_AccountCap">account::AccountCap</a>
 </code></pre>
 
 
@@ -330,7 +330,7 @@ Create a signer with the given account capability
 
 ## Function `destroy_account`
 
-Deprecated, we do not allow to destroy account object directly
+Deprecated: Direct destruction of account objects is not allowed.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x2_account_destroy_account">destroy_account</a>(_account_obj: <a href="object.md#0x2_object_Object">object::Object</a>&lt;<a href="account.md#0x2_account_Account">account::Account</a>&gt;)

--- a/frameworks/moveos-stdlib/sources/account.move
+++ b/frameworks/moveos-stdlib/sources/account.move
@@ -34,7 +34,7 @@ module moveos_std::account {
    const ErrorResourceAlreadyExists: u64 = 5;
    /// The resource with the given type not exists
    const ErrorResourceNotExists: u64 = 6;
-   /// Deprecate function
+   /// The function is deprecated
    const ErrorDeprecateFunction: u64 = 7;
 
    /// Create a new account for the given address, only callable by the system account
@@ -43,7 +43,7 @@ module moveos_std::account {
       create_account_internal(new_address)
    }
 
-   /// This function is deprecated, please use `create_account_with_cap` instead
+   /// This function is deprecated, please use `create_account_and_return_cap` instead
    public fun create_account(): Object<Account> {
       //We shoud not return Object<Account> directly,
       //Becase if other struct hold the Object<Account>, and the resource functions will not work
@@ -51,7 +51,7 @@ module moveos_std::account {
    }
 
    /// Create a new account and return the AccountCap
-   public fun create_account_with_cap(): AccountCap {
+   public fun create_account_and_return_cap(): AccountCap {
       let new_address = tx_context::fresh_address();
       let account_obj = create_account_object(new_address);
       object::transfer_extend(account_obj, new_address);
@@ -188,7 +188,7 @@ module moveos_std::account {
       object::transfer_extend(obj, account);
    }
 
-   /// Deprecated, we do not allow to destroy account object directly
+   /// Deprecated: Direct destruction of account objects is not allowed.
    public fun destroy_account(_account_obj: Object<Account>){
       abort ErrorDeprecateFunction
    }
@@ -473,8 +473,8 @@ module moveos_std::account {
 
    #[test]
    fun test_account_cap_holder(){
-      let alice = create_account_with_cap();
-      let bob = create_account_with_cap();
+      let alice = create_account_and_return_cap();
+      let bob = create_account_and_return_cap();
       let holder = AccountHolder{
          alice: alice,
          bob: bob,

--- a/frameworks/moveos-stdlib/sources/account.move
+++ b/frameworks/moveos-stdlib/sources/account.move
@@ -8,11 +8,16 @@ module moveos_std::account {
    use moveos_std::object::{Self, ObjectID, Object};
    use moveos_std::tx_context;
 
-   /// Account is part of the StorageAbstraction
-   /// It is also used to store the account's resources
+   /// Account is a struct that holds the sequence number for an address
    struct Account has key {
       addr: address,
       sequence_number: u64,
+   }
+
+   /// AccountCap is a capability for Account
+   /// The contract that has AccountCap can access the Account object
+   struct AccountCap has key, store{
+      addr: address,
    }
 
    const MAX_U64: u128 = 18446744073709551615;
@@ -29,6 +34,8 @@ module moveos_std::account {
    const ErrorResourceAlreadyExists: u64 = 5;
    /// The resource with the given type not exists
    const ErrorResourceNotExists: u64 = 6;
+   /// Deprecate function
+   const ErrorDeprecateFunction: u64 = 7;
 
    /// Create a new account for the given address, only callable by the system account
    public fun create_account_by_system(system: &signer, new_address: address): signer {
@@ -36,12 +43,20 @@ module moveos_std::account {
       create_account_internal(new_address)
    }
 
-   /// Create an Account Object with a generated address
+   /// This function is deprecated, please use `create_account_with_cap` instead
    public fun create_account(): Object<Account> {
-      let new_address = tx_context::fresh_address();
-      create_account_object(new_address)
+      //We shoud not return Object<Account> directly,
+      //Becase if other struct hold the Object<Account>, and the resource functions will not work
+      abort ErrorDeprecateFunction
    }
 
+   /// Create a new account and return the AccountCap
+   public fun create_account_with_cap(): AccountCap {
+      let new_address = tx_context::fresh_address();
+      let account_obj = create_account_object(new_address);
+      object::transfer_extend(account_obj, new_address);
+      AccountCap{addr: new_address}
+   }
 
    fun create_account_internal(new_address: address): signer {
       assert!(
@@ -102,9 +117,13 @@ module moveos_std::account {
       create_signer(addr)
    }
 
-   /// Create a signer with mutable Object<Account>
    public fun create_signer_with_account(account: &mut Object<Account>): signer{
       create_signer(object::borrow(account).addr)
+   }
+
+   /// Create a signer with the given account capability
+   public fun create_signer_with_account_cap(cap: &mut AccountCap): signer{
+      create_signer(cap.addr)
    }
 
 
@@ -117,9 +136,15 @@ module moveos_std::account {
 
    // === Account Object Functions
 
+
    public fun account_borrow_resource<T: key>(self: &Object<Account>): &T {
-      assert!(object::contains_field(self, key<T>()), ErrorResourceNotExists);
-      object::borrow_field_internal(object::id(self), key<T>())
+      account_borrow_resource_internal(self)
+   }
+
+   fun account_borrow_resource_internal<T: key>(self: &Object<Account>): &T {
+      let key = key<T>();
+      assert!(object::contains_field(self, key), ErrorResourceNotExists);
+      object::borrow_field_internal(object::id(self), key)
    }
 
    #[private_generics(T)]
@@ -132,16 +157,19 @@ module moveos_std::account {
       object::borrow_mut_field_internal(object::id(self), key<T>())
    }
 
+
    #[private_generics(T)]
    public fun account_move_resource_to<T: key>(self: &mut Object<Account>, resource: T){
       account_move_resource_to_internal(self, resource)
    }
 
    fun account_move_resource_to_internal<T: key>(self: &mut Object<Account>, resource: T){
-      assert!(!object::contains_field(self, key<T>()), ErrorResourceAlreadyExists);
-      object::add_field_internal<std::string::String, T>(object::id(self), key<T>(), resource)
+      let key = key<T>();
+      assert!(!object::contains_field(self, key), ErrorResourceAlreadyExists);
+      object::add_field_internal<std::string::String, T>(object::id(self), key, resource)
    }
 
+   
    #[private_generics(T)]
    public fun account_move_resource_from<T: key>(self: &mut Object<Account>): T {
       account_move_resource_from_internal(self)
@@ -160,10 +188,14 @@ module moveos_std::account {
       object::transfer_extend(obj, account);
    }
 
-   /// Destroy the account object
-   public fun destroy_account(account_obj: Object<Account>){
-      let account = object::remove(account_obj);
-      let Account {addr: _, sequence_number:_} = account;
+   /// Deprecated, we do not allow to destroy account object directly
+   public fun destroy_account(_account_obj: Object<Account>){
+      abort ErrorDeprecateFunction
+   }
+
+   /// Destroy the account capability
+   public fun destroy_account_cap(account_cap: AccountCap){
+      let AccountCap{addr:_} = account_cap;
    }
 
    // === Account Storage functions ===
@@ -185,7 +217,7 @@ module moveos_std::account {
    /// But we remove the restriction of the caller must be the module of T
    public fun borrow_resource<T: key>(account: address): &T {
       let account_obj = borrow_account(account);
-      account_borrow_resource<T>(account_obj)
+      account_borrow_resource_internal<T>(account_obj)
    }
 
    #[private_generics(T)]
@@ -291,56 +323,44 @@ module moveos_std::account {
    }
 
    #[test(sender=@0x42)]
-   fun test_account_object(sender: signer){
+   fun test_move_resource_to(sender: signer){
       let sender_addr = signer::address_of(&sender);
       create_account_object_to(sender_addr);
-      let obj_mut = object::borrow_mut_object<Account>(&sender, account_object_id(sender_addr));
-      account_move_resource_to(obj_mut, Test{
+      move_resource_to(&sender, Test{
          addr: sender_addr,
          version: 1,
       });
    }
 
    #[test(sender=@0x42)]
-   fun test_move_to_account_object(sender: signer){
+   fun test_move_resource_from(sender: signer){
       let sender_addr = signer::address_of(&sender);
       create_account_object_to(sender_addr);
-      let obj_mut = object::borrow_mut_object<Account>(&sender, account_object_id(sender_addr));
-      account_move_resource_to(obj_mut, Test{
-         addr: sender_addr,
-         version: 1,
-      });
-   }
-
-   #[test(sender=@0x42)]
-   fun test_move_from_account_object(sender: signer){
-      let sender_addr = signer::address_of(&sender);
-      create_account_object_to(sender_addr);
-      let obj_mut = object::borrow_mut_object<Account>(&sender, account_object_id(sender_addr));
-      account_move_resource_to(obj_mut, Test{
+   
+      move_resource_to(&sender, Test{
          addr: sender_addr,
          version: 1,
       });
       let Test {
          addr,
          version
-      } = account_move_resource_from<Test>(obj_mut);
+      } = move_resource_from<Test>(sender_addr);
       assert!(addr == sender_addr, 0x10);
       assert!(version == 1, 0x11);
    }
 
    #[test(sender=@0x42)]
    #[expected_failure(abort_code = ErrorResourceAlreadyExists, location = Self)]
-   fun test_failure_repeatedly_move_to_account_object(sender: signer){
+   fun test_failure_repeatedly_move_resource_to(sender: signer){
 
       let sender_addr = signer::address_of(&sender);
       create_account_object_to(sender_addr);
-      let obj_mut = object::borrow_mut_object<Account>(&sender, account_object_id(sender_addr));
-      account_move_resource_to(obj_mut, Test{
+   
+      move_resource_to(&sender, Test{
          addr: sender_addr,
          version: 1,
       });
-      account_move_resource_to(obj_mut, Test{
+      move_resource_to(&sender, Test{
          addr: sender_addr,
          version: 1,
       });
@@ -348,35 +368,35 @@ module moveos_std::account {
 
    #[test(sender=@0x42)]
    #[expected_failure(abort_code = ErrorResourceNotExists, location = Self)]
-   fun test_failure_repeatedly_move_from_account_object(sender: signer){
+   fun test_failure_repeatedly_move_resource_from(sender: signer){
       let sender_addr = signer::address_of(&sender);
       create_account_object_to(sender_addr);
-      let obj_mut = object::borrow_mut_object<Account>(&sender, account_object_id(sender_addr));
-      account_move_resource_to(obj_mut, Test{
+      move_resource_to(&sender, Test{
          addr: sender_addr,
          version: 1,
       });
       let Test {
-         addr: _,
+         addr,
          version: _
-      } = account_move_resource_from<Test>(obj_mut);
+      } = move_resource_from<Test>(sender_addr);
+      assert!(addr == sender_addr, 1);
       let Test {
          addr: _,
          version: _
-      } = account_move_resource_from<Test>(obj_mut);
+      } = move_resource_from<Test>(sender_addr);
    }
 
    #[test(sender=@0x42)]
    fun test_borrow_resource(sender: signer){
       let sender_addr = signer::address_of(&sender);
       create_account_object_to(sender_addr);
-      let obj_mut = object::borrow_mut_object<Account>(&sender, account_object_id(sender_addr));
-      account_move_resource_to(obj_mut, Test{
+   
+      move_resource_to(&sender, Test{
          addr: sender_addr,
          version: 1,
       });
 
-      let ref_test = account_borrow_resource<Test>(obj_mut);
+      let ref_test = borrow_resource<Test>(sender_addr);
       assert!(ref_test.version == 1, 1);
       assert!(ref_test.addr == sender_addr, 2);
    }
@@ -385,56 +405,52 @@ module moveos_std::account {
    fun test_borrow_mut_resource(sender: signer){
       let sender_addr = signer::address_of(&sender);
       create_account_object_to(sender_addr);
-      let obj_mut = object::borrow_mut_object<Account>(&sender, account_object_id(sender_addr));
-      account_move_resource_to(obj_mut, Test{
+      move_resource_to(&sender, Test{
          addr: sender_addr,
          version: 1,
       });
       {
-         let ref_test = account_borrow_mut_resource<Test>(obj_mut);
+         let ref_test = borrow_mut_resource<Test>(sender_addr);
          assert!(ref_test.version == 1, 1);
          assert!(ref_test.addr == sender_addr, 2);
          ref_test.version = 2;
       };
       {
-         let ref_test = account_borrow_resource<Test>(obj_mut);
+         let ref_test = borrow_resource<Test>(sender_addr);
          assert!(ref_test.version == 2, 3);
       };
    }
 
    #[test(sender=@0x42)]
-   #[expected_failure(abort_code = 6, location = Self)]
+   #[expected_failure(abort_code = ErrorResourceNotExists, location = Self)]
    fun test_failure_borrow_resource_no_exists(sender: signer){
       let sender_addr = signer::address_of(&sender);
       create_account_object_to(sender_addr);
-      let obj_ref = object::borrow_object<Account>(account_object_id(sender_addr));
-      account_borrow_resource<Test>(obj_ref);
+      borrow_resource<Test>(sender_addr);
    }
 
    #[test(sender=@0x42)]
-   #[expected_failure(abort_code = 6, location = Self)]
+   #[expected_failure(abort_code = ErrorResourceNotExists, location = Self)]
    fun test_failure_borrow_mut_resource_no_exists(sender: signer){
       let sender_addr = signer::address_of(&sender);
       create_account_object_to(sender_addr);
-      let obj_mut = object::borrow_mut_object<Account>(&sender, account_object_id(sender_addr));
-      account_borrow_mut_resource<Test>(obj_mut);
+      borrow_mut_resource<Test>(sender_addr);
    }
 
    #[test(sender=@0x42)]
    fun test_ensure_move_from_and_exists(sender: signer){
       let sender_addr = signer::address_of(&sender);
       create_account_object_to(sender_addr);
-      let obj_mut = object::borrow_mut_object<Account>(&sender, account_object_id(sender_addr));
-      let test_exists = account_exists_resource<Test>(obj_mut);
+      let test_exists = exists_resource<Test>(sender_addr);
       assert!(!test_exists, 1);
-      account_move_resource_to(obj_mut, Test{
+      move_resource_to(&sender, Test{
          addr: sender_addr,
          version: 1,
       });
-      let test_exists = account_exists_resource<Test>(obj_mut);
+      let test_exists = exists_resource<Test>(sender_addr);
       assert!(test_exists, 2);
-      let test = account_move_resource_from<Test>(obj_mut);
-      let test_exists = account_exists_resource<Test>(obj_mut);
+      let test = move_resource_from<Test>(sender_addr);
+      let test_exists = exists_resource<Test>(sender_addr);
       assert!(!test_exists, 3);
       let Test{
          addr: _,
@@ -451,32 +467,33 @@ module moveos_std::account {
 
    #[test_only]
    struct AccountHolder has store{
-      alice: Object<Account>,
-      bob: Object<Account>,
+      alice: AccountCap,
+      bob: AccountCap,
    }
 
    #[test]
-   fun test_account_object_holder(){
-      let alice = create_account();
-      let bob = create_account();
+   fun test_account_cap_holder(){
+      let alice = create_account_with_cap();
+      let bob = create_account_with_cap();
       let holder = AccountHolder{
          alice: alice,
          bob: bob,
       };
-      let alice_signer = create_signer_with_account(&mut holder.alice);
-      account_move_resource_to(&mut holder.alice, Test{
-         addr: signer::address_of(&alice_signer),
+      let alice_signer = create_signer_with_account_cap(&mut holder.alice);
+      let alice_addr = signer::address_of(&alice_signer);
+      move_resource_to(&alice_signer, Test{
+         addr: alice_addr,
          version: 1,
       });
       
-      let Test{addr:_, version:_} = account_move_resource_from<Test>(&mut holder.alice);
+      let Test{addr:_, version:_} = move_resource_from<Test>(alice_addr);
 
       let AccountHolder{
          alice: alice_obj,
          bob: bob_obj,
       } = holder;
-      destroy_account(alice_obj);
-      destroy_account(bob_obj);
+      destroy_account_cap(alice_obj);
+      destroy_account_cap(bob_obj);
    }
 
 }


### PR DESCRIPTION
## Summary

1. Provide AccountCap to create a contract account.
2. Deprecated original `create_account` function, the `Object<Account>` should not be held in another struct.