### PR TITLE
refactor(framework): use custom event handles for DID and payment channel events

### DIFF
--- a/frameworks/rooch-framework/sources/did.move
+++ b/frameworks/rooch-framework/sources/did.move
@@ -355,6 +355,11 @@ module rooch_framework::did {
         resolve_did_object_id(&did_identifier_str)
     }
 
+    /// Derive per-DID event handle for DID modification events
+    fun did_event_handle_id<T>(object_id: ObjectID): ObjectID {
+        event::custom_event_handle_id<ObjectID, T>(object_id)
+    }
+
 
     /// Internal function for creating DID objects. Not exposed as public entry.
     /// This function contains the core logic for DID creation and is called by
@@ -1007,7 +1012,9 @@ module rooch_framework::did {
         };
         
         // Emit verification method added event
-        event::emit(VerificationMethodAddedEvent {
+        let did_object_id = resolve_did_object_id(&did_document_data.id.identifier);
+        let event_handle_id = did_event_handle_id<VerificationMethodAddedEvent>(did_object_id);
+        event::emit_with_handle(event_handle_id, VerificationMethodAddedEvent {
             did: format_did(&did_document_data.id),
             fragment: fragment,
             method_type: method_type,
@@ -1043,7 +1050,9 @@ module rooch_framework::did {
         simple_map::remove(&mut did_document_data.verification_methods, &fragment);
         
         // Emit verification method removed event
-        event::emit(VerificationMethodRemovedEvent {
+        let did_object_id = resolve_did_object_id(&did_document_data.id.identifier);
+        let event_handle_id = did_event_handle_id<VerificationMethodRemovedEvent>(did_object_id);
+        event::emit_with_handle(event_handle_id, VerificationMethodRemovedEvent {
             did: format_did(&did_document_data.id),
             fragment: fragment,
             method_type: removed_method_type,
@@ -1128,7 +1137,9 @@ module rooch_framework::did {
         };
 
         // Emit relationship modified event
-        event::emit(VerificationRelationshipModifiedEvent {
+        let did_object_id = resolve_did_object_id(&did_document_data.id.identifier);
+        let event_handle_id = did_event_handle_id<VerificationRelationshipModifiedEvent>(did_object_id);
+        event::emit_with_handle(event_handle_id, VerificationRelationshipModifiedEvent {
             did: format_did(&did_document_data.id),
             fragment: fragment,
             relationship_type: relationship_type,
@@ -1171,7 +1182,9 @@ module rooch_framework::did {
         remove_from_verification_relationship_internal(target_relationship_vec_mut, &fragment);
         if (vector::length(target_relationship_vec_mut) < original_len) {
             // Emit verification relationship modified event only if removal was successful
-            event::emit(VerificationRelationshipModifiedEvent {
+            let did_object_id = resolve_did_object_id(&did_document_data.id.identifier);
+            let event_handle_id = did_event_handle_id<VerificationRelationshipModifiedEvent>(did_object_id);
+            event::emit_with_handle(event_handle_id, VerificationRelationshipModifiedEvent {
                 did: format_did(&did_document_data.id),
                 fragment: fragment,
                 relationship_type: relationship_type,
@@ -1206,7 +1219,9 @@ module rooch_framework::did {
         simple_map::add(&mut did_document_data.services, fragment, service);
         
         // Emit service added event
-        event::emit(ServiceAddedEvent {
+        let did_object_id = resolve_did_object_id(&did_document_data.id.identifier);
+        let event_handle_id = did_event_handle_id<ServiceAddedEvent>(did_object_id);
+        event::emit_with_handle(event_handle_id, ServiceAddedEvent {
             did: format_did(&did_document_data.id),
             fragment: fragment,
             service_type: service_type,
@@ -1315,7 +1330,9 @@ module rooch_framework::did {
         let (_,_old_service) = simple_map::upsert(&mut did_document_data.services, fragment, updated_service);
         
         // Emit service updated event
-        event::emit(ServiceUpdatedEvent {
+        let did_object_id = resolve_did_object_id(&did_document_data.id.identifier);
+        let event_handle_id = did_event_handle_id<ServiceUpdatedEvent>(did_object_id);
+        event::emit_with_handle(event_handle_id, ServiceUpdatedEvent {
             did: format_did(&did_document_data.id),
             fragment: fragment,
             old_service_type,
@@ -1343,7 +1360,9 @@ module rooch_framework::did {
         simple_map::remove(&mut did_document_data.services, &fragment);
         
         // Emit service removed event
-        event::emit(ServiceRemovedEvent {
+        let did_object_id = resolve_did_object_id(&did_document_data.id.identifier);
+        let event_handle_id = did_event_handle_id<ServiceRemovedEvent>(did_object_id);
+        event::emit_with_handle(event_handle_id, ServiceRemovedEvent {
             did: format_did(&did_document_data.id),
             fragment: fragment,
             service_type: removed_service_type,

--- a/frameworks/rooch-framework/sources/payment_channel.move
+++ b/frameworks/rooch-framework/sources/payment_channel.move
@@ -370,7 +370,8 @@ module rooch_framework::payment_channel {
         
         // Emit withdrawal event
         let hub_id = object::id(hub_obj);
-        event::emit(PaymentHubWithdrawEvent {
+        let event_handle_id = hub_event_handle_id<PaymentHubWithdrawEvent>(hub_id);
+        event::emit_with_handle(event_handle_id, PaymentHubWithdrawEvent {
             hub_id,
             owner: owner_addr,
             coin_type: coin_type_name,
@@ -584,7 +585,8 @@ module rooch_framework::payment_channel {
         };
         
         // Emit claim event
-        event::emit(ChannelClaimedEvent {
+        let event_handle_id = channel_event_handle_id<ChannelClaimedEvent>(channel_id);
+        event::emit_with_handle(event_handle_id, ChannelClaimedEvent {
             channel_id,
             receiver: channel.receiver,
             vm_id_fragment: sender_vm_id_fragment,
@@ -746,7 +748,8 @@ module rooch_framework::payment_channel {
         });
  
         // Emit sub-channel authorized event
-        event::emit(SubChannelAuthorizedEvent {
+        let event_handle_id = channel_event_handle_id<SubChannelAuthorizedEvent>(channel_id);
+        event::emit_with_handle(event_handle_id, SubChannelAuthorizedEvent {
             channel_id,
             sender: did_address,
             vm_id_fragment,
@@ -980,7 +983,8 @@ module rooch_framework::payment_channel {
         decrease_active_channel_count(channel.sender, channel.coin_type);
         
         // Emit channel closed event
-        event::emit(ChannelClosedEvent {
+        let event_handle_id = channel_event_handle_id<ChannelClosedEvent>(channel_id);
+        event::emit_with_handle(event_handle_id, ChannelClosedEvent {
             channel_id,
             sender: channel.sender,
             receiver: receiver_addr,
@@ -1038,7 +1042,8 @@ module rooch_framework::payment_channel {
             decrease_active_channel_count(sender_addr, channel.coin_type);
             
             // Emit immediate closure event (no funds to transfer)
-            event::emit(ChannelCancellationFinalizedEvent {
+            let event_handle_id = channel_event_handle_id<ChannelCancellationFinalizedEvent>(channel_id);
+            event::emit_with_handle(event_handle_id, ChannelCancellationFinalizedEvent {
                 channel_id,
                 sender: sender_addr,
                 final_amount: 0u256,
@@ -1084,7 +1089,8 @@ module rooch_framework::payment_channel {
         });
         
         // Emit cancellation event
-        event::emit(ChannelCancellationInitiatedEvent {
+        let event_handle_id = channel_event_handle_id<ChannelCancellationInitiatedEvent>(channel_id);
+        event::emit_with_handle(event_handle_id, ChannelCancellationInitiatedEvent {
             channel_id,
             sender: sender_addr,
             initiated_time: current_time,
@@ -1188,7 +1194,8 @@ module rooch_framework::payment_channel {
         };
         
         // Emit dispute event
-        event::emit(ChannelDisputeEvent {
+        let event_handle_id = channel_event_handle_id<ChannelDisputeEvent>(channel_id);
+        event::emit_with_handle(event_handle_id, ChannelDisputeEvent {
             channel_id,
             receiver,
             dispute_amount: dispute_accumulated_amount,
@@ -1267,7 +1274,8 @@ module rooch_framework::payment_channel {
         decrease_active_channel_count(channel.sender, channel.coin_type);
         
         // Emit finalization event
-        event::emit(ChannelCancellationFinalizedEvent {
+        let event_handle_id = channel_event_handle_id<ChannelCancellationFinalizedEvent>(channel_id);
+        event::emit_with_handle(event_handle_id, ChannelCancellationFinalizedEvent {
             channel_id,
             sender: channel.sender,
             final_amount,
@@ -1411,6 +1419,16 @@ module rooch_framework::payment_channel {
     }
 
     // === Internal Helper Functions ===
+
+    /// Derive per-hub event handle for hub modification events
+    fun hub_event_handle_id<T>(hub_id: ObjectID): ObjectID {
+        event::custom_event_handle_id<ObjectID, T>(hub_id)
+    }
+
+    /// Derive per-channel event handle for channel modification events
+    fun channel_event_handle_id<T>(channel_id: ObjectID): ObjectID {
+        event::custom_event_handle_id<ObjectID, T>(channel_id)
+    }
 
     /// Decrease active channel count for a specific coin type
     fun decrease_active_channel_count(sender_addr: address, coin_type_name: String) {


### PR DESCRIPTION
## Summary

Refactor event emission in `did.move` and `payment_channel.move` to use custom event handles, following the pattern established in `payment_revenue.move`. This enables efficient event retrieval by specific entity ObjectID for better indexing performance.

## Changes

### DID Module (`did.move`)
- **Keep `DIDCreatedEvent` using global `event::emit()`** to allow traversing all DID creations
- Add `did_event_handle_id<T>(did_object_id: ObjectID)` helper function
- Update modification events to use `event::emit_with_handle()`:
  - `VerificationMethodAddedEvent`
  - `VerificationMethodRemovedEvent`
  - `VerificationRelationshipModifiedEvent`
  - `ServiceAddedEvent`
  - `ServiceUpdatedEvent`
  - `ServiceRemovedEvent`

### Payment Channel Module (`payment_channel.move`)
- Add `hub_event_handle_id<T>(hub_id: ObjectID)` helper function
- Add `channel_event_handle_id<T>(channel_id: ObjectID)` helper function
- Update all events to use `event::emit_with_handle()`:
  - Hub events: `PaymentHubCreatedEvent`, `PaymentHubWithdrawEvent`, `LockedUnitConfigUpdatedEvent`
  - Channel events: `ChannelClaimedEvent`, `PaymentChannelOpenedEvent`, `SubChannelAuthorizedEvent`, `ChannelClosedEvent`, `ChannelCancellationInitiatedEvent`, `ChannelDisputeEvent`, `ChannelCancellationFinalizedEvent`

## Benefits

1. **Efficient Event Retrieval**: Events can now be efficiently queried by specific DID or PaymentChannel ObjectID
2. **Consistent Pattern**: Follows the same pattern as `payment_revenue.move`
3. **Mainnet Ready**: Improves event indexing performance for production use
4. **Flexible Querying**:
   - Global traversal: Use `DIDCreatedEvent` to find all DIDs
   - Entity-specific: Use custom handles to get all events for a specific DID or channel

## Testing

- ✅ All framework tests passed: `make test-move-frameworks`
- ✅ Code follows project conventions and linting rules

## Related

Follows the event refactoring pattern established in payment_revenue module for mainnet launch preparation.