### PR TITLE
[moveos_std] Remove key ability requirement for object_id generate function

### DIFF
--- a/frameworks/moveos-stdlib/doc/event.md
+++ b/frameworks/moveos-stdlib/doc/event.md
@@ -33,7 +33,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_custom_event_handle_id">custom_event_handle_id</a>&lt;ID: <b>copy</b>, drop, store, T: key&gt;(id: ID): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="event.md#0x2_event_custom_event_handle_id">custom_event_handle_id</a>&lt;ID: <b>copy</b>, drop, store, T&gt;(id: ID): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
 </code></pre>
 
 

--- a/frameworks/moveos-stdlib/doc/object.md
+++ b/frameworks/moveos-stdlib/doc/object.md
@@ -408,7 +408,7 @@ Generate a new ObjectID from an address
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_account_named_object_id">account_named_object_id</a>&lt;T: key&gt;(<a href="account.md#0x2_account">account</a>: <b>address</b>): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_account_named_object_id">account_named_object_id</a>&lt;T&gt;(<a href="account.md#0x2_account">account</a>: <b>address</b>): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
 </code></pre>
 
 
@@ -419,7 +419,7 @@ Generate a new ObjectID from an address
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_custom_object_id">custom_object_id</a>&lt;ID: <b>copy</b>, drop, store, T: key&gt;(id: ID): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_custom_object_id">custom_object_id</a>&lt;ID: <b>copy</b>, drop, store, T&gt;(id: ID): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
 </code></pre>
 
 
@@ -430,7 +430,7 @@ Generate a new ObjectID from an address
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_custom_object_id_with_parent">custom_object_id_with_parent</a>&lt;ID: <b>copy</b>, drop, store, T: key&gt;(parent_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, id: ID): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_custom_object_id_with_parent">custom_object_id_with_parent</a>&lt;ID: <b>copy</b>, drop, store, T&gt;(parent_id: <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>, id: ID): <a href="object.md#0x2_object_ObjectID">object::ObjectID</a>
 </code></pre>
 
 

--- a/frameworks/moveos-stdlib/sources/event.move
+++ b/frameworks/moveos-stdlib/sources/event.move
@@ -9,7 +9,7 @@ module moveos_std::event {
         object::named_object_id<T>()
     }
 
-    public fun custom_event_handle_id<ID: store + copy + drop, T: key>(id: ID): ObjectID {
+    public fun custom_event_handle_id<ID: store + copy + drop, T>(id: ID): ObjectID {
         object::custom_object_id<ID, T>(id)
     }
 

--- a/frameworks/moveos-stdlib/sources/object.move
+++ b/frameworks/moveos-stdlib/sources/object.move
@@ -126,7 +126,7 @@ module moveos_std::object {
         )
     }
 
-    public fun account_named_object_id<T: key>(account: address): ObjectID {
+    public fun account_named_object_id<T>(account: address): ObjectID {
         let bytes = bcs::to_bytes(&account);
         vector::append(&mut bytes, *std::string::bytes(&type_info::type_name<T>()));
         address_to_object_id(
@@ -136,11 +136,11 @@ module moveos_std::object {
         )
     }
 
-    public fun custom_object_id<ID: store + copy + drop, T: key>(id: ID): ObjectID {
+    public fun custom_object_id<ID: store + copy + drop, T>(id: ID): ObjectID {
         address_to_object_id(derive_object_key<ID, T>(id))
     }
 
-    public fun custom_object_id_with_parent<ID: store + copy + drop, T: key>(parent_id: ObjectID, id: ID): ObjectID {
+    public fun custom_object_id_with_parent<ID: store + copy + drop, T>(parent_id: ObjectID, id: ID): ObjectID {
         let child = derive_object_key<ID, T>(id);
         let path = parent_id.path;
         vector::push_back(&mut path, child);


### PR DESCRIPTION
Remove key ability requirement for object_id generate function