### PR TITLE
Redesign mainnet replay output store build

### DIFF
--- a/crates/rooch-pruner/src/state_prune/incremental_replayer.rs
+++ b/crates/rooch-pruner/src/state_prune/incremental_replayer.rs
@@ -4,11 +4,11 @@
 use crate::state_prune::{ProgressTracker, StatePruneMetadata};
 use anyhow::Result;
 use move_core_types::effects::Op;
+use moveos_common::utils::to_bytes;
 use moveos_config::store_config::RocksdbConfig;
 use moveos_store::transaction_store::TransactionStore as MoveOSTransactionStore;
 use moveos_store::{
-    MoveOSStore, CONFIG_GENESIS_COLUMN_FAMILY_NAME, EVENT_COLUMN_FAMILY_NAME,
-    EVENT_HANDLE_COLUMN_FAMILY_NAME, STATE_NODE_COLUMN_FAMILY_NAME,
+    MoveOSStore, CONFIG_GENESIS_COLUMN_FAMILY_NAME, STATE_NODE_COLUMN_FAMILY_NAME,
     TRANSACTION_EXECUTION_INFO_COLUMN_FAMILY_NAME,
 };
 use moveos_types::h256::H256;
@@ -19,12 +19,9 @@ use moveos_types::state_resolver::StateResolver;
 use prometheus::Registry;
 use raw_store::metrics::DBMetrics;
 use raw_store::SchemaStore;
-use rooch_config::state_prune::{
-    HistoryPruneCFStats, HistoryPruneConfig, HistoryPruneReport, ReplayConfig, ReplayReport,
-};
+use rooch_config::state_prune::{HistoryPruneReport, ReplayConfig, ReplayReport};
 use rooch_store::da_store::DAMetaStore;
 use rooch_store::proposer_store::ProposerStore;
-use rooch_store::state_store::StateStore;
 use rooch_store::{
     RoochStore, DA_BLOCK_CURSOR_COLUMN_FAMILY_NAME, DA_BLOCK_SUBMIT_STATE_COLUMN_FAMILY_NAME,
     PROPOSER_LAST_BLOCK_COLUMN_FAMILY_NAME, STATE_CHANGE_SET_COLUMN_FAMILY_NAME,
@@ -42,15 +39,19 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
-const REQUIRED_REPLAY_COLUMN_FAMILIES: &[&str] = &[
+const FULL_COPY_COLUMN_FAMILIES: &[&str] = &[
     TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME,
-    TRANSACTION_COLUMN_FAMILY_NAME,
-    TRANSACTION_EXECUTION_INFO_COLUMN_FAMILY_NAME,
-    TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME,
     CONFIG_GENESIS_COLUMN_FAMILY_NAME,
     DA_BLOCK_CURSOR_COLUMN_FAMILY_NAME,
     DA_BLOCK_SUBMIT_STATE_COLUMN_FAMILY_NAME,
     PROPOSER_LAST_BLOCK_COLUMN_FAMILY_NAME,
+];
+
+const WINDOWED_HISTORY_COLUMN_FAMILIES: &[&str] = &[
+    TRANSACTION_COLUMN_FAMILY_NAME,
+    TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME,
+    TRANSACTION_EXECUTION_INFO_COLUMN_FAMILY_NAME,
+    STATE_CHANGE_SET_COLUMN_FAMILY_NAME,
 ];
 
 /// Incremental replayer for applying changesets to a snapshot
@@ -110,12 +111,12 @@ impl IncrementalReplayer {
         // Load snapshot metadata and state store
         let snapshot_meta = self.load_snapshot_metadata(input_snapshot_path)?;
         let snapshot_store = self.load_snapshot_store(input_snapshot_path)?;
-        let source_last_order = self.load_source_last_order()?;
+        let retain_from = self.resolve_retain_from(from_order, to_order)?;
 
-        // Build output DB from a fresh store and copy only required column families.
+        // Build output DB from a fresh store and copy runtime-required column families.
         self.prepare_fresh_output_store(output_dir)?;
         metadata.mark_in_progress("Copying required column families".to_string(), 10.0);
-        self.copy_required_cfs(output_dir)?;
+        self.copy_required_cfs(output_dir, retain_from, to_order)?;
         let (output_store, _) = self.load_output_stores(output_dir)?;
 
         metadata.mark_in_progress("Importing snapshot nodes".to_string(), 20.0);
@@ -162,43 +163,12 @@ impl IncrementalReplayer {
             }
         }
 
-        metadata.mark_in_progress("Trimming output metadata".to_string(), 92.0);
-        self.trim_output_store(
-            &output_store,
-            output_dir,
-            source_last_order,
-            to_order,
-            &mut metadata,
-        )?;
+        metadata.mark_in_progress("Refreshing output metadata".to_string(), 92.0);
+        self.refresh_output_metadata(output_dir, to_order, &mut metadata)?;
 
-        // After trim/refresh, ensure startup_info and sequencer_info are consistent
+        // After metadata refresh, ensure startup_info and sequencer_info are consistent.
         self.verify_startup_sequencer_consistency(&output_store, output_dir, to_order)?;
-
-        // Perform history pruning if enabled
-        if self.config.history_prune.is_some()
-            && self.config.history_prune.as_ref().unwrap().enabled
-        {
-            metadata.mark_in_progress("Pruning historical data".to_string(), 93.0);
-            let (_moveos_store, output_rooch_store) = self.load_output_stores(output_dir)?;
-
-            match self.prune_history(
-                &output_store,
-                &output_rooch_store,
-                snapshot_meta.tx_order,
-                to_order,
-                &mut metadata,
-                &mut report,
-            ) {
-                Ok(prune_report) => {
-                    report.history_prune_report = Some(prune_report);
-                    info!("History pruning completed successfully");
-                }
-                Err(e) => {
-                    // Fail the operation if history pruning was requested
-                    return Err(e);
-                }
-            }
-        }
+        report.history_prune_report = Some(self.build_windowed_history_report(retain_from));
 
         // Create checkpoints if enabled
         if self.config.enable_checkpoints {
@@ -287,12 +257,28 @@ impl IncrementalReplayer {
         column_families
     }
 
-    fn load_source_last_order(&self) -> Result<u64> {
-        self.rooch_store
-            .get_meta_store()
-            .get_sequencer_info()?
-            .map(|info| info.last_order)
-            .ok_or_else(|| anyhow::anyhow!("Sequencer info not found in live store"))
+    fn resolve_retain_from(&self, from_order: u64, to_order: u64) -> Result<u64> {
+        let retain_from = if let Some(history_prune) = &self.config.history_prune {
+            if let Some(window) = history_prune.retain_window {
+                to_order.saturating_sub(window).saturating_add(1)
+            } else if history_prune.retain_from > 0 {
+                history_prune.retain_from
+            } else {
+                from_order
+            }
+        } else {
+            from_order
+        };
+
+        if retain_from > to_order {
+            return Err(anyhow::anyhow!(
+                "retain_from {} exceeds to_order {}",
+                retain_from,
+                to_order
+            ));
+        }
+
+        Ok(retain_from)
     }
 
     /// Create an empty output database with the full set of column families.
@@ -318,7 +304,13 @@ impl IncrementalReplayer {
         Ok(())
     }
 
-    fn copy_required_cfs(&self, output_dir: &Path) -> Result<()> {
+    fn source_moveos_store(&self) -> Result<MoveOSStore> {
+        let registry = Registry::new();
+        MoveOSStore::new_with_instance(self.rooch_store.store_instance.clone(), &registry)
+            .map_err(|e| anyhow::anyhow!("Failed to load source MoveOSStore: {}", e))
+    }
+
+    fn copy_required_cfs(&self, output_dir: &Path, retain_from: u64, to_order: u64) -> Result<()> {
         let source_db = self
             .rooch_store
             .store_instance
@@ -332,8 +324,9 @@ impl IncrementalReplayer {
             .db()
             .ok_or_else(|| anyhow::anyhow!("Failed to access output RocksDB instance"))?
             .inner();
+        let source_moveos_store = self.source_moveos_store()?;
 
-        for cf_name in REQUIRED_REPLAY_COLUMN_FAMILIES {
+        for cf_name in FULL_COPY_COLUMN_FAMILIES {
             let source_cf = source_db
                 .cf_handle(cf_name)
                 .ok_or_else(|| anyhow::anyhow!("Source CF not found: {}", cf_name))?;
@@ -363,6 +356,142 @@ impl IncrementalReplayer {
             target_db.flush_cf(&target_cf)?;
             info!("Copied CF {} with {} entries", cf_name, count);
         }
+
+        self.copy_windowed_history(
+            &source_moveos_store,
+            &output_rooch_store,
+            retain_from,
+            to_order,
+        )?;
+
+        Ok(())
+    }
+
+    fn copy_windowed_history(
+        &self,
+        source_moveos_store: &MoveOSStore,
+        output_rooch_store: &RoochStore,
+        retain_from: u64,
+        to_order: u64,
+    ) -> Result<()> {
+        if retain_from > to_order {
+            return Ok(());
+        }
+
+        let output_db = output_rooch_store
+            .store_instance
+            .db()
+            .ok_or_else(|| anyhow::anyhow!("Failed to access output RocksDB instance"))?
+            .inner();
+        let tx_cf = output_db
+            .cf_handle(TRANSACTION_COLUMN_FAMILY_NAME)
+            .ok_or_else(|| {
+                anyhow::anyhow!("Target CF not found: {}", TRANSACTION_COLUMN_FAMILY_NAME)
+            })?;
+        let tx_map_cf = output_db
+            .cf_handle(TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Target CF not found: {}",
+                    TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME
+                )
+            })?;
+        let exec_cf = output_db
+            .cf_handle(TRANSACTION_EXECUTION_INFO_COLUMN_FAMILY_NAME)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Target CF not found: {}",
+                    TRANSACTION_EXECUTION_INFO_COLUMN_FAMILY_NAME
+                )
+            })?;
+        let changeset_cf = output_db
+            .cf_handle(STATE_CHANGE_SET_COLUMN_FAMILY_NAME)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Target CF not found: {}",
+                    STATE_CHANGE_SET_COLUMN_FAMILY_NAME
+                )
+            })?;
+
+        let batch_size = self.config.default_batch_size.max(1) as u64;
+        let mut copied_transactions = 0u64;
+        let mut copied_changesets = 0u64;
+        let mut start = retain_from;
+
+        while start <= to_order {
+            let end = min(to_order, start.saturating_add(batch_size - 1));
+            let orders: Vec<u64> = (start..=end).collect();
+            let tx_hashes = self
+                .rooch_store
+                .transaction_store
+                .get_tx_hashes(orders.clone())?;
+            let mut batch = rocksdb::WriteBatch::default();
+
+            for (index, tx_hash_opt) in tx_hashes.into_iter().enumerate() {
+                let tx_order = start + index as u64;
+                let tx_hash = tx_hash_opt.ok_or_else(|| {
+                    anyhow::anyhow!("Missing tx hash for order {} during history copy", tx_order)
+                })?;
+                let tx = self
+                    .rooch_store
+                    .transaction_store
+                    .get_transaction_by_hash(tx_hash)?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Missing transaction for order {} and hash {:x}",
+                            tx_order,
+                            tx_hash
+                        )
+                    })?;
+                let execution_info = source_moveos_store
+                    .get_tx_execution_info(tx_hash)?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Missing execution info for order {} and hash {:x}",
+                            tx_order,
+                            tx_hash
+                        )
+                    })?;
+                let changeset = self
+                    .rooch_store
+                    .get_state_store()
+                    .get_state_change_set(tx_order)?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Missing state changeset for order {}", tx_order)
+                    })?;
+
+                batch.put_cf(&tx_cf, to_bytes(&tx_hash)?, bcs::to_bytes(&tx)?);
+                batch.put_cf(&tx_map_cf, to_bytes(&tx_order)?, to_bytes(&tx_hash)?);
+                batch.put_cf(
+                    &exec_cf,
+                    to_bytes(&tx_hash)?,
+                    bcs::to_bytes(&execution_info)?,
+                );
+                batch.put_cf(
+                    &changeset_cf,
+                    to_bytes(&tx_order)?,
+                    bcs::to_bytes(&changeset)?,
+                );
+
+                copied_transactions += 1;
+                copied_changesets += 1;
+            }
+
+            if !batch.is_empty() {
+                output_db.write(batch)?;
+            }
+
+            start = end.saturating_add(1);
+        }
+
+        info!(
+            "Copied windowed history [{}..={}]: {} txs, {} changesets across {:?}",
+            retain_from,
+            to_order,
+            copied_transactions,
+            copied_changesets,
+            WINDOWED_HISTORY_COLUMN_FAMILIES
+        );
 
         Ok(())
     }
