### PR TITLE
[gh-3376] docs: clean code and update readme to fix typos.

### DIFF
--- a/examples/nostr/README.md
+++ b/examples/nostr/README.md
@@ -1,6 +1,6 @@
 # Nostr In Move
 
-Nostr in Move, a Nostr referential implementation in Move programming language for reference of on-chain persistant storage of Nostr.
+Nostr in Move, a Nostr referential implementation in Move programming language for reference of on-chain persistent storage of Nostr.
 
 ## Protocol Implementation
 
@@ -8,7 +8,7 @@ Nostr in Move implements [NIP-01](https://github.com/nostr-protocol/nips/blob/ma
 
 ## Usage
 
-Nostr in Move is a base smart contract written in Move programming language that depends on Rooch Framework's verification package for Schnorr signature. It is based on Rooch, but could be rebuild and reuse in other Move oriented blockchains.
+Nostr in Move is a base smart contract written in Move programming language that depends on Rooch Framework's verification package for Schnorr signature. It is based on Rooch, but could be rebuilt and reused in other Move oriented blockchains.
 
 The base smart contract currently functions:
 
@@ -62,7 +62,7 @@ rooch object -i <pre_event_object_id>
 
 This step could be done with Rooch TypeScript, Rust, Python or Go SDK, or command-line interfaces that support signing sha256 hashed message with Schnorr signature.
 
-When signing id of Nostr pre event with Schnorr signature, make sure the leading `0x` of the id is striped.
+When signing id of Nostr pre event with Schnorr signature, make sure the leading `0x` of the id is stripped.
 
 3. Create an event of Nostr using the previously generated signature
 

--- a/examples/nostr/sources/event.move
+++ b/examples/nostr/sources/event.move
@@ -29,7 +29,6 @@ module nostr::event {
     const ErrorPreEventNotExist: u64 = 1006;
 
     #[data_struct]
-    /// TODO: merge PreEvent with Event to save storage cost.
     /// PreEvent
     struct PreEvent has key, copy, drop {
         id: vector<u8>, // 32-bytes lowercase hex-encoded sha256 of the serialized event data


### PR DESCRIPTION
## Summary

Clean code and fix typos according to https://github.com/rooch-network/rooch/pull/3590#pullrequestreview-2849013315 for Nostr in Move.

- Closes #3376.