### PR TITLE
Fix: Load snapshot store from snapshot path in replay (#3900)

### DIFF
--- a/crates/rooch-pruner/Cargo.toml
+++ b/crates/rooch-pruner/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }
+prometheus = { workspace = true }
 
 rayon = { workspace = true }
 crossbeam-deque = "0.8"
@@ -44,7 +45,6 @@ tempfile = { workspace = true }
 rand = { workspace = true }
 bcs = { workspace = true }
 bcs-ext = { workspace = true }
-prometheus = { workspace = true }
 
 [[bench]]
 name = "bench_bloom_comparison"


### PR DESCRIPTION
## Overview
This PR fixes issue #3900 where the replay function was ignoring snapshot contents and using the live MoveOSStore instead.

## Problem
The `load_snapshot_store` function in `IncrementalReplayer` was ignoring the `snapshot_path` parameter and returning the live MoveOSStore. This caused replay operations to read and write against the live database rather than the snapshot, making it impossible to perform a true replay from a snapshot.

## Solution
Modified the `load_snapshot_store` function to:
- Load the actual snapshot from `snapshot_path/snapshot.db`
- Validate that the snapshot database exists and is a valid directory
- Create a new MoveOSStore instance from the snapshot database path
- Provide clear error messages for troubleshooting

## Changes
- **`crates/rooch-pruner/src/state_prune/incremental_replayer.rs`**:
  - Fixed `load_snapshot_store` to load from the actual snapshot path
  - Removed unused `moveos_store` field from `IncrementalReplayer` struct
  - Added two regression tests:
    - `test_load_snapshot_store_uses_snapshot_path_not_live_db`: Verifies snapshot is loaded from correct path
    - `test_load_snapshot_store_validates_path`: Tests error handling for invalid paths

- **`crates/rooch-pruner/Cargo.toml`**:
  - Moved `prometheus` from `dev-dependencies` to `dependencies` (required for `MoveOSStore::new`)

## Acceptance Criteria
✅ `load_snapshot_store` uses snapshot data from disk
✅ Replay runs against snapshot content, not current DB
✅ Regression tests added that verify the fix

## Test Results
- All 104 tests in `rooch-pruner` package pass
- Binary compiles successfully
- No clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)