### PR TITLE
Windows

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -107,16 +107,46 @@ jobs:
 
         # Append required Windows libraries to RUSTFLAGS
         # Adding all necessary libraries for libgit2 to resolve missing symbols
-        $extraFlags = "-C link-arg=advapi32.lib -C link-arg=userenv.lib -C link-arg=crypt32.lib -C link-arg=secur32.lib -C link-arg=ole32.lib -C link-arg=rpcrt4.lib"
+        $extraFlags = "-C link-arg=advapi32.lib -C link-arg=userenv.lib -C link-arg=crypt32.lib -C link-arg=secur32.lib -C link-arg=ole32.lib -C link-arg=rpcrt4.lib -C link-arg=ws2_32.lib -C link-arg=bcrypt.lib"
         if ($env:RUSTFLAGS) {
           echo "RUSTFLAGS=$env:RUSTFLAGS $extraFlags" >> $env:GITHUB_ENV
         } else {
           echo "RUSTFLAGS=$extraFlags" >> $env:GITHUB_ENV
         }
 
+        # Set additional environment variables to help with linking
+        echo "LIBGIT2_SYS_USE_PKG_CONFIG=0" >> $env:GITHUB_ENV
+        echo "LIBGIT2_NO_VENDOR=0" >> $env:GITHUB_ENV
+        
         # Verify protoc is available
         Get-Command protoc
         protoc --version
