### PR TITLE
[move] Fix compat check config and allow friend function break

### DIFF
--- a/frameworks/framework-builder/src/releaser.rs
+++ b/frameworks/framework-builder/src/releaser.rs
@@ -228,6 +228,6 @@ fn check_compiled_module_compat(
     );
     // TODO: config compatibility through global configuration
     // We allow `friend` function to be broken
-    let compat = Compatibility::new(true, true, true);
+    let compat = Compatibility::new(true, true, false, true);
     compat.check(old_module, new_module)
 }

--- a/frameworks/moveos-stdlib/src/natives/moveos_stdlib/move_module.rs
+++ b/frameworks/moveos-stdlib/src/natives/moveos_stdlib/move_module.rs
@@ -299,7 +299,7 @@ fn check_compatibililty_inner(
     let mut cost = gas_params.base;
     // TODO: config compatibility through global configuration
     // We allow `friend` function to be broken
-    let compat = Compatibility::new(true, true, false);
+    let compat = Compatibility::new(true, true, false, true);
     if compat.need_check_compat() {
         let old_bytecodes = pop_arg!(args, Vec<u8>);
         let new_bytecodes = pop_arg!(args, Vec<u8>);

--- a/third_party/move/language/move-binary-format/src/compatibility.rs
+++ b/third_party/move/language/move-binary-format/src/compatibility.rs
@@ -59,12 +59,13 @@ impl Compatibility {
     }
 
     pub fn new(
+        check_struct_and_pub_function_linking: bool,
         check_struct_layout: bool,
         check_friend_linking: bool,
         treat_entry_as_public: bool,
     ) -> Self {
         Self {
-            check_struct_and_pub_function_linking: true,
+            check_struct_and_pub_function_linking,
             check_struct_layout,
             check_friend_linking,
             treat_entry_as_public,

--- a/third_party/move/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -188,6 +188,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
                     !extra_args.skip_check_struct_and_pub_function_linking,
                     !extra_args.skip_check_struct_layout,
                     !extra_args.skip_check_friend_linking,
+                    false,
                 );
 
                 session.publish_module_bundle_with_compat_config(

--- a/third_party/move/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/third_party/move/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -352,14 +352,14 @@ pub(crate) fn explain_publish_error(
 
             let old_module = state.get_module_by_id(&module_id)?.unwrap();
 
-            if Compatibility::new(false, true, false)
+            if Compatibility::new(false, true, false, false)
                 .check(&old_module, module)
                 .is_err()
             {
                 // TODO: we could choose to make this more precise by walking the global state and looking for published
                 // structs of this type. but probably a bad idea
                 println!("Layout API for structs of module {} has changed. Need to do a data migration of published structs", module_id)
-            } else if Compatibility::new(true, false, false)
+            } else if Compatibility::new(true, false, false, false)
                 .check(&old_module, module)
                 .is_err()
             {


### PR DESCRIPTION
## Summary

1. expose the `check_struct_and_pub_function_linking` config
2. Set `check_friend_linking` to false.

resolve the bug introduced from #3465 and #3473 