### PR TITLE
[moveos_std] Refactor json for address and decimal value

### DIFF
--- a/frameworks/moveos-stdlib/doc/decimal_value.md
+++ b/frameworks/moveos-stdlib/doc/decimal_value.md
@@ -9,9 +9,11 @@
 -  [Function `new`](#0x2_decimal_value_new)
 -  [Function `value`](#0x2_decimal_value_value)
 -  [Function `decimal`](#0x2_decimal_value_decimal)
+-  [Function `is_equal`](#0x2_decimal_value_is_equal)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="">0x1::u256</a>;
+</code></pre>
 
 
 
@@ -56,4 +58,16 @@
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="decimal_value.md#0x2_decimal_value_decimal">decimal</a>(self: &<a href="decimal_value.md#0x2_decimal_value_DecimalValue">decimal_value::DecimalValue</a>): u8
+</code></pre>
+
+
+
+<a name="0x2_decimal_value_is_equal"></a>
+
+## Function `is_equal`
+
+Check if two DecimalValue instances represent the same numerical value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="decimal_value.md#0x2_decimal_value_is_equal">is_equal</a>(a: &<a href="decimal_value.md#0x2_decimal_value_DecimalValue">decimal_value::DecimalValue</a>, b: &<a href="decimal_value.md#0x2_decimal_value_DecimalValue">decimal_value::DecimalValue</a>): bool
 </code></pre>

--- a/frameworks/moveos-stdlib/sources/decimal_value.move
+++ b/frameworks/moveos-stdlib/sources/decimal_value.move
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module moveos_std::decimal_value {
+    use std::u256;
+
     #[data_struct]
     struct DecimalValue has store, drop, copy {
         value: u256,
@@ -18,5 +20,56 @@ module moveos_std::decimal_value {
 
     public fun decimal(self: &DecimalValue): u8 {
         self.decimal
+    }
+
+    /// Check if two DecimalValue instances represent the same numerical value
+    public fun is_equal(a: &DecimalValue, b: &DecimalValue): bool {
+        if (a.decimal == b.decimal) {
+            // If decimal places match, just compare values directly
+            return a.value == b.value
+        };
+        
+        // Normalize to the larger decimal precision
+        if (a.decimal > b.decimal) {
+            // Scale up b.value
+            let scale_factor = u256::pow(10u256, (a.decimal - b.decimal));
+            b.value * scale_factor == a.value
+        } else {
+            // Scale up a.value
+            let scale_factor = u256::pow(10u256, (b.decimal - a.decimal));
+            a.value * scale_factor == b.value
+        }
+    }
+
+    #[test]
+    fun test_decimal_equality() {
+        // Same value, same decimal
+        assert!(is_equal(
+            &DecimalValue { value: 1234, decimal: 2 },
+            &DecimalValue { value: 1234, decimal: 2 }
+        ), 0);
+        
+        // Different representations of the same value
+        assert!(is_equal(
+            &DecimalValue { value: 10000, decimal: 4 }, // 1.0000
+            &DecimalValue { value: 1, decimal: 0 }      // 1
+        ), 1);
+        
+        assert!(is_equal(
+            &DecimalValue { value: 100, decimal: 2 },   // 1.00
+            &DecimalValue { value: 10, decimal: 1 }     // 1.0
+        ), 2);
+        
+        // Different values
+        assert!(!is_equal(
+            &DecimalValue { value: 1234, decimal: 2 },  // 12.34
+            &DecimalValue { value: 123, decimal: 1 }    // 12.3
+        ), 3);
+        
+        // Zero edge case
+        assert!(is_equal(
+            &DecimalValue { value: 0, decimal: 4 },     // 0.0000
+            &DecimalValue { value: 0, decimal: 0 }      // 0
+        ), 4);
     }
 }

--- a/moveos/moveos-types/src/addresses.rs
+++ b/moveos/moveos-types/src/addresses.rs
@@ -35,6 +35,14 @@ pub fn to_bech32(addr: &AccountAddress) -> Result<String> {
         .map_err(|e| anyhow!(format!("bech32 encode error: {}", e.to_string())))
 }
 
+pub fn from_str(s: &str) -> Result<AccountAddress> {
+    if s.starts_with("0x") {
+        Ok(AccountAddress::from_hex_literal(s)?)
+    } else {
+        from_bech32(s)
+    }
+}
+
 pub fn from_bech32(bech32: &str) -> Result<AccountAddress> {
     let (hrp, data) = bech32::decode(bech32)?;
     anyhow::ensure!(hrp == ROOCH_HRP, "invalid account address hrp");


### PR DESCRIPTION
## Summary

1. Decimal value in json default use number, The value is too big to be represented in float, it will be represented in string
2. `from_json` supports both hex address and `rooch` prefix bech32 address. 