### PR TITLE
Handle empty result for list rpc and fixup bitcoin bump error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.3"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0032b0e8ead7074cda7fc4f034409607e3f03a6f71d66ade8a307f79b4d99e73"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
  "bech32 0.11.0",
@@ -1270,7 +1270,7 @@ version = "0.9.2"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "bitcoincore-rpc",
  "coerce",
  "serde 1.0.219",
@@ -1300,7 +1300,7 @@ version = "0.9.2"
 dependencies = [
  "anyhow 1.0.95",
  "axum",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "brotli 3.5.0",
  "hex",
  "move-binary-format",
@@ -1380,7 +1380,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "serde 1.0.219",
  "serde_json",
 ]
@@ -10271,7 +10271,7 @@ dependencies = [
  "anyhow 1.0.95",
  "async-trait",
  "bcs",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "bitcoin-client",
  "ciborium",
  "clap 4.5.17",
@@ -10370,7 +10370,7 @@ dependencies = [
  "anyhow 1.0.93",
  "anyhow 1.0.95",
  "bcs",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
  "clap 4.5.17",
@@ -10555,7 +10555,7 @@ dependencies = [
 name = "rooch-framework"
 version = "0.9.2"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "fastcrypto",
  "hex",
  "move-binary-format",
@@ -10577,7 +10577,7 @@ version = "0.9.2"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "bitcoin-client",
  "clap 4.5.17",
  "coerce",
@@ -10866,7 +10866,7 @@ dependencies = [
  "anyhow 1.0.95",
  "async-trait",
  "bcs",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "bitcoin-client",
  "coerce",
  "function_name",
@@ -10911,7 +10911,7 @@ version = "0.9.2"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "bitcoin-client",
  "bitcoincore-rpc",
  "chrono",
@@ -10939,7 +10939,7 @@ dependencies = [
  "accumulator",
  "anyhow 1.0.95",
  "bcs",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "ethers",
  "hex",
  "jsonrpsee 0.24.9",
@@ -10963,7 +10963,7 @@ version = "0.9.2"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "bitcoincore-rpc",
  "futures",
  "jsonrpsee 0.24.9",
@@ -11094,7 +11094,7 @@ dependencies = [
  "argon2",
  "bcs",
  "bech32 0.11.0",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.5",
  "bitcoincore-rpc",
  "bs58 0.5.1",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,8 @@ bcs = "0.1.3"
 bytes = "1.10.1"
 bech32 = "0.11.0"
 better_any = "0.1.1"
-bitcoin = { version = "=0.32.3", features = ["rand-std", "bitcoinconsensus"] }
+bitcoin = { version = "0.32.5", features = ["rand-std", "bitcoinconsensus"] }
+#bitcoin-io = "0.2.0"
 bitcoin_hashes = { version = "0.14.0", features = ["serde"] }
 bitcoincore-rpc = "0.19.0"
 bitcoincore-rpc-json = "0.19.0"

--- a/crates/rooch-types/src/framework/auth_payload.rs
+++ b/crates/rooch-types/src/framework/auth_payload.rs
@@ -6,10 +6,9 @@ use crate::{
     transaction::RoochTransactionData,
 };
 use anyhow::{ensure, Result};
-use bitcoin::{
-    consensus::{Decodable, Encodable},
-    io::BufRead,
-};
+use bitcoin::consensus::{Decodable, Encodable};
+use bitcoin::io::{Read, Write};
+
 use fastcrypto::{
     hash::Sha256,
     secp256k1::{Secp256k1PublicKey, Secp256k1Signature},
@@ -94,17 +93,14 @@ impl SignData {
 }
 
 impl Encodable for SignData {
-    fn consensus_encode<S: bitcoin::io::Write + ?Sized>(
-        &self,
-        s: &mut S,
-    ) -> Result<usize, bitcoin::io::Error> {
+    fn consensus_encode<S: Write + ?Sized>(&self, s: &mut S) -> Result<usize, bitcoin::io::Error> {
         let len = self.message_prefix.consensus_encode(s)?;
         Ok(len + self.message_info.consensus_encode(s)?)
     }
 }
 
 impl Decodable for SignData {
-    fn consensus_decode<D: BufRead + ?Sized>(
+    fn consensus_decode<D: Read + ?Sized>(
         d: &mut D,
     ) -> Result<Self, bitcoin::consensus::encode::Error> {
         Ok(SignData {

--- a/moveos/moveos-store/src/event_store/mod.rs
+++ b/moveos/moveos-store/src/event_store/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{EVENT_COLUMN_FAMILY_NAME, EVENT_HANDLE_COLUMN_FAMILY_NAME};
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use move_core_types::language_storage::StructTag;
 use moveos_types::moveos_std::event::{Event, EventHandle, EventID, TransactionEvent};
 use moveos_types::moveos_std::object::ObjectID;

--- a/moveos/moveos-store/src/event_store/mod.rs
+++ b/moveos/moveos-store/src/event_store/mod.rs
@@ -145,14 +145,11 @@ impl EventDBStore {
         limit: u64,
         descending_order: bool,
     ) -> Result<Vec<Event>> {
-        let event_handle = self
-            .get_event_handle(event_handle_id.clone())?
-            .ok_or_else(|| {
-                anyhow!(
-                    "Can not find event handle by id: {}",
-                    event_handle_id.to_string()
-                )
-            })?;
+        let event_handle = self.get_event_handle(event_handle_id.clone())?;
+        if event_handle.is_none() {
+            return Ok(vec![]);
+        }
+        let event_handle = event_handle.unwrap();
         let last_seq = event_handle.count;
         let ids = if descending_order {
             let start = cursor.unwrap_or(last_seq);

--- a/moveos/moveos-types/src/state_resolver.rs
+++ b/moveos/moveos-types/src/state_resolver.rs
@@ -64,10 +64,10 @@ pub trait StateResolver: StatelessResolver {
         cursor: Option<FieldKey>,
         limit: usize,
     ) -> Result<Vec<StateKV>, anyhow::Error> {
-        let obj = self
-            .get_object(object_id)?
-            .ok_or_else(|| anyhow::format_err!("Object with id {} not found", object_id))?;
-        self.list_fields_at(obj.state_root(), cursor, limit)
+        match self.get_object(object_id)? {
+            Some(obj) => self.list_fields_at(obj.state_root(), cursor, limit),
+            None => Ok(vec![]),
+        }
     }
 
     fn root(&self) -> &ObjectMeta;


### PR DESCRIPTION
## Summary

1. Return empty result for list rpc if object not exists
2. Unlock the bitcoin version and Bump bitcoin from 0.32.3 to 0.32.5

- Closes #3491 #2853