### PR TITLE
[moveos_std] Support named and custom event handle id

### DIFF
--- a/crates/rooch-executor/src/actor/messages.rs
+++ b/crates/rooch-executor/src/actor/messages.rs
@@ -4,12 +4,11 @@
 use anyhow::Result;
 use coerce::actor::message::Message;
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::StructTag;
 use moveos_types::access_path::AccessPath;
 use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::event::{AnnotatedEvent, Event, EventID};
-use moveos_types::moveos_std::object::ObjectMeta;
+use moveos_types::moveos_std::object::{ObjectID, ObjectMeta};
 use moveos_types::state::{AnnotatedState, FieldKey, ObjectState, StateChangeSetExt};
 use moveos_types::state_resolver::{AnnotatedStateKV, StateKV};
 use moveos_types::transaction::TransactionExecutionInfo;
@@ -128,7 +127,7 @@ impl Message for ListAnnotatedStatesMessage {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetAnnotatedEventsByEventHandleMessage {
-    pub event_handle_type: StructTag,
+    pub event_handle_id: ObjectID,
     pub cursor: Option<u64>,
     pub limit: u64,
     pub descending_order: bool,
@@ -140,7 +139,7 @@ impl Message for GetAnnotatedEventsByEventHandleMessage {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetEventsByEventHandleMessage {
-    pub event_handle_type: StructTag,
+    pub event_handle_id: ObjectID,
     pub cursor: Option<u64>,
     pub limit: u64,
     pub descending_order: bool,

--- a/crates/rooch-executor/src/actor/reader_executor.rs
+++ b/crates/rooch-executor/src/actor/reader_executor.rs
@@ -21,7 +21,6 @@ use moveos_store::transaction_store::TransactionStore;
 use moveos_store::MoveOSStore;
 use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::function_return_value::AnnotatedFunctionReturnValue;
-use moveos_types::moveos_std::event::EventHandle;
 use moveos_types::moveos_std::event::{AnnotatedEvent, Event};
 use moveos_types::moveos_std::object::ObjectMeta;
 use moveos_types::state::{AnnotatedState, ObjectState, StateChangeSetExt};
@@ -216,16 +215,14 @@ impl Handler<GetAnnotatedEventsByEventHandleMessage> for ReaderExecutorActor {
         _ctx: &mut ActorContext,
     ) -> Result<Vec<AnnotatedEvent>> {
         let GetAnnotatedEventsByEventHandleMessage {
-            event_handle_type,
+            event_handle_id,
             cursor,
             limit,
             descending_order,
         } = msg;
         let event_store = self.moveos().event_store();
-
         let resolver = RootObjectResolver::new(self.root.clone(), &self.moveos_store);
 
-        let event_handle_id = EventHandle::derive_event_handle_id(&event_handle_type);
         let events = event_store.get_events_by_event_handle_id(
             &event_handle_id,
             cursor,
@@ -237,7 +234,7 @@ impl Handler<GetAnnotatedEventsByEventHandleMessage> for ReaderExecutorActor {
             .into_iter()
             .map(|event| {
                 let event_move_value = MoveValueAnnotator::new(&resolver)
-                    .view_resource(&event_handle_type, event.event_data())?;
+                    .view_resource(&event.event_type, event.event_data())?;
                 Ok(AnnotatedEvent::new(event, event_move_value))
             })
             .collect::<Result<Vec<_>>>()
@@ -252,14 +249,12 @@ impl Handler<GetEventsByEventHandleMessage> for ReaderExecutorActor {
         _ctx: &mut ActorContext,
     ) -> Result<Vec<Event>> {
         let GetEventsByEventHandleMessage {
-            event_handle_type,
+            event_handle_id,
             cursor,
             limit,
             descending_order,
         } = msg;
         let event_store = self.moveos().event_store();
-
-        let event_handle_id = EventHandle::derive_event_handle_id(&event_handle_type);
         event_store.get_events_by_event_handle_id(&event_handle_id, cursor, limit, descending_order)
     }
 }

--- a/crates/rooch-executor/src/proxy/mod.rs
+++ b/crates/rooch-executor/src/proxy/mod.rs
@@ -19,13 +19,12 @@ use crate::actor::{
 use anyhow::{anyhow, Result};
 use coerce::actor::ActorRef;
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::StructTag;
 use moveos_types::function_return_value::{AnnotatedFunctionResult, FunctionResult};
 use moveos_types::h256::H256;
 use moveos_types::module_binding::MoveFunctionCaller;
 use moveos_types::moveos_std::account::Account;
 use moveos_types::moveos_std::event::{Event, EventID};
-use moveos_types::moveos_std::object::ObjectMeta;
+use moveos_types::moveos_std::object::{ObjectID, ObjectMeta};
 use moveos_types::moveos_std::tx_context::TxContext;
 use moveos_types::state::{FieldKey, StateChangeSetExt};
 use moveos_types::state_resolver::{AnnotatedStateKV, StateKV};
@@ -179,14 +178,14 @@ impl ExecutorProxy {
 
     pub async fn get_annotated_events_by_event_handle(
         &self,
-        event_handle_type: StructTag,
+        event_handle_id: ObjectID,
         cursor: Option<u64>,
         limit: u64,
         descending_order: bool,
     ) -> Result<Vec<AnnotatedEvent>> {
         self.reader_actor
             .send(GetAnnotatedEventsByEventHandleMessage {
-                event_handle_type,
+                event_handle_id,
                 cursor,
                 limit,
                 descending_order,
@@ -196,14 +195,14 @@ impl ExecutorProxy {
 
     pub async fn get_events_by_event_handle(
         &self,
-        event_handle_type: StructTag,
+        event_handle_id: ObjectID,
         cursor: Option<u64>,
         limit: u64,
         descending_order: bool,
     ) -> Result<Vec<Event>> {
         self.reader_actor
             .send(GetEventsByEventHandleMessage {
-                event_handle_type,
+                event_handle_id,
                 cursor,
                 limit,
                 descending_order,

--- a/crates/rooch-framework-tests/src/binding_test.rs
+++ b/crates/rooch-framework-tests/src/binding_test.rs
@@ -24,7 +24,7 @@ use rooch_config::RoochOpt;
 use rooch_db::RoochDB;
 use rooch_executor::actor::reader_executor::ReaderExecutorActor;
 use rooch_executor::actor::{executor::ExecutorActor, messages::ExecuteTransactionResult};
-use rooch_genesis::RoochGenesis;
+use rooch_genesis::RoochGenesisV2;
 use rooch_types::address::BitcoinAddress;
 use rooch_types::crypto::RoochKeyPair;
 use rooch_types::framework::gas_coin::RGas;
@@ -88,7 +88,7 @@ impl RustBindingTest {
 
         network.mock_genesis_account(&kp)?;
 
-        let genesis = RoochGenesis::build(network.clone())?;
+        let genesis = RoochGenesisV2::build(network.clone())?;
         let opt = RoochOpt::new_with_temp_store()?;
         let store_config = opt.store_config();
         let registry_service = metrics::RegistryService::default();

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -342,6 +342,14 @@ impl RoochGenesis {
             genesis_bin: self.encode(),
         }
     }
+
+    pub fn save_to<P: AsRef<Path>>(&self, genesis_file: P) -> Result<()> {
+        eprintln!("Save genesis to {:?}", genesis_file.as_ref());
+        let mut file = File::create(genesis_file)?;
+        let contents = bcs::to_bytes(&self)?;
+        file.write_all(&contents)?;
+        Ok(())
+    }
 }
 
 impl RoochGenesisV2 {

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -400,7 +400,7 @@ impl RoochGenesisV2 {
         };
 
         match genesis {
-            Some(genesis) => Ok(genesis.into()),
+            Some(genesis) => Ok(genesis),
             None => {
                 let genesis = Self::build(network)?;
                 Ok(genesis)
@@ -595,7 +595,7 @@ impl RoochGenesisV2 {
     }
 
     pub fn decode(bytes: &[u8]) -> Result<Self> {
-        match RoochGenesis::decode(&bytes) {
+        match RoochGenesis::decode(bytes) {
             Ok(genesis) => Ok(genesis.into()),
             // Parse with the old format first, and then try to parse with the new format if it fails
             Err(_e) => bcs::from_bytes(bytes).map_err(Into::into),

--- a/crates/rooch-genesis/src/lib.rs
+++ b/crates/rooch-genesis/src/lib.rs
@@ -14,6 +14,7 @@ use move_vm_runtime::native_functions::NativeFunction;
 use moveos::gas::table::VMGasParameters;
 use moveos::moveos::{MoveOS, MoveOSConfig};
 use moveos_stdlib::natives::moveos_stdlib::base64::EncodeDecodeGasParametersOption;
+use moveos_stdlib::natives::moveos_stdlib::event::EmitWithHandleGasParameters;
 use moveos_stdlib::natives::moveos_stdlib::object::ListFieldsGasParametersOption;
 use moveos_store::MoveOSStore;
 use moveos_types::genesis_info::GenesisInfo;
@@ -22,7 +23,9 @@ use moveos_types::move_std::string::MoveString;
 use moveos_types::moveos_std::gas_schedule::{GasEntry, GasSchedule, GasScheduleConfig};
 use moveos_types::moveos_std::object::ObjectMeta;
 use moveos_types::state::{ObjectState, StateChangeSetExt};
-use moveos_types::transaction::{MoveAction, MoveOSTransaction, RawTransactionOutput};
+use moveos_types::transaction::{
+    GenesisRawTransactionOutput, MoveAction, MoveOSTransaction, RawTransactionOutput,
+};
 use moveos_types::{h256, state_resolver};
 use once_cell::sync::Lazy;
 use rooch_db::RoochDB;
@@ -51,9 +54,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::{fs::File, io::Write, path::Path};
 
-pub static ROOCH_LOCAL_GENESIS: Lazy<RoochGenesis> = Lazy::new(|| {
+pub static ROOCH_LOCAL_GENESIS: Lazy<RoochGenesisV2> = Lazy::new(|| {
     let network: RoochNetwork = BuiltinChainID::Local.into();
-    RoochGenesis::build(network).expect("build rooch genesis failed")
+    RoochGenesisV2::build(network).expect("build rooch genesis failed")
 });
 pub const LATEST_GAS_SCHEDULE_VERSION: u64 = GAS_SCHEDULE_RELEASE_V1;
 // update the gas config for function calling
@@ -61,11 +64,11 @@ pub const GAS_SCHEDULE_RELEASE_V1: u64 = 1;
 
 pub(crate) const STATIC_GENESIS_DIR: Dir = include_dir!("released");
 
-pub fn load_genesis_from_binary(chain_id: BuiltinChainID) -> Result<Option<RoochGenesis>> {
+pub fn load_genesis_from_binary(chain_id: BuiltinChainID) -> Result<Option<RoochGenesisV2>> {
     STATIC_GENESIS_DIR
         .get_file(chain_id.chain_name())
         .map(|f| {
-            let genesis = RoochGenesis::decode(f.contents())?;
+            let genesis = RoochGenesisV2::decode(f.contents())?;
             Ok(genesis)
         })
         .transpose()
@@ -175,8 +178,20 @@ impl FrameworksGasParameters {
         v2_gas_parameter
     }
 
+    pub fn v4() -> Self {
+        let mut v3_gas_parameter = FrameworksGasParameters::v3();
+
+        v3_gas_parameter
+            .rooch_framework_gas_params
+            .moveos_stdlib
+            .events
+            .emit_with_handle = EmitWithHandleGasParameters::init(1000.into(), 150.into());
+
+        v3_gas_parameter
+    }
+
     pub fn latest() -> Self {
-        FrameworksGasParameters::v3()
+        FrameworksGasParameters::v4()
     }
 
     pub fn to_gas_schedule_config(&self, chain_id: ChainID) -> GasScheduleConfig {
@@ -262,6 +277,16 @@ impl FrameworksGasParameters {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RoochGenesis {
     /// The genesis tx output
+    pub tx_output: GenesisRawTransactionOutput,
+    pub initial_gas_config: GasScheduleConfig,
+    pub genesis_objects: Vec<(ObjectState, MoveTypeLayout)>,
+    pub genesis_tx: RoochTransaction,
+    pub genesis_moveos_tx: MoveOSTransaction,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoochGenesisV2 {
+    /// The genesis tx output
     pub tx_output: RawTransactionOutput,
     pub initial_gas_config: GasScheduleConfig,
     pub genesis_objects: Vec<(ObjectState, MoveTypeLayout)>,
@@ -269,7 +294,28 @@ pub struct RoochGenesis {
     pub genesis_moveos_tx: MoveOSTransaction,
 }
 
+impl From<RoochGenesis> for RoochGenesisV2 {
+    fn from(genesis: RoochGenesis) -> Self {
+        {
+            RoochGenesisV2 {
+                tx_output: genesis.tx_output.into(),
+                initial_gas_config: genesis.initial_gas_config,
+                genesis_objects: genesis.genesis_objects,
+                genesis_tx: genesis.genesis_tx,
+                genesis_moveos_tx: genesis.genesis_moveos_tx,
+            }
+        }
+    }
+}
+
 impl RoochGenesis {
+    // released genesis file (testnet and mainnet) must by decode by RoochGenesis
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        bcs::from_bytes(bytes).map_err(Into::into)
+    }
+}
+
+impl RoochGenesisV2 {
     pub fn build(network: RoochNetwork) -> Result<Self> {
         let genesis_config = network.genesis_config;
 
@@ -354,7 +400,7 @@ impl RoochGenesis {
         };
 
         match genesis {
-            Some(genesis) => Ok(genesis),
+            Some(genesis) => Ok(genesis.into()),
             None => {
                 let genesis = Self::build(network)?;
                 Ok(genesis)
@@ -549,11 +595,15 @@ impl RoochGenesis {
     }
 
     pub fn decode(bytes: &[u8]) -> Result<Self> {
-        bcs::from_bytes(bytes).map_err(Into::into)
+        match RoochGenesis::decode(&bytes) {
+            Ok(genesis) => Ok(genesis.into()),
+            // Parse with the old format first, and then try to parse with the new format if it fails
+            Err(_e) => bcs::from_bytes(bytes).map_err(Into::into),
+        }
     }
 
     pub fn encode(&self) -> Vec<u8> {
-        bcs::to_bytes(self).expect("RoochGenesis bcs::to_bytes should success")
+        bcs::to_bytes(self).expect("RoochGenesisV2 bcs::to_bytes should success")
     }
 
     pub fn load_from<P: AsRef<Path>>(genesis_file: P) -> Result<Self> {
@@ -597,7 +647,7 @@ mod tests {
     use state_resolver::StateReaderExt;
     use tracing::info;
 
-    fn genesis_init_test_case(network: RoochNetwork, genesis: RoochGenesis) {
+    fn genesis_init_test_case(network: RoochNetwork, genesis: RoochGenesisV2) {
         info!(
             "genesis init test case for network: {:?}",
             network.chain_id.id
@@ -705,23 +755,23 @@ mod tests {
         let _ = tracing_subscriber::fmt::try_init();
         {
             let network: RoochNetwork = BuiltinChainID::Local.into();
-            let genesis = RoochGenesis::load_or_build(network.clone()).unwrap();
+            let genesis = RoochGenesisV2::load_or_build(network.clone()).unwrap();
             genesis_init_test_case(network, genesis);
         }
         {
             let network: RoochNetwork = BuiltinChainID::Dev.into();
-            let genesis = RoochGenesis::load_or_build(network.clone()).unwrap();
+            let genesis = RoochGenesisV2::load_or_build(network.clone()).unwrap();
             genesis_init_test_case(network, genesis);
         }
         {
             let network: RoochNetwork = BuiltinChainID::Test.into();
-            let genesis = RoochGenesis::load_or_build(network.clone()).unwrap();
+            let genesis = RoochGenesisV2::load_or_build(network.clone()).unwrap();
             genesis_init_test_case(network, genesis);
         }
         //We need to import the pre genesis state tree to init the mainnet genesis
         // {
         //     let network: RoochNetwork = BuiltinChainID::Main.into();
-        //     let genesis = RoochGenesis::load_or_build(network.clone()).unwrap();
+        //     let genesis = RoochGenesisV2::load_or_build(network.clone()).unwrap();
         //     genesis_init_test_case(network, genesis);
         // }
     }
@@ -730,7 +780,7 @@ mod tests {
     async fn test_custom_genesis_init() {
         let network: RoochNetwork =
             RoochNetwork::new(100.into(), BuiltinChainID::Test.genesis_config().clone());
-        let genesis = RoochGenesis::build(network.clone()).unwrap();
+        let genesis = RoochGenesisV2::build(network.clone()).unwrap();
         genesis_init_test_case(network, genesis);
     }
 

--- a/crates/rooch-genesis/src/main.rs
+++ b/crates/rooch-genesis/src/main.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{bail, Result};
 use clap::Parser;
-use rooch_genesis::{genesis_file, RoochGenesis};
+use rooch_genesis::{genesis_file, RoochGenesisV2};
 use rooch_types::rooch_network::{BuiltinChainID, RoochNetwork};
 use tracing::info;
 
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     }
     info!("start to build genesis for chain: {:?}", opts.chain_id);
     let network: RoochNetwork = RoochNetwork::builtin(opts.chain_id);
-    let genesis = RoochGenesis::build(network)?;
+    let genesis = RoochGenesisV2::build(network)?;
     let genesis_file = genesis_file(opts.chain_id);
     genesis.save_to(genesis_file)?;
     Ok(())

--- a/crates/rooch-genesis/src/main.rs
+++ b/crates/rooch-genesis/src/main.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{bail, Result};
 use clap::Parser;
-use rooch_genesis::{genesis_file, RoochGenesisV2};
+use rooch_genesis::{genesis_file, RoochGenesis, RoochGenesisV2};
 use rooch_types::rooch_network::{BuiltinChainID, RoochNetwork};
 use tracing::info;
 
@@ -31,7 +31,9 @@ async fn main() -> Result<()> {
     info!("start to build genesis for chain: {:?}", opts.chain_id);
     let network: RoochNetwork = RoochNetwork::builtin(opts.chain_id);
     let genesis = RoochGenesisV2::build(network)?;
+    // Ensure testnet and mainnet genesis file use old format
+    let genesis_v1 = RoochGenesis::from(genesis);
     let genesis_file = genesis_file(opts.chain_id);
-    genesis.save_to(genesis_file)?;
+    genesis_v1.save_to(genesis_file)?;
     Ok(())
 }

--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -336,6 +336,22 @@ impl IndexerReader {
             EventFilter::EventType(event_type) => {
                 format!("{EVENT_TYPE_STR} = \"{}\"", event_type)
             }
+            EventFilter::EventHandleWithSender {
+                event_handle_id,
+                sender,
+            } => {
+                format!(
+                    "{TX_SENDER_STR} = \"{}\" AND {EVENT_HANDLE_ID_STR} = \"{}\"",
+                    sender.to_hex_literal(),
+                    event_handle_id.to_string()
+                )
+            }
+            EventFilter::EventHandle(event_handle_id) => {
+                format!(
+                    "{EVENT_HANDLE_ID_STR} = \"{}\"",
+                    event_handle_id.to_string()
+                )
+            }
             EventFilter::Sender(sender) => {
                 format!("{TX_SENDER_STR} = \"{}\"", sender.to_hex_literal())
             }

--- a/crates/rooch-indexer/src/indexer_reader.rs
+++ b/crates/rooch-indexer/src/indexer_reader.rs
@@ -343,14 +343,11 @@ impl IndexerReader {
                 format!(
                     "{TX_SENDER_STR} = \"{}\" AND {EVENT_HANDLE_ID_STR} = \"{}\"",
                     sender.to_hex_literal(),
-                    event_handle_id.to_string()
+                    event_handle_id
                 )
             }
             EventFilter::EventHandle(event_handle_id) => {
-                format!(
-                    "{EVENT_HANDLE_ID_STR} = \"{}\"",
-                    event_handle_id.to_string()
-                )
+                format!("{EVENT_HANDLE_ID_STR} = \"{}\"", event_handle_id)
             }
             EventFilter::Sender(sender) => {
                 format!("{TX_SENDER_STR} = \"{}\"", sender.to_hex_literal())

--- a/crates/rooch-integration-test-runner/src/lib.rs
+++ b/crates/rooch-integration-test-runner/src/lib.rs
@@ -40,7 +40,7 @@ use moveos_verifier::build::build_model;
 use moveos_verifier::metadata::run_extended_checks;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use rooch_genesis::{FrameworksGasParameters, RoochGenesis};
+use rooch_genesis::{FrameworksGasParameters, RoochGenesisV2};
 use rooch_types::framework::auth_validator::TxValidateResult;
 use rooch_types::function_arg::FunctionArg;
 use std::path::PathBuf;
@@ -116,7 +116,7 @@ impl<'a> MoveOSTestAdapter<'a> for MoveOSTestRunner<'a> {
         let registry = prometheus::Registry::new();
         let moveos_store = MoveOSStore::new(temp_dir.path(), &registry).unwrap();
         let genesis_gas_parameter = FrameworksGasParameters::initial();
-        let genesis: &RoochGenesis = &rooch_genesis::ROOCH_LOCAL_GENESIS;
+        let genesis: &RoochGenesisV2 = &rooch_genesis::ROOCH_LOCAL_GENESIS;
         let moveos = MoveOS::new(
             moveos_store.clone(),
             genesis_gas_parameter.all_natives(),

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -298,13 +298,57 @@
     },
     {
       "name": "rooch_getEventsByEventHandle",
-      "description": "Get the events by event handle id",
+      "description": "Get the events by event handle type",
       "params": [
         {
           "name": "event_handle_type",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "$ref": "#/components/schemas/u64"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "$ref": "#/components/schemas/u64"
+          }
+        },
+        {
+          "name": "descending_order",
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "event_options",
+          "schema": {
+            "$ref": "#/components/schemas/EventOptions"
+          }
+        }
+      ],
+      "result": {
+        "name": "EventPageView",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/PageView_for_EventView_and_u64"
+        }
+      }
+    },
+    {
+      "name": "rooch_getEventsByEventHandleV2",
+      "description": "Get the events by event handle id",
+      "params": [
+        {
+          "name": "event_handle_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
           }
         },
         {
@@ -1347,6 +1391,44 @@
             "properties": {
               "event_type": {
                 "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Query by event handle id with sender",
+            "type": "object",
+            "required": [
+              "event_handle_with_sender"
+            ],
+            "properties": {
+              "event_handle_with_sender": {
+                "type": "object",
+                "required": [
+                  "event_handle_id",
+                  "sender"
+                ],
+                "properties": {
+                  "event_handle_id": {
+                    "$ref": "#/components/schemas/ObjectID"
+                  },
+                  "sender": {
+                    "$ref": "#/components/schemas/rooch_rpc_api::jsonrpc_types::address::UnitedAddress"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Query by event handle id.",
+            "type": "object",
+            "required": [
+              "event_handle"
+            ],
+            "properties": {
+              "event_handle": {
+                "$ref": "#/components/schemas/ObjectID"
               }
             },
             "additionalProperties": false

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -298,57 +298,13 @@
     },
     {
       "name": "rooch_getEventsByEventHandle",
-      "description": "Get the events by event handle type",
+      "description": "Get the events by event handle type or event handle id",
       "params": [
         {
-          "name": "event_handle_type",
+          "name": "event_handle",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
-          }
-        },
-        {
-          "name": "cursor",
-          "schema": {
-            "$ref": "#/components/schemas/u64"
-          }
-        },
-        {
-          "name": "limit",
-          "schema": {
-            "$ref": "#/components/schemas/u64"
-          }
-        },
-        {
-          "name": "descending_order",
-          "schema": {
-            "type": "boolean"
-          }
-        },
-        {
-          "name": "event_options",
-          "schema": {
-            "$ref": "#/components/schemas/EventOptions"
-          }
-        }
-      ],
-      "result": {
-        "name": "EventPageView",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/PageView_for_EventView_and_u64"
-        }
-      }
-    },
-    {
-      "name": "rooch_getEventsByEventHandleV2",
-      "description": "Get the events by event handle id",
-      "params": [
-        {
-          "name": "event_handle_id",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/ObjectID"
+            "$ref": "#/components/schemas/StructTagOrObjectIDView"
           }
         },
         {
@@ -3471,6 +3427,34 @@
             ]
           }
         }
+      },
+      "StructTagOrObjectIDView": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "StructTag"
+            ],
+            "properties": {
+              "StructTag": {
+                "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "ObjectID"
+            ],
+            "properties": {
+              "ObjectID": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "SyncStateFilterView": {
         "oneOf": [

--- a/crates/rooch-open-rpc-spec/schemas/openrpc.json
+++ b/crates/rooch-open-rpc-spec/schemas/openrpc.json
@@ -304,7 +304,7 @@
           "name": "event_handle",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/StructTagOrObjectIDView"
+            "type": "string"
           }
         },
         {
@@ -3427,34 +3427,6 @@
             ]
           }
         }
-      },
-      "StructTagOrObjectIDView": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "StructTag"
-            ],
-            "properties": {
-              "StructTag": {
-                "$ref": "#/components/schemas/move_core_types::language_storage::StructTag"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "ObjectID"
-            ],
-            "properties": {
-              "ObjectID": {
-                "$ref": "#/components/schemas/ObjectID"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
       },
       "SyncStateFilterView": {
         "oneOf": [

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -12,8 +12,9 @@ use crate::jsonrpc_types::{
     EventPageView, ExecuteTransactionResponseView, FieldKeyView, FieldPageView, FunctionCallView,
     H256View, IndexerEventPageView, IndexerObjectStatePageView, IndexerStateIDView, ModuleABIView,
     ObjectIDVecView, ObjectIDView, ObjectStateFilterView, ObjectStateView, QueryOptions,
-    RoochAddressView, StateChangeSetPageView, StateOptions, StatePageView, StrView, StructTagView,
-    SyncStateFilterView, TransactionWithInfoPageView, TxOptions,
+    RoochAddressView, StateChangeSetPageView, StateOptions, StatePageView, StrView,
+    StructTagOrObjectIDView, StructTagView, SyncStateFilterView, TransactionWithInfoPageView,
+    TxOptions,
 };
 use crate::jsonrpc_types::{DryRunTransactionResponseView, Status};
 use crate::RpcResult;
@@ -111,22 +112,11 @@ pub trait RoochAPI {
             .await
     }
 
-    /// Get the events by event handle type
+    /// Get the events by event handle type or event handle id
     #[method(name = "getEventsByEventHandle")]
     async fn get_events_by_event_handle(
         &self,
-        event_handle_type: StructTagView,
-        cursor: Option<StrView<u64>>,
-        limit: Option<StrView<u64>>,
-        descending_order: Option<bool>,
-        event_options: Option<EventOptions>,
-    ) -> RpcResult<EventPageView>;
-
-    /// Get the events by event handle id
-    #[method(name = "getEventsByEventHandleV2")]
-    async fn get_events_by_event_handle_v2(
-        &self,
-        event_handle_id: ObjectIDView,
+        event_handle: StructTagOrObjectIDView,
         cursor: Option<StrView<u64>>,
         limit: Option<StrView<u64>>,
         descending_order: Option<bool>,

--- a/crates/rooch-rpc-api/src/api/rooch_api.rs
+++ b/crates/rooch-rpc-api/src/api/rooch_api.rs
@@ -111,11 +111,22 @@ pub trait RoochAPI {
             .await
     }
 
-    /// Get the events by event handle id
+    /// Get the events by event handle type
     #[method(name = "getEventsByEventHandle")]
     async fn get_events_by_event_handle(
         &self,
         event_handle_type: StructTagView,
+        cursor: Option<StrView<u64>>,
+        limit: Option<StrView<u64>>,
+        descending_order: Option<bool>,
+        event_options: Option<EventOptions>,
+    ) -> RpcResult<EventPageView>;
+
+    /// Get the events by event handle id
+    #[method(name = "getEventsByEventHandleV2")]
+    async fn get_events_by_event_handle_v2(
+        &self,
+        event_handle_id: ObjectIDView,
         cursor: Option<StrView<u64>>,
         limit: Option<StrView<u64>>,
         descending_order: Option<bool>,

--- a/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/event_view.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::jsonrpc_types::{
-    AnnotatedMoveStructView, H256View, HumanReadableDisplay, RoochAddressView, StrView,
-    StructTagView, UnitedAddressView,
+    AnnotatedMoveStructView, H256View, HumanReadableDisplay, ObjectIDView, RoochAddressView,
+    StrView, StructTagView, UnitedAddressView,
 };
 use moveos_types::moveos_std::{
     event::{AnnotatedEvent, Event, EventID, TransactionEvent},
@@ -213,6 +213,13 @@ pub enum EventFilterView {
     },
     /// Query by event type.
     EventType(StructTagView),
+    /// Query by event handle id with sender
+    EventHandleWithSender {
+        event_handle_id: ObjectIDView,
+        sender: UnitedAddressView,
+    },
+    /// Query by event handle id.
+    EventHandle(ObjectIDView),
     /// Query by sender address.
     Sender(UnitedAddressView),
     /// Return events emitted by the given transaction hash.
@@ -245,6 +252,14 @@ impl From<EventFilterView> for EventFilter {
                 }
             }
             EventFilterView::EventType(event_type) => Self::EventType(event_type.into()),
+            EventFilterView::EventHandleWithSender {
+                event_handle_id,
+                sender,
+            } => Self::EventHandleWithSender {
+                event_handle_id: event_handle_id.0,
+                sender: sender.0.rooch_address.into(),
+            },
+            EventFilterView::EventHandle(event_handle_id) => Self::EventHandle(event_handle_id.0),
             EventFilterView::Sender(address) => Self::Sender(address.0.rooch_address.into()),
             EventFilterView::TxHash(tx_hash) => Self::TxHash(tx_hash.into()),
             EventFilterView::TimeRange {

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::event_view::IndexerEventIDView;
-use super::{HumanReadableDisplay, IndexerStateIDView, StateChangeSetWithTxOrderView};
+use super::{
+    HumanReadableDisplay, IndexerStateIDView, ObjectIDView, StateChangeSetWithTxOrderView,
+};
 use crate::jsonrpc_types::account_view::BalanceInfoView;
 use crate::jsonrpc_types::btc::ord::InscriptionStateView;
 use crate::jsonrpc_types::btc::utxo::UTXOStateView;
@@ -14,6 +16,7 @@ use crate::jsonrpc_types::{
     BytesView, IndexerObjectStateView, StateKVView, StrView, StructTagView,
 };
 use move_core_types::u256::U256;
+use moveos_types::moveos_std::event::EventHandle;
 use rooch_types::framework::coin::CoinInfo;
 use rooch_types::transaction::rooch::RoochTransaction;
 use schemars::JsonSchema;
@@ -121,6 +124,35 @@ impl<CoinType> From<CoinInfo<CoinType>> for CoinInfoView {
             icon_url: coin_info.icon_url(),
             decimals: coin_info.decimals(),
             supply: StrView(coin_info.supply()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub enum StructTagOrObjectIDView {
+    StructTag(StructTagView),
+    ObjectID(ObjectIDView),
+}
+
+impl From<StructTagView> for StructTagOrObjectIDView {
+    fn from(view: StructTagView) -> Self {
+        Self::StructTag(view)
+    }
+}
+
+impl From<ObjectIDView> for StructTagOrObjectIDView {
+    fn from(view: ObjectIDView) -> Self {
+        Self::ObjectID(view)
+    }
+}
+
+impl From<StructTagOrObjectIDView> for ObjectIDView {
+    fn from(view: StructTagOrObjectIDView) -> Self {
+        match view {
+            StructTagOrObjectIDView::StructTag(struct_tag) => {
+                EventHandle::derive_event_handle_id(&struct_tag.0).into()
+            }
+            StructTagOrObjectIDView::ObjectID(object_id) => object_id,
         }
     }
 }

--- a/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
+++ b/crates/rooch-rpc-api/src/jsonrpc_types/rooch_types.rs
@@ -21,6 +21,7 @@ use rooch_types::framework::coin::CoinInfo;
 use rooch_types::transaction::rooch::RoochTransaction;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use std::string::String;
 
 pub type EventPageView = PageView<EventView, StrView<u64>>;
@@ -128,21 +129,41 @@ impl<CoinType> From<CoinInfo<CoinType>> for CoinInfoView {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub enum StructTagOrObjectIDView {
-    StructTag(StructTagView),
-    ObjectID(ObjectIDView),
-}
+pub type StructTagOrObjectIDView = String;
+// pub type StructTagOrObjectIDView = StrView<String>;
+// #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+// pub enum StructTagOrObjectIDView {
+//     StructTag(StructTagView),
+//     ObjectID(ObjectIDView),
+// }
 
-impl From<StructTagView> for StructTagOrObjectIDView {
-    fn from(view: StructTagView) -> Self {
-        Self::StructTag(view)
-    }
-}
+// impl From<StructTagView> for StructTagOrObjectIDView {
+//     fn from(view: StructTagView) -> Self {
+//         Self::StructTag(view)
+//     }
+// }
+//
+// impl From<ObjectIDView> for StructTagOrObjectIDView {
+//     fn from(view: ObjectIDView) -> Self {
+//         Self::ObjectID(view)
+//     }
+// }
 
-impl From<ObjectIDView> for StructTagOrObjectIDView {
-    fn from(view: ObjectIDView) -> Self {
-        Self::ObjectID(view)
+impl FromStr for StructTagOrObjectIDView {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Try to parse as StructTagView first
+        if let Ok(struct_tag) = StructTagView::from_str(s) {
+            return Ok(StructTagOrObjectIDView::StructTag(struct_tag));
+        }
+        // If not a valid StructTag, try to parse as ObjectID
+        if let Ok(object_id) = ObjectIDView::from_str(s) {
+            return Ok(StructTagOrObjectIDView::ObjectID(object_id));
+        }
+        Err(anyhow::anyhow!(
+            "Failed to parse as either StructTag or ObjectID"
+        ))
     }
 }
 

--- a/crates/rooch-rpc-client/src/rooch_client.rs
+++ b/crates/rooch-rpc-client/src/rooch_client.rs
@@ -18,7 +18,7 @@ use rooch_rpc_api::jsonrpc_types::btc::utxo::{UTXOFilterView, UTXOObjectView};
 use rooch_rpc_api::jsonrpc_types::transaction_view::TransactionFilterView;
 use rooch_rpc_api::jsonrpc_types::{
     account_view::BalanceInfoView, transaction_view::TransactionWithInfoView, InscriptionPageView,
-    Status, UTXOPageView,
+    Status, StructTagOrObjectIDView, UTXOPageView,
 };
 use rooch_rpc_api::jsonrpc_types::{
     AccessPathView, AnnotatedFunctionResultView, BalanceInfoPageView, BytesView, EventOptions,
@@ -181,7 +181,7 @@ impl RoochRpcClient {
 
     pub async fn get_events_by_event_handle(
         &self,
-        event_handle_type: StructTagView,
+        event_handle_type: StructTagOrObjectIDView,
         cursor: Option<u64>,
         limit: Option<u64>,
         descending_order: Option<bool>,

--- a/crates/rooch-rpc-server/src/lib.rs
+++ b/crates/rooch-rpc-server/src/lib.rs
@@ -28,7 +28,7 @@ use rooch_db::RoochDB;
 use rooch_executor::actor::executor::ExecutorActor;
 use rooch_executor::actor::reader_executor::ReaderExecutorActor;
 use rooch_executor::proxy::ExecutorProxy;
-use rooch_genesis::RoochGenesis;
+use rooch_genesis::RoochGenesisV2;
 use rooch_indexer::actor::indexer::IndexerActor;
 use rooch_indexer::actor::reader_indexer::IndexerReaderActor;
 use rooch_indexer::proxy::IndexerProxy;
@@ -241,7 +241,7 @@ pub async fn run_start_server(opt: RoochOpt, server_opt: ServerOpt) -> Result<Se
         );
     }
 
-    let genesis = RoochGenesis::load_or_init(network.clone(), &rooch_db)?;
+    let genesis = RoochGenesisV2::load_or_init(network.clone(), &rooch_db)?;
 
     let root = rooch_db
         .latest_root()?

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -410,7 +410,7 @@ impl RoochAPIServer for RoochServer {
         descending_order: Option<bool>,
         event_options: Option<EventOptions>,
     ) -> RpcResult<EventPageView> {
-        let event_handle_id: ObjectIDView = event_handle.into();
+        let event_handle_id: ObjectIDView = StructTagOrObjectIDView::from_str(&event_handle()).into();
         let event_options = event_options.unwrap_or_default();
         let cursor = cursor.map(|v| v.0);
         let limit = limit.map(|v| v.0);

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -9,7 +9,6 @@ use jsonrpsee::{core::async_trait, PendingSubscriptionSink, RpcModule};
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
 };
-use moveos_types::moveos_std::event::EventHandle;
 use moveos_types::{
     access_path::AccessPath,
     h256::H256,
@@ -29,7 +28,8 @@ use rooch_rpc_api::jsonrpc_types::{
     ObjectIDVecView, ObjectIDView, ObjectStateFilterView, ObjectStateView, QueryOptions,
     RawTransactionOutputView, RoochAddressView, StateChangeSetPageView,
     StateChangeSetWithTxOrderView, StateKVView, StateOptions, StatePageView, StrView,
-    StructTagView, SyncStateFilterView, TransactionWithInfoPageView, TxOptions, UnitedAddressView,
+    StructTagOrObjectIDView, StructTagView, SyncStateFilterView, TransactionWithInfoPageView,
+    TxOptions, UnitedAddressView,
 };
 use rooch_rpc_api::jsonrpc_types::{
     repair_view::{RepairIndexerParamsView, RepairIndexerTypeView},
@@ -404,31 +404,13 @@ impl RoochAPIServer for RoochServer {
 
     async fn get_events_by_event_handle(
         &self,
-        event_handle_type: StructTagView,
+        event_handle: StructTagOrObjectIDView,
         cursor: Option<StrView<u64>>,
         limit: Option<StrView<u64>>,
         descending_order: Option<bool>,
         event_options: Option<EventOptions>,
     ) -> RpcResult<EventPageView> {
-        let event_handle_id = EventHandle::derive_event_handle_id(&event_handle_type.into());
-        self.get_events_by_event_handle_v2(
-            event_handle_id.into(),
-            cursor,
-            limit,
-            descending_order,
-            event_options,
-        )
-        .await
-    }
-
-    async fn get_events_by_event_handle_v2(
-        &self,
-        event_handle_id: ObjectIDView,
-        cursor: Option<StrView<u64>>,
-        limit: Option<StrView<u64>>,
-        descending_order: Option<bool>,
-        event_options: Option<EventOptions>,
-    ) -> RpcResult<EventPageView> {
+        let event_handle_id: ObjectIDView = event_handle.into();
         let event_options = event_options.unwrap_or_default();
         let cursor = cursor.map(|v| v.0);
         let limit = limit.map(|v| v.0);

--- a/crates/rooch-rpc-server/src/server/rooch_server.rs
+++ b/crates/rooch-rpc-server/src/server/rooch_server.rs
@@ -22,14 +22,14 @@ use rooch_rpc_api::jsonrpc_types::{
     account_view::BalanceInfoView,
     event_view::{EventFilterView, EventView, IndexerEventIDView, IndexerEventView},
     transaction_view::{TransactionFilterView, TransactionWithInfoView},
-    AccessPathView, BalanceInfoPageView, DryRunTransactionResponseView, EventOptions,
-    EventPageView, ExecuteTransactionResponseView, FieldPageView, FunctionCallView, H256View,
-    IndexerEventPageView, IndexerObjectStatePageView, IndexerStateIDView, ModuleABIView,
-    ObjectIDVecView, ObjectIDView, ObjectStateFilterView, ObjectStateView, QueryOptions,
-    RawTransactionOutputView, RoochAddressView, StateChangeSetPageView,
-    StateChangeSetWithTxOrderView, StateKVView, StateOptions, StatePageView, StrView,
-    StructTagOrObjectIDView, StructTagView, SyncStateFilterView, TransactionWithInfoPageView,
-    TxOptions, UnitedAddressView,
+    AccessPathView, BalanceInfoPageView, DryRunTransactionResponseView,
+    EnumStructTagOrObjectIDView, EventOptions, EventPageView, ExecuteTransactionResponseView,
+    FieldPageView, FunctionCallView, H256View, IndexerEventPageView, IndexerObjectStatePageView,
+    IndexerStateIDView, ModuleABIView, ObjectIDVecView, ObjectIDView, ObjectStateFilterView,
+    ObjectStateView, QueryOptions, RawTransactionOutputView, RoochAddressView,
+    StateChangeSetPageView, StateChangeSetWithTxOrderView, StateKVView, StateOptions,
+    StatePageView, StrView, StructTagOrObjectIDView, StructTagView, SyncStateFilterView,
+    TransactionWithInfoPageView, TxOptions, UnitedAddressView,
 };
 use rooch_rpc_api::jsonrpc_types::{
     repair_view::{RepairIndexerParamsView, RepairIndexerTypeView},
@@ -410,7 +410,8 @@ impl RoochAPIServer for RoochServer {
         descending_order: Option<bool>,
         event_options: Option<EventOptions>,
     ) -> RpcResult<EventPageView> {
-        let event_handle_id: ObjectIDView = StructTagOrObjectIDView::from_str(&event_handle()).into();
+        let event_handle_id: ObjectIDView =
+            EnumStructTagOrObjectIDView::from_str(event_handle.as_str())?.into();
         let event_options = event_options.unwrap_or_default();
         let cursor = cursor.map(|v| v.0);
         let limit = limit.map(|v| v.0);

--- a/crates/rooch-rpc-server/src/service/rpc_service.rs
+++ b/crates/rooch-rpc-server/src/service/rpc_service.rs
@@ -9,7 +9,7 @@ use jsonrpsee::core::SubscriptionResult;
 use jsonrpsee::PendingSubscriptionSink;
 use metrics::spawn_monitored_task;
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::{ModuleId, StructTag};
+use move_core_types::language_storage::ModuleId;
 use moveos_types::access_path::AccessPath;
 use moveos_types::function_return_value::AnnotatedFunctionResult;
 use moveos_types::h256::H256;
@@ -233,33 +233,28 @@ impl RpcService {
 
     pub async fn get_annotated_events_by_event_handle(
         &self,
-        event_handle_type: StructTag,
+        event_handle_id: ObjectID,
         cursor: Option<u64>,
         limit: u64,
         descending_order: bool,
     ) -> Result<Vec<AnnotatedEvent>> {
         let resp = self
             .executor
-            .get_annotated_events_by_event_handle(
-                event_handle_type,
-                cursor,
-                limit,
-                descending_order,
-            )
+            .get_annotated_events_by_event_handle(event_handle_id, cursor, limit, descending_order)
             .await?;
         Ok(resp)
     }
 
     pub async fn get_events_by_event_handle(
         &self,
-        event_handle_type: StructTag,
+        event_handle_id: ObjectID,
         cursor: Option<u64>,
         limit: u64,
         descending_order: bool,
     ) -> Result<Vec<Event>> {
         let resp = self
             .executor
-            .get_events_by_event_handle(event_handle_type, cursor, limit, descending_order)
+            .get_events_by_event_handle(event_handle_id, cursor, limit, descending_order)
             .await?;
         Ok(resp)
     }

--- a/crates/rooch-sequencer/tests/test_sequencer.rs
+++ b/crates/rooch-sequencer/tests/test_sequencer.rs
@@ -9,7 +9,7 @@ use raw_store::metrics::DBMetrics;
 use raw_store::StoreInstance;
 use rooch_config::RoochOpt;
 use rooch_db::RoochDB;
-use rooch_genesis::RoochGenesis;
+use rooch_genesis::RoochGenesisV2;
 use rooch_sequencer::{actor::sequencer::SequencerActor, proxy::SequencerProxy};
 use rooch_types::{
     crypto::RoochKeyPair,
@@ -30,7 +30,7 @@ fn init_rooch_db_with_instance(
 ) -> Result<RoochDB> {
     let rooch_db = RoochDB::init_with_instance(opt.store_config(), instance, registry)?;
     let network = opt.network();
-    let _genesis = RoochGenesis::load_or_init(network, &rooch_db)?;
+    let _genesis = RoochGenesisV2::load_or_init(network, &rooch_db)?;
     Ok(rooch_db)
 }
 

--- a/crates/rooch-types/src/indexer/event.rs
+++ b/crates/rooch-types/src/indexer/event.rs
@@ -10,6 +10,7 @@ use move_resource_viewer::AnnotatedMoveStruct;
 use moveos_types::h256::H256;
 use moveos_types::move_types::struct_tag_match;
 use moveos_types::moveos_std::event::{Event, EventID};
+use moveos_types::moveos_std::object::ObjectID;
 use moveos_types::moveos_std::tx_context::TxContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -90,6 +91,13 @@ pub enum EventFilter {
     },
     /// Query by event type.
     EventType(StructTag),
+    /// Query by event handle id with sender
+    EventHandleWithSender {
+        event_handle_id: ObjectID,
+        sender: AccountAddress,
+    },
+    /// Query by event handle id.
+    EventHandle(ObjectID),
     /// Query by sender address.
     Sender(AccountAddress),
     /// Return events emitted by the given transaction hash.
@@ -118,6 +126,14 @@ impl EventFilter {
                 event_type, sender, ..
             } => struct_tag_match(&item.event_type, event_type) && sender == &item.sender,
             EventFilter::EventType(event_type) => struct_tag_match(&item.event_type, event_type),
+            EventFilter::EventHandleWithSender {
+                event_handle_id,
+                sender,
+                ..
+            } => event_handle_id == &item.event_id.event_handle_id && sender == &item.sender,
+            EventFilter::EventHandle(event_handle_id) => {
+                event_handle_id == &item.event_id.event_handle_id
+            }
             EventFilter::Sender(sender) => sender == &item.sender,
             EventFilter::TxHash(tx_hash) => tx_hash == &item.tx_hash,
             EventFilter::TimeRange {

--- a/crates/rooch/src/commands/da/commands/namespace.rs
+++ b/crates/rooch/src/commands/da/commands/namespace.rs
@@ -3,7 +3,7 @@
 
 use clap::Parser;
 use rooch_config::da_config::derive_namespace_from_genesis;
-use rooch_genesis::RoochGenesisV2;
+use rooch_genesis::{RoochGenesis, RoochGenesisV2};
 use rooch_types::error::RoochResult;
 use rooch_types::rooch_network::{BuiltinChainID, RoochNetwork};
 use std::path::PathBuf;
@@ -25,7 +25,8 @@ impl NamespaceCommand {
             RoochGenesisV2::load_or_build(RoochNetwork::builtin(self.chain_id.unwrap()))?
         };
 
-        let genesis_hash = genesis.genesis_hash();
+        let genesis_v1 = RoochGenesis::from(genesis);
+        let genesis_hash = genesis_v1.genesis_hash();
         let namespace = derive_namespace_from_genesis(genesis_hash);
         println!("namespace: {}", namespace);
         let encoded_hash = hex::encode(genesis_hash.0);

--- a/crates/rooch/src/commands/da/commands/namespace.rs
+++ b/crates/rooch/src/commands/da/commands/namespace.rs
@@ -3,7 +3,7 @@
 
 use clap::Parser;
 use rooch_config::da_config::derive_namespace_from_genesis;
-use rooch_genesis::RoochGenesis;
+use rooch_genesis::RoochGenesisV2;
 use rooch_types::error::RoochResult;
 use rooch_types::rooch_network::{BuiltinChainID, RoochNetwork};
 use std::path::PathBuf;
@@ -22,7 +22,7 @@ impl NamespaceCommand {
         let genesis = if let Some(genesis_file) = self.genesis_file {
             load_genesis_from_file(genesis_file)?
         } else {
-            RoochGenesis::load_or_build(RoochNetwork::builtin(self.chain_id.unwrap()))?
+            RoochGenesisV2::load_or_build(RoochNetwork::builtin(self.chain_id.unwrap()))?
         };
 
         let genesis_hash = genesis.genesis_hash();
@@ -34,7 +34,7 @@ impl NamespaceCommand {
     }
 }
 
-fn load_genesis_from_file(path: PathBuf) -> anyhow::Result<RoochGenesis> {
+fn load_genesis_from_file(path: PathBuf) -> anyhow::Result<RoochGenesisV2> {
     let contents = std::fs::read(path)?;
-    RoochGenesis::decode(&contents)
+    RoochGenesisV2::decode(&contents)
 }

--- a/crates/rooch/src/commands/event.rs
+++ b/crates/rooch/src/commands/event.rs
@@ -5,8 +5,10 @@ use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
 use move_command_line_common::types::ParsedStructType;
-use rooch_rpc_api::jsonrpc_types::{EventOptions, EventPageView};
+use moveos_types::moveos_std::object::ObjectID;
+use rooch_rpc_api::jsonrpc_types::{EventOptions, EventPageView, StrView, StructTagOrObjectIDView};
 use rooch_types::error::{RoochError, RoochResult};
+use std::str::FromStr;
 
 /// Tool for interacting with event
 #[derive(Parser)]
@@ -31,10 +33,12 @@ pub enum EventSubCommand {
 /// Retrieves events based on their event handle.
 #[derive(Debug, Parser)]
 pub struct GetEventsByEventHandle {
-    /// Struct name as `ADDRESS::MODULE_NAME::STRUCT_NAME<TypeParam1?, TypeParam2?>`
-    /// Example: `0x123::event_test::WithdrawEvent --cursor 0 --limit 1`
-    #[clap(short = 't',long = "event-handle-type", value_parser=ParsedStructType::parse)]
-    event_handle_type: ParsedStructType,
+    /// Event handle as either:
+    /// 1. Struct name: `ADDRESS::MODULE_NAME::STRUCT_NAME<TypeParam1?, TypeParam2?>`
+    ///    Example: `0x123::event_test::WithdrawEvent`
+    /// 2. Event handle ID: `0x123...abc`
+    #[clap(short = 't', long = "event-handle")]
+    event_handle: String,
     /// start position
     #[clap(long)]
     cursor: Option<u64>,
@@ -54,12 +58,24 @@ impl CommandAction<EventPageView> for GetEventsByEventHandle {
     async fn execute(self) -> RoochResult<EventPageView> {
         let context = self.context_options.build()?;
         let address_mapping = context.address_mapping();
-        let event_handle_type = self.event_handle_type.into_struct_tag(&address_mapping)?;
         let client = context.get_client().await?;
+
+        let event_handle =
+            // Try parsing as ObjectID first
+            match ObjectID::from_str(&self.event_handle) {
+                Ok(object_id) => StructTagOrObjectIDView::ObjectID(StrView(object_id)),
+                Err(_) => {
+                    // If not a valid ObjectID, try parsing as StructTag
+                    let parsed_type = ParsedStructType::parse(&self.event_handle)?;
+                    let struct_tag = parsed_type.into_struct_tag(&address_mapping)?;
+                    StructTagOrObjectIDView::StructTag(StrView(struct_tag))
+                }
+            };
+
         let resp = client
             .rooch
             .get_events_by_event_handle(
-                event_handle_type.into(),
+                event_handle,
                 self.cursor,
                 self.limit,
                 self.descending_order,

--- a/crates/rooch/src/commands/genesis/commands/init.rs
+++ b/crates/rooch/src/commands/genesis/commands/init.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use metrics::RegistryService;
 use rooch_config::{RoochOpt, R_OPT_NET_HELP};
 use rooch_db::RoochDB;
-use rooch_genesis::RoochGenesis;
+use rooch_genesis::RoochGenesisV2;
 use rooch_types::{
     error::{RoochError, RoochResult},
     rooch_network::RoochChainID,
@@ -38,7 +38,7 @@ impl InitCommand {
         let registry_service = RegistryService::default();
         let rooch_db = RoochDB::init(store_config, &registry_service.default_registry())?;
         let network = opt.network();
-        let _genesis = RoochGenesis::load_or_init(network, &rooch_db)?;
+        let _genesis = RoochGenesisV2::load_or_init(network, &rooch_db)?;
         let root = rooch_db
             .latest_root()?
             .ok_or_else(|| RoochError::from(anyhow::anyhow!("Load latest root failed")))?;

--- a/frameworks/moveos-stdlib/doc/event.md
+++ b/frameworks/moveos-stdlib/doc/event.md
@@ -5,10 +5,36 @@
 
 
 
+-  [Function `named_event_handle_id`](#0x2_event_named_event_handle_id)
+-  [Function `custom_event_handle_id`](#0x2_event_custom_event_handle_id)
 -  [Function `emit`](#0x2_event_emit)
+-  [Function `emit_with_handle`](#0x2_event_emit_with_handle)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
+</code></pre>
+
+
+
+<a name="0x2_event_named_event_handle_id"></a>
+
+## Function `named_event_handle_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_named_event_handle_id">named_event_handle_id</a>&lt;T&gt;(): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
+</code></pre>
+
+
+
+<a name="0x2_event_custom_event_handle_id"></a>
+
+## Function `custom_event_handle_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_custom_event_handle_id">custom_event_handle_id</a>&lt;ID: <b>copy</b>, drop, store, T: key&gt;(id: ID): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
+</code></pre>
 
 
 
@@ -27,4 +53,17 @@ phantom parameters, eg. emit(MyEvent<phantom T>).
 
 <pre><code>#[private_generics(#[T])]
 <b>public</b> <b>fun</b> <a href="event.md#0x2_event_emit">emit</a>&lt;T: <b>copy</b>, drop&gt;(<a href="event.md#0x2_event">event</a>: T)
+</code></pre>
+
+
+
+<a name="0x2_event_emit_with_handle"></a>
+
+## Function `emit_with_handle`
+
+Emit a custom Move event with handle
+
+
+<pre><code>#[private_generics(#[T])]
+<b>public</b> <b>fun</b> <a href="event.md#0x2_event_emit_with_handle">emit_with_handle</a>&lt;T: <b>copy</b>, drop&gt;(event_handle_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, <a href="event.md#0x2_event">event</a>: T)
 </code></pre>

--- a/frameworks/moveos-stdlib/src/natives/moveos_stdlib/event.rs
+++ b/frameworks/moveos-stdlib/src/natives/moveos_stdlib/event.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::natives::helpers;
+use crate::natives::moveos_stdlib::object::pop_object_id;
 use better_any::{Tid, TidAble};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
@@ -13,16 +14,18 @@ use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
 use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
 };
+use moveos_types::moveos_std::event::EventHandle;
+use moveos_types::moveos_std::object::ObjectID;
 use smallvec::smallvec;
 use std::collections::VecDeque;
 
 #[derive(Default, Tid)]
 pub struct NativeEventContext {
-    events: Vec<(StructTag, Vec<u8>)>,
+    events: Vec<(StructTag, ObjectID, Vec<u8>)>,
 }
 
 impl NativeEventContext {
-    pub fn into_events(self) -> Vec<(StructTag, Vec<u8>)> {
+    pub fn into_events(self) -> Vec<(StructTag, ObjectID, Vec<u8>)> {
         self.events
     }
 }
@@ -84,8 +87,70 @@ pub fn native_emit(
         .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
     cost += gas_params.per_byte_in_str * NumBytes::new(event_data.len() as u64);
 
+    let event_handle_id = EventHandle::derive_event_handle_id(&struct_tag);
     let event_context = context.extensions_mut().get_mut::<NativeEventContext>();
-    event_context.events.push((struct_tag, event_data));
+    event_context
+        .events
+        .push((struct_tag, event_handle_id, event_data));
+
+    Ok(NativeResult::ok(cost, smallvec![]))
+}
+
+#[derive(Debug, Clone)]
+pub struct EmitWithHandleGasParameters {
+    pub base: InternalGas,
+    pub per_byte_in_str: InternalGasPerByte,
+}
+
+impl EmitWithHandleGasParameters {
+    pub fn zeros() -> Self {
+        Self {
+            base: InternalGas::zero(),
+            per_byte_in_str: InternalGasPerByte::zero(),
+        }
+    }
+}
+
+pub fn native_emit_with_handle(
+    gas_params: &EmitWithHandleGasParameters,
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 2);
+
+    let mut cost = gas_params.base;
+
+    let ty = ty_args.pop().unwrap();
+    let type_tag = context.type_to_type_tag(&ty)?;
+    let struct_tag = match type_tag {
+        TypeTag::Struct(struct_tag) => *struct_tag,
+        _ => {
+            debug_assert!(false, "Event type should be a struct");
+            return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR));
+        }
+    };
+    let msg = args.pop_back().unwrap();
+    let layout = context.type_to_type_layout(&ty)?.ok_or_else(|| {
+        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(format!(
+            "Failed to get layout of type {:?} -- this should not happen",
+            ty
+        ))
+    })?;
+    if tracing::enabled!(tracing::Level::TRACE) {
+        tracing::trace!("Emitting event {}, {:?}", struct_tag, msg);
+    }
+    let event_data = msg
+        .simple_serialize(&layout)
+        .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
+    cost += gas_params.per_byte_in_str * NumBytes::new(event_data.len() as u64);
+
+    let event_handle_id = pop_object_id(&mut args)?;
+    let event_context = context.extensions_mut().get_mut::<NativeEventContext>();
+    event_context
+        .events
+        .push((struct_tag, event_handle_id, event_data));
 
     Ok(NativeResult::ok(cost, smallvec![]))
 }
@@ -97,20 +162,29 @@ pub fn native_emit(
 #[derive(Debug, Clone)]
 pub struct GasParameters {
     pub emit: EmitGasParameters,
+    pub emit_with_handle: EmitGasParameters,
 }
 
 impl GasParameters {
     pub fn zeros() -> Self {
         Self {
             emit: EmitGasParameters::zeros(),
+            emit_with_handle: EmitGasParameters::zeros(),
         }
     }
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
-    let natives = [(
-        "native_emit",
-        helpers::make_native(gas_params.emit, native_emit),
-    )];
+    let natives = [
+        (
+            "native_emit",
+            helpers::make_native(gas_params.emit, native_emit),
+        ),
+        (
+            "native_emit_with_handle",
+            helpers::make_native(gas_params.emit_with_handle, native_emit_with_handle),
+        ),
+    ];
+
     helpers::make_module_natives(natives)
 }

--- a/frameworks/moveos-stdlib/src/natives/moveos_stdlib/event.rs
+++ b/frameworks/moveos-stdlib/src/natives/moveos_stdlib/event.rs
@@ -131,6 +131,7 @@ pub fn native_emit_with_handle(
             return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR));
         }
     };
+
     let msg = args.pop_back().unwrap();
     let layout = context.type_to_type_layout(&ty)?.ok_or_else(|| {
         PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(format!(
@@ -162,14 +163,14 @@ pub fn native_emit_with_handle(
 #[derive(Debug, Clone)]
 pub struct GasParameters {
     pub emit: EmitGasParameters,
-    pub emit_with_handle: EmitGasParameters,
+    pub emit_with_handle: EmitWithHandleGasParameters,
 }
 
 impl GasParameters {
     pub fn zeros() -> Self {
         Self {
             emit: EmitGasParameters::zeros(),
-            emit_with_handle: EmitGasParameters::zeros(),
+            emit_with_handle: EmitWithHandleGasParameters::zeros(),
         }
     }
 }

--- a/frameworks/rooch-framework/src/natives/gas_parameter/events.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/events.rs
@@ -7,4 +7,6 @@ use moveos_stdlib::natives::moveos_stdlib::event::GasParameters;
 crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "events", [
     [.emit.base, "emit.base", (52 + 1) * MUL],
     [.emit.per_byte_in_str, "emit.per_byte_in_str", (5 + 1) * MUL],
+    [.emit_with_handle.base, "emit_with_handle.base", (52 + 1) * MUL],
+    [.emit_with_handle.per_byte_in_str, "emit_with_handle.per_byte_in_str", (5 + 1) * MUL],
 ]);

--- a/frameworks/rooch-framework/src/natives/gas_parameter/events.rs
+++ b/frameworks/rooch-framework/src/natives/gas_parameter/events.rs
@@ -7,6 +7,8 @@ use moveos_stdlib::natives::moveos_stdlib::event::GasParameters;
 crate::natives::gas_parameter::native::define_gas_parameters_for_natives!(GasParameters, "events", [
     [.emit.base, "emit.base", (52 + 1) * MUL],
     [.emit.per_byte_in_str, "emit.per_byte_in_str", (5 + 1) * MUL],
-    [.emit_with_handle.base, "emit_with_handle.base", (52 + 1) * MUL],
-    [.emit_with_handle.per_byte_in_str, "emit_with_handle.per_byte_in_str", (5 + 1) * MUL],
+    // [.emit_with_handle.base, "emit_with_handle.base", (52 + 1) * MUL],
+    // [.emit_with_handle.per_byte_in_str, "emit_with_handle.per_byte_in_str", (5 + 1) * MUL],
+    [.emit_with_handle.base, optional "decode.base", 0],
+    [.emit_with_handle.per_byte_in_str, optional "decode.per_byte_in_str", 0],
 ]);

--- a/moveos/moveos-types/src/moveos_std/event.rs
+++ b/moveos/moveos-types/src/moveos_std/event.rs
@@ -177,6 +177,16 @@ impl From<GenesisTransactionEvent> for TransactionEvent {
     }
 }
 
+impl From<TransactionEvent> for GenesisTransactionEvent {
+    fn from(genesis_event: TransactionEvent) -> Self {
+        Self {
+            event_type: genesis_event.event_type.clone(),
+            event_data: genesis_event.event_data,
+            event_index: genesis_event.event_index,
+        }
+    }
+}
+
 // Implement custom Deserialize for TransactionEvent to be compatible with old data
 impl<'de> Deserialize<'de> for TransactionEvent {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/moveos/moveos-types/src/moveos_std/event.rs
+++ b/moveos/moveos-types/src/moveos_std/event.rs
@@ -177,31 +177,26 @@ impl<'de> Deserialize<'de> for TransactionEvent {
             where
                 V: serde::de::SeqAccess<'de>,
             {
-                println!("[Debug] visit_seq 1 {:?}", seq.);
+                println!("[Debug] visit_seq 1 ");
                 let event_type = seq
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
-                println!("[Debug] visit_seq 2 {:?}", seq);
+                println!("[Debug] visit_seq 2 ");
                 let event_data = seq
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
-                println!("[Debug] visit_seq 3 {:?}", seq);
+                println!("[Debug] visit_seq 3 ");
                 let event_index = seq
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
 
-                println!("[Debug] visit_seq 4 {:?}", seq);
+                println!("[Debug] visit_seq 4 ");
                 // For old data format, derive event_handle_id from event_type
-                let event_handle_id = seq
-                    .next_element()
-                    .unwrap_or(None)
-                    .unwrap_or(EventHandle::derive_event_handle_id(&event_type));
-                // For old data format, derive event_handle_id from event_type
-                // let event_handle_id = if let Some(id) = seq.next_element()? {
-                //     id
-                // } else {
-                //     EventHandle::derive_event_handle_id(&event_type)
-                // };
+                let event_handle_id = EventHandle::derive_event_handle_id(&event_type);
+                // let event_handle_id = seq
+                //     .next_element()
+                //     .unwrap_or(None)
+                //     .unwrap_or(EventHandle::derive_event_handle_id(&event_type));
 
                 Ok(TransactionEvent {
                     event_type,

--- a/moveos/moveos-types/src/transaction.rs
+++ b/moveos/moveos-types/src/transaction.rs
@@ -458,6 +458,23 @@ impl From<GenesisRawTransactionOutput> for RawTransactionOutput {
     }
 }
 
+impl From<RawTransactionOutput> for GenesisRawTransactionOutput {
+    fn from(raw_tx_output: RawTransactionOutput) -> Self {
+        Self {
+            status: raw_tx_output.status,
+            changeset: raw_tx_output.changeset,
+            events: raw_tx_output
+                .events
+                .into_iter()
+                .map(GenesisTransactionEvent::from)
+                .collect(),
+            gas_used: raw_tx_output.gas_used,
+            is_upgrade: raw_tx_output.is_upgrade,
+            is_gas_upgrade: raw_tx_output.is_gas_upgrade,
+        }
+    }
+}
+
 /// TransactionOutput is the execution result of a MoveOS transaction, and pack TransactionEvent to Event
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionOutput {

--- a/moveos/moveos/src/vm/moveos_vm.rs
+++ b/moveos/moveos/src/vm/moveos_vm.rs
@@ -612,8 +612,13 @@ where
         let events: Vec<_> = raw_events
             .into_iter()
             .enumerate()
-            .map(|(i, (struct_tag, event_data))| {
-                Ok(TransactionEvent::new(struct_tag, event_data, i as u64))
+            .map(|(i, (struct_tag, event_handle_id, event_data))| {
+                Ok(TransactionEvent::new_with_handle(
+                    struct_tag,
+                    event_data,
+                    i as u64,
+                    event_handle_id,
+                ))
             })
             .collect::<VMResult<_>>()?;
 

--- a/sdk/typescript/rooch-sdk/src/client/client.ts
+++ b/sdk/typescript/rooch-sdk/src/client/client.ts
@@ -258,7 +258,7 @@ export class RoochClient {
     }
     return await this.transport.request({
       method: 'rooch_getEventsByEventHandle',
-      params: [input.eventHandleType, input.cursor, input.limit, input.descendingOrder, opt],
+      params: [input.eventHandle, input.cursor, input.limit, input.descendingOrder, opt],
     })
   }
 

--- a/sdk/typescript/rooch-sdk/src/client/types/params.ts
+++ b/sdk/typescript/rooch-sdk/src/client/types/params.ts
@@ -61,7 +61,7 @@ export interface GetBalancesParams {
 export interface GetChainIDParams {}
 /** Get the events by event handle id */
 export interface GetEventsByEventHandleParams {
-  eventHandleType: string
+  eventHandle: string
   cursor?: string | null | undefined
   limit?: string | null | undefined
   descendingOrder?: boolean | null | undefined

--- a/sdk/typescript/rooch-sdk/test-e2e/case/checkpoint.test.ts
+++ b/sdk/typescript/rooch-sdk/test-e2e/case/checkpoint.test.ts
@@ -127,7 +127,7 @@ describe('Checkpoints Reading API', () => {
     await testBox.delay(3)
 
     const result1 = await testBox.getClient().getEvents({
-      eventHandleType: `${await testBox.defaultCmdAddress()}::event_test::WithdrawEvent`,
+      eventHandle: `${await testBox.defaultCmdAddress()}::event_test::WithdrawEvent`,
       limit: '1',
       descendingOrder: false,
     })

--- a/sdk/typescript/rooch-sdk/test-e2e/case/events.test.ts
+++ b/sdk/typescript/rooch-sdk/test-e2e/case/events.test.ts
@@ -33,7 +33,7 @@ describe('Events API', () => {
     expect(await testBox.signAndExecuteTransaction(tx)).toBeTruthy()
 
     const result1 = await testBox.getClient().getEvents({
-      eventHandleType: `${await testBox.defaultCmdAddress()}::event_test::WithdrawEvent`,
+      eventHandle: `${await testBox.defaultCmdAddress()}::event_test::WithdrawEvent`,
     })
 
     expect(result1.next_cursor).eq('0')


### PR DESCRIPTION
## Summary

1. Add new event contract API `emit_with_handle` to support emit event with specified event handle id
2. Make event RPC `rooch_getEventsByEventHandle` to support query by either event handle id or event handle type, and compatible for old request
3.  Event Indexer RPC support new filter by event handle id 
4. Subscription events support new filter by event handle id via websocket

- Closes #3477