### PR TITLE
fix: address follow-ups for PR #3867 (dedup scalability)

### DIFF
--- a/crates/rooch-da/src/backend/openda/avail.rs
+++ b/crates/rooch-da/src/backend/openda/avail.rs
@@ -144,7 +144,7 @@ impl AvailFusionClientConfig {
             Some(AvailTurboClient::new(
                 endpoint,
                 self.max_retries,
-                self.turbo_api_key.as_ref().unwrap(),
+                self.turbo_api_key.as_deref().ok_or_else(|| anyhow::anyhow!("turbo_api_key is required when turbo_endpoint is provided"))?,
             )?)
         } else {
             None

--- a/crates/rooch-da/src/backend/openda/manager.rs
+++ b/crates/rooch-da/src/backend/openda/manager.rs
@@ -12,10 +12,10 @@ use std::sync::Arc;
 
 /// manage OpenDA backends while integrating specific adapter logic
 pub struct OpenDABackendManager {
-    identifier: String,
-    adapter_stats: AdapterSubmitStat,
-    adapter_config: OpenDAAdapterConfig,
     adapter: Box<dyn OpenDAAdapter>,
+    adapter_config: OpenDAAdapterConfig,
+    adapter_stats: AdapterSubmitStat,
+    identifier: String,
 }
 
 impl OpenDABackendManager {
@@ -28,10 +28,10 @@ impl OpenDABackendManager {
         let adapter = adapter_config.build(adapter_stats.clone()).await?;
 
         Ok(Self {
-            identifier: derive_identifier(open_da_config.scheme.clone()),
-            adapter_stats: adapter_stats.clone(),
-            adapter_config,
             adapter,
+            adapter_config,
+            adapter_stats: adapter_stats.clone(),
+            identifier: derive_identifier(open_da_config.scheme.clone()),
         })
     }
 }


### PR DESCRIPTION
## Summary
This PR addresses follow-up items from PR #3867 related to dedup scalability improvements.

## Changes Made
- **Field ordering**: Fixed field ordering in `OpenDABackendManager` struct to follow Rust conventions (adapter first, then config, stats, identifier)
- **Error handling**: Replaced potential panic in `avail.rs` `unwrap()` call with proper error handling using `ok_or_else()`
- **Constructor update**: Updated the constructor in `manager.rs` to match the new field ordering

## Technical Details
- The struct field reordering improves readability and follows Rust idiomatic patterns
- The error handling fix prevents potential panics when `turbo_api_key` is `None` but `turbo_endpoint` is provided
- Maintains backward compatibility while improving code safety and maintainability

## Test Plan
- [ ] Verify compilation succeeds
- [ ] Run existing test suite
- [ ] Test with different DA backend configurations
- [ ] Verify error handling works correctly for missing API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)