+
+        # Add direct linking to Windows system libraries
+        echo "LIBGIT2_SYS_USE_PKG_CONFIG=0" >> $env:GITHUB_ENV
+        echo "LIBGIT2_NO_VENDOR=0" >> $env:GITHUB_ENV
+        echo "LIBGIT2_STATIC=1" >> $env:GITHUB_ENV
+        
+        # Force static linking of libgit2
+        echo "CARGO_FEATURE_STATIC=1" >> $env:GITHUB_ENV
+        echo "CARGO_FEATURE_VENDORED=1" >> $env:GITHUB_ENV
+        
+        # Additional Windows libraries needed for linking
+        echo "VCPKG_FEATURE_FLAGS=manifests" >> $env:GITHUB_ENV
+        
+        # Setting RUSTC_LINK_LIB_ARGS to include all required Windows libraries explicitly
+        $additionalLibs = "advapi32,secur32,crypt32,userenv,ole32,rpcrt4,ws2_32,bcrypt,dbghelp,ntdll"
+        echo "RUSTC_LINK_LIB_ARGS=$additionalLibs" >> $env:GITHUB_ENV
+        
+        # Add Visual Studio directory to PATH to find link.exe
+        $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+        if ($vsPath) {
+            $linkDir = Join-Path $vsPath "VC\Tools\MSVC\*\bin\Hostx64\x64"
+            $linkPath = Resolve-Path $linkDir -ErrorAction SilentlyContinue
+            if ($linkPath) {
+                echo "PATH=$linkPath;$env:PATH" >> $env:GITHUB_ENV
+            }
+        }
 
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,0 +1,227 @@
+name: Build and Release SDK
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: "v*"
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_names: ['rooch']
+            artifact_names: ['rooch-linux-x64']
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary_names: ['rooch']
+            artifact_names: ['rooch-macos-arm64']
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary_names: ['rooch.exe']
+            artifact_names: ['rooch-windows-x64']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'  # Add this to fetch submodules
+        
+    - name: Cache Rust dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install Linux dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          cmake \
+          gcc \
+          libssl-dev \
+          pkg-config \
+          libclang-dev \
+          protobuf-compiler \
+          lld \
+          clang
+
+    - name: Install macOS dependencies
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install openssl@3
+        brew install pkg-config
+        brew install protobuf
+        which protoc
+        protoc --version
+        
+    - name: Install Windows dependencies
+      if: matrix.os == 'windows-latest'
+      shell: powershell
+      run: |
+        # Install Scoop package manager
+        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+        
+        # Add necessary buckets
+        scoop bucket add main
+        scoop bucket add extras
+        
+        # Install LLVM, MinGW, Protobuf, and CMake using Scoop
+        scoop install llvm
+        scoop install mingw
+        scoop install protobuf
+        scoop install cmake
+        
+        # Add protoc to path for the current session and make it available for subsequent steps
+        $env:PATH += ";$env:USERPROFILE\scoop\apps\protobuf\current\bin"
+        echo "PATH=$env:PATH" >> $env:GITHUB_ENV
+        
+        # Explicitly set PROTOC environment variable
+        $protocPath = "$env:USERPROFILE\scoop\apps\protobuf\current\bin\protoc.exe"
+        echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
+        
+        # Install OpenSSL
+        scoop install openssl
+        
+        # Set environment variables for OpenSSL
+        $opensslPath = "$env:USERPROFILE\scoop\apps\openssl\current"
+        echo "OPENSSL_DIR=$opensslPath" >> $env:GITHUB_ENV
+        echo "OPENSSL_LIB_DIR=$opensslPath\lib" >> $env:GITHUB_ENV
+        echo "OPENSSL_INCLUDE_DIR=$opensslPath\include" >> $env:GITHUB_ENV
+
+        # Append required Windows libraries to RUSTFLAGS
+        # Adding all necessary libraries for libgit2 to resolve missing symbols
+        $extraFlags = "-C link-arg=advapi32.lib -C link-arg=userenv.lib -C link-arg=crypt32.lib -C link-arg=secur32.lib -C link-arg=ole32.lib -C link-arg=rpcrt4.lib"
+        if ($env:RUSTFLAGS) {
+          echo "RUSTFLAGS=$env:RUSTFLAGS $extraFlags" >> $env:GITHUB_ENV
+        } else {
+          echo "RUSTFLAGS=$extraFlags" >> $env:GITHUB_ENV
+        }
+
+        # Verify protoc is available
+        Get-Command protoc
+        protoc --version
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.target }}
+        override: true
+        
+    - name: Set Rust environment variables
+      shell: bash
+      run: |
+        if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+          # Prevent using lld on Ubuntu if not properly configured
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=gold" >> $GITHUB_ENV
+        fi
+
+    - name: Set Protoc Environment Variables
+      run: |
+        if [ "${{ matrix.os }}" = "macos-latest" ]; then
+          echo "PROTOC=$(which protoc)" >> $GITHUB_ENV
+        elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+          echo "PROTOC=$(which protoc)" >> $GITHUB_ENV
+        fi
+      shell: bash
+      if: matrix.os != 'windows-latest'
+      
+    - name: Set Protoc Environment Variables (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: powershell
+      run: |
+        # Verify protoc path is correctly set
+        if (Test-Path $env:PROTOC) {
+          echo "PROTOC environment variable is correctly set to: $env:PROTOC"
+        } else {
+          echo "PROTOC environment variable is set but file not found at: $env:PROTOC"
+          echo "Looking for protoc in PATH..."
+          $protocInPath = Get-Command protoc -ErrorAction SilentlyContinue
+          if ($protocInPath) {
+            echo "Found protoc at: $($protocInPath.Source)"
+            echo "PROTOC=$($protocInPath.Source)" >> $env:GITHUB_ENV
+          } else {
+            echo "protoc not found in PATH, trying to locate it manually..."
+            $possiblePath = "$env:USERPROFILE\scoop\apps\protobuf\current\bin\protoc.exe"
+            if (Test-Path $possiblePath) {
+              echo "Found protoc at: $possiblePath"
+              echo "PROTOC=$possiblePath" >> $env:GITHUB_ENV
+            } else {
+              echo "Could not locate protoc, build may fail."
+            }
+          }
+        }
+        
+        # Display the full PATH for debugging
+        echo "Current PATH: $env:PATH"
+
+    - name: Build
+      run: cargo build --release --target ${{ matrix.target }} --verbose
+      env:
+        OPENSSL_DIR: ${{ matrix.os == 'macos-latest' && '/usr/local/opt/openssl@3' || (matrix.os == 'ubuntu-latest' && '/usr' || '') }}
+        OPENSSL_LIB_DIR: ${{ matrix.os == 'macos-latest' && '/usr/local/opt/openssl@3/lib' || (matrix.os == 'ubuntu-latest' && '/usr/lib/x86_64-linux-gnu' || '') }}
+        OPENSSL_INCLUDE_DIR: ${{ matrix.os == 'macos-latest' && '/usr/local/opt/openssl@3/include' || (matrix.os == 'ubuntu-latest' && '/usr/include' || '') }}
+        RUSTFLAGS: ${{ env.RUSTFLAGS }}
+        LIBGIT2_SYS_USE_PKG_CONFIG: ${{ matrix.os != 'windows-latest' && '1' || '0' }}
+
+    - name: Debug binary location
+      run: ls -la target/${{ matrix.target }}/release/
+
+    - name: Compress artifacts (Unix)
+      if: matrix.os != 'windows-latest'
+      run: |
+        cd target/${{ matrix.target }}/release
+        tar -czf ${{ matrix.artifact_names[0] }}.tar.gz ${{ matrix.binary_names[0] }}
+        
+    - name: Compress artifacts (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: powershell
+      run: |
+        cd target\${{ matrix.target }}\release
+        Compress-Archive -Path ${{ matrix.binary_names[0] }} -DestinationPath "${{ matrix.artifact_names[0] }}.zip"
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact_names[0] }}
+        path: target/${{ matrix.target }}/release/${{ matrix.artifact_names[0] }}.*
+        retention-days: 5
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: rooch-*
+          merge-multiple: true
+  
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            artifacts/rooch-linux-x64.tar.gz
+            artifacts/rooch-macos-arm64.tar.gz
+            artifacts/rooch-windows-x64.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "accumulator"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-client"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -1302,7 +1302,7 @@ checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
 
 [[package]]
 name = "bitcoin-move"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "axum",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "data-verify"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "rooch-rpc-api",
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "framework-builder"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "framework-release"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "framework-types"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "move-core-types",
  "moveos-stdlib",
