### PR TITLE
Fix Typos in Comments for Move Bytecode Verifier Transactional Tests

### DIFF
--- a/third_party/move/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_non_existing.mvir
+++ b/third_party/move/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_non_existing.mvir
@@ -1,5 +1,5 @@
 //# publish
 module 0x42.M {
-    // cannot be a friend with a nonexistant module
+    // cannot be a friend with a nonexistent module
     friend 0x42.Nonexistent;
 }

--- a/third_party/move/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/read_local_ref_after_assign.mvir
+++ b/third_party/move/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/read_local_ref_after_assign.mvir
@@ -10,7 +10,7 @@ label b0:
     assign_ref = copy(read_ref);
     *copy(assign_ref) = 0;
     assert(*copy(assign_ref) == 0, 42);
-    no = *move(read_ref); // valid to read reference after assiging a copy!
+    no = *move(read_ref); // valid to read reference after assigning a copy!
     _ = move(assign_ref);
     return;
 }

--- a/third_party/move/language/move-bytecode-verifier/transactional-tests/tests/type_safety/struct_kind_inference.mvir
+++ b/third_party/move/language/move-bytecode-verifier/transactional-tests/tests/type_safety/struct_kind_inference.mvir
@@ -4,7 +4,7 @@ module 0x1.M1 {
     struct MyResource { b: bool }
     struct S<T> { t: T }
 
-    // verifer should reject; didn't move resource;
+    // verifier should reject; didn't move resource;
     public p(s: Self.S<Self.MyResource>) {
     label b0:
         return;


### PR DESCRIPTION


**Description:**  
This pull request corrects several typos in comments within the Move bytecode verifier transactional test files. Specifically, it changes "nonexistant" to "nonexistent", and "assigning" to "assigning", and clarifies the wording in test comments for better readability and accuracy. No functional code changes are included; only comment text is updated to improve documentation quality and maintain consistency.