### PR TITLE
[gh-3561] feat: commands/account: add account sign for schnorr case.

### DIFF
--- a/crates/rooch-key/src/keystore/account_keystore.rs
+++ b/crates/rooch-key/src/keystore/account_keystore.rs
@@ -138,6 +138,13 @@ pub trait AccountKeystore {
         password: Option<String>,
     ) -> Result<Signature, anyhow::Error>;
 
+    fn sign_schnorr(
+        &self,
+        address: &RoochAddress,
+        msg: &[u8],
+        password: Option<String>,
+    ) -> Result<[u8; 64], anyhow::Error>;
+
     fn sign_transaction(
         &self,
         address: &RoochAddress,

--- a/crates/rooch-key/src/keystore/base_keystore.rs
+++ b/crates/rooch-key/src/keystore/base_keystore.rs
@@ -118,6 +118,18 @@ impl AccountKeystore for BaseKeyStore {
         Ok(Signature::sign(msg, &self.get_key_pair(address, password)?))
     }
 
+    fn sign_schnorr(
+        &self,
+        address: &RoochAddress,
+        msg: &[u8],
+        password: Option<String>,
+    ) -> Result<[u8; 64], anyhow::Error> {
+        Ok(Signature::sign_schnorr(
+            msg,
+            &self.get_key_pair(address, password)?,
+        )?)
+    }
+
     fn sign_secure<T>(
         &self,
         address: &RoochAddress,

--- a/crates/rooch-key/src/keystore/file_keystore.rs
+++ b/crates/rooch-key/src/keystore/file_keystore.rs
@@ -83,6 +83,15 @@ impl AccountKeystore for FileBasedKeystore {
         self.keystore.sign_hashed(address, msg, password)
     }
 
+    fn sign_schnorr(
+        &self,
+        address: &RoochAddress,
+        msg: &[u8],
+        password: Option<String>,
+    ) -> Result<[u8; 64], anyhow::Error> {
+        self.keystore.sign_schnorr(address, msg, password)
+    }
+
     fn sign_transaction(
         &self,
         address: &RoochAddress,

--- a/crates/rooch-key/src/keystore/memory_keystore.rs
+++ b/crates/rooch-key/src/keystore/memory_keystore.rs
@@ -58,6 +58,15 @@ impl AccountKeystore for InMemKeystore {
         self.keystore.sign_hashed(address, msg, password)
     }
 
+    fn sign_schnorr(
+        &self,
+        address: &RoochAddress,
+        msg: &[u8],
+        password: Option<String>,
+    ) -> Result<[u8; 64], anyhow::Error> {
+        self.keystore.sign_schnorr(address, msg, password)
+    }
+
     fn sign_transaction(
         &self,
         address: &RoochAddress,

--- a/crates/rooch-key/src/keystore/mod.rs
+++ b/crates/rooch-key/src/keystore/mod.rs
@@ -161,6 +161,19 @@ impl AccountKeystore for Keystore {
         }
     }
 
+    fn sign_schnorr(
+        &self,
+        address: &RoochAddress,
+        msg: &[u8],
+        password: Option<String>,
+    ) -> Result<[u8; 64], anyhow::Error> {
+        // Implement this method to sign a plaintext message for the appropriate variant (File or InMem)
+        match self {
+            Keystore::File(file_keystore) => file_keystore.sign_schnorr(address, msg, password),
+            Keystore::InMem(inmem_keystore) => inmem_keystore.sign_schnorr(address, msg, password),
+        }
+    }
+
     fn sign_transaction(
         &self,
         address: &RoochAddress,

--- a/crates/rooch-types/src/crypto.rs
+++ b/crates/rooch-types/src/crypto.rs
@@ -569,7 +569,8 @@ impl Signature {
         let message =
             Message::from_digest_slice(msg).map_err(|_| RoochError::InvalidlengthError())?;
         let signature = keypair.sign_schnorr(message);
-        Ok(signature.serialize())
+        let signature_bytes = signature.serialize();
+        Ok(signature_bytes)
     }
 
     /// Sign the message with bcs serialization and use Blake2b256 to hash the message.

--- a/crates/rooch/src/commands/account/commands/sign.rs
+++ b/crates/rooch/src/commands/account/commands/sign.rs
@@ -8,12 +8,9 @@ use moveos_types::state::MoveState;
 use rooch_key::keystore::account_keystore::AccountKeystore;
 use rooch_types::{
     address::ParsedAddress,
-    crypto::SignatureScheme,
     error::RoochResult,
     framework::auth_payload::{SignData, MESSAGE_INFO_PREFIX},
 };
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 /// Sign a message with a parsed address
 #[derive(Debug, Parser)]
@@ -26,6 +23,10 @@ pub struct SignCommand {
     #[clap(short = 'm', long)]
     message: String,
 
+    /// A schnorr signature type
+    #[clap(short = 's', long)]
+    schnorr: bool,
+
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
 
@@ -34,24 +35,9 @@ pub struct SignCommand {
     json: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct AccountSignView {
-    pub signature: String,
-    pub schnorr_signature: Option<String>,
-}
-
-impl AccountSignView {
-    pub fn new(signature: String, schnorr_signature: Option<String>) -> Self {
-        Self {
-            signature,
-            schnorr_signature,
-        }
-    }
-}
-
 #[async_trait]
-impl CommandAction<Option<AccountSignView>> for SignCommand {
-    async fn execute(self) -> RoochResult<Option<AccountSignView>> {
+impl CommandAction<Option<String>> for SignCommand {
+    async fn execute(self) -> RoochResult<Option<String>> {
         let context = self.context_options.build_require_password()?;
         let password = context.get_password();
         let mapping = context.address_mapping();
@@ -61,45 +47,32 @@ impl CommandAction<Option<AccountSignView>> for SignCommand {
             SignData::new_without_tx_hash(MESSAGE_INFO_PREFIX.to_vec(), self.message.to_bytes());
         let encoded_sign_data = sign_data.encode();
 
-        // Secp256k1 Ecdsa or Ed25519 signature
-        let sig =
-            context
-                .keystore
-                .sign_hashed(&rooch_address, &encoded_sign_data, password.clone())?;
-        let signature_bytes = sig.as_ref();
-        let signature_hex = hex::encode(signature_bytes);
-        // Secp256k1 Schnorr signature
-        let kp = context
-            .keystore
-            .get_key_pair(&rooch_address, password.clone())?;
-        let pubkey = kp.public();
-        let schnorr_signature_hex = if pubkey.flag() == SignatureScheme::Secp256k1.flag() {
+        let signature_hex = if self.schnorr {
+            // Secp256k1 Schnorr signature
             let schnorr_sig = context.keystore.sign_schnorr(
                 &rooch_address,
                 &encoded_sign_data,
                 password.clone(),
             )?;
-            Some(hex::encode(schnorr_sig))
+            hex::encode(schnorr_sig)
         } else {
-            None
+            // Secp256k1 Ecdsa or Ed25519 signature
+            let sig = context.keystore.sign_hashed(
+                &rooch_address,
+                &encoded_sign_data,
+                password.clone(),
+            )?;
+            let signature_bytes = sig.as_ref();
+            hex::encode(signature_bytes)
         };
-        let account_sign_view = AccountSignView::new(signature_hex, schnorr_signature_hex);
 
         if self.json {
-            Ok(Some(account_sign_view))
+            Ok(Some(signature_hex))
         } else {
-            if account_sign_view.schnorr_signature.is_some() {
-                println!(
-                    "Sign message succeeded with the signatues {:?} and {:?}",
-                    account_sign_view.signature,
-                    account_sign_view.schnorr_signature.unwrap()
-                );
-            } else {
-                println!(
-                    "Sign message succeeded with the signatue {:?}",
-                    account_sign_view.signature
-                );
-            }
+            println!(
+                "Sign message succeeded with the signatue {:?}",
+                signature_hex
+            );
             Ok(None)
         }
     }

--- a/crates/rooch/src/commands/account/commands/sign.rs
+++ b/crates/rooch/src/commands/account/commands/sign.rs
@@ -1,6 +1,8 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
 use crate::cli_types::{CommandAction, WalletContextOptions};
 use async_trait::async_trait;
 use clap::Parser;
@@ -10,22 +12,19 @@ use rooch_types::{
     address::ParsedAddress,
     error::RoochResult,
     framework::auth_payload::{SignData, MESSAGE_INFO_PREFIX},
+    to_bech32::PREFIX_BECH32_PUBLIC_KEY,
 };
 
 /// Sign a message with a parsed address
 #[derive(Debug, Parser)]
 pub struct SignCommand {
-    // An address to be used
-    #[clap(short = 'a', long = "address", value_parser=ParsedAddress::parse, default_value = "")]
-    address: ParsedAddress,
+    // An address to be parsed
+    #[clap(short = 'a', long = "address", default_value = "default")]
+    address: String,
 
     /// A message to be signed
     #[clap(short = 'm', long)]
     message: String,
-
-    /// A schnorr signature type
-    #[clap(short = 's', long)]
-    schnorr: bool,
 
     #[clap(flatten)]
     pub context_options: WalletContextOptions,
@@ -41,16 +40,17 @@ impl CommandAction<Option<String>> for SignCommand {
         let context = self.context_options.build_require_password()?;
         let password = context.get_password();
         let mapping = context.address_mapping();
-        let rooch_address = self.address.into_rooch_address(&mapping)?;
+        let parsed_address = ParsedAddress::from_str(&self.address)?;
+        let rooch_address = parsed_address.into_rooch_address(&mapping)?;
 
-        let signature_hex = if self.schnorr {
+        let signature_hex = if self.address.starts_with(PREFIX_BECH32_PUBLIC_KEY) {
             // Secp256k1 Schnorr signature
             let msg = hex::decode(self.message)?;
-            let schnorr_sig =
+            let signature_bytes =
                 context
                     .keystore
                     .sign_schnorr(&rooch_address, &msg, password.clone())?;
-            hex::encode(schnorr_sig)
+            hex::encode(signature_bytes)
         } else {
             // Secp256k1 Ecdsa or Ed25519 signature
             let sign_data = SignData::new_without_tx_hash(

--- a/crates/rooch/src/commands/account/commands/sign.rs
+++ b/crates/rooch/src/commands/account/commands/sign.rs
@@ -79,7 +79,7 @@ impl CommandAction<Option<AccountSignView>> for SignCommand {
                 &encoded_sign_data,
                 password.clone(),
             )?;
-            Some(hex::encode(&schnorr_sig))
+            Some(hex::encode(schnorr_sig))
         } else {
             None
         };

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -37,9 +37,11 @@ Feature: Rooch CLI integration tests
 
       Then cmd: "account create"
       Then cmd: "account list --json"
-      # account sign and verify secp256k1 ecdsa and secp256k1 schnorr or ed25519
+      # account sign and verify secp256k1 ecdsa or ed25519
       Then cmd: "account sign -a {{$.account[-1].account0.address}} -m 'empty' --json"
       Then cmd: "account verify -s {{$.account[-1].signature}} -m 'empty' --json"
+      # account sign and verify secp256k1 schnorr
+      Then cmd: "account sign -a {{$.account[-1].account0.address}} -m 'empty' -s --json"
       Then assert: "{{$.account[-1]}} == true"
       Then cmd: "account list --json"
       Then cmd: "account export"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -42,7 +42,7 @@ Feature: Rooch CLI integration tests
       Then cmd: "account verify -s {{$.account[-1]}} -m 'empty' --json"
       Then assert: "{{$.account[-1]}} == true"
       # account sign and verify secp256k1 schnorr
-      Then cmd: "account sign -a {{$.account[-3].account0.address}} -m 'b1e0f0249c9d996f41a6fc0cafe58623573c6d809966b1cd34ce579e99e86131' -s --json"
+      Then cmd: "account sign -a {{$.account[-3].account0.nostr_public_key}} -m 'b1e0f0249c9d996f41a6fc0cafe58623573c6d809966b1cd34ce579e99e86131' --json"
       Then cmd: "account list --json"
       Then cmd: "account export"
       Then cmd: "account export -a {{$.account[-1].account0.address}} --json"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -42,7 +42,7 @@ Feature: Rooch CLI integration tests
       Then cmd: "account verify -s {{$.account[-1]}} -m 'empty' --json"
       Then assert: "{{$.account[-1]}} == true"
       # account sign and verify secp256k1 schnorr
-      Then cmd: "account sign -a {{$.account[-3].account0.address}} -m 'empty' -s --json"
+      Then cmd: "account sign -a {{$.account[-3].account0.address}} -m 'b1e0f0249c9d996f41a6fc0cafe58623573c6d809966b1cd34ce579e99e86131' -s --json"
       Then cmd: "account list --json"
       Then cmd: "account export"
       Then cmd: "account export -a {{$.account[-1].account0.address}} --json"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -41,7 +41,7 @@ Feature: Rooch CLI integration tests
       Then cmd: "account sign -a {{$.account[-1].account0.address}} -m 'empty' --json"
       Then cmd: "account verify -s {{$.account[-1]}} -m 'empty' --json"
       # account sign and verify secp256k1 schnorr
-      Then cmd: "account sign -a {{$.account[-1].account0.address}} -m 'empty' -s --json"
+      Then cmd: "account sign -a {{$.account[-3].account0.address}} -m 'empty' -s --json"
       Then assert: "{{$.account[-1]}} == true"
       Then cmd: "account list --json"
       Then cmd: "account export"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -40,9 +40,9 @@ Feature: Rooch CLI integration tests
       # account sign and verify secp256k1 ecdsa or ed25519
       Then cmd: "account sign -a {{$.account[-1].account0.address}} -m 'empty' --json"
       Then cmd: "account verify -s {{$.account[-1]}} -m 'empty' --json"
+      Then assert: "{{$.account[-1]}} == true"
       # account sign and verify secp256k1 schnorr
       Then cmd: "account sign -a {{$.account[-3].account0.address}} -m 'empty' -s --json"
-      Then assert: "{{$.account[-1]}} == true"
       Then cmd: "account list --json"
       Then cmd: "account export"
       Then cmd: "account export -a {{$.account[-1].account0.address}} --json"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -37,10 +37,9 @@ Feature: Rooch CLI integration tests
 
       Then cmd: "account create"
       Then cmd: "account list --json"
-      # account sign and verify secp256k1 ecdsa or ed25519
+      # account sign and verify secp256k1 ecdsa and secp256k1 schnorr or ed25519
       Then cmd: "account sign -a {{$.account[-1].account0.address}} -m 'empty' --json"
-      Then cmd: "account verify -s {{$.account[-1]}} -m 'empty' --json"
-      # TODO: account sign and verify secp256k1 schnorr
+      Then cmd: "account verify -s {{$.account[-1].signature}} -m 'empty' --json"
       Then assert: "{{$.account[-1]}} == true"
       Then cmd: "account list --json"
       Then cmd: "account export"

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -29,17 +29,18 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.rpc[-1].has_next_page}} == true"
       Then cmd: "rpc request --method rooch_getModuleABI --params '["0x2", "display"]'"
       Then assert: "{{$.rpc[-1].name}} == 'display'"
-      Then stop the server 
-    
+      Then stop the server
+
     @serial
     Scenario: account
       Given a server for account
 
       Then cmd: "account create"
       Then cmd: "account list --json"
-      # account sign and verify
+      # account sign and verify secp256k1 ecdsa or ed25519
       Then cmd: "account sign -a {{$.account[-1].account0.address}} -m 'empty' --json"
       Then cmd: "account verify -s {{$.account[-1]}} -m 'empty' --json"
+      # TODO: account sign and verify secp256k1 schnorr
       Then assert: "{{$.account[-1]}} == true"
       Then cmd: "account list --json"
       Then cmd: "account export"
@@ -102,7 +103,7 @@ Feature: Rooch CLI integration tests
     @serial
     Scenario: state
       Given a server for state
-      Then cmd: "object -i 0x3" 
+      Then cmd: "object -i 0x3"
       Then cmd: "object -i 0x2::timestamp::Timestamp"
       Then cmd: "dynamic-field list-field-states --object-id 0x3"
       Then cmd: "dynamic-field get-field-states --object-id 0x3 --field-keys 0x385f84a2110d6b31412fab278ea8c321d160fdcfa7b745e66e5bf76106280dc5"
@@ -153,7 +154,7 @@ Feature: Rooch CLI integration tests
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
     Then cmd: "move run --function default::event_test::emit_event  --args 11u64 --json"
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-    
+
     # because the indexer is async update, so sleep 5 seconds to wait indexer update.
     Then sleep: "5"
 
@@ -193,22 +194,22 @@ Feature: Rooch CLI integration tests
       # First publish and create the object counter
       Then cmd: "move publish -p ../../examples/quick_start_object_counter --named-addresses quick_start_object_counter=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      
+
       # Get the Counter object ID from event
       Then cmd: "event get-events-by-event-handle -t default::quick_start_object_counter::UserCounterCreatedEvent"
       Then assert: "{{$.event[-1].data[0].event_id.event_seq}} == 0"
-      
+
       # Increase counter to generate state change
       Then cmd: "move run --function default::quick_start_object_counter::increase --args object:{{$.event[-1].data[0].decoded_event_data.value.id}} --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      
+
       # because the indexer is async update, so sleep 2 seconds to wait indexer update.
       Then sleep: "2"
-      
+
       # Test sync_states with object_id filter - should get changes for the counter object
       Then cmd: "rpc request --method rooch_syncStates --params '[{\"object_i_d\":\"{{$.event[-1].data[0].decoded_event_data.value.id}}\"}, null, \"10\", {\"descending\":false}]' --json"
       Then assert: "'{{$.rpc[-1].data[0].state_change_set.changes[0].metadata.id}}' == '{{$.event[-1].data[0].decoded_event_data.value.id}}'"
-      
+
       # Test with a non-existent object ID - should return empty result
       Then cmd: "rpc request --method rooch_syncStates --params '[{\"object_i_d\":\"0x1234567890123456789012345678901234567890123456789012345678901234\"}, null, \"10\", {\"descending\":false}]' --json"
       Then assert: "'{{$.rpc[-1].data}}' == '[]'"
@@ -340,7 +341,7 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
       Then cmd: "move run --function default::fixed_supply_coin::faucet --args object:default::fixed_supply_coin::Treasury --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      
+
       Then cmd: "account list --json"
 
       Then cmd: "rpc request --method rooch_getBalance --params '["{{$.account[-1].default.bitcoin_address}}", "{{$.account[-1].default.hex_address}}::fixed_supply_coin::FSC"]' --json"
@@ -361,7 +362,7 @@ Feature: Rooch CLI integration tests
     Given a server for issue_coin
     Then cmd: "move publish -p ../../examples/module_template/  --named-addresses rooch_examples=default --json"
     Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-    
+
     #TODO: uncomment this once move_module::binding_module_address is ready
     #Then cmd: "move run --function default::coin_factory::issue_fixed_supply_coin --args string:my_coin  --args string:"My first coin" --args string:MyCoin --args 1010101u256 --args 8u8   --json"
     #Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
@@ -374,7 +375,7 @@ Feature: Rooch CLI integration tests
     #Then assert: "'{{$.rpc[-1].coin_type}}' == '{{$.address_mapping.default}}::my_coin::MyCoin'"
     #Then assert: "'{{$.rpc[-1].balance}}' != '0'"
     Then stop the server
-  
+
   @serial
   Scenario: basic_object example
       Given a server for basic_object
@@ -382,7 +383,7 @@ Feature: Rooch CLI integration tests
       Then cmd: "account list --json"
       Then cmd: "move publish -p ../../examples/basic_object  --named-addresses basic_object=default --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      
+
       #object pub transfer
       Then cmd: "move run --function default::third_party_module::create_and_pub_transfer --args u64:1 --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
@@ -393,18 +394,18 @@ Feature: Rooch CLI integration tests
       Then sleep: "2"
       Then cmd: "object -t default::pub_transfer::Pub"
       Then assert: "{{$.object[-1].data[0].owner}} == {{$.account[-1].account0.address}}"
-      
+
       #child object
       Then cmd: "move run --function default::third_party_module_for_child_object::create_child --args string:alice --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      
+
       Then cmd: "event get-events-by-event-handle -t default::child_object::NewChildEvent"
       Then cmd: "state --access-path /object/{{$.event[-1].data[0].decoded_event_data.value.id}}"
       Then assert: "{{$.state[-1][0].decoded_value.value.name}} == alice"
 
       Then cmd: "move run --function default::third_party_module_for_child_object::update_child_name --args object:{{$.event[-1].data[0].decoded_event_data.value.id}} --args string:bob --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
-      
+
       Then cmd: "state --access-path /object/{{$.event[-1].data[0].decoded_event_data.value.id}}"
       Then assert: "{{$.state[-1][0].decoded_value.value.name}} == bob"
 
@@ -419,8 +420,8 @@ Feature: Rooch CLI integration tests
 
       Then cmd: "move view --function default::child_object::get_age --args object:{{$.event[-1].data[0].decoded_event_data.value.id}}"
       Then assert: "{{$.move[-1].vm_status}} == Executed"
-      Then assert: "{{$.move[-1].return_values[0].decoded_value}} == 10" 
-       
+      Then assert: "{{$.move[-1].return_values[0].decoded_value}} == 10"
+
       Then cmd: "move run --function default::third_party_module_for_child_object::remove_child --args object:{{$.event[-1].data[0].decoded_event_data.value.id}} --json"
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
@@ -434,7 +435,7 @@ Feature: Rooch CLI integration tests
       Then assert: "{{$.move[-1].execution_info.status.type}} == executed"
 
       Then cmd: "move run --function default::display::create_object --sender default --args 'string:test_object' --args 'address:default' --args 'string:test object description' --json"
-      
+
       Then cmd: "event get-events-by-event-handle -t default::display::NewObjectEvent"
       Then cmd: "state --access-path /object/{{$.event[-1].data[0].decoded_event_data.value.id}}"
       Then assert: "{{$.state[-1][0].object_type}} == '{{$.address_mapping.default}}::display::ObjectType'"
@@ -452,9 +453,9 @@ Feature: Rooch CLI integration tests
       Then cmd: "rpc request --method rooch_getObjectStates --params '["{{$.event[-1].data[0].decoded_event_data.value.id}}", {"decode": false, "showDisplay": true}]' --json"
       Then assert: "{{$.rpc[-1][0].display_fields.fields.name}} == test_object"
 
-      
+
       Then stop the server
-    
+
     @serial
     Scenario: wasm test
       # prepare servers

--- a/crates/testsuite/features/cmd.feature
+++ b/crates/testsuite/features/cmd.feature
@@ -39,7 +39,7 @@ Feature: Rooch CLI integration tests
       Then cmd: "account list --json"
       # account sign and verify secp256k1 ecdsa or ed25519
       Then cmd: "account sign -a {{$.account[-1].account0.address}} -m 'empty' --json"
-      Then cmd: "account verify -s {{$.account[-1].signature}} -m 'empty' --json"
+      Then cmd: "account verify -s {{$.account[-1]}} -m 'empty' --json"
       # account sign and verify secp256k1 schnorr
       Then cmd: "account sign -a {{$.account[-1].account0.address}} -m 'empty' -s --json"
       Then assert: "{{$.account[-1]}} == true"


### PR DESCRIPTION
## Summary

Add schnorr signature support for `rooch account sign` command based on Rooch address type of `npub` or Nostr public key address.

- Closes #3561