### PR TITLE
sdk/typescript: add schnorr signature support to typescript sdk.

### DIFF
--- a/sdk/typescript/rooch-sdk/.gitignore
+++ b/sdk/typescript/rooch-sdk/.gitignore
@@ -21,3 +21,5 @@ generated/
 
 # yarn error
 yarn-error.log
+
+deno.lock

--- a/sdk/typescript/rooch-sdk/src/crypto/signatureScheme.ts
+++ b/sdk/typescript/rooch-sdk/src/crypto/signatureScheme.ts
@@ -5,10 +5,6 @@ export const SIGNATURE_SCHEME_TO_FLAG = {
   ED25519: 0x00,
   Secp256k1: 0x01,
 } as const
-export const SIGNATURE_SCHEME_TO_SIZE = {
-  ED25519: 32,
-  Secp256k1: 33,
-}
 
 export const SIGNATURE_FLAG_TO_SCHEME = {
   0x00: 'ED25519',

--- a/sdk/typescript/rooch-sdk/src/keypairs/secp256k1/keypair.test.ts
+++ b/sdk/typescript/rooch-sdk/src/keypairs/secp256k1/keypair.test.ts
@@ -79,6 +79,14 @@ describe('Secp256k1 keypair', () => {
       expect(isValid).toBeTruthy()
     })
 
+    it('should sign data with schnorr signature', async () => {
+      const keypair = new Secp256k1Keypair()
+      const message = new TextEncoder().encode('hello world')
+      const signature = await keypair.sign_schnorr(message)
+      const isValid = await keypair.getSchnorrPublicKey().verify_schnorr(message, signature)
+      expect(isValid).toBeTruthy()
+    })
+
     it('Sign data same as rooch cli', async () => {
       // TODO:
     })

--- a/sdk/typescript/rooch-sdk/src/keypairs/secp256k1/keypair.ts
+++ b/sdk/typescript/rooch-sdk/src/keypairs/secp256k1/keypair.ts
@@ -147,7 +147,7 @@ export class Secp256k1Keypair extends Keypair {
   }
 
   /**
-   * Return the signature for the provided data.
+   * Return the ecdsa signature for the provided data.
    */
   async sign(input: Bytes) {
     const msgHash = sha256(input)
@@ -156,6 +156,15 @@ export class Secp256k1Keypair extends Keypair {
     })
 
     return sig.toCompactRawBytes()
+  }
+
+  /**
+   * Return the schnorr signature for the provided data.
+   */
+  async sign_schnorr(input: Bytes, auxRand?: Bytes) {
+    const sig = schnorr.sign(input, this.keypair.secretKey, auxRand)
+
+    return sig
   }
 
   async signTransaction(input: Transaction): Promise<Authenticator> {

--- a/sdk/typescript/rooch-sdk/vitest.config.js
+++ b/sdk/typescript/rooch-sdk/vitest.config.js
@@ -1,7 +1,7 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-import * as path from 'path'
+import * as path from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Add signature signing and verification based on secp256k1 32 bytes public key size.

- Closes #3555