@@ -533,25 +662,19 @@ impl IncrementalReplayer {
         Ok(())
     }
 
-    fn trim_output_store(
+    fn refresh_output_metadata(
         &self,
-        output_store: &MoveOSStore,
         output_dir: &Path,
-        source_last_order: u64,
         to_order: u64,
         metadata: &mut StatePruneMetadata,
     ) -> Result<()> {
         let (_moveos_store, output_rooch_store) = self.load_output_stores(output_dir)?;
 
-        if to_order > source_last_order {
-            return Err(anyhow::anyhow!(
-                "to_order {} exceeds source last_order {}",
-                to_order,
-                source_last_order
-            ));
-        }
+        metadata.mark_in_progress(
+            format!("Refreshing runtime metadata at order {}", to_order),
+            92.0,
+        );
 
-        // Always ensure sequencer_info is synchronized to to_order, even when no trim is needed
         let target_tx = output_rooch_store
             .transaction_store
             .get_tx_by_order(to_order)?
@@ -566,58 +689,6 @@ impl IncrementalReplayer {
         output_rooch_store
             .get_meta_store()
             .save_sequencer_info_unsafe(new_sequencer_info)?;
-
-        if to_order == source_last_order {
-            info!(
-                "Output store already at to_order {}, refreshed sequencer info",
-                to_order
-            );
-            return Ok(());
-        }
-
-        metadata.mark_in_progress(
-            format!(
-                "Trimming output metadata ({} -> {})",
-                source_last_order, to_order
-            ),
-            92.0,
-        );
-
-        let mut removed_transactions = 0u64;
-        let mut removed_changesets = 0u64;
-        let mut start = to_order
-            .checked_add(1)
-            .ok_or_else(|| anyhow::anyhow!("to_order overflow"))?;
-        let batch_size = self.config.default_batch_size.max(1) as u64;
-
-        while start <= source_last_order {
-            let end = min(source_last_order, start.saturating_add(batch_size - 1));
-            let orders: Vec<u64> = (start..=end).collect();
-            let tx_hashes = output_rooch_store.transaction_store.get_tx_hashes(orders)?;
-
-            for (index, tx_hash_opt) in tx_hashes.into_iter().enumerate() {
-                let tx_order = start + index as u64;
-
-                output_rooch_store
-                    .get_state_store()
-                    .remove_state_change_set(tx_order)?;
-                removed_changesets += 1;
-
-                if let Some(tx_hash) = tx_hash_opt {
-                    output_rooch_store
-                        .transaction_store
-                        .remove_transaction(tx_hash, tx_order)?;
-                    output_store
-                        .get_transaction_store()
-                        .remove_tx_execution_info(tx_hash)?;
-                    removed_transactions += 1;
-                } else {
-                    warn!("Missing tx hash for order {} during trim", tx_order);
-                }
-            }
-
-            start = end.saturating_add(1);
-        }
 
         let (da_issues, da_fixed) =
             output_rooch_store.try_repair_da_meta(to_order, false, None, false, false)?;
@@ -641,11 +712,24 @@ impl IncrementalReplayer {
         }
 
         info!(
-            "Trimmed output store to order {} (removed {} txs, {} changesets)",
-            to_order, removed_transactions, removed_changesets
+            "Refreshed output metadata at order {} after windowed history copy",
+            to_order
         );
 
         Ok(())
+    }
+
+    fn build_windowed_history_report(&self, retain_from: u64) -> HistoryPruneReport {
+        HistoryPruneReport {
+            enabled: true,
+            retain_from,
+            cfs_pruned: WINDOWED_HISTORY_COLUMN_FAMILIES
+                .iter()
+                .map(|cf| (*cf).to_string())
+                .collect(),
+            dry_run: false,
+            ..Default::default()
+        }
     }
 
     /// Load changesets in specified range
@@ -978,446 +1062,6 @@ impl IncrementalReplayer {
         Ok(())
     }
 
-    /// Prune history data from output store
-    /// This should be called after changeset replay and before checkpointing
-    fn prune_history(
-        &self,
-        output_store: &MoveOSStore,
-        output_rooch_store: &RoochStore,
-        snapshot_tx_order: u64,
-        to_order: u64,
-        metadata: &mut StatePruneMetadata,
-        report: &mut ReplayReport,
-    ) -> Result<HistoryPruneReport> {
-        let config = self
-            .config
-            .history_prune
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("History pruning config not found"))?;
-
-        if !config.enabled {
-            return Ok(HistoryPruneReport::default());
-        }
-
-        // Resolve retain_from: if 0, use snapshot tx_order
-        let retain_from = if config.retain_from == 0 {
-            snapshot_tx_order
-        } else {
-            config.retain_from
-        };
-
-        info!(
-            "Starting history prune: retain_from={}, dry_run={}",
-            retain_from, config.dry_run
-        );
-
-        let start_time = Instant::now();
-        let mut prune_report = HistoryPruneReport {
-            enabled: true,
-            retain_from,
-            dry_run: config.dry_run,
-            ..Default::default()
-        };
-
-        // Safety check: don't allow pruning beyond replay range
-        if retain_from > to_order {
-            return Err(anyhow::anyhow!(
-                "Invalid retain_from {}: exceeds to_order {}. History pruning would delete replayed data.",
-                retain_from, to_order
-            ));
-        }
-
-        metadata.mark_in_progress("Pruning historical data".to_string(), 92.0);
-
-        // Execute pruning for each CF in the config
-        for cf_name in &config.prune_cfs {
-            let (records, bytes) = match cf_name.as_str() {
-                TRANSACTION_COLUMN_FAMILY_NAME => {
-                    Self::prune_transactions(output_rooch_store, retain_from, config.dry_run)?
-                }
-                TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME => {
-                    // Sequence mapping is removed together with transactions; keep no-op here to avoid double-delete.
-                    (0, 0)
-                }
-                STATE_CHANGE_SET_COLUMN_FAMILY_NAME => {
-                    Self::prune_state_change_sets(output_rooch_store, retain_from, config.dry_run)?
-                }
-                TRANSACTION_EXECUTION_INFO_COLUMN_FAMILY_NAME => {
-                    Self::prune_transaction_execution_infos(
-                        output_store,
-                        output_rooch_store,
-                        retain_from,
-                        config.dry_run,
-                    )?
-                }
-                EVENT_COLUMN_FAMILY_NAME => Self::prune_events(
-                    output_store,
-                    output_rooch_store,
-                    retain_from,
-                    config.dry_run,
-                )?,
-                EVENT_HANDLE_COLUMN_FAMILY_NAME => {
-                    Self::prune_event_handles(output_store, retain_from, config.dry_run)?
-                }
-                // Accumulator pruning not implemented yet.
-                TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME => (0, 0),
-                DA_BLOCK_SUBMIT_STATE_COLUMN_FAMILY_NAME => Self::prune_da_block_submit_state(
-                    output_rooch_store,
-                    retain_from,
-                    config.dry_run,
-                )?,
-                _ => {
-                    warn!("Unknown column family for pruning: {}", cf_name);
-                    continue;
-                }
-            };
-
-            prune_report.cf_stats.push(HistoryPruneCFStats {
-                cf_name: cf_name.clone(),
-                records_deleted: records,
-                bytes_estimated: bytes,
-            });
-            prune_report.records_deleted += records;
-            prune_report.bytes_estimated += bytes;
-            info!("Pruned {}: {} records, ~{} bytes", cf_name, records, bytes);
-        }
-
-        // Truncate DA cursor if needed
-        if config
-            .prune_cfs
-            .contains(&DA_BLOCK_CURSOR_COLUMN_FAMILY_NAME.to_string())
-        {
-            if let Err(e) =
-                Self::truncate_da_cursor(output_rooch_store, retain_from, config.dry_run)
-            {
-                warn!("Failed to truncate DA cursor: {}", e);
-            } else {
-                info!("DA cursor truncated based on retain_from={}", retain_from);
-            }
-        }
-
-        prune_report.cfs_pruned = config.prune_cfs.clone();
-        prune_report.enabled = true;
-
-        info!(
-            "History pruning completed in {:?}: {} records, ~{} bytes across {} CFs",
-            start_time.elapsed(),
-            prune_report.records_deleted,
-            prune_report.bytes_estimated,
-            prune_report.cf_stats.len()
-        );
-
-        Ok(prune_report)
-    }
-
-    /// Prune column family by tx_order range (0 to retain_from exclusive)
-    /// Keys are tx_order encoded as u64
-    fn prune_by_tx_order_range(
-        output_store: &MoveOSStore,
-        output_rooch_store: &RoochStore,
-        cf_name: &'static str,
-        min_order: u64,
-        retain_from: u64,
-        dry_run: bool,
-    ) -> Result<(u64, u64)> {
-        if retain_from <= min_order {
-            return Ok((0, 0));
-        }
-
-        let store_instance = output_store.get_state_node_store().get_store().store();
-        let db = store_instance
-            .db()
-            .ok_or_else(|| anyhow::anyhow!("Failed to access DB instance"))?
-            .inner();
-
-        let cf_handle = db
-            .cf_handle(cf_name)
-            .ok_or_else(|| anyhow::anyhow!("CF not found: {}", cf_name))?;
-
-        let mut records = 0u64;
-        let mut bytes = 0u64;
-        let batch_size = 1000;
-
-        // Process in batches
-        for batch_start in (min_order..retain_from).step_by(batch_size) {
-            let batch_end = (batch_start + batch_size as u64).min(retain_from);
-            let mut delete_keys = Vec::new();
-
-            for order in batch_start..batch_end {
-                let key = order.to_le_bytes();
-                if let Ok(Some(value)) = db.get_pinned_cf(&cf_handle, key) {
-                    records += 1;
-                    bytes += value.len() as u64;
-                    delete_keys.push(key.to_vec());
-                }
-            }
-
-            if !dry_run && !delete_keys.is_empty() {
-                // Batch delete
-                for key in delete_keys {
-                    if let Err(e) = db.delete_cf(&cf_handle, key) {
-                        debug!("Error deleting key from CF {}: {}", cf_name, e);
-                    }
-                }
-            }
-        }
-
-        Ok((records, bytes))
-    }
-
-    /// Prune transactions and sequence mappings for orders < retain_from
-    fn prune_transactions(
-        output_rooch_store: &RoochStore,
-        retain_from: u64,
-        dry_run: bool,
-    ) -> Result<(u64, u64)> {
-        if retain_from == 0 {
-            return Ok((0, 0));
-        }
-
-        let mut records = 0u64;
-        let mut bytes = 0u64;
-        let batch_size = 1000;
-
-        for batch_start in (0..retain_from).step_by(batch_size) {
-            let batch_end = (batch_start + batch_size as u64).min(retain_from);
-            let orders: Vec<u64> = (batch_start..batch_end).collect();
-            let tx_hashes = output_rooch_store.transaction_store.get_tx_hashes(orders)?;
-
-            for (i, tx_hash_opt) in tx_hashes.into_iter().enumerate() {
-                let tx_order = batch_start + i as u64;
-                if let Some(tx_hash) = tx_hash_opt {
-                    if let Ok(Some(tx)) = output_rooch_store
-                        .transaction_store
-                        .get_transaction_by_hash(tx_hash)
-                    {
-                        bytes += bcs::serialized_size(&tx).unwrap_or(0) as u64;
-                    }
-                    records += 1;
-                    if !dry_run {
-                        if let Err(e) = output_rooch_store
-                            .transaction_store
-                            .remove_transaction(tx_hash, tx_order)
-                        {
-                            debug!(
-                                "Error removing transaction/order {} hash {:?}: {}",
-                                tx_order, tx_hash, e
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok((records, bytes))
-    }
-
-    /// Prune state change sets by tx_order
-    fn prune_state_change_sets(
-        output_rooch_store: &RoochStore,
-        retain_from: u64,
-        dry_run: bool,
-    ) -> Result<(u64, u64)> {
-        let mut records = 0u64;
-        let mut bytes = 0u64;
-        let batch_size = 1000;
-
-        for batch_start in (0..retain_from).step_by(batch_size) {
-            let batch_end = (batch_start + batch_size as u64).min(retain_from);
-            let orders: Vec<u64> = (batch_start..batch_end).collect();
-
-            for order in orders {
-                match output_rooch_store.get_state_change_set(order) {
-                    Ok(Some(changeset)) => {
-                        let size = bcs::serialized_size(&changeset).unwrap_or(0) as u64;
-                        records += 1;
-                        bytes += size;
-
-                        if !dry_run {
-                            if let Err(e) = output_rooch_store.remove_state_change_set(order) {
-                                debug!("Error removing changeset for order {}: {}", order, e);
-                            }
-                        }
-                    }
-                    Ok(None) => {}
-                    Err(e) => {
-                        debug!("Error getting changeset for order {}: {}", order, e);
-                    }
-                }
-            }
-        }
-
-        Ok((records, bytes))
-    }
-
-    /// Prune transaction execution infos by resolving tx_hash from tx_order
-    fn prune_transaction_execution_infos(
-        output_store: &MoveOSStore,
-        output_rooch_store: &RoochStore,
-        retain_from: u64,
-        dry_run: bool,
-    ) -> Result<(u64, u64)> {
-        let mut records = 0u64;
-        let mut bytes = 0u64;
-        let batch_size = 1000;
-
-        for batch_start in (0..retain_from).step_by(batch_size) {
-            let batch_end = (batch_start + batch_size as u64).min(retain_from);
-            let orders: Vec<u64> = (batch_start..batch_end).collect();
-
-            let tx_hashes = match output_rooch_store.transaction_store.get_tx_hashes(orders) {
-                Ok(hashes) => hashes,
-                Err(e) => {
-                    debug!("Error getting tx_hashes for batch {}: {}", batch_start, e);
-                    continue;
-                }
-            };
-
-            for tx_hash_opt in tx_hashes {
-                if let Some(tx_hash) = tx_hash_opt {
-                    match output_store.get_tx_execution_info(tx_hash) {
-                        Ok(Some(info)) => {
-                            let size = bcs::serialized_size(&info).unwrap_or(0) as u64;
-                            records += 1;
-                            bytes += size;
-
-                            if !dry_run {
-                                if let Err(e) = output_store.remove_tx_execution_info(tx_hash) {
-                                    debug!(
-                                        "Error removing execution info for tx_hash {:?}: {}",
-                                        tx_hash, e
-                                    );
-                                }
-                            }
-                        }
-                        Ok(None) => {}
-                        Err(e) => {
-                            debug!(
-                                "Error getting execution info for tx_hash {:?}: {}",
-                                tx_hash, e
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok((records, bytes))
-    }
-
-    /// Prune events by scanning event CF
-    fn prune_events(
-        output_store: &MoveOSStore,
-        output_rooch_store: &RoochStore,
-        retain_from: u64,
-        dry_run: bool,
-    ) -> Result<(u64, u64)> {
-        // Events are indexed by EventID which contains tx_order
-        // This is a simplified implementation - in practice we'd need to scan for EventIDs
-        // with tx_order < retain_from
-        let mut records = 0u64;
-        let mut bytes = 0u64;
-
-        // For now, estimate based on changeset count
-        // A full implementation would scan the event CF
-        info!("Event pruning is estimated based on tx_order count");
-
-        for order in 0..retain_from {
-            // Try to get events for this order
-            // This is a placeholder - actual implementation would query by EventID
-            records += 1;
-            bytes += 100; // Average event size estimate
-        }
-
-        Ok((records, bytes))
-    }
-
-    /// Prune event handles
-    fn prune_event_handles(
-        output_store: &MoveOSStore,
-        retain_from: u64,
-        dry_run: bool,
-    ) -> Result<(u64, u64)> {
-        // Event handles are keyed by EventHandleID + event_seq
-        // This requires complex logic - placeholder for now
-        info!("Event handle pruning is not fully implemented");
-        Ok((0, 0))
-    }
-
-    /// Prune accumulator nodes for transactions < retain_from
-    fn prune_accumulator_nodes(
-        output_store: &MoveOSStore,
-        output_rooch_store: &RoochStore,
-        retain_from: u64,
-        dry_run: bool,
-    ) -> Result<(u64, u64)> {
-        // Accumulator nodes are stored by hash, not by order
-        // We need to track which nodes are referenced by transactions < retain_from
-        // This is complex - placeholder for now
-        info!("Accumulator node pruning is not fully implemented");
-        Ok((0, 0))
-    }
-
-    /// Prune DA block submit state (truncate to window)
-    fn prune_da_block_submit_state(
-        output_rooch_store: &RoochStore,
-        retain_from: u64,
-        dry_run: bool,
-    ) -> Result<(u64, u64)> {
-        // DA blocks are submitted in ranges (tx_order_start, tx_order_end)
-        // We need to remove blocks that end before retain_from
-        let submitting_blocks = match output_rooch_store.get_submitting_blocks(0, None) {
-            Ok(blocks) => blocks,
-            Err(e) => {
-                debug!("Error getting submitting blocks: {}", e);
-                return Ok((0, 0));
-            }
-        };
-
-        let mut records = 0u64;
-        let mut bytes = 0u64;
-
-        for block in submitting_blocks {
-            if block.tx_order_end < retain_from {
-                let size = bcs::serialized_size(&block).unwrap_or(0) as u64;
-                records += 1;
-                bytes += size;
-
-                if !dry_run {
-                    // Remove this block's state
-                    // Note: This is a simplified approach
-                }
-            }
-        }
-
-        Ok((records, bytes))
-    }
-
-    /// Truncate DA cursor to remove references to pruned blocks
-    fn truncate_da_cursor(
-        output_rooch_store: &RoochStore,
-        retain_from: u64,
-        dry_run: bool,
-    ) -> Result<()> {
-        if dry_run {
-            // In dry run mode we only log the intended cursor change.
-            info!(
-                "Dry run: would truncate DA cursor to retain_from tx order {}",
-                retain_from
-            );
-            return Ok(());
-        }
-
-        // The DA cursor (LAST_BLOCK_NUMBER_KEY) is automatically updated
-        // when blocks are removed via prune_da_block_submit_state.
-        // No additional cursor truncation needed here.
-        info!(
-            "DA cursor will be updated automatically when blocks with tx_order_end < {} are removed",
-            retain_from
-        );
-        Ok(())
-    }
-
     /// Validate state after batch
     fn validate_batch_state(
         &self,
@@ -1497,10 +1141,10 @@ impl IncrementalReplayer {
 mod tests {
     use super::*;
     use crate::state_prune::metadata::OperationStatus;
-    use accumulator::accumulator_info::AccumulatorInfo;
     use moveos_common::utils::to_bytes;
     use moveos_config::store_config::RocksdbConfig;
     use moveos_store::{MoveOSStore, CONFIG_STARTUP_INFO_COLUMN_FAMILY_NAME};
+    use moveos_types::transaction::TransactionExecutionInfo;
     use prometheus::Registry;
     use raw_store::metrics::DBMetrics;
     use raw_store::rocks::RocksDB;
@@ -1517,6 +1161,49 @@ mod tests {
         let db = store.store_instance.db().unwrap().inner();
         let cf = db.cf_handle(cf_name).unwrap();
         db.put_cf(&cf, key, value).unwrap();
+    }
+
+    fn seed_windowed_history(
+        moveos_store: &MoveOSStore,
+        rooch_store: &RoochStore,
+        tx_order: u64,
+    ) -> H256 {
+        let mut sequence_info = TransactionSequenceInfo::random();
+        sequence_info.tx_order = tx_order;
+        let tx = LedgerTransaction::new_l2_tx(RoochTransaction::mock(), sequence_info);
+        let tx_hash = {
+            let mut tx_clone = tx.clone();
+            tx_clone.tx_hash()
+        };
+
+        put_raw_cf(
+            rooch_store,
+            TRANSACTION_COLUMN_FAMILY_NAME,
+            to_bytes(&tx_hash).unwrap(),
+            bcs::to_bytes(&tx).unwrap(),
+        );
+        put_raw_cf(
+            rooch_store,
+            TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME,
+            to_bytes(&tx_order).unwrap(),
+            to_bytes(&tx_hash).unwrap(),
+        );
+
+        let mut execution_info = TransactionExecutionInfo::random();
+        execution_info.tx_hash = tx_hash;
+        moveos_store.save_tx_execution_info(execution_info).unwrap();
+        rooch_store
+            .get_state_store()
+            .save_state_change_set(
+                tx_order,
+                StateChangeSetExt::new(
+                    moveos_types::state::StateChangeSet::new(H256::random(), tx_order),
+                    tx_order,
+                ),
+            )
+            .unwrap();
+
+        tx_hash
     }
 
     fn create_combined_test_stores() -> (MoveOSStore, RoochStore, TempDir) {
@@ -1578,7 +1265,7 @@ mod tests {
     #[test]
     fn test_copy_required_cfs_skips_runtime_rebuilt_column_families() {
         let config = ReplayConfig::default();
-        let (_moveos_store, rooch_store, _tmpdir) = create_combined_test_stores();
+        let (moveos_store, rooch_store, _tmpdir) = create_combined_test_stores();
         let replayer = IncrementalReplayer::new(config, rooch_store.clone()).unwrap();
 
         put_raw_cf(
@@ -1593,11 +1280,12 @@ mod tests {
             b"startup_info".to_vec(),
             vec![7, 8, 9],
         );
+        let retained_tx_hash = seed_windowed_history(&moveos_store, &rooch_store, 5);
 
         let output_dir = TempDir::new().unwrap();
         let output_store = output_dir.path().join("store");
         replayer.prepare_fresh_output_store(&output_store).unwrap();
-        replayer.copy_required_cfs(&output_store).unwrap();
+        replayer.copy_required_cfs(&output_store, 5, 5).unwrap();
 
         let (moveos_store, output_rooch_store) =
             replayer.load_output_stores(&output_store).unwrap();
@@ -1614,6 +1302,20 @@ mod tests {
                 .to_vec(),
             vec![4, 5, 6]
         );
+        assert!(output_rooch_store
+            .transaction_store
+            .get_transaction_by_hash(retained_tx_hash)
+            .unwrap()
+            .is_some());
+        assert!(moveos_store
+            .get_tx_execution_info(retained_tx_hash)
+            .unwrap()
+            .is_some());
+        assert!(output_rooch_store
+            .get_state_store()
+            .get_state_change_set(5)
+            .unwrap()
+            .is_some());
 
         assert!(
             moveos_store
@@ -1626,9 +1328,9 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_output_store_rewrites_sequencer_without_copied_meta() {
+    fn test_refresh_output_metadata_rewrites_sequencer_without_copied_meta() {
         let config = ReplayConfig::default();
-        let (rooch_store, _rooch_tmpdir) = RoochStore::mock_rooch_store().unwrap();
+        let (_source_moveos_store, rooch_store, _tmpdir) = create_combined_test_stores();
         let replayer = IncrementalReplayer::new(config, rooch_store).unwrap();
 
         let output_dir = TempDir::new().unwrap();
@@ -1641,7 +1343,7 @@ mod tests {
 
         let tx = LedgerTransaction::new_l2_tx(
             RoochTransaction::mock(),
-            TransactionSequenceInfo::new(0, vec![], AccumulatorInfo::default(), 0),
+            TransactionSequenceInfo::random(),
         );
         let tx_hash = {
             let mut tx_clone = tx.clone();
@@ -1665,12 +1367,12 @@ mod tests {
             .get_config_store()
             .save_startup_info(StartupInfo::new(H256::random(), 1))
             .unwrap();
+        drop(moveos_store);
+        drop(output_rooch_store);
 
         replayer
-            .trim_output_store(
-                &moveos_store,
+            .refresh_output_metadata(
                 &output_store_path,
-                0,
                 0,
                 &mut StatePruneMetadata::new(
                     crate::state_prune::OperationType::Replay {

--- a/crates/rooch-pruner/src/state_prune/incremental_replayer.rs
+++ b/crates/rooch-pruner/src/state_prune/incremental_replayer.rs
@@ -7,8 +7,9 @@ use move_core_types::effects::Op;
 use moveos_config::store_config::RocksdbConfig;
 use moveos_store::transaction_store::TransactionStore as MoveOSTransactionStore;
 use moveos_store::{
-    MoveOSStore, EVENT_COLUMN_FAMILY_NAME, EVENT_HANDLE_COLUMN_FAMILY_NAME,
-    STATE_NODE_COLUMN_FAMILY_NAME, TRANSACTION_EXECUTION_INFO_COLUMN_FAMILY_NAME,
+    MoveOSStore, CONFIG_GENESIS_COLUMN_FAMILY_NAME, EVENT_COLUMN_FAMILY_NAME,
+    EVENT_HANDLE_COLUMN_FAMILY_NAME, STATE_NODE_COLUMN_FAMILY_NAME,
+    TRANSACTION_EXECUTION_INFO_COLUMN_FAMILY_NAME,
 };
 use moveos_types::h256::H256;
 use moveos_types::moveos_std::object::GENESIS_STATE_ROOT;
@@ -18,7 +19,6 @@ use moveos_types::state_resolver::StateResolver;
 use prometheus::Registry;
 use raw_store::metrics::DBMetrics;
 use raw_store::SchemaStore;
-use rocksdb::checkpoint::Checkpoint;
 use rooch_config::state_prune::{
     HistoryPruneCFStats, HistoryPruneConfig, HistoryPruneReport, ReplayConfig, ReplayReport,
 };
@@ -27,9 +27,9 @@ use rooch_store::proposer_store::ProposerStore;
 use rooch_store::state_store::StateStore;
 use rooch_store::{
     RoochStore, DA_BLOCK_CURSOR_COLUMN_FAMILY_NAME, DA_BLOCK_SUBMIT_STATE_COLUMN_FAMILY_NAME,
-    META_SEQUENCER_INFO_COLUMN_FAMILY_NAME, PROPOSER_LAST_BLOCK_COLUMN_FAMILY_NAME,
-    STATE_CHANGE_SET_COLUMN_FAMILY_NAME, TRANSACTION_COLUMN_FAMILY_NAME,
-    TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME, TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME,
+    PROPOSER_LAST_BLOCK_COLUMN_FAMILY_NAME, STATE_CHANGE_SET_COLUMN_FAMILY_NAME,
+    TRANSACTION_COLUMN_FAMILY_NAME, TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME,
+    TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME,
 };
 use rooch_types::sequencer::SequencerInfo;
 use serde_json;
@@ -41,6 +41,17 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
+
+const REQUIRED_REPLAY_COLUMN_FAMILIES: &[&str] = &[
+    TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME,
+    TRANSACTION_COLUMN_FAMILY_NAME,
+    TRANSACTION_EXECUTION_INFO_COLUMN_FAMILY_NAME,
+    TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME,
+    CONFIG_GENESIS_COLUMN_FAMILY_NAME,
+    DA_BLOCK_CURSOR_COLUMN_FAMILY_NAME,
+    DA_BLOCK_SUBMIT_STATE_COLUMN_FAMILY_NAME,
+    PROPOSER_LAST_BLOCK_COLUMN_FAMILY_NAME,
+];
 
 /// Incremental replayer for applying changesets to a snapshot
 pub struct IncrementalReplayer {
@@ -99,13 +110,13 @@ impl IncrementalReplayer {
         // Load snapshot metadata and state store
         let snapshot_meta = self.load_snapshot_metadata(input_snapshot_path)?;
         let snapshot_store = self.load_snapshot_store(input_snapshot_path)?;
+        let source_last_order = self.load_source_last_order()?;
 
-        // Build output DB from live store checkpoint
-        self.prepare_output_store(output_dir)?;
+        // Build output DB from a fresh store and copy only required column families.
+        self.prepare_fresh_output_store(output_dir)?;
+        metadata.mark_in_progress("Copying required column families".to_string(), 10.0);
+        self.copy_required_cfs(output_dir)?;
         let (output_store, _) = self.load_output_stores(output_dir)?;
-
-        metadata.mark_in_progress("Resetting state nodes".to_string(), 10.0);
-        self.clear_state_nodes(&output_store)?;
 
         metadata.mark_in_progress("Importing snapshot nodes".to_string(), 20.0);
         self.import_snapshot_nodes(&snapshot_store, &output_store, &mut report, &mut metadata)?;
@@ -152,7 +163,13 @@ impl IncrementalReplayer {
         }
 
         metadata.mark_in_progress("Trimming output metadata".to_string(), 92.0);
-        self.trim_output_store(&output_store, output_dir, to_order, &mut metadata)?;
+        self.trim_output_store(
+            &output_store,
+            output_dir,
+            source_last_order,
+            to_order,
+            &mut metadata,
+        )?;
 
         // After trim/refresh, ensure startup_info and sequencer_info are consistent
         self.verify_startup_sequencer_consistency(&output_store, output_dir, to_order)?;
@@ -262,8 +279,24 @@ impl IncrementalReplayer {
         Ok(snapshot_store)
     }
 
-    /// Create output database by checkpointing the live store
-    fn prepare_output_store(&self, output_dir: &Path) -> Result<()> {
+    fn all_column_families() -> Vec<&'static str> {
+        let mut column_families = moveos_store::StoreMeta::get_column_family_names().to_vec();
+        column_families.extend_from_slice(rooch_store::StoreMeta::get_column_family_names());
+        column_families.sort();
+        column_families.dedup();
+        column_families
+    }
+
+    fn load_source_last_order(&self) -> Result<u64> {
+        self.rooch_store
+            .get_meta_store()
+            .get_sequencer_info()?
+            .map(|info| info.last_order)
+            .ok_or_else(|| anyhow::anyhow!("Sequencer info not found in live store"))
+    }
+
+    /// Create an empty output database with the full set of column families.
+    fn prepare_fresh_output_store(&self, output_dir: &Path) -> Result<()> {
         if output_dir.exists() {
             return Err(anyhow::anyhow!(
                 "Output directory already exists: {:?}. Please provide an empty path.",
@@ -275,20 +308,62 @@ impl IncrementalReplayer {
             fs::create_dir_all(parent)?;
         }
 
-        let rocks_db = self
+        raw_store::rocks::RocksDB::new(
+            output_dir,
+            Self::all_column_families(),
+            RocksdbConfig::default(),
+        )?;
+
+        info!("Created fresh output database at {:?}", output_dir);
+        Ok(())
+    }
+
+    fn copy_required_cfs(&self, output_dir: &Path) -> Result<()> {
+        let source_db = self
             .rooch_store
             .store_instance
             .db()
-            .ok_or_else(|| anyhow::anyhow!("Failed to access RocksDB instance"))?
+            .ok_or_else(|| anyhow::anyhow!("Failed to access source RocksDB instance"))?
+            .inner();
+        let (_moveos_store, output_rooch_store) = self.load_output_stores(output_dir)?;
+
+        let target_db = output_rooch_store
+            .store_instance
+            .db()
+            .ok_or_else(|| anyhow::anyhow!("Failed to access output RocksDB instance"))?
             .inner();
 
-        let checkpoint = Checkpoint::new(rocks_db)
-            .map_err(|e| anyhow::anyhow!("Checkpoint init failed: {}", e))?;
-        checkpoint
-            .create_checkpoint(output_dir)
-            .map_err(|e| anyhow::anyhow!("Failed to create output checkpoint: {}", e))?;
+        for cf_name in REQUIRED_REPLAY_COLUMN_FAMILIES {
+            let source_cf = source_db
+                .cf_handle(cf_name)
+                .ok_or_else(|| anyhow::anyhow!("Source CF not found: {}", cf_name))?;
+            let target_cf = target_db
+                .cf_handle(cf_name)
+                .ok_or_else(|| anyhow::anyhow!("Target CF not found: {}", cf_name))?;
 
-        info!("Created output database checkpoint at {:?}", output_dir);
+            let mut batch = rocksdb::WriteBatch::default();
+            let mut count = 0usize;
+            let iter = source_db.iterator_cf(source_cf, rocksdb::IteratorMode::Start);
+
+            for item in iter {
+                let (key, value) = item?;
+                batch.put_cf(&target_cf, key, value);
+                count += 1;
+
+                if count % self.config.default_batch_size.max(1) == 0 {
+                    target_db.write(batch)?;
+                    batch = rocksdb::WriteBatch::default();
+                }
+            }
+
+            if !batch.is_empty() {
+                target_db.write(batch)?;
+            }
+
+            target_db.flush_cf(&target_cf)?;
+            info!("Copied CF {} with {} entries", cf_name, count);
+        }
+
         Ok(())
     }
 
@@ -301,16 +376,13 @@ impl IncrementalReplayer {
             ));
         }
 
-        // Combine MoveOS + Rooch CFs and ensure uniqueness
-        let mut column_families = moveos_store::StoreMeta::get_column_family_names().to_vec();
-        column_families.extend_from_slice(rooch_store::StoreMeta::get_column_family_names());
-        column_families.sort();
-        column_families.dedup();
-
         let registry = Registry::new();
         let db_metrics = DBMetrics::get_or_init(&registry).clone();
-        let rocksdb =
-            raw_store::rocks::RocksDB::new(output_dir, column_families, RocksdbConfig::default())?;
+        let rocksdb = raw_store::rocks::RocksDB::new(
+            output_dir,
+            Self::all_column_families(),
+            RocksdbConfig::default(),
+        )?;
         let instance = raw_store::StoreInstance::new_db_instance(rocksdb, db_metrics);
 
         // Share the same instance between MoveOSStore and RoochStore to avoid locks
@@ -319,18 +391,6 @@ impl IncrementalReplayer {
             .map_err(|e| anyhow::anyhow!("Failed to load output RoochStore: {}", e))?;
 
         Ok((moveos_store, rooch_store))
-    }
-
-    /// Clear state nodes in output store before importing snapshot
-    fn clear_state_nodes(&self, output_store: &MoveOSStore) -> Result<()> {
-        let node_store = output_store.get_state_node_store();
-        let start = H256::zero();
-        let end = H256::from_slice(&[0xFFu8; 32]);
-
-        node_store.delete_range_nodes(start, end, true)?;
-        node_store.delete_nodes_with_flush(vec![end], true)?;
-
-        Ok(())
     }
 
     /// Import snapshot nodes into output store
@@ -477,22 +537,17 @@ impl IncrementalReplayer {
         &self,
         output_store: &MoveOSStore,
         output_dir: &Path,
+        source_last_order: u64,
         to_order: u64,
         metadata: &mut StatePruneMetadata,
     ) -> Result<()> {
         let (_moveos_store, output_rooch_store) = self.load_output_stores(output_dir)?;
 
-        let sequencer_info = output_rooch_store
-            .get_meta_store()
-            .get_sequencer_info()?
-            .ok_or_else(|| anyhow::anyhow!("Sequencer info not found in output store"))?;
-        let last_order = sequencer_info.last_order;
-
-        if to_order > last_order {
+        if to_order > source_last_order {
             return Err(anyhow::anyhow!(
-                "to_order {} exceeds output store last_order {}",
+                "to_order {} exceeds source last_order {}",
                 to_order,
-                last_order
+                source_last_order
             ));
         }
 
@@ -512,7 +567,7 @@ impl IncrementalReplayer {
             .get_meta_store()
             .save_sequencer_info_unsafe(new_sequencer_info)?;
 
-        if to_order == last_order {
+        if to_order == source_last_order {
             info!(
                 "Output store already at to_order {}, refreshed sequencer info",
                 to_order
@@ -521,7 +576,10 @@ impl IncrementalReplayer {
         }
 
         metadata.mark_in_progress(
-            format!("Trimming output metadata ({} -> {})", last_order, to_order),
+            format!(
+                "Trimming output metadata ({} -> {})",
+                source_last_order, to_order
+            ),
             92.0,
         );
 
@@ -532,8 +590,8 @@ impl IncrementalReplayer {
             .ok_or_else(|| anyhow::anyhow!("to_order overflow"))?;
         let batch_size = self.config.default_batch_size.max(1) as u64;
 
-        while start <= last_order {
-            let end = min(last_order, start.saturating_add(batch_size - 1));
+        while start <= source_last_order {
+            let end = min(source_last_order, start.saturating_add(batch_size - 1));
             let orders: Vec<u64> = (start..=end).collect();
             let tx_hashes = output_rooch_store.transaction_store.get_tx_hashes(orders)?;
 
@@ -1439,10 +1497,43 @@ impl IncrementalReplayer {
 mod tests {
     use super::*;
     use crate::state_prune::metadata::OperationStatus;
+    use accumulator::accumulator_info::AccumulatorInfo;
+    use moveos_common::utils::to_bytes;
+    use moveos_config::store_config::RocksdbConfig;
+    use moveos_store::{MoveOSStore, CONFIG_STARTUP_INFO_COLUMN_FAMILY_NAME};
+    use prometheus::Registry;
+    use raw_store::metrics::DBMetrics;
+    use raw_store::rocks::RocksDB;
+    use raw_store::StoreInstance;
     use rooch_config::state_prune::SnapshotMeta;
     use rooch_store::RoochStore;
+    use rooch_types::transaction::{LedgerTransaction, RoochTransaction, TransactionSequenceInfo};
+    use std::collections::HashSet;
     use std::fs;
+    use std::sync::Arc;
     use tempfile::TempDir;
+
+    fn put_raw_cf(store: &RoochStore, cf_name: &str, key: Vec<u8>, value: Vec<u8>) {
+        let db = store.store_instance.db().unwrap().inner();
+        let cf = db.cf_handle(cf_name).unwrap();
+        db.put_cf(&cf, key, value).unwrap();
+    }
+
+    fn create_combined_test_stores() -> (MoveOSStore, RoochStore, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let registry = Registry::new();
+        let db = RocksDB::new(
+            temp_dir.path(),
+            IncrementalReplayer::all_column_families(),
+            RocksdbConfig::default(),
+        )
+        .unwrap();
+        let db_metrics = DBMetrics::new(&registry);
+        let instance = StoreInstance::new_db_instance(db, Arc::new(db_metrics));
+        let moveos_store = MoveOSStore::new_with_instance(instance.clone(), &registry).unwrap();
+        let rooch_store = RoochStore::new_with_instance(instance, &registry).unwrap();
+        (moveos_store, rooch_store, temp_dir)
+    }
 
     #[test]
     fn test_incremental_replayer_creation() {
@@ -1462,6 +1553,151 @@ mod tests {
         let (rooch_store, _rooch_tmpdir) = RoochStore::mock_rooch_store().unwrap();
         let replayer = IncrementalReplayer::new(config, rooch_store);
         assert!(replayer.is_err());
+    }
+
+    #[test]
+    fn test_prepare_fresh_output_store_creates_all_column_families() {
+        let config = ReplayConfig::default();
+        let (rooch_store, _rooch_tmpdir) = RoochStore::mock_rooch_store().unwrap();
+        let replayer = IncrementalReplayer::new(config, rooch_store).unwrap();
+        let output_dir = TempDir::new().unwrap();
+        let output_store = output_dir.path().join("store");
+
+        replayer.prepare_fresh_output_store(&output_store).unwrap();
+
+        let actual: HashSet<_> = raw_store::rocks::RocksDB::list_cf(&output_store)
+            .unwrap()
+            .into_iter()
+            .collect();
+
+        for cf in IncrementalReplayer::all_column_families() {
+            assert!(actual.contains(cf), "missing column family {}", cf);
+        }
+    }
+
+    #[test]
+    fn test_copy_required_cfs_skips_runtime_rebuilt_column_families() {
+        let config = ReplayConfig::default();
+        let (_moveos_store, rooch_store, _tmpdir) = create_combined_test_stores();
+        let replayer = IncrementalReplayer::new(config, rooch_store.clone()).unwrap();
+
+        put_raw_cf(
+            &rooch_store,
+            TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME,
+            vec![1, 2, 3],
+            vec![4, 5, 6],
+        );
+        put_raw_cf(
+            &rooch_store,
+            CONFIG_STARTUP_INFO_COLUMN_FAMILY_NAME,
+            b"startup_info".to_vec(),
+            vec![7, 8, 9],
+        );
+
+        let output_dir = TempDir::new().unwrap();
+        let output_store = output_dir.path().join("store");
+        replayer.prepare_fresh_output_store(&output_store).unwrap();
+        replayer.copy_required_cfs(&output_store).unwrap();
+
+        let (moveos_store, output_rooch_store) =
+            replayer.load_output_stores(&output_store).unwrap();
+        let output_db = output_rooch_store.store_instance.db().unwrap().inner();
+
+        let copied_cf = output_db
+            .cf_handle(TX_ACCUMULATOR_NODE_COLUMN_FAMILY_NAME)
+            .unwrap();
+        assert_eq!(
+            output_db
+                .get_pinned_cf(&copied_cf, vec![1, 2, 3])
+                .unwrap()
+                .unwrap()
+                .to_vec(),
+            vec![4, 5, 6]
+        );
+
+        assert!(
+            moveos_store
+                .get_config_store()
+                .get_startup_info()
+                .unwrap()
+                .is_none(),
+            "startup_info should be rebuilt instead of copied"
+        );
+    }
+
+    #[test]
+    fn test_trim_output_store_rewrites_sequencer_without_copied_meta() {
+        let config = ReplayConfig::default();
+        let (rooch_store, _rooch_tmpdir) = RoochStore::mock_rooch_store().unwrap();
+        let replayer = IncrementalReplayer::new(config, rooch_store).unwrap();
+
+        let output_dir = TempDir::new().unwrap();
+        let output_store_path = output_dir.path().join("store");
+        replayer
+            .prepare_fresh_output_store(&output_store_path)
+            .unwrap();
+        let (moveos_store, output_rooch_store) =
+            replayer.load_output_stores(&output_store_path).unwrap();
+
+        let tx = LedgerTransaction::new_l2_tx(
+            RoochTransaction::mock(),
+            TransactionSequenceInfo::new(0, vec![], AccumulatorInfo::default(), 0),
+        );
+        let tx_hash = {
+            let mut tx_clone = tx.clone();
+            tx_clone.tx_hash()
+        };
+
+        put_raw_cf(
+            &output_rooch_store,
+            TRANSACTION_COLUMN_FAMILY_NAME,
+            to_bytes(&tx_hash).unwrap(),
+            bcs::to_bytes(&tx).unwrap(),
+        );
+        put_raw_cf(
+            &output_rooch_store,
+            TX_SEQUENCE_INFO_MAPPING_COLUMN_FAMILY_NAME,
+            to_bytes(&0u64).unwrap(),
+            to_bytes(&tx_hash).unwrap(),
+        );
+
+        moveos_store
+            .get_config_store()
+            .save_startup_info(StartupInfo::new(H256::random(), 1))
+            .unwrap();
+
+        replayer
+            .trim_output_store(
+                &moveos_store,
+                &output_store_path,
+                0,
+                0,
+                &mut StatePruneMetadata::new(
+                    crate::state_prune::OperationType::Replay {
+                        snapshot_path: PathBuf::from("/tmp/snapshot"),
+                        from_order: 0,
+                        to_order: 0,
+                        output_dir: output_store_path.clone(),
+                    },
+                    serde_json::json!({}),
+                ),
+            )
+            .unwrap();
+
+        let (_moveos_store, output_rooch_store) =
+            replayer.load_output_stores(&output_store_path).unwrap();
+        let sequencer_info = output_rooch_store
+            .get_meta_store()
+            .get_sequencer_info()
+            .unwrap()
+            .unwrap();
+        assert_eq!(sequencer_info.last_order, 0);
+
+        assert!(output_rooch_store
+            .get_meta_store()
+            .get_sequencer_info()
+            .unwrap()
+            .is_some());
     }
 
     #[test]

--- a/crates/rooch/src/commands/db/commands/state_prune/command.rs
+++ b/crates/rooch/src/commands/db/commands/state_prune/command.rs
@@ -19,7 +19,7 @@ pub struct StatePruneCommand {
 pub enum StatePruneAction {
     /// Create a snapshot of active state nodes
     Snapshot(SnapshotCommand),
-    /// Replay incremental changesets onto a snapshot
+    /// Replay incremental changesets onto a snapshot using a fresh output DB
     Replay(ReplayCommand),
 }
 

--- a/crates/rooch/src/commands/db/commands/state_prune/replay.rs
+++ b/crates/rooch/src/commands/db/commands/state_prune/replay.rs
@@ -13,7 +13,7 @@ use rooch_types::rooch_network::RoochChainID;
 use serde_json;
 use std::path::PathBuf;
 
-/// Replay incremental changesets onto a snapshot
+/// Replay incremental changesets onto a snapshot using a fresh output DB
 #[derive(Debug, Parser)]
 pub struct ReplayCommand {
     /// Base data directory for the blockchain data
@@ -37,7 +37,7 @@ pub struct ReplayCommand {
     pub to_order: u64,
 
     /// Output data directory (base dir). Store will be created at
-    /// <output>/<chain>/roochdb/store as a RocksDB checkpoint.
+    /// <output>/<chain>/roochdb/store as a fresh RocksDB database.
     #[clap(long, short = 'o', required = true)]
     pub output: PathBuf,
 

--- a/crates/rooch/src/commands/db/commands/state_prune/replay.rs
+++ b/crates/rooch/src/commands/db/commands/state_prune/replay.rs
@@ -57,29 +57,13 @@ pub struct ReplayCommand {
     #[clap(long)]
     pub verbose: bool,
 
-    /// Enable history pruning during replay
-    #[clap(long)]
-    pub history_prune: bool,
-
-    /// Keep history from this tx_order (inclusive). Default is snapshot tx_order
+    /// Keep history from this tx_order (inclusive). Default is from_order
     #[clap(long)]
     pub history_retain_from: Option<u64>,
 
     /// Alternative: keep history for last N orders
     #[clap(long, conflicts_with = "history_retain_from")]
     pub history_retain_window: Option<u64>,
-
-    /// Comma-separated list of column families to prune.
-    /// Note: `event`/`event_handle`/`transaction_acc_node` pruning is not implemented yet.
-    #[clap(
-        long,
-        default_value = "transaction,transaction_execution_info,state_change_set,tx_sequence_info_mapping,da_block_submit_state"
-    )]
-    pub history_prune_cfs: String,
-
-    /// Dry-run mode: only report would-be deletions without modifying database
-    #[clap(long)]
-    pub history_dry_run: bool,
 }
 
 #[async_trait]
@@ -94,34 +78,26 @@ impl CommandAction<String> for ReplayCommand {
         );
         let rooch_store = rooch_db.rooch_store;
 
-        // Build history pruning config if enabled
-        let history_prune = if self.history_prune {
-            // Determine retain_from based on flags
-            let retain_from = if let Some(window) = self.history_retain_window {
-                // Calculate retain_from based on window
-                self.to_order.saturating_sub(window).saturating_add(1)
-            } else if let Some(from) = self.history_retain_from {
-                from
-            } else {
-                // Default: use snapshot tx_order (will be resolved during replay)
-                0 // Will be resolved from snapshot metadata
-            };
-
-            Some(HistoryPruneConfig {
-                enabled: true,
-                retain_from,
-                retain_window: self.history_retain_window,
-                prune_cfs: self
-                    .history_prune_cfs
-                    .split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect(),
-                dry_run: self.history_dry_run,
-            })
+        let retain_from = if let Some(window) = self.history_retain_window {
+            self.to_order.saturating_sub(window).saturating_add(1)
+        } else if let Some(from) = self.history_retain_from {
+            from
         } else {
-            None
+            self.from_order
         };
+
+        let history_prune = Some(HistoryPruneConfig {
+            enabled: true,
+            retain_from,
+            retain_window: self.history_retain_window,
+            prune_cfs: vec![
+                "transaction".to_string(),
+                "transaction_execution_info".to_string(),
+                "state_change_set".to_string(),
+                "tx_sequence_info_mapping".to_string(),
+            ],
+            dry_run: false,
+        });
 
         // Create replay configuration
         let replay_config = ReplayConfig {
@@ -173,7 +149,8 @@ impl CommandAction<String> for ReplayCommand {
             "output_store_dir": output_store_dir,
             "batch_size": self.batch_size,
             "verify_root": self.verify_root,
-            "history_prune_enabled": self.history_prune,
+            "history_prune_enabled": true,
+            "history_retain_from": retain_from,
             "replay_report": {
                 "changesets_processed": replay_report.changesets_processed,
                 "nodes_updated": replay_report.nodes_updated,


### PR DESCRIPTION
## Summary
- replace replay output construction with a fresh RocksDB plus selective CF copy
- import snapshot state nodes into the fresh DB and rebuild startup/sequencer metadata during replay
- add regression tests for fresh output creation, selective CF copy, and sequencer rewrite behavior

## Testing
- cargo check -p rooch-pruner --tests (still running / not completed in this session)
- cargo test -p rooch-pruner incremental_replayer -- --nocapture (build started but not completed in this session)