@@ -6666,16 +6666,16 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
- "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -6867,7 +6867,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -7720,7 +7720,7 @@ dependencies = [
 
 [[package]]
 name = "moveos"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "clap 4.5.17",
@@ -7759,7 +7759,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-common"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-compiler"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "move-binary-format",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-config"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "clap 4.5.17",
  "serde 1.0.219",
@@ -7792,7 +7792,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-eventbus"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "coerce",
@@ -7803,7 +7803,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-gas-profiling"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "handlebars",
@@ -7820,7 +7820,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-object-runtime"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "bcs",
  "better_any",
@@ -7836,7 +7836,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-stdlib"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "base64 0.22.1",
@@ -7869,7 +7869,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-store"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "accumulator",
  "anyhow 1.0.95",
@@ -7892,7 +7892,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-types"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -7920,7 +7920,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-verifier"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -7945,7 +7945,7 @@ dependencies = [
 
 [[package]]
 name = "moveos-wasm"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "once_cell",
@@ -9810,7 +9810,7 @@ dependencies = [
 
 [[package]]
 name = "raw-store"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "metrics",
@@ -10280,7 +10280,7 @@ dependencies = [
 
 [[package]]
 name = "rooch"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "accumulator",
  "anyhow 1.0.95",
@@ -10303,6 +10303,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "lazy_static 1.5.0",
+ "libsqlite3-sys",
  "metrics",
  "mimalloc",
  "move-binary-format",
@@ -10380,7 +10381,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-anomalies"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -10394,7 +10395,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-benchmarks"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.76",
  "anyhow 1.0.93",
@@ -10449,7 +10450,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-common"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "libc",
@@ -10457,7 +10458,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-config"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "clap 4.5.17",
@@ -10476,7 +10477,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-cosmwasm-vm"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-vm",
@@ -10488,7 +10489,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-da"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -10512,7 +10513,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-db"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "accumulator",
  "anyhow 1.0.95",
@@ -10531,7 +10532,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-executor"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -10556,7 +10557,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-faucet"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -10584,7 +10585,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-framework"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "bitcoin 0.32.5",
  "fastcrypto",
@@ -10604,7 +10605,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-framework-tests"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -10642,7 +10643,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-genesis"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "accumulator",
  "anyhow 1.0.95",
@@ -10674,7 +10675,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-indexer"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -10703,7 +10704,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-integration-test-runner"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -10736,7 +10737,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-key"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "argon2",
@@ -10755,7 +10756,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-notify"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -10777,7 +10778,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-nursery"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "ciborium",
  "cosmwasm-std",
@@ -10802,7 +10803,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-open-rpc"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "clap 4.5.17",
@@ -10817,7 +10818,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-open-rpc-macros"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -10829,7 +10830,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-open-rpc-spec"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "clap 4.5.17",
  "pretty_assertions",
@@ -10840,7 +10841,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-open-rpc-spec-builder"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "clap 4.5.17",
@@ -10853,7 +10854,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-oracle"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -10878,7 +10879,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-ord"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "ordinals",
@@ -10892,7 +10893,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-pipeline-processor"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -10918,7 +10919,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-proposer"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -10935,7 +10936,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-relayer"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "async-trait",
@@ -10962,7 +10963,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-rpc-api"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "accumulator",
  "anyhow 1.0.95",
@@ -10987,7 +10988,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-rpc-client"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -11009,7 +11010,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-rpc-server"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "axum",
@@ -11060,7 +11061,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-sequencer"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "accumulator",
  "anyhow 1.0.95",
@@ -11085,7 +11086,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-store"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "accumulator",
  "anyhow 1.0.95",
@@ -11102,7 +11103,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-test-transaction-builder"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "bcs",
@@ -11116,7 +11117,7 @@ dependencies = [
 
 [[package]]
 name = "rooch-types"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "accumulator",
  "anyhow 1.0.95",
@@ -12402,7 +12403,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "smt"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "backtrace",
@@ -12989,7 +12990,7 @@ dependencies = [
 
 [[package]]
 name = "testsuite"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "assert_cmd",
@@ -13068,18 +13069,17 @@ dependencies = [
 [[package]]
 name = "tikv-jemalloc-sys"
 version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+source = "git+https://github.com/jamesatomc/jemallocator.git#49db433eb9620bdad0bc88a35bf7af28c1cabcf4"
 dependencies = [
  "cc",
  "libc",
+ "winapi",
 ]
 
 [[package]]
 name = "tikv-jemallocator"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+source = "git+https://github.com/jamesatomc/jemallocator.git#49db433eb9620bdad0bc88a35bf7af28c1cabcf4"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -13120,7 +13120,7 @@ dependencies = [
 
 [[package]]
 name = "timeout-join-handler"
-version = "0.9.6"
+version = "0.9.4"
 dependencies = [
  "anyhow 1.0.95",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/rooch-network/rooch"
 rust-version = "1.82.0"
-version = "0.9.6"
+version = "0.9.4"
 
 [workspace.dependencies]
 # Internal crate dependencies.
@@ -173,7 +173,7 @@ bip32 = "0.4.0"
 byteorder = "1.4.3"
 clap = { version = "4.5.13", features = ["derive", "env"] }
 brotli = "3.4.0"
-chrono = "0.4.41"
+chrono = "0.4.40"
 coerce = "0.8"
 datatest-stable = "0.1.3"
 derive_more = { version = "1.0.0", features = ["as_ref", "from"] }
@@ -223,13 +223,13 @@ serde_with = { version = "2.1.0", features = ["hex", "base64"] }
 signature = "2.2.0"
 strum = "^0.26"
 strum_macros = "^0.26"
-sha2 = "0.10.9"
+sha2 = "0.10.2"
 sha3 = "0.10.8"
 smallvec = "1.15.0"
 thiserror = "1.0.69"
 tiny-keccak = { version = "2", features = ["keccak", "sha3"] }
 tiny-bip39 = "2.0.0"
-tokio = { version = "1.45.0", features = ["full"] }
+tokio = { version = "1.44.2", features = ["full"] }
 tokio-tungstenite = { version = "0.24.0", features = ["native-tls"] }
 tokio-stream = "0.1.17"
 tracing = "0.1.41"
@@ -244,7 +244,7 @@ quote = "1.0"
 proc-macro2 = "1.0.95"
 derive-syn-parse = "0.1.5"
 unescape = "0.1.0"
-tempfile = "3.20.0"
+tempfile = "3.19.1"
 regex = "1.11.1"
 walkdir = "2.3.3"
 prometheus = "0.13.3"
@@ -273,7 +273,7 @@ tower_governor = { version = "0.4.3", features = ["tracing"] }
 pin-project = "1.1.10"
 mirai-annotations = "1.12.0"
 lru = "0.11.0"
-quick_cache = "0.6.14"
+quick_cache = "0.6.13"
 bs58 = "0.5.1"
 dirs-next = "2.0.0"
 chacha20poly1305 = "0.10.1"
@@ -335,7 +335,7 @@ pprof = { version = "0.13.0", features = [
 celestia-rpc = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "129272e8d926b4c7badf27a26dea915323dd6489" }
 celestia-types = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "129272e8d926b4c7badf27a26dea915323dd6489" }
 opendal = { version = "0.50.2", features = ["services-fs", "services-gcs"] }
-toml = "0.8.22"
+toml = "0.8.20"
 tabled = "0.16.0"
 csv = "1.3.1"
 revm-precompile = "16.2.0"
@@ -343,7 +343,14 @@ revm-primitives = "15.2.0"
 scopeguard = "1.1"
 uuid = { version = "1.16.0", features = ["v4", "fast-rng"] }
 protobuf = { version = "2.28", features = ["with-bytes"] }
-rocksdb = { version = "0.23.0", features = ["lz4", "mt_static", "jemalloc"] }
+# windows no longer supports jemalloc, so we need to use tikv-jemallocator
+rocksdb = { version = "0.23.0", features = ["lz4", "mt_static"] }
+# Use jemalloc for Linux and MacOS
+# rocksdb = { version = "0.23.0", features = ["lz4", "mt_static", "jemalloc"] }
+
+# we need to use the bundled version of libsqlite3-sys for Windows
+libsqlite3-sys = { version = "0.33.0", features = ["bundled"] }
+
 lz4 = { version = "1.28.1" }
 ripemd = { version = "0.1.3" }
 function_name = { version = "0.3.0" }
@@ -355,7 +362,7 @@ crossbeam-channel = "0.5.15"
 inferno = "0.11.21"
 handlebars = "4.2.2"
 indexmap = "2.9.0"
-tikv-jemallocator = { version = "0.6.0", features = [
+tikv-jemallocator = { git = "https://github.com/jamesatomc/jemallocator.git", features = [
     "unprefixed_malloc_on_supported_platforms",
     "profiling",
 ] }

--- a/crates/rooch/Cargo.toml
+++ b/crates/rooch/Cargo.toml
@@ -113,6 +113,9 @@ rooch-oracle = { workspace = true }
 framework-release = { workspace = true }
 framework-builder = { workspace = true }
 
+# we need to use the same version of libsqlite3-sys as the one used in tikv-jemallocator
+libsqlite3-sys.workspace = true
+
 #We should keep the allocator in the last of the dependencies
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }

--- a/crates/rooch/src/commands/da/commands/exec.rs
+++ b/crates/rooch/src/commands/da/commands/exec.rs
@@ -47,7 +47,10 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(unix)]
 use tokio::signal::unix::{signal, SignalKind};
+#[cfg(not(unix))]
+use tokio::signal::ctrl_c;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
@@ -203,17 +206,28 @@ impl ExecCommand {
         let shutdown_tx_clone = shutdown_tx.clone();
 
         tokio::spawn(async move {
-            let mut sigterm =
-                signal(SignalKind::terminate()).expect("Failed to listen for SIGTERM");
-            let mut sigint = signal(SignalKind::interrupt()).expect("Failed to listen for SIGINT");
+            #[cfg(unix)]
+            {
+                let mut sigterm =
+                    signal(SignalKind::terminate()).expect("Failed to listen for SIGTERM");
+                let mut sigint = signal(SignalKind::interrupt()).expect("Failed to listen for SIGINT");
 
-            tokio::select! {
-                _ = sigterm.recv() => {
-                    info!("SIGTERM received, shutting down...");
-                    let _ = shutdown_tx_clone.send(());
+                tokio::select! {
+                    _ = sigterm.recv() => {
+                        info!("SIGTERM received, shutting down...");
+                        let _ = shutdown_tx_clone.send(());
+                    }
+                    _ = sigint.recv() => {
+                        info!("SIGINT received (Ctrl+C), shutting down...");
+                        let _ = shutdown_tx_clone.send(());
+                    }
                 }
-                _ = sigint.recv() => {
-                    info!("SIGINT received (Ctrl+C), shutting down...");
+            }
+            
+            #[cfg(not(unix))]
+            {
+                if let Ok(()) = ctrl_c().await {
+                    info!("Ctrl+C received, shutting down...");
                     let _ = shutdown_tx_clone.send(());
                 }
             }

--- a/frameworks/framework-release/build.rs
+++ b/frameworks/framework-release/build.rs
@@ -4,6 +4,13 @@
 use std::env::current_dir;
 
 fn main() {
+    // Skip the release process on Windows to avoid stack overflow
+    if cfg!(windows) {
+        println!("cargo:warning=Skipping framework release on Windows to avoid stack overflow");
+        println!("cargo:warning=The framework will be built on non-Windows platforms");
+        return;
+    }
+
     if std::env::var("SKIP_STDLIB_BUILD").is_err() {
         std::env::set_var("RUST_LOG", "WARN");
         let _ = tracing_subscriber::fmt::try_init();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,6 @@
 [toolchain]
-channel = "1.82.0"
+# channel = "1.82.0"
+
+channel = "stable"
+
+# channel = "nightly"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and releasing the SDK, updates dependencies in the `Cargo.toml` file, and makes platform-specific adjustments to improve compatibility and stability. Below are the most important changes grouped by theme:

### CI/CD Workflow Enhancements:
* Added a new GitHub Actions workflow `.github/workflows/sdk.yml` to automate the build and release process for the SDK across Linux, macOS, and Windows platforms. This includes caching dependencies, installing platform-specific tools, and uploading compressed artifacts.

### Dependency Updates:
* Downgraded several dependencies in `Cargo.toml`, including `chrono` (from `0.4.41` to `0.4.40`), `sha2` (from `0.10.9` to `0.10.2`), and `tokio` (from `1.45.0` to `1.44.2`), likely for compatibility or stability reasons. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L176-R176) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L226-R232)
* Replaced the `jemalloc` feature for `rocksdb` with a Windows-compatible configuration and added `libsqlite3-sys` with the `bundled` feature for Windows builds. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L338-R353) [[2]](diffhunk://#diff-3335575c91dc5fc75b0e7a8b45684635863c9a7b83b3a1101660b8a52de8a475R116-R118)

### Platform-Specific Adjustments:
* Introduced conditional signal handling in `exec.rs` to handle `SIGTERM` and `SIGINT` on Unix systems and `Ctrl+C` on non-Unix systems, improving cross-platform compatibility. [[1]](diffhunk://#diff-43c7b88f3b5d51a0545d83e0dd38986ed2183f5914ecdcfdc43baca112e2d015R50-R53) [[2]](diffhunk://#diff-43c7b88f3b5d51a0545d83e0dd38986ed2183f5914ecdcfdc43baca112e2d015R209-R210) [[3]](diffhunk://#diff-43c7b88f3b5d51a0545d83e0dd38986ed2183f5914ecdcfdc43baca112e2d015R225-R233)
* Skipped the framework release process on Windows in `framework-release/build.rs` to avoid stack overflow issues.

### Rust Toolchain Configuration:
* Updated `rust-toolchain.toml` to use the stable Rust channel instead of pinning to a specific version (`1.82.0`), allowing more flexibility.

## Summary

Summary about this PR

- Closes #issue